### PR TITLE
HEEDLS-207 Add link to LearningMenu course initial menu

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -8,6 +8,8 @@
   ViewData["Application"] = Model.Title;
   ViewData["Title"] = "Learning Menu";
   ViewData["CustomisationId"] = Model.Id;
+  ViewData["HeaderPath"] = $"/LearningMenu/{Model.Id}";
+  ViewData["HeaderPathName"] = Model.Title;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />


### PR DESCRIPTION
## Changes
Add header link and alt text for the Learning Menu initial course page

## Testing
Tested on Chrome, Firefox, Edge and IE11 using a screenreader and large zoom.

## Screenshots
### Initial menu page, wide viewport
![initial_menu](https://user-images.githubusercontent.com/3650110/100867275-e150c000-3491-11eb-82b0-1440d3fd5785.png)
### Initial menu page, narrow viewport
![narrow_initial_menu](https://user-images.githubusercontent.com/3650110/100867273-e01f9300-3491-11eb-85de-8cab606a4888.png)