### PR TITLE
Add objectives to tutorial page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -160,5 +160,66 @@
             // Then
             tutorialViewModel.TutorialRecommendation.Should().Be("optional");
         }
+
+        [Test]
+        public void Tutorial_parsed_objectives_are_null_when_objectives_are_null()
+        {
+            // Given
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                objectives: null
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(expectedTutorialInformation, CustomisationId, SectionId);
+
+            // Then
+            tutorialViewModel.Objectives.Should().BeNull();
+        }
+
+        [Test]
+        public void Tutorial_parses_inline_html_objectives()
+        {
+            // Given
+            const string objectives =
+                "Here are some example objectives: <ul> <li> objective 1 </li> <li> objective 2 </li> </ul>";
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                objectives: objectives
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(expectedTutorialInformation, CustomisationId, SectionId);
+
+            // Then
+            tutorialViewModel.Objectives.Should().Be(objectives);
+        }
+
+        [Test]
+        public void Tutorial_parses_html_document_of_objectives()
+        {
+            // Given
+            const string objectives =
+                "<html> <head> <title>Tutorial Objective</title> </head>" +
+                "<body> In this tutorial you will learn to: " +
+                  "<ul>" +
+                    "<li>open another window on to a workbook</li>" +
+                    "<li>arrange workbook windows</li>" +
+                    "<li>hide and show windows</li>" +
+                 "</ul>" +
+                "</body> </html>";
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                objectives: objectives
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(expectedTutorialInformation, CustomisationId, SectionId);
+
+            // Then
+            tutorialViewModel.Objectives.Should().Be(" In this tutorial you will learn to: " +
+                                                     "<ul>" +
+                                                       "<li>open another window on to a workbook</li>" +
+                                                       "<li>arrange workbook windows</li>" +
+                                                       "<li>hide and show windows</li>" +
+                                                     "</ul>");
+        }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -162,7 +162,7 @@
         }
 
         [Test]
-        public void Tutorial_parsed_objectives_are_null_when_objectives_are_null()
+        public void Tutorial_handles_null_objectives()
         {
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(

--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="FluentMigrator.Runner" Version="3.2.9" />
     <PackageReference Include="FluentMigrator.Runner.SqlServer" Version="3.2.9" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.28" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.4" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="2.0.0" />

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -1,10 +1,14 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
 {
+    using System.Linq;
+    using System.Net;
     using DigitalLearningSolutions.Data.Models.TutorialContent;
+    using HtmlAgilityPack;
 
     public class TutorialViewModel
     {
         public TutorialInformation TutorialInformation { get; }
+        public string? Objectives { get; }
         public int CustomisationId { get; }
         public int SectionId { get; }
 
@@ -13,6 +17,7 @@
             TutorialInformation = tutorialInformation;
             CustomisationId = customisationId;
             SectionId = sectionId;
+            Objectives = ParseObjectives(tutorialInformation.Objectives);
         }
 
         public bool CanShowProgress => TutorialInformation.CanShowDiagnosticStatus && TutorialInformation.AttemptCount > 0;
@@ -34,6 +39,22 @@
                 return $"{minutes / 60}h {minutes % 60}m";
             }
             return $"{minutes}m";
+        }
+
+        private static string? ParseObjectives(string? objectives)
+        {
+            if (objectives == null)
+            {
+                return null;
+            }
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(objectives);
+
+            var body = doc.DocumentNode.SelectNodes("//body");
+
+            return body?.FirstOrDefault()?.InnerHtml
+                   ?? WebUtility.HtmlDecode(objectives);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -51,10 +51,9 @@
             var doc = new HtmlDocument();
             doc.LoadHtml(objectives);
 
-            var body = doc.DocumentNode.SelectNodes("//body");
+            var body = doc.DocumentNode.SelectSingleNode("//body");
 
-            return body?.FirstOrDefault()?.InnerHtml
-                   ?? WebUtility.HtmlDecode(objectives);
+            return body?.InnerHtml ?? objectives;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -40,13 +40,7 @@
       </span>
     </summary>
     <div class="nhsuk-details__text">
-      <p>Here are some example objectives:</p>
-      <ul>
-        <li>objective 1</li>
-        <li>objective 2</li>
-        <li>objective 3</li>
-        <li>objective 4</li>
-      </ul>
+      @Html.Raw(Model.Objectives)
     </div>
   </details>
 }


### PR DESCRIPTION
## Changes
- Install the Html Agility Pack NuGet package.
- Add tutorial objective parsing, to the view model, and display it in
the Tutorial view.
- Add tests for this view model parsing method.

## Testing
Add view model unit tests, test in Chrome, Firefox, Edge and IE11, using a screen reader and large zoom.

## Screenshots
### Collapsed objectives
![no_objectives](https://user-images.githubusercontent.com/3650110/102096904-22938900-3e1d-11eb-8d0d-c71dbbe84b37.png)

### Expanded objectives
![objectives_expanded](https://user-images.githubusercontent.com/3650110/102096907-232c1f80-3e1d-11eb-9cef-aa06eeb3598d.png)

### A tutorial without any objectives
![objectives_collapsed](https://user-images.githubusercontent.com/3650110/102096908-23c4b600-3e1d-11eb-8810-07efae5713a5.png)
