### PR TITLE
HEEDLS-NONE Improve the ftp deployment script

### DIFF
--- a/DeployToFtpServer.bat
+++ b/DeployToFtpServer.bat
@@ -9,7 +9,7 @@ dotnet build DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj -c
 if %ERRORLEVEL% neq 0 goto builderror 
 
 rem ftp upload
-"C:\Program Files (x86)\WinSCP\WinSCP.exe" /log="WinSCP.log" /ini=nul /script="DeployToFtpServer.txt" /parameter %1 %3
+"C:\Program Files (x86)\WinSCP\WinSCP.exe" /log="WinSCP.log" /ini=nul /script="DeployToFtpServer.txt" /parameter %1 %3 %4
 if %ERRORLEVEL% neq 0 goto ftperror 
 
 echo Deployment succeeded
@@ -21,5 +21,8 @@ exit /b 1
 
 :ftperror
 echo Ftp transfer failed
-FOR /F "tokens=* delims=" %%x in (WinSCP.log) DO echo %%x
+FOR /F "tokens=* delims=" %%x in (WinSCP.log) DO (
+    rem do not print a line containing the word "Command-line" as that line will include the ftp password
+    (echo %%x | findstr /i /c:"Command-line" >nul) || (echo %%x)
+)
 exit /b 1

--- a/DeployToFtpServer.txt
+++ b/DeployToFtpServer.txt
@@ -1,4 +1,4 @@
-open ftp://%1%@10.0.1.82/ -passive=0
+open ftp://%1%@%3%/ -passive=0
 
 lcd DigitalLearningSolutions.Web\OfflineMode
 cd /%2%

--- a/DeployToProduction.bat
+++ b/DeployToProduction.bat
@@ -1,2 +1,2 @@
 @echo off
-DeployToFtpServer.bat %1 PublishToFolderForProduction dlsweb-v2
+DeployToFtpServer.bat %1 PublishToFolderForProduction dlsweb-v2 %2

--- a/DeployToUAT.bat
+++ b/DeployToUAT.bat
@@ -1,2 +1,2 @@
 @echo off
-DeployToFtpServer.bat %1 PublishToFolderForUAT dls-dev-my-learning-portal
+DeployToFtpServer.bat %1 PublishToFolderForUAT dls-dev-my-learning-portal %2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
             }
             steps {
                 withCredentials([string(credentialsId: 'ftp-password', variable: 'PASSWORD')]) {
-                    bat "DeployToUAT.bat \"Frida.Tveit:$PASSWORD\""
+                    bat "DeployToUAT.bat \"Frida.Tveit:$PASSWORD\" 40.69.40.103"
                 }
                 slack(":tada: Successfully deployed to UAT", "good")
             }


### PR DESCRIPTION
Made some minor improvements to the deployment script.

I noticed that you'd changed the ftp ip. To avoid having to change this back and forth I've now made it a parameter to be passed in to the script. So you can call the script by e.g.:
```
DeployToUAT.bat "USERNAME:PASSWORD" 10.0.1.82
```

I also made some minor changes to how the WinSCP logs are printed, to prevent them from printing the ftp password. The complete logs will still be available in the log file 🙂 