### PR TITLE
Create progress entry on first launch

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
 {
     using System;
+    using System.Linq;
     using Dapper;
     using Microsoft.Data.SqlClient;
 
@@ -65,6 +66,19 @@
         {
             var twoMinutesAgo = DateTime.Now.AddMinutes(-2);
             return timeToCheck >= twoMinutesAgo && timeToCheck <= DateTime.Now;
+        }
+
+        public bool DoesProgressExist(int candidateId, int customisationId)
+        {
+            return connection.Query<int>(
+                @"SELECT ProgressId
+                        FROM Progress
+                        WHERE CandidateID = @candidateId
+                          AND CustomisationID = @customisationId
+                          AND SystemRefreshed = 0
+                          AND RemovedDate IS NULL",
+                new { candidateId, customisationId }
+            ).Any();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -173,17 +173,20 @@
             const int centreId = 53;
             var initialDoesProgressExist = courseContentTestHelper.DoesProgressExist(candidateId, customisationId);
 
-            // When
-            var result = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId);
+            using (new TransactionScope())
+            {
+                // When
+                var result = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId);
 
-            // Then
-            initialDoesProgressExist.Should().BeTrue();
-            const int expectedProgressId = 10;
-            result.Should().Be(expectedProgressId);
+                // Then
+                initialDoesProgressExist.Should().BeTrue();
+                const int expectedProgressId = 10;
+                result.Should().Be(expectedProgressId);
+            }
         }
 
         [Test]
-        public void Insert_new_progress_should_insert_progress()
+        public void Get_or_create_progress_id_should_insert_new_progress_if_does_not_exist()
         {
             // Given
             const int candidateId = 187251;
@@ -195,12 +198,12 @@
             {
                 // When
                 var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId);
-                var result = courseContentTestHelper.DoesProgressExist(candidateId, customisationId);
+                var isProgressAdded = courseContentTestHelper.DoesProgressExist(candidateId, customisationId);
 
                 //Then
                 progressId.Should().NotBeNull();
                 initialDoesProgressExist.Should().BeFalse();
-                result.Should().BeTrue();
+                isProgressAdded.Should().BeTrue();
             }
         }
 

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -165,46 +165,21 @@
         }
 
         [Test]
-        public void Get_progress_id_should_return_progress_id()
+        public void Get_existing_progress_id_should_return_progress_id()
         {
             // Given
             const int candidateId = 9;
             const int customisationId = 259;
+            const int centreId = 53;
+            var initialDoesProgressExist = courseContentTestHelper.DoesProgressExist(candidateId, customisationId);
 
             // When
-            var result = courseContentService.GetProgressId(candidateId, customisationId);
+            var result = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId);
 
             // Then
+            initialDoesProgressExist.Should().BeTrue();
             const int expectedProgressId = 10;
             result.Should().Be(expectedProgressId);
-        }
-
-        [Test]
-        public void Does_progress_exist_returns_true_for_existing_progress()
-        {
-            // Given
-            const int candidateId = 9;
-            const int customisationId = 259;
-
-            // When
-            var result = courseContentService.DoesProgressExist(candidateId, customisationId);
-
-            // Then
-            result.Should().BeTrue();
-        }
-
-        [Test]
-        public void Does_progress_exist_returns_false_for_non_existing_progress()
-        {
-            // Given
-            const int candidateId = 123;
-            const int customisationId = 123;
-
-            // When
-            var result = courseContentService.DoesProgressExist(candidateId, customisationId);
-
-            // Then
-            result.Should().BeFalse();
         }
 
         [Test]
@@ -214,15 +189,16 @@
             const int candidateId = 187251;
             const int customisationId = 17468;
             const int centreId = 549;
-            var initialDoesProgressExist = courseContentService.DoesProgressExist(candidateId, customisationId);
+            var initialDoesProgressExist = courseContentTestHelper.DoesProgressExist(candidateId, customisationId);
 
             using (new TransactionScope())
             {
                 // When
-                courseContentService.InsertNewProgress(candidateId, customisationId, centreId);
-                var result = courseContentService.DoesProgressExist(candidateId, customisationId);
+                var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId);
+                var result = courseContentTestHelper.DoesProgressExist(candidateId, customisationId);
 
                 //Then
+                progressId.Should().NotBeNull();
                 initialDoesProgressExist.Should().BeFalse();
                 result.Should().BeTrue();
             }
@@ -361,7 +337,6 @@
         {
             // Given
             const int progressId = 10;
-            var initialSubmittedTime = courseContentTestHelper.GetSubmittedTime(progressId);
 
             using (new TransactionScope())
             {

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -180,6 +180,55 @@
         }
 
         [Test]
+        public void Does_progress_exist_returns_true_for_existing_progress()
+        {
+            // Given
+            const int candidateId = 9;
+            const int customisationId = 259;
+
+            // When
+            var result = courseContentService.DoesProgressExist(candidateId, customisationId);
+
+            // Then
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void Does_progress_exist_returns_false_for_non_existing_progress()
+        {
+            // Given
+            const int candidateId = 123;
+            const int customisationId = 123;
+
+            // When
+            var result = courseContentService.DoesProgressExist(candidateId, customisationId);
+
+            // Then
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void Insert_new_progress_should_insert_progress()
+        {
+            // Given
+            const int candidateId = 187251;
+            const int customisationId = 17468;
+            const int centreId = 549;
+            var initialDoesProgressExist = courseContentService.DoesProgressExist(candidateId, customisationId);
+
+            using (new TransactionScope())
+            {
+                // When
+                courseContentService.InsertNewProgress(candidateId, customisationId, centreId);
+                var result = courseContentService.DoesProgressExist(candidateId, customisationId);
+
+                //Then
+                initialDoesProgressExist.Should().BeFalse();
+                result.Should().BeTrue();
+            }
+        }
+
+        [Test]
         public void Update_progress_should_not_increment_login_count_if_no_new_session()
         {
             // Given

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -165,7 +165,7 @@
         }
 
         [Test]
-        public void Get_existing_progress_id_should_return_progress_id()
+        public void Get_or_create_progress_id_should_return_progress_id_if_exists()
         {
             // Given
             const int candidateId = 9;

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -83,9 +83,11 @@
 
         public int? GetOrCreateProgressId(int candidateId, int customisationId, int centreId)
         {
-            if (DoesProgressExist(candidateId, customisationId))
+            var progressId = GetProgressId(candidateId, customisationId);
+
+            if (progressId != null)
             {
-                return GetProgressId(candidateId, customisationId);
+                return progressId;
             }
 
             var errorCode = connection.QueryFirst<int>(
@@ -108,22 +110,22 @@
                 case 1:
                     logger.LogError(
                         "Not enrolled candidate on course as progress already exists. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
+                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                     break;
                 case 100:
                     logger.LogError(
                         "Not enrolled candidate on course as customisation id doesn't match centre id. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
+                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                     break;
                 case 101:
                     logger.LogError(
                         "Not enrolled candidate on course as candidate id doesn't match centre id. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
+                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                     break;
                 default:
                     logger.LogError(
                         "Not enrolled candidate on course as stored procedure failed. " +
-                        $"Unknown error code: {errorCode}, candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
+                        $"Unknown error code: {errorCode}, candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                     break;
             }
 
@@ -156,19 +158,6 @@
                     $"Progress id: {progressId}"
                 );
             }
-        }
-
-        private bool DoesProgressExist(int candidateId, int customisationId)
-        {
-            return connection.Query<int>(
-                @"SELECT ProgressId
-                        FROM Progress
-                        WHERE CandidateID = @candidateId
-                          AND CustomisationID = @customisationId
-                          AND SystemRefreshed = 0
-                          AND RemovedDate IS NULL",
-                new { candidateId, customisationId }
-            ).Any();
         }
 
         public int? GetProgressId(int candidateId, int customisationId)

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -160,7 +160,7 @@
             }
         }
 
-        public int? GetProgressId(int candidateId, int customisationId)
+        private int? GetProgressId(int candidateId, int customisationId)
         {
             try
             {

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
+    using System;
     using System.Data;
     using System.Linq;
     using Dapper;
@@ -107,22 +108,22 @@
                 case 1:
                     logger.LogError(
                         "Not enrolled candidate on course as progress already exists. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId{centreId}");
+                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
                     break;
                 case 100:
                     logger.LogError(
                         "Not enrolled candidate on course as customisation id doesn't match centre id. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId{centreId}");
+                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
                     break;
                 case 101:
                     logger.LogError(
                         "Not enrolled candidate on course as candidate id doesn't match centre id. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId{centreId}");
+                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
                     break;
                 default:
                     logger.LogError(
                         "Not enrolled candidate on course as stored procedure failed. " +
-                        $"Candidate id: {candidateId}, customisation id: {customisationId}, centreId{centreId}");
+                        $"Unknown error code: {errorCode}, candidate id: {candidateId}, customisation id: {customisationId}, centreId: {centreId}");
                     break;
             }
 
@@ -170,17 +171,24 @@
             ).Any();
         }
 
-        private int GetProgressId(int candidateId, int customisationId)
+        public int? GetProgressId(int candidateId, int customisationId)
         {
-            return connection.QueryFirst<int>(
-                @"SELECT ProgressId
-                        FROM Progress
-                        WHERE CandidateID = @candidateId
-                          AND CustomisationID = @customisationId
-                          AND SystemRefreshed = 0
-                          AND RemovedDate IS NULL",
-                new { candidateId, customisationId }
-            );
+            try
+            {
+                return connection.QueryFirst<int>(
+                    @"SELECT ProgressId
+                    FROM Progress
+                    WHERE CandidateID = @candidateId
+                      AND CustomisationID = @customisationId
+                      AND SystemRefreshed = 0
+                      AND RemovedDate IS NULL",
+                    new { candidateId, customisationId }
+                );
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -141,7 +141,6 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.GetOrCreateProgressId(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -119,6 +119,19 @@
         }
 
         [Test]
+        public void Index_invalid_customisation_id_should_not_insert_new_progress()
+        {
+            // Given
+            A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId)).Returns(null);
+
+            // When
+            controller.Index(CustomisationId);
+
+            // Then
+            A.CallTo(() => courseContentService.InsertNewProgress(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
+        }
+
+        [Test]
         public void Index_invalid_customisation_id_should_not_update_login_and_duration()
         {
             // Given
@@ -130,6 +143,32 @@
             // Then
             A.CallTo(() => courseContentService.GetProgressId(A<int>._, A<int>._)).MustNotHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Index_launching_new_course_should_insert_new_progress()
+        {
+            // Given
+            A.CallTo(() => courseContentService.DoesProgressExist(CandidateId, CustomisationId)).Returns(false);
+
+            // When
+            controller.Index(CustomisationId);
+
+            // Then
+            A.CallTo(() => courseContentService.InsertNewProgress(CandidateId, CustomisationId, CentreId)).MustHaveHappened();
+        }
+
+        [Test]
+        public void Index_launching_existing_course_should_not_insert_new_progress()
+        {
+            // Given
+            A.CallTo(() => courseContentService.DoesProgressExist(CandidateId, CustomisationId)).Returns(true);
+
+            // When
+            controller.Index(CustomisationId);
+
+            // Then
+            A.CallTo(() => courseContentService.InsertNewProgress(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -48,6 +48,7 @@
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
             A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId))
              .Returns(expectedCourseContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(10);
 
             // When
             var result = controller.Index(CustomisationId);
@@ -108,13 +109,12 @@
             var defaultCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
             A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId))
              .Returns(defaultCourseContent);
-            A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(progressId);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(progressId);
 
             // When
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
         }
 
@@ -128,7 +128,7 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.InsertNewProgress(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
         }
 
         [Test]
@@ -141,34 +141,21 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.GetProgressId(A<int>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
         }
 
         [Test]
-        public void Index_launching_new_course_should_insert_new_progress()
+        public void Index_failing_to_insert_progress_should_not_update_progress()
         {
             // Given
-            A.CallTo(() => courseContentService.DoesProgressExist(CandidateId, CustomisationId)).Returns(false);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(null);
 
             // When
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.InsertNewProgress(CandidateId, CustomisationId, CentreId)).MustHaveHappened();
-        }
-
-        [Test]
-        public void Index_launching_existing_course_should_not_insert_new_progress()
-        {
-            // Given
-            A.CallTo(() => courseContentService.DoesProgressExist(CandidateId, CustomisationId)).Returns(true);
-
-            // When
-            controller.Index(CustomisationId);
-
-            // Then
-            A.CallTo(() => courseContentService.InsertNewProgress(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -36,6 +36,11 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
+            if (!courseContentService.DoesProgressExist(User.GetCandidateId(), customisationId))
+            {
+                courseContentService.InsertNewProgress(User.GetCandidateId(), customisationId, User.GetCentreId().Value);
+            }
+
             var progressId = courseContentService.GetProgressId(User.GetCandidateId(), customisationId);
             courseContentService.UpdateProgress(progressId);
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -36,13 +36,14 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            if (!courseContentService.DoesProgressExist(User.GetCandidateId(), customisationId))
+            var progressId = courseContentService.GetOrCreateProgressId(User.GetCandidateId(), customisationId, User.GetCentreId().Value);
+
+            if (progressId == null)
             {
-                courseContentService.InsertNewProgress(User.GetCandidateId(), customisationId, User.GetCentreId().Value);
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 500 });
             }
 
-            var progressId = courseContentService.GetProgressId(User.GetCandidateId(), customisationId);
-            courseContentService.UpdateProgress(progressId);
+            courseContentService.UpdateProgress(progressId.Value);
 
             var model = new InitialMenuViewModel(courseContent);
             return View(model);

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -36,7 +36,7 @@
             {
                 logger.LogError(
                     "Redirecting to 404 as course/centre id was not found. " +
-                    $"Candidate id: {User.GetCandidateId()}, customisation id: {customisationId}");
+                    $"Candidate id: {User.GetCandidateId()}, customisation id: {customisationId}, centre id: {centreId?.ToString() ?? "null"}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -30,16 +30,23 @@
         public IActionResult Index(int customisationId)
         {
             var courseContent = courseContentService.GetCourseContent(User.GetCandidateId(), customisationId);
+            var centreId = User.GetCentreId();
 
-            if (courseContent == null)
+            if (courseContent == null || centreId == null)
             {
+                logger.LogError(
+                    "Redirecting to 404 as course/centre id was not found. " +
+                    $"Candidate id: {User.GetCandidateId()}, customisation id: {customisationId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            var progressId = courseContentService.GetOrCreateProgressId(User.GetCandidateId(), customisationId, User.GetCentreId().Value);
+            var progressId = courseContentService.GetOrCreateProgressId(User.GetCandidateId(), customisationId, centreId.Value);
 
             if (progressId == null)
             {
+                logger.LogError(
+                    "Redirecting to 500 as no progress id was returned. " +
+                    $"Candidate id: {User.GetCandidateId()}, customisation id: {customisationId}, centre id: {centreId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 500 });
             }
 


### PR DESCRIPTION
Add a new method to check if a given entry exists in the progress table and executes the uspCreateProgressRecord_V3 stored procedure if the entry doesn't exist.

The stored procedure has a few checks and doesn't insert the entry if any fail. This will be logged but the program will still try to run GetProgress method so this has been kept as QueryFirstOrDefault to prevent crashing if the entry wasn't added.

Ran and passed all unit tests and manually tested on Firefox, "Current Activities" will show newly enrolled courses.