### PR TITLE
HEEDLS-212 Add SessionService (and tests) to track sessions

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/SessionTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/SessionTestHelper.cs
@@ -1,0 +1,45 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
+{
+    using System.Collections.Generic;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models;
+    using FluentAssertions;
+    using Microsoft.Data.SqlClient;
+
+    public class SessionTestHelper
+    {
+        private SqlConnection connection;
+
+        public SessionTestHelper(SqlConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public Session? GetSession(int sessionId)
+        {
+            return connection.QueryFirstOrDefault<Session>(
+                @"SELECT SessionID, CandidateID, CustomisationID, LoginTime, Duration, Active
+                    FROM Sessions
+                   WHERE SessionID = @sessionId",
+                new { sessionId });
+        }
+
+        public IEnumerable<Session> GetCandidateSessions(int candidateId)
+        {
+            return connection.Query<Session>(
+                @"SELECT SessionID, CandidateID, CustomisationID, LoginTime, Duration, Active
+                    FROM Sessions
+                   WHERE CandidateID = @candidateId",
+                new { candidateId });
+        }
+
+        public static void SessionsShouldBeApproximatelyEquivalent(Session session1, Session session2)
+        {
+            session1.CandidateId.Should().Be(session2.CandidateId);
+            session1.CustomisationId.Should().Be(session2.CustomisationId);
+            session1.Duration.Should().Be(session2.Duration);
+            session1.Active.Should().Be(session2.Active);
+            session1.LoginTime.Should().BeCloseTo(session2.LoginTime, 10000);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Helpers/SessionTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/SessionTestHelper.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
 {
+    using System;
     using System.Collections.Generic;
     using Dapper;
     using DigitalLearningSolutions.Data.Models;
@@ -33,13 +34,28 @@
                 new { candidateId });
         }
 
+        public static Session CreateDefaultSession(
+            int sessionId,
+            int candidateId = 101,
+            int customisationId = 1240,
+            DateTime? loginTime = null,
+            int duration = 0,
+            bool active = true
+        )
+        {
+            loginTime ??= DateTime.Now;
+            return new Session(sessionId, candidateId, customisationId, loginTime.Value, duration, active);
+        }
+
         public static void SessionsShouldBeApproximatelyEquivalent(Session session1, Session session2)
         {
+            const int tenSecondsInMilliseconds = 10000;
+
             session1.CandidateId.Should().Be(session2.CandidateId);
             session1.CustomisationId.Should().Be(session2.CustomisationId);
             session1.Duration.Should().Be(session2.Duration);
             session1.Active.Should().Be(session2.Active);
-            session1.LoginTime.Should().BeCloseTo(session2.LoginTime, 10000);
+            session1.LoginTime.Should().BeCloseTo(session2.LoginTime, tenSecondsInMilliseconds);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/SessionServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SessionServiceTests.cs
@@ -38,14 +38,7 @@
                 newSession.Should().NotBeNull();
                 SessionTestHelper.SessionsShouldBeApproximatelyEquivalent(
                     newSession!,
-                    new Session(
-                        sessionId,
-                        candidateId,
-                        customisationId,
-                        DateTime.Now,
-                        0,
-                        true
-                    )
+                    SessionTestHelper.CreateDefaultSession(sessionId, candidateId, customisationId)
                 );
             }
         }
@@ -66,14 +59,7 @@
                 newSession.Should().NotBeNull();
                 SessionTestHelper.SessionsShouldBeApproximatelyEquivalent(
                     newSession!,
-                    new Session(
-                        sessionId,
-                        candidateId,
-                        customisationId,
-                        DateTime.Now,
-                        0,
-                        true
-                    )
+                    SessionTestHelper.CreateDefaultSession(sessionId)
                 );
             }
         }
@@ -121,26 +107,25 @@
 
             using (new TransactionScope())
             {
-                // When
+                // Given
                 const int candidateId = 9;
-                const int sessionId = 473;
                 var startingSessions = sessionTestHelper.GetCandidateSessions(candidateId);
 
+                // When
+                const int sessionId = 473;
                 sessionService.UpdateSessionDuration(sessionId);
 
                 // Then
-                var newSessions = sessionTestHelper.GetCandidateSessions(candidateId).ToList();
+                var updatedSessions = sessionTestHelper.GetCandidateSessions(candidateId).ToList();
 
-                newSessions
+                updatedSessions
                     .Where(session => session.SessionId != sessionId)
                     .Should()
                     .BeEquivalentTo(startingSessions.Where(session => session.SessionId != sessionId));
 
-                var newSession = newSessions.First(session => session.SessionId == sessionId);
-                DateTime.Now.Should().BeCloseTo(
-                    newSession.LoginTime.AddMinutes(newSession.Duration),
-                    twoMinutesInMilliseconds
-                );
+                var activeSession = updatedSessions.First(session => session.SessionId == sessionId);
+                activeSession.LoginTime.AddMinutes(activeSession.Duration)
+                    .Should().BeCloseTo(DateTime.Now, twoMinutesInMilliseconds);
             }
         }
 
@@ -149,17 +134,18 @@
         {
             using (new TransactionScope())
             {
-                // When
+                // Given
                 const int candidateId = 9;
-                const int sessionId = 468;
                 var startingSessions = sessionTestHelper.GetCandidateSessions(candidateId);
 
+                // When
+                const int sessionId = 468;
                 sessionService.UpdateSessionDuration(sessionId);
 
                 // Then
-                var newSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+                var updatedSessions = sessionTestHelper.GetCandidateSessions(candidateId);
 
-                newSessions.Should().BeEquivalentTo(startingSessions);
+                updatedSessions.Should().BeEquivalentTo(startingSessions);
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/SessionServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SessionServiceTests.cs
@@ -1,0 +1,166 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    using System;
+    using System.Linq;
+    using System.Transactions;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.Helpers;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    internal class SessionServiceTests
+    {
+        private SessionService sessionService;
+        private SessionTestHelper sessionTestHelper;
+
+        [SetUp]
+        public void Setup()
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            sessionService = new SessionService(connection);
+            sessionTestHelper = new SessionTestHelper(connection);
+        }
+
+        [Test]
+        public void StartOrRestartSession_Should_Start_Users_First_Session()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 29;
+                const int customisationId = 100;
+                var sessionId = sessionService.StartOrRestartSession(candidateId, customisationId);
+
+                // Then
+                var newSession = sessionTestHelper.GetSession(sessionId);
+
+                newSession.Should().NotBeNull();
+                SessionTestHelper.SessionsShouldBeApproximatelyEquivalent(
+                    newSession!,
+                    new Session(
+                        sessionId,
+                        candidateId,
+                        customisationId,
+                        DateTime.Now,
+                        0,
+                        true
+                    )
+                );
+            }
+        }
+
+        [Test]
+        public void StartOrRestartSession_Should_Start_Subsequent_Session()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 101;
+                const int customisationId = 1240;
+                var sessionId = sessionService.StartOrRestartSession(candidateId, customisationId);
+
+                // Then
+                var newSession = sessionTestHelper.GetSession(sessionId);
+
+                newSession.Should().NotBeNull();
+                SessionTestHelper.SessionsShouldBeApproximatelyEquivalent(
+                    newSession!,
+                    new Session(
+                        sessionId,
+                        candidateId,
+                        customisationId,
+                        DateTime.Now,
+                        0,
+                        true
+                    )
+                );
+            }
+        }
+
+        [Test]
+        public void StartOrRestartSession_Should_Stop_Other_Sessions()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 101;
+                const int customisationId = 1240;
+                var sessionId = sessionService.StartOrRestartSession(candidateId, customisationId);
+
+                // Then
+                var sessions = sessionTestHelper.GetCandidateSessions(candidateId);
+                var activeSessions = sessions.Where(session => session.Active);
+
+                activeSessions.Should().HaveCount(1);
+                activeSessions.First().SessionId.Should().Be(sessionId);
+            }
+        }
+
+        [Test]
+        public void StopSession_Should_Stop_Candidates_Sessions()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 101;
+                sessionService.StopSession(candidateId);
+
+                // Then
+                var sessions = sessionTestHelper.GetCandidateSessions(candidateId);
+                var activeSessions = sessions.Where(session => session.Active);
+
+                activeSessions.Should().BeEmpty();
+            }
+        }
+
+        [Test]
+        public void UpdateSessionDuration_Should_Only_Update_Given_Active_Sessions()
+        {
+            const int twoMinutesInMilliseconds = 120 * 1000;
+
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 9;
+                const int sessionId = 473;
+                var startingSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+
+                sessionService.UpdateSessionDuration(sessionId);
+
+                // Then
+                var newSessions = sessionTestHelper.GetCandidateSessions(candidateId).ToList();
+
+                newSessions
+                    .Where(session => session.SessionId != sessionId)
+                    .Should()
+                    .BeEquivalentTo(startingSessions.Where(session => session.SessionId != sessionId));
+
+                var newSession = newSessions.First(session => session.SessionId == sessionId);
+                DateTime.Now.Should().BeCloseTo(
+                    newSession.LoginTime.AddMinutes(newSession.Duration),
+                    twoMinutesInMilliseconds
+                );
+            }
+        }
+
+        [Test]
+        public void UpdateSessionDuration_Should_Not_Update_Inactive_Session()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 9;
+                const int sessionId = 468;
+                var startingSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+
+                sessionService.UpdateSessionDuration(sessionId);
+
+                // Then
+                var newSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+
+                newSessions.Should().BeEquivalentTo(startingSessions);
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/Session.cs
+++ b/DigitalLearningSolutions.Data/Models/Session.cs
@@ -1,0 +1,30 @@
+﻿using System;
+namespace DigitalLearningSolutions.Data.Models
+{
+    public class Session
+    {
+        public int SessionId { get; }
+        public int CandidateId { get; }
+        public int CustomisationId { get; }
+        public DateTime LoginTime { get; }
+        public int Duration { get; }
+        public bool Active { get; }
+
+        public Session(
+            int sessionId,
+            int candidateId,
+            int customisationId,
+            DateTime loginTime,
+            int duration,
+            bool active
+        )
+        {
+            SessionId = sessionId;
+            CandidateId = candidateId;
+            CustomisationId = customisationId;
+            LoginTime = loginTime;
+            Duration = duration;
+            Active = active;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Data/Services/SessionService.cs
@@ -20,14 +20,14 @@
         }
 
         private const string stopSessionsSql =
-            @"UPDATE [Sessions] SET [Active] = 0
-              WHERE [CandidateId] = @candidateId;";
+            @"UPDATE Sessions SET Active = 0
+               WHERE CandidateId = @candidateId;";
 
         public int StartOrRestartSession(int candidateId, int customisationId)
         {
             return connection.QueryFirst<int>(
                 stopSessionsSql +
-                @"INSERT INTO [Sessions] ([CandidateID], [CustomisationID], [LoginTime], [Duration], [Active])
+                @"INSERT INTO Sessions (CandidateID, CustomisationID, LoginTime, Duration, Active)
                   VALUES (@candidateId, @customisationId, GetUTCDate(), 0, 1);
 
                   SELECT SCOPE_IDENTITY();",
@@ -43,8 +43,8 @@
         public void UpdateSessionDuration(int sessionId)
         {
             connection.Query(
-                @"UPDATE [Sessions] SET [Duration] = DATEDIFF(minute, [LoginTime], GetUTCDate())
-                   WHERE [SessionID] = @sessionId AND [Active] = 1;",
+                @"UPDATE Sessions SET Duration = DATEDIFF(minute, LoginTime, GetUTCDate())
+                   WHERE [SessionID] = @sessionId AND Active = 1;",
                 new { sessionId }
             );
         }

--- a/DigitalLearningSolutions.Data/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Data/Services/SessionService.cs
@@ -1,0 +1,52 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using System.Data;
+    using Dapper;
+
+    public interface ISessionService
+    {
+        int StartOrRestartSession(int candidateId, int customisationId);
+        void StopSession(int candidateId);
+        void UpdateSessionDuration(int sessionId);
+    }
+
+    public class SessionService : ISessionService
+    {
+        private readonly IDbConnection connection;
+
+        public SessionService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        private const string stopSessionsSql =
+            @"UPDATE [Sessions] SET [Active] = 0
+              WHERE [CandidateId] = @candidateId;";
+
+        public int StartOrRestartSession(int candidateId, int customisationId)
+        {
+            return connection.QueryFirst<int>(
+                stopSessionsSql +
+                @"INSERT INTO [Sessions] ([CandidateID], [CustomisationID], [LoginTime], [Duration], [Active])
+                  VALUES (@candidateId, @customisationId, GetUTCDate(), 0, 1);
+
+                  SELECT SCOPE_IDENTITY();",
+                new { candidateId, customisationId }
+            );
+        }
+
+        public void StopSession(int candidateId)
+        {
+            connection.Query(stopSessionsSql, new { candidateId });
+        }
+
+        public void UpdateSessionDuration(int sessionId)
+        {
+            connection.Query(
+                @"UPDATE [Sessions] SET [Duration] = DATEDIFF(minute, [LoginTime], GetUTCDate())
+                   WHERE [SessionID] = @sessionId AND [Active] = 1;",
+                new { sessionId }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Data/Services/SessionService.cs
@@ -12,16 +12,16 @@
 
     public class SessionService : ISessionService
     {
+        private const string stopSessionsSql =
+            @"UPDATE Sessions SET Active = 0
+               WHERE CandidateId = @candidateId;";
+
         private readonly IDbConnection connection;
 
         public SessionService(IDbConnection connection)
         {
             this.connection = connection;
         }
-
-        private const string stopSessionsSql =
-            @"UPDATE Sessions SET Active = 0
-               WHERE CandidateId = @candidateId;";
 
         public int StartOrRestartSession(int candidateId, int customisationId)
         {


### PR DESCRIPTION
## Changes

- Add `SessionService` to manage interactions with sessions, with methods to:
    - Start or restart a session
    - Update the duration of a session
    - Make a session as inactive
This is the DB side of HEEDLS-212. This will need to be connected up to the Controllers in a future PR.

## Testing
Added unit tests to check the three methods of the service to ensure they behave as expected.