### PR TITLE
HEEDLS-NONE Add more tests for initial menu SQL query

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
     using System;
+    using System.Linq;
     using System.Transactions;
     using DigitalLearningSolutions.Data.Models.CourseContent;
     using DigitalLearningSolutions.Data.Services;
@@ -395,6 +396,37 @@
                     }
                 );
                 result.Should().BeEquivalentTo(expectedCourse);
+            }
+        }
+
+        [TestCase(254480, 12589, 101, 285054)]
+        [TestCase(1, 15853, 101, 173218)]
+        [TestCase(254480, 24224, 101, null)]
+        [TestCase(22044, 10059, 121, 100467)]
+        public void Get_course_content_should_have_same_sections_as_stored_procedure(
+            int candidateId,
+            int customisationId,
+            int centreId,
+            int? progressId
+        )
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                var validProgressId = progressId ?? courseContentTestHelper.CreateProgressId(customisationId, candidateId, centreId);
+
+                var sectionIdsReturnedFromOldStoredProcedure = courseContentTestHelper
+                    .SectionsFromOldStoredProcedure(validProgressId)
+                    .Select(section => section.SectionID);
+
+                // When
+                var sectionIdsInCourseContent = courseContentService
+                    .GetCourseContent(candidateId, customisationId)?
+                    .Sections
+                    .Select(section => section.Id);
+
+                // Then
+                sectionIdsInCourseContent.Should().BeEquivalentTo(sectionIdsReturnedFromOldStoredProcedure);
             }
         }
 

--- a/DigitalLearningSolutions.Data/Models/CourseContent/OldCourseSection.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseContent/OldCourseSection.cs
@@ -1,0 +1,7 @@
+﻿namespace DigitalLearningSolutions.Data.Models.CourseContent
+{
+    public class OldCourseSection
+    {
+        public int SectionID { get; set; }
+    }
+}


### PR DESCRIPTION
Since we've had issues with our queries not matching the old stored procedures I thought tests like this might be useful. If you come across a course worth adding to the test list (e.g. because it wasn't working at any point, or it has some interesting properties) then feel free to add it. I'll try to find time to hunt for some more useful courses to add to the test list. I'll also try to add something similar for the section and tutorial pages 🙂 