### PR TITLE
Fix too many sections on initial menu

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -126,13 +126,8 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Introducing Outlook", 96, false, 0),
-                    new CourseSection("Writing and sending emails", 97, false, 0),
-                    new CourseSection("Managing emails", 98, false, 0),
                     new CourseSection("Using the Calendar", 99, true, 300/ 11.0),
-                    new CourseSection("Working with Contacts", 100, false, 0),
-                    new CourseSection("Using Tasks", 101, false, 0),
-                    new CourseSection("Using Notes and  the  Journal", 102, true, 0),
+                    new CourseSection("Using Notes and  the  Journal", 102, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -160,13 +155,8 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Introducing Outlook", 96, false, 0),
-                    new CourseSection("Writing and sending emails", 97, false, 0),
-                    new CourseSection("Managing emails", 98, false, 0),
                     new CourseSection("Using the Calendar", 99, true, 0),
-                    new CourseSection("Working with Contacts", 100, false, 0),
-                    new CourseSection("Using Tasks", 101, false, 0),
-                    new CourseSection("Using Notes and  the  Journal", 102, true, 0),
+                    new CourseSection("Using Notes and  the  Journal", 102, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -285,12 +275,7 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Getting started", 2123, false, 0),
-                    new CourseSection("Digital devices", 2124, false, 0),
-                    new CourseSection("Apps, applications and files", 2125, false, 0),
-                    new CourseSection("Staying safe", 2126, false, 0),
-                    new CourseSection("Communication", 2127, false, 0),
-                    new CourseSection("The Internet", 2128, false, 0)
+                    new CourseSection("Getting started", 2123, false, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -390,7 +375,6 @@
             using (new TransactionScope())
             {
                 // When
-                courseContentTestHelper.UpdateSystemRefreshed(candidateId, customisationId, true);
                 var result = courseContentService.GetCourseContent(candidateId, customisationId);
 
                 // Then

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -380,6 +380,39 @@
             }
         }
 
+        [Test]
+        public void Get_course_content_should_only_return_sections_with_tutorials_in_customisation()
+        {
+            // Given
+            const int candidateId = 254480;
+            const int customisationId = 24224;
+
+            using (new TransactionScope())
+            {
+                // When
+                courseContentTestHelper.UpdateSystemRefreshed(candidateId, customisationId, true);
+                var result = courseContentService.GetCourseContent(candidateId, customisationId);
+
+                // Then
+                var expectedCourse = new CourseContent(
+                    24224,
+                    "CMS Demonstration Course",
+                    "Captivate Test",
+                    "13m",
+                    "Test Centre NHSD",
+                    null,
+                    false,
+                    null
+                );
+                expectedCourse.Sections.AddRange(
+                    new[]
+                    {
+                        new CourseSection("Dementia Awareness", 245, true, 0),
+                    }
+                );
+                result.Should().BeEquivalentTo(expectedCourse);
+            }
+        }
 
         [Test]
         public void Get_or_create_progress_id_should_return_progress_id_if_exists()

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -56,7 +56,9 @@
                   INNER JOIN Customisations ON Applications.ApplicationID = Customisations.ApplicationID
                   INNER JOIN Sections ON Sections.ApplicationID = Applications.ApplicationID
                   INNER JOIN Centres ON Customisations.CentreID = Centres.CentreID
-                  LEFT JOIN Tutorials ON Sections.SectionID = Tutorials.SectionID
+                  INNER JOIN Tutorials ON Sections.SectionID = Tutorials.SectionID
+                  INNER JOIN CustomisationTutorials ON Customisations.CustomisationID = CustomisationTutorials.CustomisationID
+                                                   AND Tutorials.TutorialID = CustomisationTutorials.TutorialID
                   LEFT JOIN Progress ON Customisations.CustomisationID = Progress.CustomisationID AND Progress.CandidateID = @candidateId AND Progress.RemovedDate IS NULL AND Progress.SystemRefreshed = 0
                   LEFT JOIN aspProgress ON aspProgress.ProgressID = Progress.ProgressID AND aspProgress.TutorialID = Tutorials.TutorialID
                   WHERE Customisations.CustomisationID = @customisationId

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -62,6 +62,8 @@
                   LEFT JOIN Progress ON Customisations.CustomisationID = Progress.CustomisationID AND Progress.CandidateID = @candidateId AND Progress.RemovedDate IS NULL AND Progress.SystemRefreshed = 0
                   LEFT JOIN aspProgress ON aspProgress.ProgressID = Progress.ProgressID AND aspProgress.TutorialID = Tutorials.TutorialID
                   WHERE Customisations.CustomisationID = @customisationId
+                    AND Sections.ArchivedDate IS NULL
+                    AND (CustomisationTutorials.Status = 1 OR CustomisationTutorials.DiagStatus = 1 OR Customisations.IsAssessed = 1)
                   GROUP BY
                          Sections.SectionID,
                          Customisations.CustomisationID,


### PR DESCRIPTION
## Changes

- Inner join against the CustomisationsTutorials to make sure we only
consider tutorials selected for this course customisation.
- Fix a percentage complete counting bug, which when counting the number
of tutorials that need to be completed it considered all potential
tutorials instead of just the ones selected for this course.

I spotted the percentage counting bug when discussing this ticket with Frank 
and fixing this bug solved the main issue of the ticket (pretty much by accident)
so I said I would push it up.

## Testing
Added a test for the bug in this ticket. 