### PR TITLE
HEEDLS-208 Initial Menu Page Front End

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseSectionHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseSectionHelper.cs
@@ -14,7 +14,7 @@
                 sectionName,
                 hasLearning,
                 percentComplete
-                );
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseSectionHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseSectionHelper.cs
@@ -1,0 +1,20 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.TestHelpers
+{
+    using DigitalLearningSolutions.Data.Models.CourseContent;
+
+    internal class CourseSectionHelper
+    {
+        public static CourseSection CreateDefaultCourseSection(
+            string sectionName = "SectionName",
+            bool hasLearning = true,
+            double percentComplete = 15.0
+        )
+        {
+            return new CourseSection(
+                sectionName,
+                hasLearning,
+                percentComplete
+                );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FluentAssertions;
@@ -8,7 +9,7 @@
     public class InitialMenuViewModelTests
     {
         [Test]
-        public void Initial_menu_should_have_name()
+        public void Initial_menu_should_have_values_for_all_courseContent_fields()
         {
             // Given
             const int customisationId = 12;
@@ -25,13 +26,21 @@
                 centreName,
                 bannerText
             );
+            const string sectionName = "TestName";
+            const bool hasLearning = true;
+            const double percentComplete = 12.00;
+            var section = new CourseSection(sectionName, hasLearning, percentComplete);
+            expectedCourseContent.Sections.Add(section);
 
             // When
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.CourseContent.Title.Should().Be($"{applicationName} - {customisationName}");
-            initialMenuViewModel.CourseContent.Should().BeEquivalentTo(expectedCourseContent);
+            initialMenuViewModel.Title.Should().Be($"{applicationName} - {customisationName}");
+            initialMenuViewModel.Id.Should().Be(customisationId);
+            initialMenuViewModel.AverageDuration.Should().Be(averageDuration);
+            initialMenuViewModel.CentreName.Should().Be(centreName);
+            initialMenuViewModel.BannerText.Should().Be(bannerText);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
@@ -9,38 +10,119 @@
     public class InitialMenuViewModelTests
     {
         [Test]
-        public void Initial_menu_should_have_values_for_all_courseContent_fields()
+        public void Initial_menu_should_have_name()
         {
             // Given
-            const int customisationId = 12;
             const string customisationName = "Custom";
             const string applicationName = "My course";
-            const string averageDuration = "5h 33m";
-            const string centreName = "Central";
-            const string bannerText = "Centre Banner";
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                customisationId,
-                customisationName,
-                applicationName,
-                averageDuration,
-                centreName,
-                bannerText
+                customisationName: customisationName,
+                applicationName: applicationName
             );
-            const string sectionName = "TestName";
-            const bool hasLearning = true;
-            const double percentComplete = 12.00;
-            var section = new CourseSection(sectionName, hasLearning, percentComplete);
-            expectedCourseContent.Sections.Add(section);
 
             // When
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
             initialMenuViewModel.Title.Should().Be($"{applicationName} - {customisationName}");
-            initialMenuViewModel.Id.Should().Be(customisationId);
-            initialMenuViewModel.AverageDuration.Should().Be(averageDuration);
+        }
+
+        [Test]
+        public void Initial_menu_should_have_id()
+        {
+            // Given
+            const int customisationId = 12;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                customisationId: customisationId
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.Id.Should().Be(12);
+        }
+
+        [Test]
+        public void Initial_menu_should_have_averageDuration()
+        {
+            // Given
+            const int customisationId = 12;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                customisationId: customisationId
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.Id.Should().Be(12);
+        }
+
+        [Test]
+        public void Initial_menu_should_have_centre_name()
+        {
+            // Given
+            const string centreName = "CentreName";
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                centreName: centreName
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
             initialMenuViewModel.CentreName.Should().Be(centreName);
+        }
+
+        [Test]
+        public void Initial_menu_can_have_banner_text()
+        {
+            // Given
+            const string bannerText = "BannerText";
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                bannerText: bannerText
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
             initialMenuViewModel.BannerText.Should().Be(bannerText);
+        }
+
+        [Test]
+        public void Initial_menu_banner_text_can_be_null()
+        {
+            // Given
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                bannerText: null
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.BannerText.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void Initial_menu_should_have_list_of_section_card_view_model()
+        {
+            // Given
+            const string sectionName = "TestSectionName";
+            const bool hasLearning = true;
+            const double percentComplete = 12.00;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent();
+            var section = CourseSectionHelper.CreateDefaultCourseSection(sectionName, hasLearning, percentComplete);
+            var expectedSection = new SectionCardViewModel(section);
+            expectedCourseContent.Sections.Add(section);
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.Sections.First().Should().BeEquivalentTo(expectedSection);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -48,7 +48,7 @@
         public void Initial_menu_should_have_averageDuration()
         {
             // Given
-            const string averageDuration = "TestDuration";
+            const string averageDuration = "3h 20m";
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
                 averageDuration: averageDuration
             );

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
@@ -40,23 +41,23 @@
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.Id.Should().Be(12);
+            initialMenuViewModel.Id.Should().Be(customisationId);
         }
 
         [Test]
         public void Initial_menu_should_have_averageDuration()
         {
             // Given
-            const int customisationId = 12;
+            const string averageDuration = "TestDuration";
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                customisationId: customisationId
+                averageDuration: averageDuration
             );
 
             // When
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.Id.Should().Be(12);
+            initialMenuViewModel.AverageDuration.Should().Be(averageDuration);
         }
 
         [Test]
@@ -115,14 +116,18 @@
             const double percentComplete = 12.00;
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent();
             var section = CourseSectionHelper.CreateDefaultCourseSection(sectionName, hasLearning, percentComplete);
-            var expectedSection = new SectionCardViewModel(section);
             expectedCourseContent.Sections.Add(section);
+            var expectedSection = new SectionCardViewModel(section);
+            var expectedSectionList = new List<SectionCardViewModel>
+            {
+                expectedSection
+            };
 
             // When
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.Sections.First().Should().BeEquivalentTo(expectedSection);
+            initialMenuViewModel.Sections.Should().BeEquivalentTo(expectedSectionList);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -12,34 +12,32 @@
         public void Section_should_return_empty_string_if_has_learning_is_false()
         {
             // Given
-            const string sectionName = "TestName";
             const bool hasLearning = false;
-            const double percentComplete = 12.00;
-            var section = new CourseSection(sectionName, hasLearning, percentComplete);
+            var section = CourseSectionHelper.CreateDefaultCourseSection(hasLearning: hasLearning);
 
             // When
             var sectionCardViewModel = new SectionCardViewModel(section);
 
             // Then
-            sectionCardViewModel.HasLearning.Should().BeFalse();
-            sectionCardViewModel.GetPercentComplete().Should().Be("");
+            sectionCardViewModel.PercentComplete.Should().Be("");
         }
 
         [Test]
         public void Section_should_return_correct_string_if_has_learning_is_true()
         {
             // Given
-            const string sectionName = "TestName";
             const bool hasLearning = true;
             const double percentComplete = 12.00;
-            var section = new CourseSection(sectionName, hasLearning, percentComplete);
+            var section = CourseSectionHelper.CreateDefaultCourseSection(
+                hasLearning: hasLearning,
+                percentComplete: percentComplete
+                );
 
             // When
             var sectionCardViewModel = new SectionCardViewModel(section);
 
             // Then
-            sectionCardViewModel.HasLearning.Should().BeTrue();
-            sectionCardViewModel.GetPercentComplete().Should().Be($"{percentComplete}% Complete");
+            sectionCardViewModel.PercentComplete.Should().Be($"{percentComplete}% Complete");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -1,0 +1,45 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Data.Models.CourseContent;
+    using DigitalLearningSolutions.Web.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    class SectionCardViewModelTest
+    {
+        [Test]
+        public void Section_should_return_empty_string_if_has_learning_is_false()
+        {
+            // Given
+            const string sectionName = "TestName";
+            const bool hasLearning = false;
+            const double percentComplete = 12.00;
+            var section = new CourseSection(sectionName, hasLearning, percentComplete);
+
+            // When
+            var sectionCardViewModel = new SectionCardViewModel(section);
+
+            // Then
+            sectionCardViewModel.HasLearning.Should().BeFalse();
+            sectionCardViewModel.GetPercentComplete().Should().Be("");
+        }
+
+        [Test]
+        public void Section_should_return_correct_string_if_has_learning_is_true()
+        {
+            // Given
+            const string sectionName = "TestName";
+            const bool hasLearning = true;
+            const double percentComplete = 12.00;
+            var section = new CourseSection(sectionName, hasLearning, percentComplete);
+
+            // When
+            var sectionCardViewModel = new SectionCardViewModel(section);
+
+            // Then
+            sectionCardViewModel.HasLearning.Should().BeTrue();
+            sectionCardViewModel.GetPercentComplete().Should().Be($"{percentComplete}% Complete");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -31,7 +31,7 @@
             var section = CourseSectionHelper.CreateDefaultCourseSection(
                 hasLearning: hasLearning,
                 percentComplete: percentComplete
-                );
+            );
 
             // When
             var sectionCardViewModel = new SectionCardViewModel(section);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -6,12 +6,20 @@
 
     public class InitialMenuViewModel
     {
-        public CourseContent CourseContent { get; }
+        public int Id { get; }
+        public string Title { get; }
+        public string AverageDuration { get; }
+        public string CentreName { get; }
+        public string? BannerText { get; }
         public IEnumerable<SectionCardViewModel> Sections { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
-            CourseContent = courseContent;
+            Id = courseContent.Id;
+            Title = courseContent.Title;
+            AverageDuration = courseContent.AverageDuration;
+            CentreName = courseContent.CentreName;
+            BannerText = courseContent.BannerText;
             Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section));
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -1,14 +1,18 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.CourseContent;
 
     public class InitialMenuViewModel
     {
         public CourseContent CourseContent { get; }
+        public IEnumerable<SectionCardViewModel> Sections { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
             CourseContent = courseContent;
+            Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section));
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -4,20 +4,16 @@
 
     public class SectionCardViewModel
     {
-        public readonly string Title;
-        public readonly bool HasLearning;
-        public readonly double PercentComplete;
+        public string Title { get; }
+        public string PercentComplete { get; private set; }
+        private bool HasLearning;
+        
 
         public SectionCardViewModel(CourseSection section)
         {
             Title = section.Title;
             HasLearning = section.HasLearning;
-            PercentComplete = section.PercentComplete;
-        }
-
-        public string GetPercentComplete()
-        {
-            return HasLearning ? $"{PercentComplete}% Complete" : "";
+            PercentComplete = HasLearning ? $"{section.PercentComplete}% Complete" : "";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -1,0 +1,23 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Data.Models.CourseContent;
+
+    public class SectionCardViewModel
+    {
+        public readonly string Title;
+        public readonly bool HasLearning;
+        public readonly double PercentComplete;
+
+        public SectionCardViewModel(CourseSection section)
+        {
+            Title = section.Title;
+            HasLearning = section.HasLearning;
+            PercentComplete = section.PercentComplete;
+        }
+
+        public string GetPercentComplete()
+        {
+            return HasLearning ? $"{PercentComplete}% Complete" : "";
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -5,15 +5,12 @@
     public class SectionCardViewModel
     {
         public string Title { get; }
-        public string PercentComplete { get; private set; }
-        private bool HasLearning;
-        
+        public string PercentComplete { get; }
 
         public SectionCardViewModel(CourseSection section)
         {
             Title = section.Title;
-            HasLearning = section.HasLearning;
-            PercentComplete = HasLearning ? $"{section.PercentComplete}% Complete" : "";
+            PercentComplete = section.HasLearning ? $"{section.PercentComplete}% Complete" : "";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -17,6 +17,13 @@
   </div>
 </div>
 
+<div>
+  @for (var i = 0; i < 3; i++)
+  {
+    <partial name="_SectionCard" />
+  }
+</div>
+
 <div class="nhsuk-back-link">
   <a class="nhsuk-back-link__link" asp-action="Current" asp-controller="LearningPortal">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -17,13 +17,6 @@
   </div>
 </div>
 
-<div>
-  @for (var i = 0; i < 3; i++)
-  {
-    <partial name="_SectionCard" />
-  }
-</div>
-
 <div class="nhsuk-back-link">
   <a class="nhsuk-back-link__link" asp-action="Current" asp-controller="LearningPortal">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
@@ -31,4 +24,11 @@
     </svg>
     Return to your current activities
   </a>
+</div>
+
+<div>
+  @foreach(var section in Model.Sections)
+  {
+    <partial name="_SectionCard" model="section" />
+  }
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -3,17 +3,17 @@
 
 @{
   ViewData["HeaderPrefix"] = "";
-  ViewData["Application"] = Model.CourseContent.Title;
+  ViewData["Application"] = Model.Title;
   ViewData["Title"] = "Learning Menu";
-  ViewData["CustomisationId"] = Model.CourseContent.Id;
+  ViewData["CustomisationId"] = Model.Id;
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading" class="nhsuk-heading-xl">@Model.CourseContent.Title</h1>
-    <h2 class="nhsuk-u-secondary-text-color nhsuk-heading-l">Average Course Time: @Model.CourseContent.AverageDuration</h2>
-    <p class="nhsuk-u-margin-bottom-0">@Model.CourseContent.CentreName</p>
-    <p class="nhsuk-u-secondary-text-color">@Model.CourseContent.BannerText</p>
+    <h1 id="page-heading" class="nhsuk-heading-xl">@Model.Title</h1>
+    <h2 class="nhsuk-u-secondary-text-color nhsuk-heading-l">Average Course Time: @Model.AverageDuration</h2>
+    <p class="nhsuk-u-margin-bottom-0">@Model.CentreName</p>
+    <p class="nhsuk-u-secondary-text-color">@Model.BannerText</p>
   </div>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -11,7 +11,7 @@
       </div>
       <div class="nhsuk-grid-column-one-quarter">
         <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
-          @Model.GetPercentComplete()
+          @Model.PercentComplete
         </h3>
       </div>
     </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -1,14 +1,17 @@
-﻿<div class="nhsuk-card nhsuk-u-margin-bottom-3">
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningMenu
+@model SectionCardViewModel
+
+<div class="nhsuk-card nhsuk-u-margin-bottom-3">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-three-quarters">
         <h3 class="nhsuk-card__heading">
-          Introduction to this course
+          @Model.Title
         </h3>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
         <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
-          70% Complete
+          @Model.GetPercentComplete()
         </h3>
       </div>
     </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -1,0 +1,23 @@
+﻿<div class="nhsuk-card nhsuk-u-margin-bottom-3">
+  <div class="nhsuk-card__content">
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-three-quarters">
+        <h3 class="nhsuk-card__heading">
+          Introduction to this course
+        </h3>
+      </div>
+      <div class="nhsuk-grid-column-one-quarter">
+        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
+          70% Complete
+        </h3>
+      </div>
+    </div>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-full">
+        <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
+          Launch section
+        </a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
I tried to reuse code from the course cards (but this time utilising the nhsuk course card css class). I had to hard code in the padding as it by default it was far too large.

With this method, the return to activity button is stuck all the way at the bottom. Would we prefer to put it just above the section cards?

What still needs to be added is:

- A `SectionCardViewModel` which I can give to the section card partial
- A list of `Sections` (custom class) added to the `courseContent` @benjimarshall is doing this on his end
- Change the current `for` loop to a `foreach section in courseContent.Sections`
- Change the hard coded values to use values from the View Models

![image](https://user-images.githubusercontent.com/44266225/100368761-e29a6c80-2ffb-11eb-9e8d-437e5d619590.png)
