### PR TITLE
Round percentage completion to nearest integer

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -39,5 +39,25 @@
             // Then
             sectionCardViewModel.PercentComplete.Should().Be($"{percentComplete}% Complete");
         }
+
+        [Test]
+        public void Section_should_round_percent_complete()
+        {
+            // Given
+            const bool hasLearning = true;
+            const double percentComplete = 16.6666666667;
+            const double percentCompleteRounded = 17;
+            var section = CourseSectionHelper.CreateDefaultCourseSection(
+                hasLearning: hasLearning,
+                percentComplete: percentComplete
+            );
+
+            // When
+            var sectionCardViewModel = new SectionCardViewModel(section);
+
+            // Then
+            sectionCardViewModel.PercentComplete.Should().Be($"{percentCompleteRounded}% Complete");
+        }
+
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -10,7 +10,7 @@
         public SectionCardViewModel(CourseSection section)
         {
             Title = section.Title;
-            PercentComplete = section.HasLearning ? $"{section.PercentComplete}% Complete" : "";
+            PercentComplete = section.HasLearning ? $"{section.PercentComplete:f0}% Complete" : "";
         }
     }
 }


### PR DESCRIPTION
### Changes
Add a rounding to the percentage completion using string formatting.

### Testing
Tested on Google Chrome only because this is just changing a string before it gets passed to the View.

### Screenshot
![percent_rounded](https://user-images.githubusercontent.com/3650110/100906592-3bb54500-34c1-11eb-92d9-a84ed937da57.png)
