### PR TITLE
HEEDLS-201 Change test old system url

### DIFF
--- a/DigitalLearningSolutions.Web/appsettings.Test.json
+++ b/DigitalLearningSolutions.Web/appsettings.Test.json
@@ -3,7 +3,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True;"
   },
-  "CurrentSystemBaseUrl": "https://www.dls.nhs.uk",
+  "CurrentSystemBaseUrl": "https://www.dls.nhs.uk/dev-prev",
   "AppRootPath": "",
   "FeatureManagement": {
     "Login": true


### PR DESCRIPTION
Plan for SCORM player testing documented here: https://swiki.softwire.com/display/HEE/Testing.

The only code change necessary was to change the test application to point to the UAT version of the old system. This isn't strictly necessary, as we shouldn't be doing SCORM testing on test (we should be testing locally and on UAT). But just in case some content works and is launched during testing it would be better for the tracking for that content to be updated in the UAT database. As we're just using a test account it shouldn't matter much either way but might as well be safe 🙂 