### PR TITLE
HEEDLS-177 Section page basic info integration

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/SectionContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SectionContentServiceTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DigitalLearningSolutions.Data.Tests.Services
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
     using DigitalLearningSolutions.Data.Models.SectionContent;
     using DigitalLearningSolutions.Data.Services;
@@ -97,10 +93,12 @@ namespace DigitalLearningSolutions.Data.Tests.Services
         [Test]
         public void Get_section_content_should_still_return_content_if_candidate_is_not_enrolled()
         {
-            // When
+            // Given
             const int customisationId = 19262;
             const int candidateId = 0;
             const int sectionId = 1011;
+
+            // When
             var result = sectionContentService.GetSectionContent(customisationId, candidateId, sectionId);
 
             // Then
@@ -108,7 +106,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 "Testing",
                 "Excel 2013 for the Workplace",
                 "Entering data",
-                null,
+                0,
                 28,
                 true,
                 0

--- a/DigitalLearningSolutions.Data/Services/SectionContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SectionContentService.cs
@@ -30,7 +30,7 @@
                         Customisations.CustomisationName,
                         Applications.ApplicationName,
                         Sections.SectionName,
-                        SUM(aspProgress.TutTime) AS TimeMins, 
+                        COALESCE(SUM(aspProgress.TutTime), 0) AS TimeMins, 
                         Sections.AverageSectionMins AS AverageSectionTime, 
                         dbo.CheckCustomisationSectionHasLearning(Customisations.CustomisationID, Sections.SectionID) AS HasLearning,
                         (CASE

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -21,6 +21,7 @@
         private ICourseContentService courseContentService;
         private ITutorialContentService tutorialContentService;
         private ISessionService sessionService;
+        private ISectionContentService sectionContentService;
         private ISession httpContextSession;
         private IConfiguration config;
         private const int CandidateId = 11;
@@ -37,6 +38,7 @@
             courseContentService = A.Fake<ICourseContentService>();
             tutorialContentService = A.Fake<ITutorialContentService>();
             sessionService = A.Fake<ISessionService>();
+            sectionContentService = A.Fake<ISectionContentService>();
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
@@ -45,7 +47,7 @@
             }, "mock"));
             httpContextSession = new MockHttpContextSession();
 
-            controller = new LearningMenuController(logger, config, courseContentService, tutorialContentService, sessionService)
+            controller = new LearningMenuController(logger, config, courseContentService, sectionContentService, tutorialContentService, sessionService)
             {
                 ControllerContext = new ControllerContext {
                     HttpContext = new DefaultHttpContext
@@ -245,15 +247,19 @@
             A.CallTo(() => sessionService.StartOrUpdateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
         }
 
-
         [Test]
-        public void Sections_should_StartOrUpdate_course_sessions()
+        public void Sections_should_StartOrUpdate_course_sessions_if_valid_section()
         {
             // Given
-            const int sectionId = 199;
+            const int progressId = 299;
+            var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(defaultSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId))
+                .Returns(progressId);
 
             // When
-            controller.Section(CustomisationId, sectionId);
+            controller.Section(CustomisationId, SectionId);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateSession(CandidateId, CustomisationId, httpContextSession)).MustHaveHappenedOnceExactly();
@@ -261,6 +267,145 @@
                 .WhenArgumentsMatch((int candidateId, int customisationId, ISession session) =>
                     candidateId != CandidateId || customisationId != CustomisationId)
                 .MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Sections_should_not_StartOrUpdate_course_sessions_if_session_not_found()
+        {
+            // Given
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(null);
+
+            // When
+            controller.Section(CustomisationId, SectionId);
+
+            // Then
+            A.CallTo(() => sessionService.StartOrUpdateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Sections_should_not_StartOrUpdate_course_sessions_if_unable_to_enrol()
+        {
+            // Given
+            var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(defaultSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId))
+                .Returns(null);
+
+            // When
+            controller.Section(CustomisationId, SectionId);
+
+            // Then
+            A.CallTo(() => sessionService.StartOrUpdateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Sections_should_UpdateProgress_course_sessions_if_valid_section()
+        {
+            // Given
+            const int progressId = 299;
+            var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(defaultSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId))
+                .Returns(progressId);
+
+            // When
+            controller.Section(CustomisationId, SectionId);
+
+            // Then
+            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+        }
+
+        [Test]
+        public void Sections_should_not_UpdateProgress_course_sessions_if_invalid_section()
+        {
+            // Given
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(null);
+
+            // When
+            controller.Section(CustomisationId, SectionId);
+
+            // Then
+            A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Sections_should_UpdateProgress_course_sessions_if_unable_to_enrol()
+        {
+            // Given
+            var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(defaultSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId))
+                .Returns(null);
+
+            // When
+            controller.Section(CustomisationId, SectionId);
+
+            // Then
+            A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Sections_should_render_view()
+        {
+            // Given
+            const int progressId = 299;
+            var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(defaultSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).
+                Returns(progressId);
+
+            // When
+            var result = controller.Section(CustomisationId, SectionId);
+
+            // Then
+            var expectedModel = new SectionContentViewModel(defaultSectionContent, CustomisationId);
+            result.Should().BeViewResult()
+                .Model.Should().BeEquivalentTo(expectedModel);
+        }
+
+        [Test]
+        public void Sections_should_404_if_section_not_found()
+        {
+            // Given
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(null);
+
+            // When
+            var result = controller.Section(CustomisationId, SectionId);
+
+            // Then
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 404);
+        }
+
+        [Test]
+        public void Sections_should_500_if_failed_to_enrol()
+        {
+            // Given
+            var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
+            A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
+                .Returns(defaultSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(null);
+
+            // When
+            var result = controller.Section(CustomisationId, SectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningSolutions")
+                .WithActionName("StatusCode")
+                .WithRouteValue("code", 500);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -47,9 +47,16 @@
             }, "mock"));
             httpContextSession = new MockHttpContextSession();
 
-            controller = new LearningMenuController(logger, config, courseContentService, sectionContentService, tutorialContentService, sessionService)
+            controller = new LearningMenuController(
+                logger,
+                config,
+                courseContentService,
+                sectionContentService,
+                tutorialContentService,
+                sessionService)
             {
-                ControllerContext = new ControllerContext {
+                ControllerContext = new ControllerContext
+                {
                     HttpContext = new DefaultHttpContext
                     {
                         User = user,
@@ -301,7 +308,7 @@
         }
 
         [Test]
-        public void Sections_should_UpdateProgress_course_sessions_if_valid_section()
+        public void Sections_should_UpdateProgress_if_valid_section()
         {
             // Given
             const int progressId = 299;
@@ -319,7 +326,7 @@
         }
 
         [Test]
-        public void Sections_should_not_UpdateProgress_course_sessions_if_invalid_section()
+        public void Sections_should_not_UpdateProgress_if_invalid_section()
         {
             // Given
             A.CallTo(() => sectionContentService.GetSectionContent(CustomisationId, CandidateId, SectionId))
@@ -333,7 +340,7 @@
         }
 
         [Test]
-        public void Sections_should_UpdateProgress_course_sessions_if_unable_to_enrol()
+        public void Sections_should_UpdateProgress_if_unable_to_enrol()
         {
             // Given
             var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
@@ -389,7 +396,7 @@
         }
 
         [Test]
-        public void Sections_should_500_if_failed_to_enrol()
+        public void Sections_should_404_if_failed_to_enrol()
         {
             // Given
             var defaultSectionContent = SectionContentHelper.CreateDefaultSectionContent();
@@ -405,7 +412,7 @@
                 .BeRedirectToActionResult()
                 .WithControllerName("LearningSolutions")
                 .WithActionName("StatusCode")
-                .WithRouteValue("code", 500);
+                .WithRouteValue("code", 404);
         }
 
         [Test]
@@ -460,7 +467,7 @@
         }
 
         [Test]
-        public void Tutorials_should_UpdateProgress_course_sessions_if_valid_tutorial()
+        public void Tutorials_should_UpdateProgress_if_valid_tutorial()
         {
             // Given
             const int progressId = 3;
@@ -477,7 +484,7 @@
         }
 
         [Test]
-        public void Tutorials_should_not_UpdateProgress_course_sessions_if_invalid_tutorial()
+        public void Tutorials_should_not_UpdateProgress_if_invalid_tutorial()
         {
             // Given
             const int progressId = 3;
@@ -493,7 +500,7 @@
         }
 
         [Test]
-        public void Tutorials_should_not_UpdateProgress_course_sessions_if_unable_to_enrol()
+        public void Tutorials_should_not_UpdateProgress_if_unable_to_enrol()
         {
             // Given
             var defaultTutorialContent = TutorialContentHelper.CreateDefaultTutorialContent(TutorialId);

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
@@ -11,7 +11,7 @@
             int? timeMins = 1,
             int averageSectionTime = 2,
             bool hasLearning = true,
-            double percentComplete = 0.25
+            double percentComplete = 10
         )
         {
             return new SectionContent(

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
@@ -1,0 +1,28 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.TestHelpers
+{
+    using DigitalLearningSolutions.Data.Models.SectionContent;
+
+    public static class SectionContentHelper
+    {
+        public static SectionContent CreateDefaultSectionContent(
+            string customisationName = "customisation name",
+            string applicationName = "application name",
+            string sectionName = "section name",
+            int? timeMins = 1,
+            int averageSectionTime = 2,
+            bool hasLearning = true,
+            double percentComplete = 0.25
+        )
+        {
+            return new SectionContent(
+                customisationName,
+                applicationName,
+                sectionName,
+                timeMins,
+                averageSectionTime,
+                hasLearning,
+                percentComplete
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -1,0 +1,117 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Web.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class SectionContentViewModelTests
+    {
+        [Test]
+        public void Section_content_should_have_title()
+        {
+            // Given
+            const string applicationName = "Application name";
+            const string customisationName = "Customisation name";
+            const int customisationId = 5;
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                applicationName: applicationName,
+                customisationName: customisationName
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+
+            // Then
+            sectionContentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+        }
+
+        [Test]
+        public void Section_content_should_have_section_name()
+        {
+            // Given
+            const string sectionName = "Section name";
+            const int customisationId = 5;
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                sectionName: sectionName
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+
+            // Then
+            sectionContentViewModel.SectionName.Should().Be(sectionName);
+        }
+
+        [Test]
+        public void Section_content_with_has_learning_should_have_percent_complete()
+        {
+            // Given
+            const bool hasLearning = true;
+            const double percentComplete = 0.5;
+            const int customisationId = 5;
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                hasLearning: hasLearning,
+                percentComplete: percentComplete
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+
+            // Then
+            sectionContentViewModel.PercentComplete.Should().Be($"{percentComplete:f0}% Complete");
+        }
+
+        [Test]
+        public void Section_content_without_has_learning_should_have_empty_percent_complete()
+        {
+            // Given
+            const bool hasLearning = false;
+            const double percentComplete = 0.5;
+            const int customisationId = 5;
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                hasLearning: hasLearning,
+                percentComplete: percentComplete
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+
+            // Then
+            sectionContentViewModel.PercentComplete.Should().Be("");
+        }
+
+        [Test]
+        public void Section_content_should_have_time_information()
+        {
+            // Given
+            const int timeMins = 4;
+            const int averageSectionTime = 10;
+            const int customisationId = 5;
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                timeMins: timeMins,
+                averageSectionTime: averageSectionTime
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+
+            // Then
+            sectionContentViewModel.TimeInformation.Should().Be($"{timeMins}m (average time {averageSectionTime}m)");
+        }
+
+        [Test]
+        public void Section_content_should_have_customisation_id()
+        {
+            // Given
+            const int customisationId = 5;
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent();
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+
+            // Then
+            sectionContentViewModel.CustomisationId.Should().Be(customisationId);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -7,20 +7,21 @@
 
     public class SectionContentViewModelTests
     {
+        private const int CustomisationId = 5;
+
         [Test]
         public void Section_content_should_have_title()
         {
             // Given
             const string applicationName = "Application name";
             const string customisationName = "Customisation name";
-            const int customisationId = 5;
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 applicationName: applicationName,
                 customisationName: customisationName
             );
 
             // When
-            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, CustomisationId);
 
             // Then
             sectionContentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
@@ -31,13 +32,12 @@
         {
             // Given
             const string sectionName = "Section name";
-            const int customisationId = 5;
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 sectionName: sectionName
             );
 
             // When
-            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, CustomisationId);
 
             // Then
             sectionContentViewModel.SectionName.Should().Be(sectionName);
@@ -48,18 +48,17 @@
         {
             // Given
             const bool hasLearning = true;
-            const double percentComplete = 0.5;
-            const int customisationId = 5;
+            const double percentComplete = 50.1;
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 hasLearning: hasLearning,
                 percentComplete: percentComplete
             );
 
             // When
-            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, CustomisationId);
 
             // Then
-            sectionContentViewModel.PercentComplete.Should().Be($"{percentComplete:f0}% Complete");
+            sectionContentViewModel.PercentComplete.Should().Be("50% Complete");
         }
 
         [Test]
@@ -67,15 +66,14 @@
         {
             // Given
             const bool hasLearning = false;
-            const double percentComplete = 0.5;
-            const int customisationId = 5;
+            const double percentComplete = 50;
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 hasLearning: hasLearning,
                 percentComplete: percentComplete
             );
 
             // When
-            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, CustomisationId);
 
             // Then
             sectionContentViewModel.PercentComplete.Should().Be("");
@@ -87,14 +85,13 @@
             // Given
             const int timeMins = 4;
             const int averageSectionTime = 10;
-            const int customisationId = 5;
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 timeMins: timeMins,
                 averageSectionTime: averageSectionTime
             );
 
             // When
-            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, CustomisationId);
 
             // Then
             sectionContentViewModel.TimeInformation.Should().Be($"{timeMins}m (average time {averageSectionTime}m)");
@@ -104,14 +101,13 @@
         public void Section_content_should_have_customisation_id()
         {
             // Given
-            const int customisationId = 5;
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent();
 
             // When
-            var sectionContentViewModel = new SectionContentViewModel(sectionContent, customisationId);
+            var sectionContentViewModel = new SectionContentViewModel(sectionContent, CustomisationId);
 
             // Then
-            sectionContentViewModel.CustomisationId.Should().Be(customisationId);
+            sectionContentViewModel.CustomisationId.Should().Be(CustomisationId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -81,22 +81,14 @@
         {
             var candidateId = User.GetCandidateId();
             var centreId = User.GetCentreId();
-
-            if (centreId == null)
-            {
-                logger.LogError(
-                    "Redirecting to 404 as centre id was not found. " +
-                    $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: null, section id: {sectionId}");
-                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
-            }
-
             var sectionContent = sectionContentService.GetSectionContent(customisationId, candidateId, sectionId);
-            
-            if (sectionContent == null)
+
+            if (sectionContent == null || centreId == null)
             {
                 logger.LogError(
-                    "Redirecting to 404 as section was not found. " +
-                    $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}, section id: {sectionId}");
+                    "Redirecting to 404 as section/centre id was not found. " +
+                    $"Candidate id: {candidateId}, customisation id: {customisationId}, " +
+                    $"centre id: {centreId?.ToString() ?? "null"}, section id: {sectionId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
@@ -105,9 +97,10 @@
             if (progressId == null)
             {
                 logger.LogError(
-                    "Redirecting to 500 as no progress id was returned. " +
-                    $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
-                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 500 });
+                    "Redirecting to 404 as no progress id was returned. " +
+                    $"Candidate id: {candidateId}, customisation id: {customisationId}, " +
+                    $"centre id: {centreId}, section id: {sectionId}");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
             sessionService.StartOrUpdateSession(candidateId, customisationId, HttpContext.Session);

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -95,6 +95,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ITutorialContentService, TutorialContentService>();
             services.AddScoped<ISessionDataService, SessionDataService>();
             services.AddScoped<ISessionService, SessionService>();
+            services.AddScoped<ISectionContentService, SectionContentService>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
@@ -1,0 +1,22 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Data.Models.SectionContent;
+
+    public class SectionContentViewModel
+    {
+        public string CourseTitle { get; }
+        public string SectionName { get; }
+        public string PercentComplete { get; }
+        public string TimeInformation { get; }
+        public int CustomisationId { get; }
+
+        public SectionContentViewModel(SectionContent sectionContent, int customisationId)
+        {
+            CourseTitle = sectionContent.CourseTitle;
+            SectionName = sectionContent.SectionName;
+            PercentComplete = sectionContent.HasLearning ? $"{sectionContent.PercentComplete:f0}% Complete" : "";
+            TimeInformation = $"{sectionContent.TimeMins}m (average time {sectionContent.AverageSectionTime}m)";
+            CustomisationId = customisationId;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -1,30 +1,31 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningMenu
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
+@model SectionContentViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
 
 @{
   ViewData["HeaderPrefix"] = "";
-  ViewData["Application"] = "CMS Demonstration Course";
-  ViewData["Title"] = "CMS Demonstration Course";
-  ViewData["CustomisationId"] = 18438;
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/18438";
-  ViewData["HeaderPathName"] = "CMS Demonstration Course";
+  ViewData["Application"] = Model.CourseTitle;
+  ViewData["Title"] = Model.CourseTitle;
+  ViewData["CustomisationId"] = Model.CustomisationId;
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.CustomisationId}";
+  ViewData["HeaderPathName"] = Model.CourseTitle;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading" class="nhsuk-heading-xl">Working with Microsoft Office applications</h1>
-    <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">0% Complete</h2>
-    <p class="nhsuk-u-secondary-text-color">0m (average time 0m)</p>
+    <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
+    <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">@Model.PercentComplete</h2>
+    <p class="nhsuk-u-secondary-text-color">@Model.TimeInformation</p>
   </div>
 </div>
 
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-action="Index" asp-controller="LearningMenu" asp-route-customisationId="18438">
+  <a class="nhsuk-back-link__link" asp-action="Index" asp-controller="LearningMenu" asp-route-customisationId="@Model.CustomisationId">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
     </svg>


### PR DESCRIPTION
Integrate the front and back ends for basic info on the section page.

Replace hardcoded values in view with view model values.

Add tests for view model and controller.

Ran and passed all unit tests. Manually tested on Firefox and pages are displaying the correct information, including when opening a unenrolled section via URL.