### PR TITLE
HEEDLS-222 Fix learning menu tab name

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -8,7 +8,7 @@
 @{
   ViewData["HeaderPrefix"] = "";
   ViewData["Application"] = Model.Title;
-  ViewData["Title"] = "Learning Menu";
+  ViewData["Title"] = Model.Title;
   ViewData["CustomisationId"] = Model.Id;
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.Id}";
   ViewData["HeaderPathName"] = Model.Title;


### PR DESCRIPTION
Set the ViewData title to be the course title for learning menu pages. This means the tab name for learning menu pages will be the course name - Digital Learning Solutions.

@kwunkiuma @benjimarshall this should be set for the section page and tutorial page as well. I think it makes sense to set it to the course name for both of those, no need to include section or tutorial name 🙂 