### PR TITLE
HEEDLS-210 Link to completion summary back end

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -62,10 +62,12 @@
             );
         }
 
-        public bool IsApproximatelyNow(DateTime timeToCheck)
+        public bool IsApproximatelyNow(DateTime? timeToCheck)
         {
             var twoMinutesAgo = DateTime.Now.AddMinutes(-2);
-            return timeToCheck >= twoMinutesAgo && timeToCheck <= DateTime.Now;
+            return timeToCheck != null
+                && timeToCheck >= twoMinutesAgo
+                && timeToCheck <= DateTime.Now;
         }
 
         public bool DoesProgressExist(int candidateId, int customisationId)
@@ -79,6 +81,20 @@
                           AND RemovedDate IS NULL",
                 new { candidateId, customisationId }
             ).Any();
+        }
+
+        public void UpdateIncludeCertification(int customisationId, bool includeCertification)
+        {
+            connection.Execute(
+                @"UPDATE Applications
+                        SET IncludeCertification = @includeCertification
+                        WHERE ApplicationID = (
+                            SELECT Applications.ApplicationID
+                            FROM Applications JOIN Customisations
+                              ON Applications.ApplicationID = Customisations.ApplicationID
+                            WHERE Customisations.CustomisationID = @customisationId)",
+                new { customisationId, includeCertification }
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CourseContentTestHelper.cs
@@ -72,14 +72,6 @@
                 new { candidateId, customisationId, systemRefreshed }
             );
         }
-        
-        public bool IsApproximatelyNow(DateTime? timeToCheck)
-        {
-            var twoMinutesAgo = DateTime.Now.AddMinutes(-2);
-            return timeToCheck != null
-                && timeToCheck >= twoMinutesAgo
-                && timeToCheck <= DateTime.Now;
-        }
 
         public bool DoesProgressExist(int candidateId, int customisationId)
         {

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -565,7 +565,8 @@
                 var result = courseContentTestHelper.GetSubmittedTime(progressId);
 
                 // Then
-                courseContentTestHelper.IsApproximatelyNow(result).Should().BeTrue();
+                const int twoMinutesInMilliseconds = 120000;
+                result.Should().BeCloseTo(DateTime.Now, twoMinutesInMilliseconds);
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -39,7 +39,9 @@
                 "MOS Excel 2010 CORE",
                 "5h 49m",
                 "Northumbria Healthcare NHS Foundation Trust",
-                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                false,
+                null
             );
             expectedCourse.Sections.AddRange(
                 new[]
@@ -77,7 +79,9 @@
                 "MOS Excel 2010 CORE",
                 "5h 49m",
                 "Northumbria Healthcare NHS Foundation Trust",
-                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                false,
+                null
             );
             expectedCourse.Sections.AddRange(
                 new[]
@@ -115,7 +119,9 @@
                 "MOST OUTLOOK CORE 2007",
                 "46m",
                 "Northumbria Healthcare NHS Foundation Trust",
-                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                false,
+                null
             );
             expectedCourse.Sections.AddRange(
                 new[]
@@ -147,7 +153,9 @@
                 "MOST OUTLOOK CORE 2007",
                 "46m",
                 "Northumbria Healthcare NHS Foundation Trust",
-                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                false,
+                null
             );
             expectedCourse.Sections.AddRange(
                 new[]
@@ -163,6 +171,96 @@
             );
             result.Should().BeEquivalentTo(expectedCourse);
         }
+
+        [Test]
+        public void Get_course_content_with_non_null_completed_date_should_return_completed_date()
+        {
+            // Given
+            const int candidateId = 144100;
+            const int customisationId = 4169;
+
+            using (new TransactionScope())
+            {
+                // When
+                var result = courseContentService.GetCourseContent(candidateId, customisationId);
+
+                // Then
+                var expectedCourse = new CourseContent(
+                    4169,
+                    "Level 2 - Microsoft Excel 2010",
+                    "MOS Excel 2010 CORE",
+                    "5h 49m",
+                    "Northumbria Healthcare NHS Foundation Trust",
+                    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    false,
+                    new DateTime(2016, 9, 15, 13, 1, 30, 623)
+                );
+                expectedCourse.Sections.AddRange(
+                    new[]
+                    {
+                        new CourseSection("Viewing workbooks", true, 100.0),
+                        new CourseSection("Manipulating worksheets", true, 100.0),
+                        new CourseSection("Manipulating information", true, 100.0),
+                        new CourseSection("Using formulas", true, 100.0),
+                        new CourseSection("Using functions", true, 100.0),
+                        new CourseSection("Managing formulas and functions", true, 100.0),
+                        new CourseSection("Working with data", true, 100.0),
+                        new CourseSection("Formatting cells and worksheets", true, 100.0),
+                        new CourseSection("Formatting numbers", true, 100.0),
+                        new CourseSection("Working with charts", true, 100.0),
+                        new CourseSection("Working with illustrations", true, 100.0),
+                        new CourseSection("Collaborating with others", true, 100.0),
+                        new CourseSection("Preparing to print", true, 100.0)
+                    }
+                );
+                result.Should().BeEquivalentTo(expectedCourse);
+            }
+        }
+
+        [Test]
+        public void Get_course_content_with_include_certification_should_return_include_certification()
+        {
+            // Given
+            const int candidateId = 22044;
+            const int customisationId = 4169;
+
+            using (new TransactionScope())
+            {
+                // Then
+                courseContentTestHelper.UpdateIncludeCertification(customisationId, true);
+                var result = courseContentService.GetCourseContent(candidateId, customisationId);
+                var expectedCourse = new CourseContent(
+                    4169,
+                    "Level 2 - Microsoft Excel 2010",
+                    "MOS Excel 2010 CORE",
+                    "5h 49m",
+                    "Northumbria Healthcare NHS Foundation Trust",
+                    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    true,
+                    null
+                );
+                expectedCourse.Sections.AddRange(
+                    new[]
+                    {
+                        new CourseSection("Viewing workbooks", true, 12.5),
+                        new CourseSection("Manipulating worksheets", true, 20),
+                        new CourseSection("Manipulating information", true, 25),
+                        new CourseSection("Using formulas", true, 100 / 3.0),
+                        new CourseSection("Using functions", true, 400 / 7.0),
+                        new CourseSection("Managing formulas and functions", true, 0),
+                        new CourseSection("Working with data", true, 0),
+                        new CourseSection("Formatting cells and worksheets", true, 0),
+                        new CourseSection("Formatting numbers", true, 0),
+                        new CourseSection("Working with charts", true, 0),
+                        new CourseSection("Working with illustrations", true, 0),
+                        new CourseSection("Collaborating with others", true, 0),
+                        new CourseSection("Preparing to print", true, 0)
+                    }
+                );
+                result.Should().BeEquivalentTo(expectedCourse);
+            }
+        }
+
 
         [Test]
         public void Get_or_create_progress_id_should_return_progress_id_if_exists()

--- a/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
@@ -1,7 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.CourseContent
 {
+    using System;
     using System.Collections.Generic;
-    using DigitalLearningSolutions.Data.Models.Courses;
 
     public class CourseContent
     {
@@ -10,6 +10,8 @@
         public string AverageDuration { get; }
         public string CentreName { get; }
         public string? BannerText { get; }
+        public bool IncludeCertification { get; }
+        public DateTime? Completed { get; }
         public List<CourseSection> Sections { get; } = new List<CourseSection>();
 
         public CourseContent(
@@ -18,7 +20,9 @@
             string customisationName,
             string averageDuration,
             string centreName,
-            string? bannerText
+            string? bannerText,
+            bool includeCertification,
+            DateTime? completed
         )
         {
             Id = id;
@@ -26,6 +30,8 @@
             AverageDuration = averageDuration;
             CentreName = centreName;
             BannerText = bannerText;
+            IncludeCertification = includeCertification;
+            Completed = completed;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -41,6 +41,8 @@
                          dbo.GetMinsForCustomisation(Customisations.CustomisationID) AS AverageDuration,
                          Centres.CentreName,
                          Centres.BannerText,
+                         Applications.IncludeCertification,
+                         Progress.Completed,
                          Sections.SectionName,
                          dbo.CheckCustomisationSectionHasLearning(Customisations.CustomisationID, Sections.SectionID) AS HasLearning,
                          (CASE
@@ -65,6 +67,8 @@
                          Customisations.CustomisationName,
                          Centres.CentreName,
                          Centres.BannerText,
+                         Applications.IncludeCertification,
+                         Progress.Completed,
                          Sections.SectionName,
                          Sections.SectionNumber,
                          Progress.CandidateID

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseContentHelper.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.TestHelpers
 {
+    using System;
     using DigitalLearningSolutions.Data.Models.CourseContent;
 
     internal class CourseContentHelper
@@ -10,7 +11,9 @@
             string applicationName = "Application",
             string averageDuration = "Duration",
             string centreName = "Centre",
-            string? bannerText = "Banner"
+            string? bannerText = "Banner",
+            bool includeCertification = false,
+            DateTime? completed = null
         )
         {
             return new CourseContent(
@@ -19,7 +22,9 @@
                 customisationName,
                 averageDuration,
                 centreName,
-                bannerText
+                bannerText,
+                includeCertification,
+                completed
             );
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -1,8 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FluentAssertions;
@@ -108,6 +107,70 @@
         }
 
         [Test]
+        public void Initial_menu_include_certification_can_be_true()
+        {
+            // Given
+            const bool includeCertification = true;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                includeCertification: includeCertification
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.IncludeCertification.Should().Be(includeCertification);
+        }
+
+        [Test]
+        public void Initial_menu_include_certification_can_be_false()
+        {
+            // Given
+            const bool includeCertification = false;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                includeCertification: includeCertification
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.IncludeCertification.Should().Be(includeCertification);
+        }
+
+        [Test]
+        public void Initial_menu_can_have_completed()
+        {
+            // Given
+            var completed = DateTime.Today;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: completed
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.Completed.Should().Be(completed);
+        }
+
+        [Test]
+        public void Initial_menu_completed_can_be_null()
+        {
+            // Given
+            var completed = DateTime.Today;
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: null
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+
+            // Then
+            initialMenuViewModel.Completed.Should().BeNull();
+        }
+
+        [Test]
         public void Initial_menu_should_have_list_of_section_card_view_model()
         {
             // Given
@@ -128,6 +191,66 @@
 
             // Then
             initialMenuViewModel.Sections.Should().BeEquivalentTo(expectedSectionList);
+        }
+
+        [Test]
+        public void Get_completion_status_for_completed_should_return_complete()
+        {
+            // Given
+            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: DateTime.Now
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
+
+            // Then
+            initialMenuViewModel.GetCompletionStatus().Should().Be("Complete");
+        }
+
+        [Test]
+        public void Get_completion_status_for_null_completed_should_return_incomplete()
+        {
+            // Given
+            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: null
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
+
+            // Then
+            initialMenuViewModel.GetCompletionStatus().Should().Be("Incomplete");
+        }
+
+        [Test]
+        public void Get_completion_styling_for_completed_should_return_complete()
+        {
+            // Given
+            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: DateTime.Now
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
+
+            // Then
+            initialMenuViewModel.GetCompletionStyling().Should().Be("complete");
+        }
+
+        [Test]
+        public void Get_completion_styling_for_null_completed_should_return_incomplete()
+        {
+            // Given
+            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: null
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
+
+            // Then
+            initialMenuViewModel.GetCompletionStyling().Should().Be("incomplete");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -107,7 +107,7 @@
         }
 
         [Test]
-        public void Initial_menu_include_certification_can_be_true()
+        public void Initial_menu_should_show_certification_summary_can_be_true()
         {
             // Given
             const bool includeCertification = true;
@@ -119,11 +119,11 @@
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.IncludeCertification.Should().Be(includeCertification);
+            initialMenuViewModel.ShouldShowCompletionSummary.Should().Be(includeCertification);
         }
 
         [Test]
-        public void Initial_menu_include_certification_can_be_false()
+        public void Initial_menu_should_show_certification_summary_can_be_false()
         {
             // Given
             const bool includeCertification = false;
@@ -135,39 +135,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.IncludeCertification.Should().Be(includeCertification);
-        }
-
-        [Test]
-        public void Initial_menu_can_have_completed()
-        {
-            // Given
-            var completed = DateTime.Today;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: completed
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.Completed.Should().Be(completed);
-        }
-
-        [Test]
-        public void Initial_menu_completed_can_be_null()
-        {
-            // Given
-            var completed = DateTime.Today;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: null
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.Completed.Should().BeNull();
+            initialMenuViewModel.ShouldShowCompletionSummary.Should().Be(includeCertification);
         }
 
         [Test]
@@ -205,7 +173,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(courseContent);
 
             // Then
-            initialMenuViewModel.GetCompletionStatus().Should().Be("Complete");
+            initialMenuViewModel.CompletionStatus.Should().Be("Complete");
         }
 
         [Test]
@@ -220,7 +188,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(courseContent);
 
             // Then
-            initialMenuViewModel.GetCompletionStatus().Should().Be("Incomplete");
+            initialMenuViewModel.CompletionStatus.Should().Be("Incomplete");
         }
 
         [Test]
@@ -235,7 +203,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(courseContent);
 
             // Then
-            initialMenuViewModel.GetCompletionStyling().Should().Be("complete");
+            initialMenuViewModel.CompletionStyling.Should().Be("complete");
         }
 
         [Test]
@@ -250,7 +218,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(courseContent);
 
             // Then
-            initialMenuViewModel.GetCompletionStyling().Should().Be("incomplete");
+            initialMenuViewModel.CompletionStyling.Should().Be("incomplete");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -107,7 +107,7 @@
         }
 
         [Test]
-        public void Initial_menu_should_show_certification_summary_can_be_true()
+        public void Initial_menu_show_completion_summary_should_be_include_certification_when_true()
         {
             // Given
             const bool includeCertification = true;
@@ -123,7 +123,7 @@
         }
 
         [Test]
-        public void Initial_menu_should_show_certification_summary_can_be_false()
+        public void Initial_menu_show_completion_summary_should_be_include_certification_when_false()
         {
             // Given
             const bool includeCertification = false;

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -16,7 +16,6 @@
         public IEnumerable<SectionCardViewModel> Sections { get; }
         public string CompletionStatus { get; }
         public string CompletionStyling { get; }
-        private DateTime? Completed { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
@@ -26,10 +25,9 @@
             CentreName = courseContent.CentreName;
             BannerText = courseContent.BannerText;
             ShouldShowCompletionSummary = courseContent.IncludeCertification;
-            Completed = courseContent.Completed;
             Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section));
-            CompletionStatus = Completed == null ? "Incomplete" : "Complete";
-            CompletionStyling = Completed == null ? "incomplete" : "complete";
+            CompletionStatus = courseContent.Completed == null ? "Incomplete" : "Complete";
+            CompletionStyling = courseContent.Completed == null ? "incomplete" : "complete";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.CourseContent;
@@ -11,6 +12,8 @@
         public string AverageDuration { get; }
         public string CentreName { get; }
         public string? BannerText { get; }
+        public bool IncludeCertification { get; }
+        public DateTime? Completed { get; }
         public IEnumerable<SectionCardViewModel> Sections { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
@@ -20,7 +23,19 @@
             AverageDuration = courseContent.AverageDuration;
             CentreName = courseContent.CentreName;
             BannerText = courseContent.BannerText;
+            IncludeCertification = courseContent.IncludeCertification;
+            Completed = courseContent.Completed;
             Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section));
+        }
+
+        public string GetCompletionStyling()
+        {
+            return Completed == null ? "incomplete" : "complete";
+        }
+
+        public string GetCompletionStatus()
+        {
+            return Completed == null ? "Incomplete" : "Complete";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -12,9 +12,11 @@
         public string AverageDuration { get; }
         public string CentreName { get; }
         public string? BannerText { get; }
-        public bool IncludeCertification { get; }
-        public DateTime? Completed { get; }
+        public bool ShouldShowCompletionSummary { get; }
         public IEnumerable<SectionCardViewModel> Sections { get; }
+        public string CompletionStatus { get; }
+        public string CompletionStyling { get; }
+        private DateTime? Completed { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
@@ -23,19 +25,11 @@
             AverageDuration = courseContent.AverageDuration;
             CentreName = courseContent.CentreName;
             BannerText = courseContent.BannerText;
-            IncludeCertification = courseContent.IncludeCertification;
+            ShouldShowCompletionSummary = courseContent.IncludeCertification;
             Completed = courseContent.Completed;
             Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section));
-        }
-
-        public string GetCompletionStyling()
-        {
-            return Completed == null ? "incomplete" : "complete";
-        }
-
-        public string GetCompletionStatus()
-        {
-            return Completed == null ? "Incomplete" : "Complete";
+            CompletionStatus = Completed == null ? "Incomplete" : "Complete";
+            CompletionStyling = Completed == null ? "incomplete" : "complete";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -41,11 +41,11 @@
   }
 </div>
 
-@if (Model.IncludeCertification) {
-  <div class="nhsuk-card @Model.GetCompletionStyling()">
+@if (Model.ShouldShowCompletionSummary) {
+  <div class="nhsuk-card @Model.CompletionStyling">
     <div class="nhsuk-card__content">
       <h2 class="nhsuk-card__heading nhsuk-heading-m">
-        Course Completion Status: @Model.GetCompletionStatus()
+        Course Completion Status: @Model.CompletionStatus
       </h2>
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -41,17 +41,19 @@
   }
 </div>
 
-<div class="nhsuk-card incomplete">
-  <div class="nhsuk-card__content">
-    <h2 class="nhsuk-card__heading nhsuk-heading-m">
-      Course Completion Status: Incomplete
-    </h2>
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
-        <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
-          Show Summary
-        </a>
+@if (Model.IncludeCertification) {
+  <div class="nhsuk-card @Model.GetCompletionStyling()">
+    <div class="nhsuk-card__content">
+      <h2 class="nhsuk-card__heading nhsuk-heading-m">
+        Course Completion Status: @Model.GetCompletionStatus()
+      </h2>
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full">
+          <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
+            Show Summary
+          </a>
+        </div>
       </div>
     </div>
   </div>
-</div>
+}


### PR DESCRIPTION
Add extra fields to `GetCourseContent` query and `CourseContent` class for extra information used in summary page. Had to amend some existing tests that use the CourseContent class.

Add extra properties to `InitialViewModel` and helper methods to get styling and completed status.

Integrate backend into frontend by replacing hardcoded values.

Ran and passed all unit tests, manually tested on Firefox by setting `IncludeCertificate` to 1 for a complete and incomplete course then opening the pages. The summary card was displayed when expected and the information was also correct, appearing as shown in #53.