### PR TITLE
HEEDLS-180 Add default values to TutorialContent query

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -55,7 +55,7 @@
         {
             // Given
             const int candidateId = 1;
-            const int customisationId = -1;
+            const int customisationId = 1378;
             const int sectionId = 74;
             const int tutorialId = 50;
 
@@ -72,7 +72,7 @@
             // Given
             const int candidateId = 1;
             const int customisationId = 1379;
-            const int sectionId = 100;
+            const int sectionId = 75;
             const int tutorialId = 50;
 
             // When

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -55,7 +55,7 @@
         {
             // Given
             const int candidateId = 1;
-            const int customisationId = 1378;
+            const int customisationId = -1;
             const int sectionId = 74;
             const int tutorialId = 50;
 
@@ -72,7 +72,7 @@
             // Given
             const int candidateId = 1;
             const int customisationId = 1379;
-            const int sectionId = 75;
+            const int sectionId = 100;
             const int tutorialId = 50;
 
             // When
@@ -99,7 +99,7 @@
         }
 
         [Test]
-        public void Get_tutorial_content_should_return_null_if_candidate_not_on_course()
+        public void Get_tutorial_content_should_return_tutorial_with_default_progress_if_candidate_not_on_course()
         {
             // Given
             const int candidateId = 100;
@@ -111,7 +111,24 @@
             var tutorial = tutorialContentService.GetTutorialContent(candidateId, customisationId, sectionId, tutorialId);
 
             // Then
-            tutorial.Should().BeNull();
+            tutorial.Should().BeEquivalentTo(new TutorialContent(
+                50,
+                "Navigate documents",
+                "Level 2 - Microsoft Word 2007",
+                "Testing",
+                "Not started",
+                0,
+                5,
+                0,
+                3,
+                true,
+                0,
+                "<html><head><title>Tutorial Objective</title></head><body>In this tutorial you will learn to:" +
+                "<ul><li>use the Go To feature to jump to a particular page</li><li>browse a document by a specific element</li></ul></body></html>",
+                "/MOST/Word07Core/swf/1_1_02_Navigate_documents.swf",
+                "/MOST/Word07Core/MOST_Word07_1_1_02.dcr",
+                "/MOST/Word07Core/support.html?popup=1&item=navigateDocs"
+            ));
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -49,6 +49,8 @@
                          LEFT JOIN Progress
                          ON CustomisationTutorials.CustomisationID = Progress.CustomisationID
                             AND Progress.CandidateID = @candidateId
+                            AND Progress.RemovedDate IS NULL
+                            AND Progress.SystemRefreshed = 0
 
                          LEFT JOIN aspProgress
                          ON aspProgress.TutorialID = Tutorials.TutorialID
@@ -60,8 +62,7 @@
                      AND Tutorials.SectionId = @sectionId
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
-                     AND CustomisationTutorials.Status = 1
-                     AND (Progress.CandidateID IS NULL OR (Progress.RemovedDate IS NULL AND Progress.SystemRefreshed = 0));",
+                     AND CustomisationTutorials.Status = 1;",
             new { candidateId, customisationId, sectionId, tutorialId });
         }
     }

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -25,24 +25,18 @@
                          Tutorials.TutorialName AS Name,
                          Applications.ApplicationName,
                          Customisations.CustomisationName,
-                         TutStatus.Status,
-                         aspProgress.TutTime AS TimeSpent,
+                         COALESCE(TutStatus.Status, 'Not started') AS Status,
+                         COALESCE(aspProgress.TutTime, 0) AS TimeSpent,
                          Tutorials.AverageTutMins AS AverageTutorialDuration,
-                         aspProgress.DiagLast AS CurrentScore,
+                         COALESCE(aspProgress.DiagLast, 0) AS CurrentScore,
                          Tutorials.DiagAssessOutOf AS PossibleScore,
                          CustomisationTutorials.DiagStatus AS CanShowDiagnosticStatus,
-                         aspProgress.DiagAttempts AS AttemptCount,
+                         COALESCE(aspProgress.DiagAttempts, 0) AS AttemptCount,
                          Tutorials.Objectives,
                          Tutorials.VideoPath,
                          Tutorials.TutorialPath,
                          Tutorials.SupportingMatsPath AS SupportingMaterialPath
                     FROM Tutorials
-                         INNER JOIN aspProgress
-                         ON aspProgress.TutorialID = Tutorials.TutorialID
-
-                         INNER JOIN TutStatus
-                         ON aspProgress.TutStat = TutStatus.TutStatusID
-
                          INNER JOIN CustomisationTutorials
                          ON CustomisationTutorials.TutorialID = Tutorials.TutorialID
 
@@ -52,17 +46,22 @@
                          INNER JOIN Applications
                          ON Customisations.ApplicationId = Applications.ApplicationId
 
-                         INNER JOIN Progress
-                         ON aspProgress.ProgressID = Progress.ProgressID
-                            AND CustomisationTutorials.CustomisationID = Progress.CustomisationID
-                   WHERE Progress.CandidateID = @candidateId
-                     AND CustomisationTutorials.CustomisationID = @customisationId
+                         LEFT JOIN Progress
+                         ON CustomisationTutorials.CustomisationID = Progress.CustomisationID
+                            AND Progress.CandidateID = @candidateId
+
+                         LEFT JOIN aspProgress
+                         ON aspProgress.TutorialID = Tutorials.TutorialID
+                            AND aspProgress.ProgressID = Progress.ProgressID
+
+                         LEFT JOIN TutStatus
+                         ON aspProgress.TutStat = TutStatus.TutStatusID
+                   WHERE CustomisationTutorials.CustomisationID = @customisationId
                      AND Tutorials.SectionId = @sectionId
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
                      AND CustomisationTutorials.Status = 1
-                     AND Progress.RemovedDate IS NULL
-                     AND Progress.SystemRefreshed = 0;",
+                     AND (Progress.CandidateID IS NULL OR (Progress.RemovedDate IS NULL AND Progress.SystemRefreshed = 0));",
             new { candidateId, customisationId, sectionId, tutorialId });
         }
     }


### PR DESCRIPTION
## Changes
- When a candidate is not enrolled on a course but queries a tutorial in
it, return the tutorial with progress values set to a default (eg.
TimeSpent = 0).
- Adjust the TutorialContentService tests to reflect this.
- Automatically enrol a user after returning a tutorial if they are
not already enrolled is part of the LearningMenuController already.

## Testing
Add unit tests for this default behaviour.