### PR TITLE
HEEDLS-198 Update login count and duration

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -2,12 +2,19 @@
 {
     using System;
     using Dapper;
+    using Microsoft.Data.SqlClient;
 
-    public static class CourseContentTestHelper
+    public class CourseContentTestHelper
     {
-        public static int GetLoginCount(int progressId)
+        private SqlConnection connection;
+
+        public CourseContentTestHelper(SqlConnection connection)
         {
-            var connection = ServiceTestHelper.GetDatabaseConnection();
+            this.connection = connection;
+        }
+
+        public int GetLoginCount(int progressId)
+        {
             return connection.QueryFirstOrDefault<int>(
                 @"SELECT LoginCount
                         FROM Progress
@@ -16,9 +23,8 @@
             );
         }
 
-        public static int GetDuration(int progressId)
+        public int GetDuration(int progressId)
         {
-            var connection = ServiceTestHelper.GetDatabaseConnection();
             return connection.QueryFirstOrDefault<int>(
                 @"SELECT Duration
                         FROM Progress
@@ -27,10 +33,12 @@
             );
         }
 
-        public static void InsertSession(
-            int candidateId, int customisationId, DateTime loginTime, int duration, int active)
+        public void InsertSession(
+            int candidateId,
+            int customisationId,
+            DateTime loginTime,
+            int duration)
         {
-            var connection = ServiceTestHelper.GetDatabaseConnection();
             connection.Execute(
                 @"INSERT INTO SESSIONS
                         ([CandidateID]
@@ -38,8 +46,8 @@
                         ,[LoginTime]
                         ,[Duration]
                         ,[Active])
-                    VALUES (@candidateId, @customisationId, @loginTime, @duration, @active)",
-                new { candidateId, customisationId, loginTime, duration, active }
+                    VALUES (@candidateId, @customisationId, @loginTime, @duration, 0)",
+                new { candidateId, customisationId, loginTime, duration }
             );
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -1,0 +1,46 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
+{
+    using System;
+    using Dapper;
+
+    public static class CourseContentTestHelper
+    {
+        public static int GetLoginCount(int progressId)
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            return connection.QueryFirstOrDefault<int>(
+                @"SELECT LoginCount
+                        FROM Progress
+                        WHERE ProgressID = @progressId",
+                new { progressId }
+            );
+        }
+
+        public static int GetDuration(int progressId)
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            return connection.QueryFirstOrDefault<int>(
+                @"SELECT Duration
+                        FROM Progress
+                        WHERE ProgressID = @progressId",
+                new { progressId }
+            );
+        }
+
+        public static void InsertSession(
+            int candidateId, int customisationId, DateTime loginTime, int duration, int active)
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            connection.Execute(
+                @"INSERT INTO SESSIONS
+                        ([CandidateID]
+                        ,[CustomisationID]
+                        ,[LoginTime]
+                        ,[Duration]
+                        ,[Active])
+                    VALUES (@candidateId, @customisationId, @loginTime, @duration, @active)",
+                new { candidateId, customisationId, loginTime, duration, active }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -12,6 +12,7 @@
     internal class CourseContentServiceTests
     {
         private CourseContentService courseContentService;
+        private CourseContentTestHelper courseContentTestHelper;
 
         [SetUp]
         public void Setup()
@@ -19,6 +20,7 @@
             var connection = ServiceTestHelper.GetDatabaseConnection();
             var logger = A.Fake<ILogger<CourseContentService>>();
             courseContentService = new CourseContentService(connection, logger);
+            courseContentTestHelper = new CourseContentTestHelper(connection);
         }
 
         [Test]
@@ -41,41 +43,43 @@
         [Test]
         public void Get_progress_id_should_return_progress_id()
         {
-            // When
+            // Given
             const int candidateId = 9;
             const int customisationId = 259;
+
+            // When
             var result = courseContentService.GetProgressId(candidateId, customisationId);
 
             // Then
-            var expectedProgressId = 10;
+            const int expectedProgressId = 10;
             result.Should().Be(expectedProgressId);
         }
 
         [Test]
         public void Update_login_count_should_not_increment_login_if_no_new_session()
         {
+            // Given
+            const int progressId = 10;
+            var expectedLoginCount = courseContentTestHelper.GetLoginCount(progressId);
+
             // When
-            const int candidateId = 9;
-            const int customisationId = 259;
-            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var expectedLoginCount = CourseContentTestHelper.GetLoginCount(progressId);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentTestHelper.GetLoginCount(progressId);
+            var result = courseContentTestHelper.GetLoginCount(progressId);
 
             // Then
             result.Should().Be(expectedLoginCount);
         }
 
         [Test]
-        public void Update_duration_should_not_increment_login_if_no_new_session()
+        public void Update_duration_should_not_increment_duration_if_no_new_session()
         {
+            // Given
+            const int progressId = 10;
+            var expectedDuration = courseContentTestHelper.GetDuration(progressId);
+
             // When
-            const int candidateId = 9;
-            const int customisationId = 259;
-            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var expectedDuration = CourseContentTestHelper.GetDuration(progressId);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentTestHelper.GetDuration(progressId);
+            var result = courseContentTestHelper.GetDuration(progressId);
 
             // Then
             result.Should().Be(expectedDuration);
@@ -84,36 +88,38 @@
         [Test]
         public void Update_login_count_should_increment_login_if_new_session()
         {
-            // When
+            // Given
             const int candidateId = 9;
             const int customisationId = 259;
+            const int progressId = 10;
             const int duration = 5;
-            const int active = 0;
             var loginTime = new DateTime(2010, 9, 23);
-            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var initialLoginCount = CourseContentTestHelper.GetLoginCount(progressId);
-            CourseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
+            var initialLoginCount = courseContentTestHelper.GetLoginCount(progressId);
+
+            // When
+            courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentTestHelper.GetLoginCount(progressId);
+            var result = courseContentTestHelper.GetLoginCount(progressId);
 
             // Then
             result.Should().Be(initialLoginCount + 1);
         }
 
         [Test]
-        public void Update_duration_should_increment_login_if_new_session()
+        public void Update_duration_should_increment_duration_if_new_session()
         {
-            // When
+            // Given
             const int candidateId = 9;
             const int customisationId = 259;
+            const int progressId = 10;
             const int duration = 5;
-            const int active = 0;
             var loginTime = new DateTime(2010, 9, 23);
-            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var initialDuration = CourseContentTestHelper.GetDuration(progressId);
-            CourseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
+            var initialDuration = courseContentTestHelper.GetDuration(progressId);
+
+            // When
+            courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentTestHelper.GetDuration(progressId);
+            var result = courseContentTestHelper.GetDuration(progressId);
 
             // Then
             result.Should().Be(initialDuration + duration);

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
+    using System;
     using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
@@ -35,6 +36,87 @@
                 ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD"
             };
             result.Should().BeEquivalentTo(expectedCourse);
+        }
+
+        [Test]
+        public void Get_progress_id_should_return_progress_id()
+        {
+            // When
+            const int candidateId = 9;
+            const int customisationId = 259;
+            var result = courseContentService.GetProgressId(candidateId, customisationId);
+
+            // Then
+            var expectedProgressId = 10;
+            result.Should().Be(expectedProgressId);
+        }
+
+        [Test]
+        public void Update_login_count_should_not_increment_login_if_no_new_session()
+        {
+            // When
+            const int candidateId = 9;
+            const int customisationId = 259;
+            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
+            var expectedLoginCount = CourseContentHelper.GetLoginCount(progressId);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+            var result = CourseContentHelper.GetLoginCount(progressId);
+
+            // Then
+            result.Should().Be(expectedLoginCount);
+        }
+
+        [Test]
+        public void Update_duration_should_not_increment_login_if_no_new_session()
+        {
+            // When
+            const int candidateId = 9;
+            const int customisationId = 259;
+            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
+            var expectedDuration = CourseContentHelper.GetDuration(progressId);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+            var result = CourseContentHelper.GetDuration(progressId);
+
+            // Then
+            result.Should().Be(expectedDuration);
+        }
+
+        [Test]
+        public void Update_login_count_should_increment_login_if_new_session()
+        {
+            // When
+            const int candidateId = 9;
+            const int customisationId = 259;
+            const int duration = 5;
+            const int active = 0;
+            var loginTime = new DateTime(2010, 9, 23);
+            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
+            var initialLoginCount = CourseContentHelper.GetLoginCount(progressId);
+            CourseContentHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+            var result = CourseContentHelper.GetLoginCount(progressId);
+
+            // Then
+            result.Should().Be(initialLoginCount + 1);
+        }
+
+        [Test]
+        public void Update_duration_should_increment_login_if_new_session()
+        {
+            // When
+            const int candidateId = 9;
+            const int customisationId = 259;
+            const int duration = 5;
+            const int active = 0;
+            var loginTime = new DateTime(2010, 9, 23);
+            var progressId = courseContentService.GetProgressId(candidateId, customisationId);
+            var initialDuration = CourseContentHelper.GetDuration(progressId);
+            CourseContentHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+            var result = CourseContentHelper.GetDuration(progressId);
+
+            // Then
+            result.Should().Be(initialDuration + duration);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -58,9 +58,9 @@
             const int candidateId = 9;
             const int customisationId = 259;
             var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var expectedLoginCount = CourseContentHelper.GetLoginCount(progressId);
+            var expectedLoginCount = CourseContentTestHelper.GetLoginCount(progressId);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentHelper.GetLoginCount(progressId);
+            var result = CourseContentTestHelper.GetLoginCount(progressId);
 
             // Then
             result.Should().Be(expectedLoginCount);
@@ -73,9 +73,9 @@
             const int candidateId = 9;
             const int customisationId = 259;
             var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var expectedDuration = CourseContentHelper.GetDuration(progressId);
+            var expectedDuration = CourseContentTestHelper.GetDuration(progressId);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentHelper.GetDuration(progressId);
+            var result = CourseContentTestHelper.GetDuration(progressId);
 
             // Then
             result.Should().Be(expectedDuration);
@@ -91,10 +91,10 @@
             const int active = 0;
             var loginTime = new DateTime(2010, 9, 23);
             var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var initialLoginCount = CourseContentHelper.GetLoginCount(progressId);
-            CourseContentHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
+            var initialLoginCount = CourseContentTestHelper.GetLoginCount(progressId);
+            CourseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentHelper.GetLoginCount(progressId);
+            var result = CourseContentTestHelper.GetLoginCount(progressId);
 
             // Then
             result.Should().Be(initialLoginCount + 1);
@@ -110,10 +110,10 @@
             const int active = 0;
             var loginTime = new DateTime(2010, 9, 23);
             var progressId = courseContentService.GetProgressId(candidateId, customisationId);
-            var initialDuration = CourseContentHelper.GetDuration(progressId);
-            CourseContentHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
+            var initialDuration = CourseContentTestHelper.GetDuration(progressId);
+            CourseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration, active);
             courseContentService.UpdateLoginCountAndDuration(progressId);
-            var result = CourseContentHelper.GetDuration(progressId);
+            var result = CourseContentTestHelper.GetDuration(progressId);
 
             // Then
             result.Should().Be(initialDuration + duration);

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -56,7 +56,7 @@
         }
 
         [Test]
-        public void Update_login_count_should_not_increment_login_if_no_new_session()
+        public void Update_login_count_should_not_increment_login_count_if_no_new_session()
         {
             // Given
             const int progressId = 10;
@@ -86,7 +86,47 @@
         }
 
         [Test]
-        public void Update_login_count_should_increment_login_if_new_session()
+        public void Update_login_count_should_not_increment_login_count_if_session_time_not_in_range()
+        {
+            // Given
+            const int candidateId = 9;
+            const int customisationId = 259;
+            const int progressId = 10;
+            const int duration = 5;
+            var loginTime = new DateTime(2011, 9, 23);
+            var expectedLoginCount = courseContentTestHelper.GetLoginCount(progressId);
+
+            // When
+            courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+            var result = courseContentTestHelper.GetLoginCount(progressId);
+
+            // Then
+            result.Should().Be(expectedLoginCount);
+        }
+
+        [Test]
+        public void Update_duration_should_not_increment_duration_if_session_time_not_in_range()
+        {
+            // Given
+            const int candidateId = 9;
+            const int customisationId = 259;
+            const int progressId = 10;
+            const int duration = 5;
+            var loginTime = new DateTime(2011, 9, 23);
+            var expectedDuration = courseContentTestHelper.GetDuration(progressId);
+
+            // When
+            courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+            var result = courseContentTestHelper.GetDuration(progressId);
+            
+            // Then
+            result.Should().Be(expectedDuration);
+        }
+
+        [Test]
+        public void Update_login_count_should_increment_login_count_if_new_session()
         {
             // Given
             const int candidateId = 9;

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -8,6 +8,8 @@
     public interface ICourseContentService
     {
         CourseContent? GetCourseContent(int customisationId);
+        int GetProgressId(int candidateId, int customisationId);
+        void UpdateLoginCountAndDuration(int progressId);
     }
 
     public class CourseContentService : ICourseContentService
@@ -30,6 +32,44 @@
                       WHERE C.CustomisationID = @customisationId",
                 new { customisationId }
             );
+        }
+
+        public int GetProgressId(int candidateId, int customisationId)
+        {
+            return connection.QueryFirstOrDefault<int>(
+                @"SELECT ProgressId
+                        FROM Progress
+                        WHERE CandidateId = @candidateId
+                          AND customisationId = @customisationId",
+                new { candidateId, customisationId }
+            );
+        }
+
+        public void UpdateLoginCountAndDuration(int progressId)
+        {
+            var numberOfAffectedRows = connection.Execute(
+                @"UPDATE Progress
+	                    SET LoginCount = (SELECT COALESCE(COUNT(*), 0)
+		                    FROM Sessions as s
+		                    WHERE s.CandidateID = Progress.CandidateID
+		                      AND s.CustomisationID = Progress.CustomisationID
+		                      AND (s.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime)),
+                            Duration = (SELECT COALESCE(SUM(S1.Duration), 0)
+		                    FROM Sessions as s1
+		                    WHERE s1.CandidateID = Progress.CandidateID
+		                      AND s1.CustomisationID = Progress.CustomisationID
+		                      AND (s1.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime))
+	                    WHERE Progress.ProgressID = @progressId",
+                new { progressId }
+            );
+            
+            if (numberOfAffectedRows < 1)
+            {
+                logger.LogWarning(
+                    "Not updating login count and duration as db update failed. " +
+                    $"Progress id: {progressId}"
+                );
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -36,11 +36,12 @@
 
         public int GetProgressId(int candidateId, int customisationId)
         {
+            // TODO HEEDLS-202: change QueryFirstOrDefault to creating progress record if not found
             return connection.QueryFirstOrDefault<int>(
                 @"SELECT ProgressId
                         FROM Progress
-                        WHERE CandidateId = @candidateId
-                          AND customisationId = @customisationId",
+                        WHERE CandidateID = @candidateId
+                          AND CustomisationID = @customisationId",
                 new { candidateId, customisationId }
             );
         }
@@ -50,15 +51,15 @@
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE Progress
 	                    SET LoginCount = (SELECT COALESCE(COUNT(*), 0)
-		                    FROM Sessions as s
-		                    WHERE s.CandidateID = Progress.CandidateID
-		                      AND s.CustomisationID = Progress.CustomisationID
-		                      AND (s.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime)),
+		                    FROM Sessions AS S
+		                    WHERE S.CandidateID = Progress.CandidateID
+		                      AND S.CustomisationID = Progress.CustomisationID
+		                      AND (S.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime)),
                             Duration = (SELECT COALESCE(SUM(S1.Duration), 0)
-		                    FROM Sessions as s1
-		                    WHERE s1.CandidateID = Progress.CandidateID
-		                      AND s1.CustomisationID = Progress.CustomisationID
-		                      AND (s1.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime))
+		                    FROM Sessions AS S1
+		                    WHERE S1.CandidateID = Progress.CandidateID
+		                      AND S1.CustomisationID = Progress.CustomisationID
+		                      AND (S1.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime))
 	                    WHERE Progress.ProgressID = @progressId",
                 new { progressId }
             );

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -85,5 +85,38 @@
             result.Should().BeViewResult()
                 .Model.Should().BeEquivalentTo(expectedModel);
         }
+
+        [Test]
+        public void Index_valid_customisation_id_should_call_the_course_content_service()
+        {
+            // Given
+            const int progressId = 13;
+            var defaultCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
+            A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).Returns(defaultCourseContent);
+            A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(progressId);
+
+            // When
+            controller.Index(CustomisationId);
+
+            // Then
+            A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).MustHaveHappened();
+            A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).MustHaveHappened();
+            A.CallTo(() => courseContentService.UpdateLoginCountAndDuration(progressId)).MustHaveHappened();
+        }
+
+        [Test]
+        public void Index_invalid_customisation_id_should_not_call_the_course_content_service()
+        {
+            // Given
+            A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).Returns(null);
+
+            // When
+            controller.Index(CustomisationId);
+
+            // Then
+            A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).MustHaveHappened();
+            A.CallTo(() => courseContentService.GetProgressId(A<int>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => courseContentService.UpdateLoginCountAndDuration(A<int>._)).MustNotHaveHappened();
+        }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -87,6 +87,19 @@
         }
 
         [Test]
+        public void Index_always_calls_checks_course_content()
+        {
+            // Given
+            const int customisationId = 1;
+
+            // When
+            controller.Index(1);
+
+            // Then
+            A.CallTo(() => courseContentService.GetCourseContent(customisationId)).MustHaveHappened();
+        }
+
+        [Test]
         public void Index_valid_customisation_id_should_call_the_course_content_service()
         {
             // Given
@@ -99,7 +112,6 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).MustHaveHappened();
             A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateLoginCountAndDuration(progressId)).MustHaveHappened();
         }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -87,7 +87,7 @@
         }
 
         [Test]
-        public void Index_always_calls_checks_course_content()
+        public void Index_always_calls_get_course_content()
         {
             // Given
             const int customisationId = 1;
@@ -100,7 +100,7 @@
         }
 
         [Test]
-        public void Index_valid_customisation_id_should_call_the_course_content_service()
+        public void Index_valid_customisation_id_should_update_login_and_duration()
         {
             // Given
             const int progressId = 13;
@@ -117,7 +117,7 @@
         }
 
         [Test]
-        public void Index_invalid_customisation_id_should_not_call_the_course_content_service()
+        public void Index_invalid_customisation_id_should_not_update_login_and_duration()
         {
             // Given
             A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).Returns(null);
@@ -126,7 +126,6 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.GetCourseContent(CustomisationId)).MustHaveHappened();
             A.CallTo(() => courseContentService.GetProgressId(A<int>._, A<int>._)).MustNotHaveHappened();
             A.CallTo(() => courseContentService.UpdateLoginCountAndDuration(A<int>._)).MustNotHaveHappened();
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -36,6 +36,9 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
+            var progressId = courseContentService.GetProgressId(User.GetCandidateId(), customisationId);
+            courseContentService.UpdateLoginCountAndDuration(progressId);
+
             var model = new InitialMenuViewModel(courseContent);
             return View(model);
         }


### PR DESCRIPTION
Added an method for updating LoginCount and Duration in Progress; this required a new method for obtaining ProgressID from Progress using CandidateID and CustomisationID which was also added. This update will be ran whenever a learning menu is opened.

Ran and passed all unit tests then manually tested by changing the stored value then opening the page on Firefox.