### PR TITLE
HEEDLS-216 Section page basic info front end

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -5,18 +5,18 @@
 
 @{
   ViewData["HeaderPrefix"] = "";
-  ViewData["Application"] = "Model.Title";
-  ViewData["Title"] = "Learning Menu";
+  ViewData["Application"] = "CMS Demonstration Course";
+  ViewData["Title"] = "CMS Demonstration Course";
   ViewData["CustomisationId"] = 18438;
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/18438";
-  ViewData["HeaderPathName"] = "Model.Title";
+  ViewData["HeaderPathName"] = "CMS Demonstration Course";
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading" class="nhsuk-heading-xl">Model.SectionTitle</h1>
+    <h1 id="page-heading" class="nhsuk-heading-xl">Working with Microsoft Office applications</h1>
     <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">0% Complete</h2>
     <p class="nhsuk-u-secondary-text-color">0m (average time 0m)</p>
   </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -3,6 +3,30 @@
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
 
+@{
+  ViewData["HeaderPrefix"] = "";
+  ViewData["Application"] = "Model.Title";
+  ViewData["Title"] = "Learning Menu";
+  ViewData["CustomisationId"] = 18438;
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/18438";
+  ViewData["HeaderPathName"] = "Model.Title";
+}
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 id="page-heading" class="nhsuk-heading-xl">Model.SectionTitle</h1>
+    <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">0% Complete</h2>
+    <p class="nhsuk-u-secondary-text-color">0m (average time 0m)</p>
+  </div>
+</div>
+
+<div class="nhsuk-back-link">
+  <a class="nhsuk-back-link__link" asp-action="Index" asp-controller="LearningMenu" asp-route-customisationId="18438">
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+    </svg>
+    Return to course menu
+  </a> 
+</div>


### PR DESCRIPTION
Adds basic info to section page.

Displays the section title, %complete, minutes spent, average minutes spent, and back button.

![image](https://user-images.githubusercontent.com/36454654/101465742-3d0ac580-3938-11eb-93c1-f810a9598dff.png)
