### PR TITLE
HEEDLS-201 Use UAT values for hardcoded SCORM content

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
@@ -37,8 +37,8 @@
         public void Content_viewer_should_have_scorm_url()
         {
             // Given
-            var expectedScormUrl = $"{BaseUrl}/scoplayer/sco?CentreID=101&CustomisationID=27639&CandidateID=254480&Version=2"
-                                  + "&tutpath=https://www.dls.nhs.uk/CMS/CMSContent/Course37/Section245/Tutorials/officeessentials/imsmanifest.xml";
+            var expectedScormUrl = $"{BaseUrl}/scoplayer/sco?CentreID=101&CustomisationID=37545&CandidateID=254480&Version=1"
+                                  + "&tutpath=https://www.dls.nhs.uk/cms/CMSContent/Course589/Section2295/Tutorials/2 Patient Reg PDS/imsmanifest.xml";
 
             // When
             var contentViewerViewModel = new ContentViewerViewModel(config);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/ContentViewerViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/ContentViewerViewModel.cs
@@ -34,11 +34,11 @@
 
         private static string GetScormSource(IConfiguration config)
         {
-            const string tutorialPath = "https://www.dls.nhs.uk/CMS/CMSContent/Course37/Section245/Tutorials/officeessentials/imsmanifest.xml";
+            const string tutorialPath = "https://www.dls.nhs.uk/cms/CMSContent/Course589/Section2295/Tutorials/2 Patient Reg PDS/imsmanifest.xml";
             const int centreId = 101;
-            const int customisationId = 27639;
+            const int customisationId = 37545;
             const int candidateId = 254480;
-            const int version = 2;
+            const int version = 1;
             return $"{config.GetScormPlayerUrl()}" +
                    $"?CentreID={centreId}" +
                    $"&CustomisationID={customisationId}" +


### PR DESCRIPTION
As the SCORM urls in the db refer to content hosted in the live application, running them with customisation values from the test db won't work.

The UAT values won't work when running locally or on test, but should work when deployed to UAT, so that should be enough for a proof of concept.