### PR TITLE
HEEDLS-207 add header link

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -6,7 +6,7 @@
 @{
     ViewData["Application"] = "Learning Portal";
     ViewData["Title"] = "Learning Portal - Available";
-    ViewData["HeaderPath"] = "LearningPortal/Current";
+    ViewData["HeaderPath"] = "/LearningPortal/Current";
     ViewData["HeaderPathName"] = "My Current Activities";
 }
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -6,6 +6,8 @@
 @{
     ViewData["Application"] = "Learning Portal";
     ViewData["Title"] = "Learning Portal - Available";
+    ViewData["HeaderPath"] = "LearningPortal/Current";
+    ViewData["HeaderPathName"] = "My Current Activities";
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -7,6 +7,8 @@
 @{
     ViewData["Application"] = "Learning Portal";
     ViewData["Title"] = "Learning Portal - Completed";
+    ViewData["HeaderPath"] = "LearningPortal/Current";
+    ViewData["HeaderPathName"] = "My Current Activities";
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems"/>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -7,7 +7,7 @@
 @{
     ViewData["Application"] = "Learning Portal";
     ViewData["Title"] = "Learning Portal - Completed";
-    ViewData["HeaderPath"] = "LearningPortal/Current";
+    ViewData["HeaderPath"] = "/LearningPortal/Current";
     ViewData["HeaderPathName"] = "My Current Activities";
 }
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -8,6 +8,8 @@
 @{
     ViewData["Application"] = "Learning Portal";
     ViewData["Title"] = "Learning Portal - Current";
+    ViewData["HeaderPath"] = "LearningPortal/Current";
+    ViewData["HeaderPathName"] = "My Current Activities";
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems"/>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -8,7 +8,7 @@
 @{
     ViewData["Application"] = "Learning Portal";
     ViewData["Title"] = "Learning Portal - Current";
-    ViewData["HeaderPath"] = "LearningPortal/Current";
+    ViewData["HeaderPath"] = "/LearningPortal/Current";
     ViewData["HeaderPathName"] = "My Current Activities";
 }
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
@@ -2,6 +2,11 @@
 @model CurrentCourseViewModel
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Remove - Confirmation";
+  ViewData["Application"] = "Learning Portal - Remove Confirmation";
+}
+
+@section NavMenuItems {
+  <partial name="Shared/_NavMenuItems"/>
 }
 
 <div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
@@ -3,7 +3,7 @@
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Remove - Confirmation";
   ViewData["Application"] = "Learning Portal";
-  ViewData["HeaderPath"] = "LearningPortal/Current";
+  ViewData["HeaderPath"] = "/LearningPortal/Current";
   ViewData["HeaderPathName"] = "My Current Activities";
 }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
@@ -3,6 +3,8 @@
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Remove - Confirmation";
   ViewData["Application"] = "Learning Portal - Remove Confirmation";
+  ViewData["HeaderPath"] = "LearningPortal/Current";
+  ViewData["HeaderPathName"] = "My Current Activities";
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentCourseConfirmation.cshtml
@@ -2,7 +2,7 @@
 @model CurrentCourseViewModel
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Remove - Confirmation";
-  ViewData["Application"] = "Learning Portal - Remove Confirmation";
+  ViewData["Application"] = "Learning Portal";
   ViewData["HeaderPath"] = "LearningPortal/Current";
   ViewData["HeaderPathName"] = "My Current Activities";
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -3,7 +3,7 @@
 @model CurrentLearningItemViewModel
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Set completion date";
-  ViewData["Application"] = "Learning Portal - Set completion date";
+  ViewData["Application"] = "Learning Portal";
   ViewData["HeaderPath"] = "LearningPortal/Current";
   ViewData["HeaderPathName"] = "My Current Activities";
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -4,6 +4,8 @@
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Set completion date";
   ViewData["Application"] = "Learning Portal - Set completion date";
+  ViewData["HeaderPath"] = "LearningPortal/Current";
+  ViewData["HeaderPathName"] = "My Current Activities";
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -4,7 +4,7 @@
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Set completion date";
   ViewData["Application"] = "Learning Portal";
-  ViewData["HeaderPath"] = "LearningPortal/Current";
+  ViewData["HeaderPath"] = "/LearningPortal/Current";
   ViewData["HeaderPathName"] = "My Current Activities";
 }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -3,6 +3,11 @@
 @model CurrentLearningItemViewModel
 @{
   ViewData["Title"] = $"Learning Portal - {Model.Name} - Set completion date";
+  ViewData["Application"] = "Learning Portal - Set completion date";
+}
+
+@section NavMenuItems {
+  <partial name="Shared/_NavMenuItems" />
 }
 
 @{

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
@@ -1,5 +1,10 @@
 ﻿@{
   ViewData["Title"] = $"Learning Portal - Request Unlock";
+  ViewData["Application"] = "Learning Portal - Request Unlock";
+}
+
+@section NavMenuItems {
+  <partial name="Shared/_NavMenuItems"/>
 }
 
 <div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
@@ -1,6 +1,8 @@
 ﻿@{
   ViewData["Title"] = $"Learning Portal - Request Unlock";
   ViewData["Application"] = "Learning Portal - Request Unlock";
+  ViewData["HeaderPath"] = "LearningPortal/Current";
+  ViewData["HeaderPathName"] = "My Current Activities";
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
@@ -1,7 +1,7 @@
 ﻿@{
   ViewData["Title"] = $"Learning Portal - Request Unlock";
   ViewData["Application"] = "Learning Portal";
-  ViewData["HeaderPath"] = "LearningPortal/Current";
+  ViewData["HeaderPath"] = "/LearningPortal/Current";
   ViewData["HeaderPathName"] = "My Current Activities";
 }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/UnlockCurrentCourse.cshtml
@@ -1,6 +1,6 @@
 ﻿@{
   ViewData["Title"] = $"Learning Portal - Request Unlock";
-  ViewData["Application"] = "Learning Portal - Request Unlock";
+  ViewData["Application"] = "Learning Portal";
   ViewData["HeaderPath"] = "LearningPortal/Current";
   ViewData["HeaderPathName"] = "My Current Activities";
 }

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -44,7 +44,7 @@
       <div class="nhsuk-width-container nhsuk-header__container">
         <div class="nhsuk-header__logo">
           <a class="nhsuk-header__link nhsuk-header__link--service"
-             href="@Configuration["CurrentSystemBaseUrl"]/@(ViewData["HeaderPath"] ?? "Home?action=appselect")"
+             href="@(ViewData["HeaderPath"] ?? @Configuration["CurrentSystemBaseUrl"] + "/Home?action=appselect")"
              aria-label="NHS Digital Learning Solutions - @(ViewData["HeaderPathName"] ?? "Switch Application")">
             <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
               <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -43,17 +43,17 @@
     <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white" role="banner">
       <div class="nhsuk-width-container nhsuk-header__container">
         <div class="nhsuk-header__logo">
-          <div class="nhsuk-header__link--service">
-            <a class="nhsuk-header__link" href="@Configuration["CurrentSystemBaseUrl"]/Home?action=appselect" aria-label="NHS Digital Learning Solutions @(ViewData["Application"] ?? "") - Switch Application">
-              <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
-                <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
-                <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-                <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
-              </svg>
-            </a>
+          <a class="nhsuk-header__link nhsuk-header__link--service"
+             href="@Configuration["CurrentSystemBaseUrl"]/@(ViewData["HeaderPath"] ?? "Home?action=appselect")"
+             aria-label="NHS Digital Learning Solutions - @(ViewData["HeaderPathName"] ?? "Switch Application")">
+            <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
+              <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
+              <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+              <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+            </svg>
 
-            <span class="nhsuk-header__transactional-service-name">Digital Learning Solutions @(ViewData["Application"] ?? "")</span>
-          </div>
+            <span class="nhsuk-header__service-name">Digital Learning Solutions @(ViewData["Application"] ?? "")</span>
+          </a>
         </div>
 
         <div class="nhsuk-header__content" id="content-header">

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -2,7 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True;"
   },
-  "CurrentSystemBaseUrl": "https://localhost:44367",
+  "CurrentSystemBaseUrl": "https://localhost:44363",
   "AppRootPath": "https://localhost:44363",
   "FeatureManagement": {
     "Login": true

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -2,7 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True;"
   },
-  "CurrentSystemBaseUrl": "https://localhost:44363",
+  "CurrentSystemBaseUrl": "https://localhost:44367",
   "AppRootPath": "https://localhost:44363",
   "FeatureManagement": {
     "Login": true


### PR DESCRIPTION
## Changes
- Make base URL port consistent across AppSettings JSON (I think this is just a bugfix but will this break something I don't know about?)
- Add Application name and nav menu to all LearningPortal pages
- Add header links to LearningPortal pages to link back to Current Courses (with alt text), with the default link for other pages (eg. error pages) linking to switch application

## Testing
Tested using Chrome, Firefox, Edge and IE11 using high zoom, narrow viewports and a screenreader.

## Screenshots
### Current activities page
![current_activities](https://user-images.githubusercontent.com/3650110/100778047-71452a00-33fe-11eb-8e23-2e6bc3792c0b.png)

### Current activities page using a narrow viewport
![narrow_completed](https://user-images.githubusercontent.com/3650110/100778042-7013fd00-33fe-11eb-93d4-6b2079f2e02a.png)

## Set completion date page with updated nav menu
![set_completion](https://user-images.githubusercontent.com/3650110/100778043-70ac9380-33fe-11eb-809a-c523ec07471d.png)

## Remove activities page with updated nav menu
![remove_activities](https://user-images.githubusercontent.com/3650110/100778045-71452a00-33fe-11eb-8f53-3f703c966c4f.png)
