### PR TITLE
HEEDLS-NONE Add script to fix inconsistencies in obfuscated database

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ We've added data for the Digital Capabilities self assessment to the database. T
 4. Press the Execute button to run the script.
 5. Do the same for the EnrolUserOnSelfAssessment.sql script. This will enrol the test user on the self assessment.
 
+## Fix inconsistencies with live
+
+There are a few inconsistencies with the live database, as there were some changes made after the db backup was created. There is a script which will fix this, MakeLocalDatabaseConsistentWithLive. Run this on the mbdbx101 database in the same way as the script to add the self assessment data.
+
 ### Inspecting the database
 
 It can be useful to have a look at what's in the database, to test out and plan SQL queries. The easiest way to do this is:

--- a/SQLScripts/MakeLocalDatabaseConsistentWithLive.sql
+++ b/SQLScripts/MakeLocalDatabaseConsistentWithLive.sql
@@ -1,0 +1,17 @@
+BEGIN TRANSACTION
+
+ALTER TABLE Customisations 
+ADD 
+	Question1 NVARCHAR(100) NULL, 
+	Question2 NVARCHAR(100) NULL, 
+	Question3 NVARCHAR(100) NULL, 
+	CreatedTime DATETIME NOT NULL CONSTRAINT DF_Customisations_CreatedDate DEFAULT GETUTCDATE()
+
+ALTER TABLE Customisations
+DROP
+	CONSTRAINT DF_Customisations_DefaultSupervisorAdminID,
+	CONSTRAINT DF_Customisations_DefaultSupervisionTool,
+	COLUMN DefaultSupervisorAdminID,
+	COLUMN DefaultAppointmentTypeID
+
+COMMIT


### PR DESCRIPTION
There were some changes made to the database after the obfuscated database backup was created and before the project was setup to use migrations for database changes. Therefore there are some inconsistencies between the database backup and the live
& UAT databases. I've added a script to fix this which should be run on any locally created databases and on test.