### PR TITLE
HEEDLS-212 Add session tracking to LearningMenu controller

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/MockHttpContextSession.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/MockHttpContextSession.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.ControllerHelpers
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
 {
     using System;
     using System.Collections.Generic;
@@ -6,7 +6,7 @@
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
 
-    internal class MockHttpContextSession : ISession
+    public class MockHttpContextSession : ISession
     {
         private readonly Dictionary<string, byte[]> store = new Dictionary<string, byte[]>();
 

--- a/DigitalLearningSolutions.Data.Tests/Services/SessionDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SessionDataServiceTests.cs
@@ -1,0 +1,151 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    using System;
+    using System.Linq;
+    using System.Transactions;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.Helpers;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    internal class SessionDataServiceTests
+    {
+        private SessionDataService sessionDataService;
+        private SessionTestHelper sessionTestHelper;
+
+        [SetUp]
+        public void Setup()
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            sessionDataService = new SessionDataService(connection);
+            sessionTestHelper = new SessionTestHelper(connection);
+        }
+
+        [Test]
+        public void StartOrRestartSession_Should_Start_Users_First_Session()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 29;
+                const int customisationId = 100;
+                var sessionId = sessionDataService.StartOrRestartSession(candidateId, customisationId);
+
+                // Then
+                var newSession = sessionTestHelper.GetSession(sessionId);
+
+                newSession.Should().NotBeNull();
+                SessionTestHelper.SessionsShouldBeApproximatelyEquivalent(
+                    newSession!,
+                    SessionTestHelper.CreateDefaultSession(sessionId, candidateId, customisationId)
+                );
+            }
+        }
+
+        [Test]
+        public void StartOrRestartSession_Should_Start_Subsequent_Session()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 101;
+                const int customisationId = 1240;
+                var sessionId = sessionDataService.StartOrRestartSession(candidateId, customisationId);
+
+                // Then
+                var newSession = sessionTestHelper.GetSession(sessionId);
+
+                newSession.Should().NotBeNull();
+                SessionTestHelper.SessionsShouldBeApproximatelyEquivalent(
+                    newSession!,
+                    SessionTestHelper.CreateDefaultSession(sessionId)
+                );
+            }
+        }
+
+        [Test]
+        public void StartOrRestartSession_Should_Stop_Other_Sessions()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 101;
+                const int customisationId = 1240;
+                var sessionId = sessionDataService.StartOrRestartSession(candidateId, customisationId);
+
+                // Then
+                var sessions = sessionTestHelper.GetCandidateSessions(candidateId);
+                var activeSessions = sessions.Where(session => session.Active);
+
+                activeSessions.Should().HaveCount(1);
+                activeSessions.First().SessionId.Should().Be(sessionId);
+            }
+        }
+
+        [Test]
+        public void StopSession_Should_Stop_Candidates_Sessions()
+        {
+            using (new TransactionScope())
+            {
+                // When
+                const int candidateId = 101;
+                sessionDataService.StopSession(candidateId);
+
+                // Then
+                var sessions = sessionTestHelper.GetCandidateSessions(candidateId);
+                var activeSessions = sessions.Where(session => session.Active);
+
+                activeSessions.Should().BeEmpty();
+            }
+        }
+
+        [Test]
+        public void UpdateSessionDuration_Should_Only_Update_Given_Active_Sessions()
+        {
+            const int twoMinutesInMilliseconds = 120 * 1000;
+
+            using (new TransactionScope())
+            {
+                // Given
+                const int candidateId = 9;
+                var startingSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+
+                // When
+                const int sessionId = 473;
+                sessionDataService.UpdateSessionDuration(sessionId);
+
+                // Then
+                var updatedSessions = sessionTestHelper.GetCandidateSessions(candidateId).ToList();
+
+                updatedSessions
+                    .Where(session => session.SessionId != sessionId)
+                    .Should()
+                    .BeEquivalentTo(startingSessions.Where(session => session.SessionId != sessionId));
+
+                var activeSession = updatedSessions.First(session => session.SessionId == sessionId);
+                activeSession.LoginTime.AddMinutes(activeSession.Duration)
+                    .Should().BeCloseTo(DateTime.Now, twoMinutesInMilliseconds);
+            }
+        }
+
+        [Test]
+        public void UpdateSessionDuration_Should_Not_Update_Inactive_Session()
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                const int candidateId = 9;
+                var startingSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+
+                // When
+                const int sessionId = 468;
+                sessionDataService.UpdateSessionDuration(sessionId);
+
+                // Then
+                var updatedSessions = sessionTestHelper.GetCandidateSessions(candidateId);
+
+                updatedSessions.Should().BeEquivalentTo(startingSessions);
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/SessionServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SessionServiceTests.cs
@@ -85,9 +85,6 @@
                 .MustNotHaveHappened();
 
             A.CallTo(() => sessionDataService.StartOrRestartSession(A<int>._, A<int>._)).MustNotHaveHappened();
-
-            httpContextSession.Keys.Should().BeEquivalentTo($"SessionID-{courseInSession}");
-            httpContextSession.GetInt32($"SessionID-{courseInSession}").Should().Be(DefaultSessionId);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/DigitalLearningSolutions.Data.csproj
+++ b/DigitalLearningSolutions.Data/DigitalLearningSolutions.Data.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="Dapper.FluentMap" Version="2.0.0" />
     <PackageReference Include="MailKit" Version="2.8.0" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
   </ItemGroup>
 

--- a/DigitalLearningSolutions.Data/Services/SessionDataService.cs
+++ b/DigitalLearningSolutions.Data/Services/SessionDataService.cs
@@ -1,0 +1,52 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using System.Data;
+    using Dapper;
+
+    public interface ISessionDataService
+    {
+        int StartOrRestartSession(int candidateId, int customisationId);
+        void StopSession(int candidateId);
+        void UpdateSessionDuration(int sessionId);
+    }
+
+    public class SessionDataService : ISessionDataService
+    {
+        private const string stopSessionsSql =
+            @"UPDATE Sessions SET Active = 0
+               WHERE CandidateId = @candidateId;";
+
+        private readonly IDbConnection connection;
+
+        public SessionDataService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public int StartOrRestartSession(int candidateId, int customisationId)
+        {
+            return connection.QueryFirst<int>(
+                stopSessionsSql +
+                @"INSERT INTO Sessions (CandidateID, CustomisationID, LoginTime, Duration, Active)
+                  VALUES (@candidateId, @customisationId, GetUTCDate(), 0, 1);
+
+                  SELECT SCOPE_IDENTITY();",
+                new { candidateId, customisationId }
+            );
+        }
+
+        public void StopSession(int candidateId)
+        {
+            connection.Query(stopSessionsSql, new { candidateId });
+        }
+
+        public void UpdateSessionDuration(int sessionId)
+        {
+            connection.Query(
+                @"UPDATE Sessions SET Duration = DATEDIFF(minute, LoginTime, GetUTCDate())
+                   WHERE [SessionID] = @sessionId AND Active = 1;",
+                new { sessionId }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Data/Services/SessionService.cs
@@ -1,71 +1,44 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
-    using System.Data;
-    using Dapper;
     using Microsoft.AspNetCore.Http;
 
     public interface ISessionService
     {
-        void StartOrUpdateSession(int candidateId, int customisationId, ISession httpSession);
-        void StopSession(int candidateId, ISession httpSession);
+        void StartOrUpdateSession(int candidateId, int customisationId, ISession httpContextSession);
+        void StopSession(int candidateId, ISession httpContextSession);
     }
 
     public class SessionService : ISessionService
     {
-        private const string stopSessionsSql =
-            @"UPDATE Sessions SET Active = 0
-               WHERE CandidateId = @candidateId;";
+        private readonly ISessionDataService sessionDataService;
 
-        private readonly IDbConnection connection;
-
-        public SessionService(IDbConnection connection)
+        public SessionService(ISessionDataService sessionDataService)
         {
-            this.connection = connection;
+            this.sessionDataService = sessionDataService;
         }
 
-        public void StartOrUpdateSession(int candidateId, int customisationId, ISession httpSession)
+        public void StartOrUpdateSession(int candidateId, int customisationId, ISession httpContextSession)
         {
-            var currentSessionId = httpSession.GetInt32($"SessionID-{customisationId}");
+            var currentSessionId = httpContextSession.GetInt32($"SessionID-{customisationId}");
             if (currentSessionId != null)
             {
-                UpdateSessionDuration(currentSessionId.Value);
+                sessionDataService.UpdateSessionDuration(currentSessionId.Value);
             }
             else
             {
                 // Clear all session variables
-                httpSession.Clear();
+                httpContextSession.Clear();
 
                 // Make and keep track of a new session starting at this request
-                var newSessionId = StartOrRestartSession(candidateId, customisationId);
-                httpSession.SetInt32($"SessionID-{customisationId}", newSessionId);
+                var newSessionId = sessionDataService.StartOrRestartSession(candidateId, customisationId);
+                httpContextSession.SetInt32($"SessionID-{customisationId}", newSessionId);
             }
         }
 
-        public void StopSession(int candidateId, ISession httpSession)
+        public void StopSession(int candidateId, ISession httpContextSession)
         {
-            httpSession.Clear();
-            connection.Query(stopSessionsSql, new { candidateId });
-        }
-
-        private int StartOrRestartSession(int candidateId, int customisationId)
-        {
-            return connection.QueryFirst<int>(
-                stopSessionsSql +
-                @"INSERT INTO Sessions (CandidateID, CustomisationID, LoginTime, Duration, Active)
-                  VALUES (@candidateId, @customisationId, GetUTCDate(), 0, 1);
-
-                  SELECT SCOPE_IDENTITY();",
-                new { candidateId, customisationId }
-            );
-        }
-
-        private void UpdateSessionDuration(int sessionId)
-        {
-            connection.Query(
-                @"UPDATE Sessions SET Duration = DATEDIFF(minute, LoginTime, GetUTCDate())
-                   WHERE [SessionID] = @sessionId AND Active = 1;",
-                new { sessionId }
-            );
+            sessionDataService.StopSession(candidateId);
+            httpContextSession.Clear();
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ControllerHelpers/MockHttpContextSession.cs
+++ b/DigitalLearningSolutions.Web.Tests/ControllerHelpers/MockHttpContextSession.cs
@@ -1,0 +1,47 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ControllerHelpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+
+    internal class MockHttpContextSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> store = new Dictionary<string, byte[]>();
+
+        public void Clear()
+        {
+            store.Clear();
+        }
+
+        public Task CommitAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task LoadAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Remove(string key)
+        {
+            store.Remove(key);
+        }
+
+        public void Set(string key, byte[] value)
+        {
+            store.Add(key, value);
+        }
+
+        public bool TryGetValue(string key, out byte[] value)
+        {
+            return store.TryGetValue(key, out value);
+        }
+
+        public string Id => "1";
+        public bool IsAvailable => true;
+        public IEnumerable<string> Keys => store.Keys;
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -4,7 +4,6 @@
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using DigitalLearningSolutions.Web.Controllers.LearningMenuController;
-    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FakeItEasy;

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -37,7 +37,7 @@
             var centreId = User.GetCentreId();
             var courseContent = courseContentService.GetCourseContent(candidateId, customisationId);
 
-            StartOrUpdateSession(candidateId, customisationId);
+            sessionService.StartOrUpdateSession(candidateId, customisationId, HttpContext.Session);
 
             if (courseContent == null || centreId == null)
             {
@@ -67,8 +67,7 @@
         [Route("/LearningMenu/Close")]
         public IActionResult Close()
         {
-            sessionService.StopSession(User.GetCandidateId());
-            HttpContext.Session.Clear();
+            sessionService.StopSession(User.GetCandidateId(), HttpContext.Session);
 
             return RedirectToAction("Current", "LearningPortal");
         }
@@ -77,24 +76,6 @@
         {
             var model = new ContentViewerViewModel(config);
             return View(model);
-        }
-
-        private void StartOrUpdateSession(int candidateId, int customisationId)
-        {
-            var currentSessionId = HttpContext.Session.GetInt32($"SessionID-{customisationId}");
-            if (currentSessionId != null)
-            {
-                sessionService.UpdateSessionDuration(currentSessionId.Value);
-            }
-            else
-            {
-                // Clear all session variables
-                HttpContext.Session.Clear();
-
-                // Make and keep track of a new session starting at this request
-                var newSessionId = sessionService.StartOrRestartSession(candidateId, customisationId);
-                HttpContext.Session.SetInt32($"SessionID-{customisationId}", newSessionId);
-            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -4,6 +4,7 @@
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -14,39 +15,46 @@
         private readonly ILogger<LearningMenuController> logger;
         private readonly IConfiguration config;
         private readonly ICourseContentService courseContentService;
+        private readonly ISessionService sessionService;
 
         public LearningMenuController(
             ILogger<LearningMenuController> logger,
             IConfiguration config,
-            ICourseContentService courseContentService
+            ICourseContentService courseContentService,
+            ISessionService sessionService
         )
         {
             this.logger = logger;
             this.config = config;
             this.courseContentService = courseContentService;
+            this.sessionService = sessionService;
         }
 
         [Route("/LearningMenu/{customisationId:int}")]
         public IActionResult Index(int customisationId)
         {
-            var courseContent = courseContentService.GetCourseContent(User.GetCandidateId(), customisationId);
+            var candidateId = User.GetCandidateId();
             var centreId = User.GetCentreId();
+            var courseContent = courseContentService.GetCourseContent(candidateId, customisationId);
+
+            StartOrUpdateSession(candidateId, customisationId);
 
             if (courseContent == null || centreId == null)
             {
                 logger.LogError(
                     "Redirecting to 404 as course/centre id was not found. " +
-                    $"Candidate id: {User.GetCandidateId()}, customisation id: {customisationId}, centre id: {centreId?.ToString() ?? "null"}");
+                    $"Candidate id: {candidateId}, customisation id: {customisationId}, " +
+                    $"centre id: {centreId?.ToString() ?? "null"}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            var progressId = courseContentService.GetOrCreateProgressId(User.GetCandidateId(), customisationId, centreId.Value);
+            var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId.Value);
 
             if (progressId == null)
             {
                 logger.LogError(
                     "Redirecting to 500 as no progress id was returned. " +
-                    $"Candidate id: {User.GetCandidateId()}, customisation id: {customisationId}, centre id: {centreId}");
+                    $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 500 });
             }
 
@@ -56,10 +64,37 @@
             return View(model);
         }
 
+        [Route("/LearningMenu/Close")]
+        public IActionResult Close()
+        {
+            sessionService.StopSession(User.GetCandidateId());
+            HttpContext.Session.Clear();
+
+            return RedirectToAction("Current", "LearningPortal");
+        }
+
         public IActionResult ContentViewer()
         {
             var model = new ContentViewerViewModel(config);
             return View(model);
+        }
+
+        private void StartOrUpdateSession(int candidateId, int customisationId)
+        {
+            var currentSessionId = HttpContext.Session.GetInt32($"SessionID-{customisationId}");
+            if (currentSessionId != null)
+            {
+                sessionService.UpdateSessionDuration(currentSessionId.Value);
+            }
+            else
+            {
+                // Clear all session variables
+                HttpContext.Session.Clear();
+
+                // Make and keep track of a new session starting at this request
+                var newSessionId = sessionService.StartOrRestartSession(candidateId, customisationId);
+                HttpContext.Session.SetInt32($"SessionID-{customisationId}", newSessionId);
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -92,6 +92,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ISelfAssessmentService, SelfAssessmentService>();
             services.AddScoped<IFilteredApiHelperService, FilteredApiHelper>();
             services.AddScoped<ICourseContentService, CourseContentService>();
+            services.AddScoped<ISessionService, SessionService>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -92,6 +92,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ISelfAssessmentService, SelfAssessmentService>();
             services.AddScoped<IFilteredApiHelperService, FilteredApiHelper>();
             services.AddScoped<ICourseContentService, CourseContentService>();
+            services.AddScoped<ISessionDataService, SessionDataService>();
             services.AddScoped<ISessionService, SessionService>();
         }
 

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -26,7 +26,7 @@
 </div>
 
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-action="Current" asp-controller="LearningPortal">
+  <a class="nhsuk-back-link__link" asp-action="Close" asp-controller="LearningMenu">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
     </svg>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_NavMenuItems.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_NavMenuItems.cshtml
@@ -1,5 +1,5 @@
 ﻿<li class="nhsuk-header__navigation-item">
-  <a class="nhsuk-header__navigation-link" asp-controller="LearningPortal" asp-action="Current">
+  <a class="nhsuk-header__navigation-link" asp-controller="LearningMenu" asp-action="Close">
     Learning portal
     <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>


### PR DESCRIPTION
## Changes
- Inject SessionService into Web project.
- Maintain Session state in the LearningMenu using the SessionService.
- Add a mock HttpContext.Session class and use this to test the new
LearningMenu controller session tracking.

## Testing
Add new unit tests and check they run. Tested links in Chrome, Firefox, Edge and IE11