### PR TITLE
HEEDLS-198 Update submitted time and change tests

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -33,6 +33,16 @@
             );
         }
 
+        public DateTime GetSubmittedTime(int progressId)
+        {
+            return connection.QueryFirstOrDefault<DateTime>(
+                @"SELECT SubmittedTime
+                        FROM Progress
+                        WHERE ProgressID = @progressId",
+                new { progressId }
+            );
+        }
+
         public void InsertSession(
             int candidateId,
             int customisationId,
@@ -49,6 +59,12 @@
                     VALUES (@candidateId, @customisationId, @loginTime, @duration, 0)",
                 new { candidateId, customisationId, loginTime, duration }
             );
+        }
+
+        public bool IsApproximatelyNow(DateTime timeToCheck)
+        {
+            var twoMinutesAgo = DateTime.Now.AddMinutes(-2);
+            return (timeToCheck >= twoMinutesAgo && timeToCheck <= DateTime.Now);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -64,7 +64,7 @@
         public bool IsApproximatelyNow(DateTime timeToCheck)
         {
             var twoMinutesAgo = DateTime.Now.AddMinutes(-2);
-            return (timeToCheck >= twoMinutesAgo && timeToCheck <= DateTime.Now);
+            return timeToCheck >= twoMinutesAgo && timeToCheck <= DateTime.Now;
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -59,7 +59,7 @@
         }
 
         [Test]
-        public void Update_login_count_should_not_increment_login_count_if_no_new_session()
+        public void Update_progress_should_not_increment_login_count_if_no_new_session()
         {
             // Given
             const int progressId = 10;
@@ -68,7 +68,7 @@
             using (new TransactionScope())
             {
                 // When
-                courseContentService.UpdateLoginCountAndDuration(progressId);
+                courseContentService.UpdateProgress(progressId);
                 var result = courseContentTestHelper.GetLoginCount(progressId);
 
                 // Then
@@ -77,7 +77,7 @@
         }
 
         [Test]
-        public void Update_duration_should_not_increment_duration_if_no_new_session()
+        public void Update_progress_should_not_increment_duration_if_no_new_session()
         {
             // Given
             const int progressId = 10;
@@ -86,7 +86,7 @@
             using (new TransactionScope())
             {
                 // When
-                courseContentService.UpdateLoginCountAndDuration(progressId);
+                courseContentService.UpdateProgress(progressId);
                 var result = courseContentTestHelper.GetDuration(progressId);
 
                 // Then
@@ -95,7 +95,7 @@
         }
 
         [Test]
-        public void Update_login_count_should_not_increment_login_count_if_session_time_is_before_first_submitted_time()
+        public void Update_progress_should_not_increment_login_count_if_session_time_is_before_first_submitted_time()
         {
             // Given
             const int candidateId = 9;
@@ -109,7 +109,7 @@
             {
                 // When
                 courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
-                courseContentService.UpdateLoginCountAndDuration(progressId);
+                courseContentService.UpdateProgress(progressId);
                 var result = courseContentTestHelper.GetLoginCount(progressId);
 
                 // Then
@@ -118,7 +118,7 @@
         }
 
         [Test]
-        public void Update_duration_should_not_increment_duration_if_session_time_is_before_first_submitted_time()
+        public void Update_progress_should_not_increment_duration_if_session_time_is_before_first_submitted_time()
         {
             // Given
             const int candidateId = 9;
@@ -132,7 +132,7 @@
             {
                 // When
                 courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
-                courseContentService.UpdateLoginCountAndDuration(progressId);
+                courseContentService.UpdateProgress(progressId);
                 var result = courseContentTestHelper.GetDuration(progressId);
 
                 // Then
@@ -141,7 +141,7 @@
         }
 
         [Test]
-        public void Update_login_count_should_increment_login_count_if_new_session()
+        public void Update_progress_should_increment_login_count_if_new_session()
         {
             // Given
             const int candidateId = 9;
@@ -155,7 +155,7 @@
             {
                 // When
                 courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
-                courseContentService.UpdateLoginCountAndDuration(progressId);
+                courseContentService.UpdateProgress(progressId);
                 var result = courseContentTestHelper.GetLoginCount(progressId);
 
                 // Then
@@ -164,7 +164,7 @@
         }
 
         [Test]
-        public void Update_duration_should_increment_duration_if_new_session()
+        public void Update_progress_should_increment_duration_if_new_session()
         {
             // Given
             const int candidateId = 9;
@@ -178,11 +178,29 @@
             {
                 // When
                 courseContentTestHelper.InsertSession(candidateId, customisationId, loginTime, duration);
-                courseContentService.UpdateLoginCountAndDuration(progressId);
+                courseContentService.UpdateProgress(progressId);
                 var result = courseContentTestHelper.GetDuration(progressId);
 
                 // Then
                 result.Should().Be(initialDuration + duration);
+            }
+        }
+
+        [Test]
+        public void Update_progress_should_update_submitted_time()
+        {
+            // Given
+            const int progressId = 10;
+            var initialSubmittedTime = courseContentTestHelper.GetSubmittedTime(progressId);
+
+            using (new TransactionScope())
+            {
+                // When
+                courseContentService.UpdateProgress(progressId);
+                var result = courseContentTestHelper.GetSubmittedTime(progressId);
+
+                // Then
+                courseContentTestHelper.IsApproximatelyNow(result).Should().Be(true);
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -200,7 +200,7 @@
                 var result = courseContentTestHelper.GetSubmittedTime(progressId);
 
                 // Then
-                courseContentTestHelper.IsApproximatelyNow(result).Should().Be(true);
+                courseContentTestHelper.IsApproximatelyNow(result).Should().BeTrue();
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -95,14 +95,14 @@
         }
 
         [Test]
-        public void Update_login_count_should_not_increment_login_count_if_session_time_not_in_range()
+        public void Update_login_count_should_not_increment_login_count_if_session_time_is_before_first_submitted_time()
         {
             // Given
             const int candidateId = 9;
             const int customisationId = 259;
             const int progressId = 10;
             const int duration = 5;
-            var loginTime = new DateTime(2011, 9, 23);
+            var loginTime = new DateTime(2010, 8, 23);
             var expectedLoginCount = courseContentTestHelper.GetLoginCount(progressId);
 
             using (new TransactionScope())
@@ -118,14 +118,14 @@
         }
 
         [Test]
-        public void Update_duration_should_not_increment_duration_if_session_time_not_in_range()
+        public void Update_duration_should_not_increment_duration_if_session_time_is_before_first_submitted_time()
         {
             // Given
             const int candidateId = 9;
             const int customisationId = 259;
             const int progressId = 10;
             const int duration = 5;
-            var loginTime = new DateTime(2011, 9, 23);
+            var loginTime = new DateTime(2010, 8, 23);
             var expectedDuration = courseContentTestHelper.GetDuration(progressId);
 
             using (new TransactionScope())

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -9,7 +9,7 @@
     {
         CourseContent? GetCourseContent(int customisationId);
         int GetProgressId(int candidateId, int customisationId);
-        void UpdateLoginCountAndDuration(int progressId);
+        void UpdateProgress(int progressId);
     }
 
     public class CourseContentService : ICourseContentService
@@ -52,7 +52,7 @@
             );
         }
 
-        public void UpdateLoginCountAndDuration(int progressId)
+        public void UpdateProgress(int progressId)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE Progress
@@ -66,7 +66,7 @@
 		                    WHERE S1.CandidateID = Progress.CandidateID
 		                      AND S1.CustomisationID = Progress.CustomisationID
 		                      AND S1.LoginTime >= Progress.FirstSubmittedTime),
-                            SubmittedTime = GETDATE()
+                            SubmittedTime = GETUTCDATE()
 	                    WHERE Progress.ProgressID = @progressId",
                 new { progressId }
             );

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -60,12 +60,13 @@
 		                    FROM Sessions AS S
 		                    WHERE S.CandidateID = Progress.CandidateID
 		                      AND S.CustomisationID = Progress.CustomisationID
-		                      AND (S.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime)),
+		                      AND S.LoginTime >= Progress.FirstSubmittedTime),
                             Duration = (SELECT COALESCE(SUM(S1.Duration), 0)
 		                    FROM Sessions AS S1
 		                    WHERE S1.CandidateID = Progress.CandidateID
 		                      AND S1.CustomisationID = Progress.CustomisationID
-		                      AND (S1.LoginTime BETWEEN Progress.FirstSubmittedTime AND Progress.SubmittedTime))
+		                      AND S1.LoginTime >= Progress.FirstSubmittedTime),
+                            SubmittedTime = GETDATE()
 	                    WHERE Progress.ProgressID = @progressId",
                 new { progressId }
             );

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -113,7 +113,7 @@
 
             // Then
             A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).MustHaveHappened();
-            A.CallTo(() => courseContentService.UpdateLoginCountAndDuration(progressId)).MustHaveHappened();
+            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
         }
 
         [Test]
@@ -127,7 +127,7 @@
 
             // Then
             A.CallTo(() => courseContentService.GetProgressId(A<int>._, A<int>._)).MustNotHaveHappened();
-            A.CallTo(() => courseContentService.UpdateLoginCountAndDuration(A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -37,7 +37,7 @@
             }
 
             var progressId = courseContentService.GetProgressId(User.GetCandidateId(), customisationId);
-            courseContentService.UpdateLoginCountAndDuration(progressId);
+            courseContentService.UpdateProgress(progressId);
 
             var model = new InitialMenuViewModel(courseContent);
             return View(model);


### PR DESCRIPTION
Update the SubmittedTime in the Progress table when launching a course.

Also small changes to the tests because they were previously testing dates after SubmittedTime.

Ran and passed all unit tests then manually tested by launching a course on Firefox.