### PR TITLE
HEEDLS-203 Menu Header Course information back end

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -24,17 +24,17 @@
         public void Get_course_content_should_return_course()
         {
             // When
-            const int customisationId = 1;
+            const int customisationId = 1604;
             var result = courseContentService.GetCourseContent(customisationId);
 
             // Then
             var expectedCourse = new CourseContent(
-                1,
-                "Entry Level - Win XP, Office 2003/07 OLD",
-                "Standard",
-                "N/A",
-                "North West Boroughs Healthcare NHS Foundation Trust",
-                "xxxxxxxxxxxxxxxxxxxx"
+                1604,
+                "Level 2 - Microsoft Word 2007",
+                "Word Core 07 Testing",
+                "3h 56m",
+                "Northumbria Healthcare NHS Foundation Trust",
+                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
             );
             result.Should().BeEquivalentTo(expectedCourse);
         }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -28,12 +28,14 @@
             var result = courseContentService.GetCourseContent(customisationId);
 
             // Then
-            var expectedCourse = new CourseContent
-            {
-                Id = 1,
-                CustomisationName = "Standard",
-                ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD"
-            };
+            var expectedCourse = new CourseContent(
+                1,
+                "Entry Level - Win XP, Office 2003/07 OLD",
+                "Standard",
+                "N/A",
+                "North West Boroughs Healthcare NHS Foundation Trust",
+                "xxxxxxxxxxxxxxxxxxxx"
+            );
             result.Should().BeEquivalentTo(expectedCourse);
         }
     }

--- a/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
@@ -2,11 +2,11 @@
 {
     public class CourseContent
     {
-        public int Id { get; }
-        public string Title { get; }
-        public string AverageDuration { get; }
-        public string CentreName { get; }
-        public string? BannerText { get; }
+        public int Id { get; private set; }
+        public string Title { get; private set; }
+        public string AverageDuration { get; private set; }
+        public string CentreName { get; private set; }
+        public string? BannerText { get; private set; }
 
         public CourseContent(
             int id,

--- a/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
@@ -2,8 +2,26 @@
 {
     public class CourseContent
     {
-        public string CustomisationName { get; set; }
-        public string ApplicationName { get; set; }
-        public int Id { get; set; }
+        public int Id { get; }
+        public string Title { get; }
+        public string AverageDuration { get; }
+        public string CentreName { get; }
+        public string? BannerText { get; }
+
+        public CourseContent(
+            int id,
+            string applicationName,
+            string customisationName,
+            string averageDuration,
+            string centreName,
+            string? bannerText
+        )
+        {
+            Id = id;
+            Title = $"{applicationName} - {customisationName}";
+            AverageDuration = averageDuration;
+            CentreName = centreName;
+            BannerText = bannerText;
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -24,10 +24,16 @@
         public CourseContent? GetCourseContent(int customisationId)
         {
             return connection.QueryFirstOrDefault<CourseContent>(
-                @"SELECT C.CustomisationID AS Id, C.CustomisationName, A.ApplicationName 
-                      FROM Customisations as C
-                      JOIN Applications AS A ON C.ApplicationID = A.ApplicationID
-                      WHERE C.CustomisationID = @customisationId",
+                @"SELECT Customisations.CustomisationID AS id,
+                         Applications.ApplicationName,
+	                     Customisations.CustomisationName,
+	                     dbo.GetMinsForCustomisation(Customisations.CustomisationID) AS AverageDuration,
+	                     Centres.CentreName,
+	                     Centres.BannerText
+                  FROM Applications
+                  INNER JOIN Customisations ON Applications.ApplicationID = Customisations.ApplicationID
+                  INNER JOIN Centres ON Customisations.CentreID = Centres.CentreID
+                  WHERE Customisations.CustomisationID = @customisationId;",
                 new { customisationId }
             );
         }

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseContentHelper.cs
@@ -7,15 +7,20 @@
         public static CourseContent CreateDefaultCourseContent(
             int customisationId = 1,
             string customisationName = "Customisation",
-            string applicationName = "Application"
+            string applicationName = "Application",
+            string averageDuration = "Duration",
+            string centreName = "Centre",
+            string? bannerText = "Banner"
         )
         {
-            return new CourseContent
-            {
-                Id = customisationId,
-                CustomisationName = customisationName,
-                ApplicationName = applicationName
-            };
+            return new CourseContent(
+                customisationId,
+                applicationName,
+                customisationName,
+                averageDuration,
+                centreName,
+                bannerText
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -31,9 +31,7 @@
 
             // Then
             initialMenuViewModel.CourseContent.Title.Should().Be($"{applicationName} - {customisationName}");
-            initialMenuViewModel.CourseContent.AverageDuration.Should().Be(averageDuration);
-            initialMenuViewModel.CourseContent.CentreName.Should().Be(centreName);
-            initialMenuViewModel.CourseContent.BannerText.Should().Be(bannerText);
+            initialMenuViewModel.CourseContent.Should().BeEquivalentTo(expectedCourseContent);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -30,10 +30,10 @@
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.Title.Should().Be($"{applicationName} - {customisationName}");
-            initialMenuViewModel.AverageDuration.Should().Be(averageDuration);
-            initialMenuViewModel.CentreName.Should().Be(centreName);
-            initialMenuViewModel.BannerText.Should().Be(bannerText);
+            initialMenuViewModel.CourseContent.Title.Should().Be($"{applicationName} - {customisationName}");
+            initialMenuViewModel.CourseContent.AverageDuration.Should().Be(averageDuration);
+            initialMenuViewModel.CourseContent.CentreName.Should().Be(centreName);
+            initialMenuViewModel.CourseContent.BannerText.Should().Be(bannerText);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -14,13 +14,26 @@
             const int customisationId = 12;
             const string customisationName = "Custom";
             const string applicationName = "My course";
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(customisationId, customisationName, applicationName);
+            const string averageDuration = "5h 33m";
+            const string centreName = "Central";
+            const string bannerText = "Centre Banner";
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                customisationId,
+                customisationName,
+                applicationName,
+                averageDuration,
+                centreName,
+                bannerText
+            );
 
             // When
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.Name.Should().Be($"{applicationName} - {customisationName}");
+            initialMenuViewModel.Title.Should().Be($"{applicationName} - {customisationName}");
+            initialMenuViewModel.AverageDuration.Should().Be(averageDuration);
+            initialMenuViewModel.CentreName.Should().Be(centreName);
+            initialMenuViewModel.BannerText.Should().Be(bannerText);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -4,11 +4,17 @@
 
     public class InitialMenuViewModel
     {
-        public string Name { get; }
+        public string Title { get; }
+        public string AverageDuration { get; }
+        public string CentreName { get; }
+        public string? BannerText { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
-            Name = $"{courseContent.ApplicationName} - {courseContent.CustomisationName}";
+            Title = courseContent.Title;
+            AverageDuration = courseContent.AverageDuration;
+            CentreName = courseContent.CentreName;
+            BannerText = courseContent.BannerText;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -4,17 +4,11 @@
 
     public class InitialMenuViewModel
     {
-        public string Title { get; }
-        public string AverageDuration { get; }
-        public string CentreName { get; }
-        public string? BannerText { get; }
+        public CourseContent CourseContent { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
-            Title = courseContent.Title;
-            AverageDuration = courseContent.AverageDuration;
-            CentreName = courseContent.CentreName;
-            BannerText = courseContent.BannerText;
+            CourseContent = courseContent;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -8,6 +8,6 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">Course: @Model.Title</h1>
+    <h1 id="page-heading">Course: @Model.CourseContent.Title</h1>
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -8,6 +8,6 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">Course: @Model.Name</h1>
+    <h1 id="page-heading">Course: @Model.Title</h1>
   </div>
 </div>


### PR DESCRIPTION
Subtask of HEEDLS-173

### Changes
1. Add the following pieces of information to the `CourseContent` model:
    - Course title (`"{Application Name} - {Customisation Name}"`)
    - Average course duration
    - Centre name
    - Centre banner text (nullable)
2. Rewrite the `GetCourseContent` method in `CourseService`, to run a query similar to the one on the HEEDLS-173 ticket to get this information, trimmed to only get the required information
3. Modify the `InitialMenuViewModel` to collect these new fields and assign them to its own fields, including renaming one of the fields for consistency (`Name` to `Title`) 
4. Amend tests to use the new fields of the `CourseContent` and `InitialMenuViewModel`

### Testing
Refactored and amended the tests that use this code to cover the new fields. After this, ran all unit tests and they pass.