### PR TITLE
HEEDLS-216 Add customisation ID to section page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -184,6 +184,23 @@
         }
 
         [Test]
+        public void Sections_should_StartOrUpdate_course_sessions()
+        {
+            // Given
+            const int sectionId = 199;
+
+            // When
+            controller.Section(CustomisationId, sectionId);
+
+            // Then
+            A.CallTo(() => sessionService.StartOrUpdateSession(CandidateId, CustomisationId, httpContextSession)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => sessionService.StartOrUpdateSession(A<int>._, A<int>._, A<ISession>._))
+                .WhenArgumentsMatch((int candidateId, int customisationId, ISession session) =>
+                    candidateId != CandidateId || customisationId != CustomisationId)
+                .MustNotHaveHappened();
+        }
+
+        [Test]
         public void Close_should_close_sessions()
         {
             // When

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -145,10 +145,11 @@
             const string sectionName = "TestSectionName";
             const bool hasLearning = true;
             const double percentComplete = 12.00;
+            const int customisationId = 1;
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent();
             var section = CourseSectionHelper.CreateDefaultCourseSection(sectionName: sectionName, hasLearning: hasLearning, percentComplete: percentComplete);
             expectedCourseContent.Sections.Add(section);
-            var expectedSection = new SectionCardViewModel(section, 1);
+            var expectedSection = new SectionCardViewModel(section, customisationId);
             var expectedSectionList = new List<SectionCardViewModel>
             {
                 expectedSection

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -146,9 +146,9 @@
             const bool hasLearning = true;
             const double percentComplete = 12.00;
             const int customisationId = 1;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent();
+            var courseContent = CourseContentHelper.CreateDefaultCourseContent(customisationId: customisationId);
             var section = CourseSectionHelper.CreateDefaultCourseSection(sectionName: sectionName, hasLearning: hasLearning, percentComplete: percentComplete);
-            expectedCourseContent.Sections.Add(section);
+            courseContent.Sections.Add(section);
             var expectedSection = new SectionCardViewModel(section, customisationId);
             var expectedSectionList = new List<SectionCardViewModel>
             {
@@ -156,7 +156,7 @@
             };
 
             // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
+            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
 
             // Then
             initialMenuViewModel.Sections.Should().BeEquivalentTo(expectedSectionList);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -148,7 +148,7 @@
             var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent();
             var section = CourseSectionHelper.CreateDefaultCourseSection(sectionName: sectionName, hasLearning: hasLearning, percentComplete: percentComplete);
             expectedCourseContent.Sections.Add(section);
-            var expectedSection = new SectionCardViewModel(section);
+            var expectedSection = new SectionCardViewModel(section, 1);
             var expectedSectionList = new List<SectionCardViewModel>
             {
                 expectedSection

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
-    using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FluentAssertions;
@@ -16,7 +15,7 @@
             var section = CourseSectionHelper.CreateDefaultCourseSection(hasLearning: hasLearning);
 
             // When
-            var sectionCardViewModel = new SectionCardViewModel(section);
+            var sectionCardViewModel = new SectionCardViewModel(section, 1);
 
             // Then
             sectionCardViewModel.PercentComplete.Should().Be("");
@@ -34,10 +33,24 @@
             );
 
             // When
-            var sectionCardViewModel = new SectionCardViewModel(section);
+            var sectionCardViewModel = new SectionCardViewModel(section, 1);
 
             // Then
             sectionCardViewModel.PercentComplete.Should().Be($"{percentComplete}% Complete");
+        }
+
+        [Test]
+        public void Section_should_return_customisation_id()
+        {
+            // Given
+            const int customisationId = 10;
+            var section = CourseSectionHelper.CreateDefaultCourseSection();
+
+            // When
+            var sectionCardViewModel = new SectionCardViewModel(section, customisationId);
+
+            // Then
+            sectionCardViewModel.CustomisationId.Should().Be(customisationId);
         }
 
         [Test]
@@ -53,7 +66,7 @@
             );
 
             // When
-            var sectionCardViewModel = new SectionCardViewModel(section);
+            var sectionCardViewModel = new SectionCardViewModel(section, 1);
 
             // Then
             sectionCardViewModel.PercentComplete.Should().Be($"{percentCompleteRounded}% Complete");

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -12,10 +12,11 @@
         {
             // Given
             const bool hasLearning = false;
+            const int customisationId = 1;
             var section = CourseSectionHelper.CreateDefaultCourseSection(hasLearning: hasLearning);
 
             // When
-            var sectionCardViewModel = new SectionCardViewModel(section, 1);
+            var sectionCardViewModel = new SectionCardViewModel(section, customisationId);
 
             // Then
             sectionCardViewModel.PercentComplete.Should().Be("");
@@ -27,13 +28,14 @@
             // Given
             const bool hasLearning = true;
             const double percentComplete = 12.00;
+            const int customisationId = 1;
             var section = CourseSectionHelper.CreateDefaultCourseSection(
                 hasLearning: hasLearning,
                 percentComplete: percentComplete
             );
 
             // When
-            var sectionCardViewModel = new SectionCardViewModel(section, 1);
+            var sectionCardViewModel = new SectionCardViewModel(section, customisationId);
 
             // Then
             sectionCardViewModel.PercentComplete.Should().Be($"{percentComplete}% Complete");
@@ -60,13 +62,14 @@
             const bool hasLearning = true;
             const double percentComplete = 16.6666666667;
             const double percentCompleteRounded = 17;
+            const int customisationId = 1;
             var section = CourseSectionHelper.CreateDefaultCourseSection(
                 hasLearning: hasLearning,
                 percentComplete: percentComplete
             );
 
             // When
-            var sectionCardViewModel = new SectionCardViewModel(section, 1);
+            var sectionCardViewModel = new SectionCardViewModel(section, customisationId);
 
             // Then
             sectionCardViewModel.PercentComplete.Should().Be($"{percentCompleteRounded}% Complete");

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -72,8 +72,8 @@
             return RedirectToAction("Current", "LearningPortal");
         }
 
-        [Route("/LearningMenu/Section/{sectionId:int}")]
-        public IActionResult Section(int sectionId)
+        [Route("/LearningMenu/{customisationId:int}/{sectionId:int}")]
+        public IActionResult Section(int customisationId, int sectionId)
         {
             return View("Section/Section");
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -75,6 +75,7 @@
         [Route("/LearningMenu/{customisationId:int}/{sectionId:int}")]
         public IActionResult Section(int customisationId, int sectionId)
         {
+            sessionService.StartOrUpdateSession(User.GetCandidateId(), customisationId, HttpContext.Session);
             return View("Section/Section");
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -25,7 +25,7 @@
             CentreName = courseContent.CentreName;
             BannerText = courseContent.BannerText;
             ShouldShowCompletionSummary = courseContent.IncludeCertification;
-            Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section));
+            Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section, Id));
             CompletionStatus = courseContent.Completed == null ? "Incomplete" : "Complete";
             CompletionStyling = courseContent.Completed == null ? "incomplete" : "complete";
         }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -7,12 +7,14 @@
         public string Title { get; }
         public int SectionId { get; }
         public string PercentComplete { get; }
+        public int CustomisationId { get; }
 
-        public SectionCardViewModel(CourseSection section)
+        public SectionCardViewModel(CourseSection section, int customisationId)
         {
             Title = section.Title;
             SectionId = section.Id;
             PercentComplete = section.HasLearning ? $"{section.PercentComplete:f0}% Complete" : "";
+            CustomisationId = customisationId;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -17,7 +17,7 @@
     </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
-        <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0" asp-action="Section" asp-route-sectionId="@Model.SectionId">
+        <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0" asp-action="Section" asp-route-sectionId="@Model.SectionId" asp-route-customisationId="@Model.CustomisationId">
           Launch section
         </a>
       </div>


### PR DESCRIPTION
Add customisation ID to the section page URL and section card view model. The customisation ID is needed for the backend methods and session tracking.