### PR TITLE
HEEDLS-165 Move shared pages to own controller

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/AvailableTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/AvailableTests.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.Controllers
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
 {
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Available;

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CompletedTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CompletedTests.cs
@@ -1,6 +1,5 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.Controllers
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
 {
-    using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Completed;
     using FakeItEasy;

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -1,7 +1,6 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.Controllers
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
 {
     using System;
-    using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current;
     using FakeItEasy;
@@ -65,8 +64,11 @@
             var result = controller.SetCurrentCourseCompleteByDate(currentCourse.Id, null, null, null);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/Forbidden");
-            controller.Response.StatusCode.Should().Be(403);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 403);
         }
 
         [Test]
@@ -83,8 +85,11 @@
             var result = controller.SetCurrentCourseCompleteByDate(3, null, null, null);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/PageNotFound");
-            controller.Response.StatusCode.Should().Be(404);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 404);
         }
 
         [Test]
@@ -202,8 +207,11 @@
             var result = controller.RemoveCurrentCourseConfirmation(3);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/PageNotFound");
-            controller.Response.StatusCode.Should().Be(404);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 404);
         }
 
         [Test]
@@ -238,8 +246,11 @@
             var result = controller.RequestUnlock(3);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/PageNotFound");
-            controller.Response.StatusCode.Should().Be(404);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 404);
         }
 
         [Test]
@@ -257,8 +268,11 @@
             var result = controller.RequestUnlock(progressId);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/PageNotFound");
-            controller.Response.StatusCode.Should().Be(404);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 404);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
@@ -1,0 +1,60 @@
+namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
+{
+    using System.Security.Claims;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
+    using DigitalLearningSolutions.Web.Helpers.ExternalApis;
+    using FakeItEasy;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+
+    public partial class LearningPortalControllerTests
+    {
+        private LearningPortalController controller;
+        private ICentresService centresService;
+        private ICourseService courseService;
+        private ISelfAssessmentService selfAssessmentService;
+        private IUnlockService unlockService;
+        private IConfiguration config;
+        private IFilteredApiHelperService filteredApiHelperService;
+        private const string BaseUrl = "https://www.dls.nhs.uk";
+        private const int CandidateId = 11;
+        private const int SelfAssessmentId = 1;
+        private const int CentreId = 2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            centresService = A.Fake<ICentresService>();
+            courseService = A.Fake<ICourseService>();
+            selfAssessmentService = A.Fake<ISelfAssessmentService>();
+            unlockService = A.Fake<IUnlockService>();
+            var logger = A.Fake<ILogger<LearningPortalController>>();
+            config = A.Fake<IConfiguration>();
+            filteredApiHelperService = A.Fake<IFilteredApiHelperService>();
+            
+            A.CallTo(() => config["CurrentSystemBaseUrl"]).Returns(BaseUrl);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("learnCandidateID", CandidateId.ToString()),
+                new Claim("UserCentreID", CentreId.ToString())
+            }, "mock"));
+            controller = new LearningPortalController(
+                centresService,
+                courseService,
+                selfAssessmentService,
+                unlockService,
+                logger,
+                config,
+                filteredApiHelperService
+            )
+            {
+                ControllerContext = new ControllerContext() { HttpContext = new DefaultHttpContext { User = user } }
+            };
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.Controllers
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
 {
     using System;
     using System.Collections.Generic;
@@ -69,8 +69,11 @@
             var result = controller.SelfAssessment(SelfAssessmentId);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/Forbidden");
-            controller.Response.StatusCode.Should().Be(403);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 403);
         }
 
         [Test]
@@ -126,7 +129,6 @@
             // Given
             const int competencyNumber = 3;
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            var competency = new Competency();
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)).Returns(selfAssessment);
             A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, CandidateId)).Returns(null);
 
@@ -147,8 +149,11 @@
             var result = controller.SelfAssessmentCompetency(SelfAssessmentId, 1);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/Forbidden");
-            controller.Response.StatusCode.Should().Be(403);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 403);
         }
 
         [Test]
@@ -222,8 +227,11 @@
             var result = controller.SelfAssessmentCompetency(1, null, 1, 1);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/Forbidden");
-            controller.Response.StatusCode.Should().Be(403);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 403);
         }
 
         [Test]
@@ -314,8 +322,11 @@
             var result = controller.SelfAssessmentReview(SelfAssessmentId);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/Forbidden");
-            controller.Response.StatusCode.Should().Be(403);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 403);
         }
 
         [Test]
@@ -419,8 +430,11 @@
             var result = controller.SetSelfAssessmentCompleteByDate(2, 2, 2020, 999);
 
             // Then
-            result.Should().BeViewResult().WithViewName("Error/Forbidden");
-            controller.Response.StatusCode.Should().Be(403);
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 403);
         }
 
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningSolutions/LearningSolutionsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningSolutions/LearningSolutionsControllerTests.cs
@@ -1,33 +1,23 @@
-namespace DigitalLearningSolutions.Web.Tests.Controllers
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningSolutions
 {
-    using System;
     using System.Security.Claims;
     using DigitalLearningSolutions.Data.Services;
-    using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
-    using DigitalLearningSolutions.Web.Helpers.ExternalApis;
-    using DigitalLearningSolutions.Web.ViewModels.LearningPortal;
+    using DigitalLearningSolutions.Web.Controllers;
+    using DigitalLearningSolutions.Web.ViewModels.LearningSolutions;
     using FakeItEasy;
     using FluentAssertions;
     using FluentAssertions.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
 
-    public partial class LearningPortalControllerTests
+    class LearningSolutionsControllerTests
     {
-        private LearningPortalController controller;
+        private LearningSolutionsController controller;
         private ICentresService centresService;
         private IConfigService configService;
-        private ICourseService courseService;
-        private ISelfAssessmentService selfAssessmentService;
-        private IUnlockService unlockService;
-        private IConfiguration config;
-        private IFilteredApiHelperService filteredApiHelperService;
-        private const string BaseUrl = "https://www.dls.nhs.uk";
         private const int CandidateId = 11;
-        private const int SelfAssessmentId = 1;
         private const int CentreId = 2;
 
         [SetUp]
@@ -35,29 +25,17 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         {
             centresService = A.Fake<ICentresService>();
             configService = A.Fake<IConfigService>();
-            courseService = A.Fake<ICourseService>();
-            selfAssessmentService = A.Fake<ISelfAssessmentService>();
-            unlockService = A.Fake<IUnlockService>();
-            var logger = A.Fake<ILogger<LearningPortalController>>();
-            config = A.Fake<IConfiguration>();
-            filteredApiHelperService = A.Fake<IFilteredApiHelperService>();
-            
-            A.CallTo(() => config["CurrentSystemBaseUrl"]).Returns(BaseUrl);
+            var logger = A.Fake<ILogger<LearningSolutionsController>>();
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
                 new Claim("learnCandidateID", CandidateId.ToString()),
                 new Claim("UserCentreID", CentreId.ToString())
             }, "mock"));
-            controller = new LearningPortalController(
-                centresService,
+            controller = new LearningSolutionsController(
                 configService,
-                courseService,
-                selfAssessmentService,
-                unlockService,
                 logger,
-                config,
-                filteredApiHelperService
+                centresService
             )
             {
                 ControllerContext = new ControllerContext() { HttpContext = new DefaultHttpContext { User = user } }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Available.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Available.cs
@@ -3,7 +3,7 @@
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Available;
     using Microsoft.AspNetCore.Mvc;
-    using System.Data;
+    using DigitalLearningSolutions.Web.Helpers;
 
     public partial class LearningPortalController
     {
@@ -15,7 +15,7 @@
             int page = 1
         )
         {
-            var availableCourses = courseService.GetAvailableCourses(GetCandidateId(), GetCentreId());
+            var availableCourses = courseService.GetAvailableCourses(User.GetCandidateId(), User.GetCentreId());
             var bannerText = GetBannerText();
             var model = new AvailablePageViewModel(
                 availableCourses,
@@ -31,14 +31,14 @@
 
         public IActionResult AllAvailableItems()
         {
-            var availableCourses = courseService.GetAvailableCourses(GetCandidateId(), GetCentreId());
+            var availableCourses = courseService.GetAvailableCourses(User.GetCandidateId(), User.GetCentreId());
             var model = new AllAvailableItemsPageViewModel(availableCourses, config);
             return View("Available/AllAvailableItems", model);
         }
 
         public IActionResult EnrolOnSelfAssessment(int selfAssessmentId)
         {
-            courseService.EnrolOnSelfAssessment(selfAssessmentId, GetCandidateId());
+            courseService.EnrolOnSelfAssessment(selfAssessmentId, User.GetCandidateId());
             return RedirectToAction("SelfAssessment", new { selfAssessmentId = selfAssessmentId});
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Completed.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Completed.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.LearningPortalController
 {
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Completed;
     using Microsoft.AspNetCore.Mvc;
@@ -14,7 +15,7 @@
             int page = 1
         )
         {
-            var completedCourses = courseService.GetCompletedCourses(GetCandidateId());
+            var completedCourses = courseService.GetCompletedCourses(User.GetCandidateId());
             var bannerText = GetBannerText();
             var model = new CompletedPageViewModel(
                 completedCourses,
@@ -30,7 +31,7 @@
 
         public IActionResult AllCompletedItems()
         {
-            var completedCourses = courseService.GetCompletedCourses(GetCandidateId());
+            var completedCourses = courseService.GetCompletedCourses(User.GetCandidateId());
             var model = new AllCompletedItemsPageViewModel(completedCourses, config);
             return View("Completed/AllCompletedItems", model);
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Web.ControllerHelpers;
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
@@ -14,15 +15,15 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}")]
         public IActionResult SelfAssessment(int selfAssessmentId)
         {
-            var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(GetCandidateId(), selfAssessmentId);
+            var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateId(), selfAssessmentId);
 
             if (selfAssessment == null)
             {
-                logger.LogWarning($"Attempt to display self assessment description for candidate {GetCandidateId()} with no self assessment");
-                return StatusCode(403);
+                logger.LogWarning($"Attempt to display self assessment description for candidate {User.GetCandidateId()} with no self assessment");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-            selfAssessmentService.IncrementLaunchCount(selfAssessment.Id, GetCandidateId());
-            selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, GetCandidateId());
+            selfAssessmentService.IncrementLaunchCount(selfAssessment.Id, User.GetCandidateId());
+            selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, User.GetCandidateId());
 
             var model = new SelfAssessmentDescriptionViewModel(selfAssessment);
             return View("SelfAssessments/SelfAssessmentDescription", model);
@@ -32,21 +33,21 @@
         public IActionResult SelfAssessmentCompetency(int selfAssessmentId, int competencyNumber)
         {
             string destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId.ToString() + "/" + competencyNumber.ToString();
-            selfAssessmentService.SetBookmark(selfAssessmentId, GetCandidateId(), destUrl);
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(GetCandidateId(), selfAssessmentId);
+            selfAssessmentService.SetBookmark(selfAssessmentId, User.GetCandidateId(), destUrl);
+            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateId(), selfAssessmentId);
             if (assessment == null)
             {
-                logger.LogWarning($"Attempt to display self assessment competency for candidate {GetCandidateId()} with no self assessment");
-                return StatusCode(403);
+                logger.LogWarning($"Attempt to display self assessment competency for candidate {User.GetCandidateId()} with no self assessment");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
-            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id, GetCandidateId());
+            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id, User.GetCandidateId());
             if (competency == null)
             {
                 return RedirectToAction("SelfAssessmentReview", new { selfAssessmentId = assessment.Id });
             }
 
-            selfAssessmentService.UpdateLastAccessed(assessment.Id, GetCandidateId());
+            selfAssessmentService.UpdateLastAccessed(assessment.Id, User.GetCandidateId());
 
             var model = new SelfAssessmentCompetencyViewModel(assessment, competency, competencyNumber, assessment.NumberOfCompetencies);
             return View("SelfAssessments/SelfAssessmentCompetency", model);
@@ -56,12 +57,12 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{competencyNumber:int}")]
         public IActionResult SelfAssessmentCompetency(int selfAssessmentId, ICollection<AssessmentQuestion> assessmentQuestions, int competencyNumber, int competencyId)
         {
-            var candidateID = GetCandidateId();
+            var candidateID = User.GetCandidateId();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateID, selfAssessmentId);
             if (assessment == null)
             {
                 logger.LogWarning($"Attempt to set self assessment competency for candidate {candidateID} with no self assessment");
-                return StatusCode(403);
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
             foreach (var assessmentQuestion in assessmentQuestions)
@@ -69,7 +70,7 @@
                 selfAssessmentService.SetResultForCompetency(
                     competencyId,
                     assessment.Id,
-                    GetCandidateId(),
+                    User.GetCandidateId(),
                     assessmentQuestion.Id,
                     assessmentQuestion.Result.Value,
                     null
@@ -83,17 +84,17 @@
         public IActionResult SelfAssessmentReview(int selfAssessmentId)
         {
             string destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId.ToString() + "/Review";
-            selfAssessmentService.SetBookmark(selfAssessmentId, GetCandidateId(), destUrl);
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(GetCandidateId(), selfAssessmentId);
+            selfAssessmentService.SetBookmark(selfAssessmentId, User.GetCandidateId(), destUrl);
+            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateId(), selfAssessmentId);
             if (assessment == null)
             {
-                logger.LogWarning($"Attempt to display self assessment review for candidate {GetCandidateId()} with no self assessment");
-                return StatusCode(403);
+                logger.LogWarning($"Attempt to display self assessment review for candidate {User.GetCandidateId()} with no self assessment");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
-            selfAssessmentService.UpdateLastAccessed(assessment.Id, GetCandidateId());
+            selfAssessmentService.UpdateLastAccessed(assessment.Id, User.GetCandidateId());
 
-            var competencies = selfAssessmentService.GetMostRecentResults(assessment.Id, GetCandidateId()).ToList();
+            var competencies = selfAssessmentService.GetMostRecentResults(assessment.Id, User.GetCandidateId()).ToList();
             var model = new SelfAssessmentReviewViewModel()
             {
                 SelfAssessment = assessment,
@@ -107,15 +108,15 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/CompleteBy")]
         public IActionResult SetSelfAssessmentCompleteByDate(int selfAssessmentId, int day, int month, int year)
         {
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(GetCandidateId(), selfAssessmentId);
+            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateId(), selfAssessmentId);
             if (assessment.Id == 0)
             {
-                logger.LogWarning($"Attempt to set complete by date for candidate {GetCandidateId()} with no self assessment");
-                return StatusCode(403);
+                logger.LogWarning($"Attempt to set complete by date for candidate {User.GetCandidateId()} with no self assessment");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
             if (day == 0 && month == 0 && year == 0)
             {
-                selfAssessmentService.SetCompleteByDate(selfAssessmentId, GetCandidateId(), null);
+                selfAssessmentService.SetCompleteByDate(selfAssessmentId, User.GetCandidateId(), null);
                 return RedirectToAction("Current");
             }
 
@@ -126,18 +127,18 @@
             }
 
             var completeByDate = new DateTime(year, month, day);
-            selfAssessmentService.SetCompleteByDate(selfAssessmentId, GetCandidateId(), completeByDate);
+            selfAssessmentService.SetCompleteByDate(selfAssessmentId, User.GetCandidateId(), completeByDate);
             return RedirectToAction("Current");
         }
 
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/CompleteBy")]
         public IActionResult SetSelfAssessmentCompleteByDate(int selfAssessmentId, int? day, int? month, int? year)
         {
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(GetCandidateId(), selfAssessmentId);
+            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateId(), selfAssessmentId);
             if (assessment == null)
             {
-                logger.LogWarning($"Attempt to view self assessment complete by date edit page for candidate {GetCandidateId()} with no self assessment");
-                return StatusCode(403);
+                logger.LogWarning($"Attempt to view self assessment complete by date edit page for candidate {User.GetCandidateId()} with no self assessment");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
             var model = new SelfAssessmentCardViewModel(assessment);

--- a/DigitalLearningSolutions.Web/Controllers/LearningSolutionsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningSolutionsController.cs
@@ -1,0 +1,98 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers
+{
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ViewModels.LearningSolutions;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+
+    [Authorize(Policy = CustomPolicies.UserOnly)]
+    public class LearningSolutionsController : Controller
+    {
+        private readonly IConfigService configService;
+        private readonly ILogger<LearningSolutionsController> logger;
+        private readonly ICentresService centresService;
+
+        public LearningSolutionsController(
+            IConfigService configService,
+            ILogger<LearningSolutionsController> logger,
+            ICentresService centresService
+        )
+        {
+            this.configService = configService;
+            this.logger = logger;
+            this.centresService = centresService;
+        }
+
+        public IActionResult AccessibilityHelp()
+        {
+            var accessibilityText = configService.GetConfigValue(ConfigService.AccessibilityHelpText);
+            if (accessibilityText == null)
+            {
+                logger.LogError("Accessibility text from Config table is null");
+                return StatusCode(500);
+            }
+
+            var model = new AccessibilityHelpViewModel(accessibilityText);
+            return View(model);
+        }
+
+        public IActionResult Terms()
+        {
+            var termsText = configService.GetConfigValue(ConfigService.TermsText);
+            if (termsText == null)
+            {
+                logger.LogError("Terms text from Config table is null");
+                return StatusCode(500);
+            }
+
+            var model = new TermsViewModel(termsText);
+            return View(model);
+        }
+
+        public IActionResult Error()
+        {
+            var model = GetErrorModel();
+            Response.StatusCode = 500;
+            return View("Error/UnknownError", model);
+        }
+
+        [Route("/LearningSolutions/StatusCode/{code:int}")]
+        [IgnoreAntiforgeryToken]
+        public new IActionResult StatusCode(int code)
+        {
+            var model = GetErrorModel();
+            Response.StatusCode = code;
+
+            return code switch
+                {
+                404 => View("Error/PageNotFound", model),
+                403 => View("Error/Forbidden", model),
+                _ => View("Error/UnknownError", model)
+                };
+        }
+
+        private ErrorViewModel GetErrorModel()
+        {
+            try
+            {
+                var bannerText = GetBannerText();
+                return new ErrorViewModel(bannerText);
+            }
+            catch
+            {
+                return new ErrorViewModel(null);
+            }
+        }
+
+        private string? GetBannerText()
+        {
+            var centreId = User.GetCentreId();
+            var bannerText = centreId == null
+                ? null
+                : centresService.GetBannerText(centreId.Value);
+            return bannerText;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -4,6 +4,16 @@
 
     public static class CustomClaimHelper
     {
+        public static int GetCandidateId(this ClaimsPrincipal user)
+        {
+            return user.GetCustomClaimAsRequiredInt(CustomClaimTypes.LearnCandidateId);
+        }
+
+        public static int? GetCentreId(this ClaimsPrincipal user)
+        {
+            return user.GetCustomClaimAsInt(CustomClaimTypes.UserCentreId);
+        }
+
         public static string? GetCustomClaim(this ClaimsPrincipal user, string customClaimType)
         {
             return user.FindFirst(customClaimType)?.Value;

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -3,7 +3,6 @@ namespace DigitalLearningSolutions.Web
     using System.Data;
     using System.IO;
     using System.Threading.Tasks;
-    using Dapper.FluentMap;
     using DigitalLearningSolutions.Data.Factories;
     using DigitalLearningSolutions.Data.Mappers;
     using DigitalLearningSolutions.Data.Services;
@@ -93,8 +92,8 @@ namespace DigitalLearningSolutions.Web
                 app.UseBrowserLink();
             }
 
-            app.UseExceptionHandler("/Frameworks/Error");
-            app.UseStatusCodePagesWithReExecute("/Frameworks/StatusCode/{0}");
+            app.UseExceptionHandler("/LearningSolutions/Error");
+            app.UseStatusCodePagesWithReExecute("/LearningSolutions/StatusCode/{0}");
             app.UseStaticFiles();
             app.UseSerilogRequestLogging();
             app.UseRouting();

--- a/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/AccessibilityHelpViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/AccessibilityHelpViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 {
     using Microsoft.AspNetCore.Html;
 

--- a/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/ErrorViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/ErrorViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 {
     public class ErrorViewModel
     {

--- a/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/TermsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/TermsViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 {
     using Microsoft.AspNetCore.Html;
 

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/AccessibilityHelp.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/AccessibilityHelp.cshtml
@@ -1,7 +1,7 @@
-@using DigitalLearningSolutions.Web.ViewModels.LearningPortal
+@using DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 @model AccessibilityHelpViewModel
 @{
-  ViewData["Title"] = "Learning Portal - Accessibility";
+  ViewData["Title"] = "Digital Learning Solutions - Accessibility";
 }
 
 <div class="nhsuk-grid-row">

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Error/Forbidden.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Error/Forbidden.cshtml
@@ -1,4 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 @model ErrorViewModel
 @{
   ViewData["Title"] = "Digital Learning Solutions - You don't have permission to view this page";

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Error/PageNotFound.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Error/PageNotFound.cshtml
@@ -1,4 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 @model ErrorViewModel
 @{
   ViewData["Title"] = "Digital Learning Solutions - Page not found";

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Error/UnknownError.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Error/UnknownError.cshtml
@@ -1,7 +1,7 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 @model ErrorViewModel
 @{
-  ViewData["Title"] = "Learning Portal - Something went wrong";
+  ViewData["Title"] = "Digital Learning Solutions - Something went wrong";
 }
 
 <div class="nhsuk-grid-row">

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Terms.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Terms.cshtml
@@ -1,7 +1,7 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningSolutions
 @model TermsViewModel
 @{
-  ViewData["Title"] = "Learning Portal - Terms of Use";
+  ViewData["Title"] = "Digital Learning Solutions - Terms of Use";
 }
 
 <div class="nhsuk-grid-row">

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -1,6 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.Extensions
-@using DigitalLearningSolutions.Web.ViewModels.LearningPortal
-@using Microsoft.Extensions.Configuration
+﻿@using Microsoft.Extensions.Configuration
 
 @inject IConfiguration Configuration
 
@@ -119,10 +117,10 @@
           <h2 class="nhsuk-u-visually-hidden">Support links</h2>
           <ul class="nhsuk-footer__list">
             <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" asp-action="Terms">Terms of use</a>
+              <a class="nhsuk-footer__list-item-link" asp-controller="LearningSolutions" asp-action="Terms">Terms of use</a>
             </li>
             <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" asp-action="AccessibilityHelp">Accessibility</a>
+              <a class="nhsuk-footer__list-item-link" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility</a>
             </li>
             <li class="nhsuk-footer__list-item">
               <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy</a>


### PR DESCRIPTION
Summary of changes:
* Moved error pages, terms and accessibility actions to their own controller

* Moved view models and views for the corresponding pages to a new learning solutions folder

* Moved some helper methods to get candidate id and centre id to the claims helper so that they can be used from anywhere in the application, not just the learning portal controller

* Updated all redirects to the error pages to redirect to the new controller

Testing:
* Checked navigating to an unknown url gave 404

* Checked navigating to an existing page but with invalid parameter gave 404

* Checked causing exception gave 500

* Checked footer links working on both learning portal pages and error pages