### PR TITLE
HEEDLS-244 Tutorial next button back end

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -445,6 +445,7 @@
         [TestCase(1, 15853, 101, 173218)]
         [TestCase(254480, 24224, 101, null)]
         [TestCase(22044, 10059, 121, 100467)]
+        [TestCase(11, 6226, 101, 89490)]
         public void Get_course_content_should_have_same_sections_as_stored_procedure(
             int candidateId,
             int customisationId,

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -129,6 +129,44 @@
         }
 
         [Test]
+        public void Get_tutorial_information_nextTutorial_can_return_smaller_tutorialId()
+        {
+            // Given
+            const int candidateId = 210934;
+            const int customisationId = 17731;
+            const int sectionId = 801;
+            const int tutorialId = 3332;
+
+            const int nextTutorialId = 3334;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextSection_can_return_smaller_sectionId()
+        {
+            // Given
+            const int candidateId = 210962;
+            const int customisationId = 24057;
+            const int sectionId = 2201;
+            const int tutorialId = 10184;
+
+            const int nextSectionId = 2193;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextSectionId.Should().Be(nextSectionId);
+        }
+
+        [Test]
         public void Get_tutorial_information_should_return_null_if_customisation_id_invalid()
         {
             // Given

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -135,9 +135,9 @@
             const int candidateId = 210934;
             const int customisationId = 17731;
             const int sectionId = 801;
-            const int tutorialId = 3332;
+            const int tutorialId = 3334;
 
-            const int nextTutorialId = 3334;
+            const int nextTutorialId = 3333;
 
             // When
             var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
@@ -164,6 +164,77 @@
             // Then
             tutorial.Should().NotBeNull();
             tutorial!.NextSectionId.Should().Be(nextSectionId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextTutorial_returns_smaller_tutorialId_for_shared_orderByNumber()
+        {
+            // Given
+            const int candidateId = 1;
+            const int customisationId = 8194;
+            const int sectionId = 216;
+            const int tutorialId = 927;
+
+            // All in section 216
+            // Tutorial: 927  OrderByNumber 34
+            // Tutorial: 928  OrderByNumber 35
+            // Tutorial: 929  OrderByNumber 35
+            const int nextTutorialId = 928;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextTutorial_returns_next_tutorialId_with_shared_orderByNumber()
+        {
+            // Given
+            const int candidateId = 1;
+            const int customisationId = 8194;
+            const int sectionId = 216;
+            const int tutorialId = 928;
+
+            // All in section 216
+            // Tutorial: 927  OrderByNumber 34
+            // Tutorial: 928  OrderByNumber 35
+            // Tutorial: 929  OrderByNumber 35
+            // Tutorial: 930  OrderByNumber 36
+            const int nextTutorialId = 929;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextTutorial_returns_tutorialId_after_shared_orderByNumber()
+        {
+            // Given
+            const int candidateId = 1;
+            const int customisationId = 8194;
+            const int sectionId = 216;
+            const int tutorialId = 929;
+
+            // All in section 216
+            // Tutorial: 927  OrderByNumber 34
+            // Tutorial: 928  OrderByNumber 35
+            // Tutorial: 929  OrderByNumber 35
+            // Tutorial: 930  OrderByNumber 36
+            const int nextTutorialId = 930;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -46,8 +46,86 @@
                 "<ul><li>use the Go To feature to jump to a particular page</li><li>browse a document by a specific element</li></ul></body></html>",
                 "/MOST/Word07Core/swf/1_1_02_Navigate_documents.swf",
                 "/MOST/Word07Core/MOST_Word07_1_1_02.dcr",
-                "/MOST/Word07Core/support.html?popup=1&item=navigateDocs"
+                "/MOST/Word07Core/support.html?popup=1&item=navigateDocs",
+                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/Assess/L2_Word_2007_Post_1.dcr",
+                51,
+                75
             ));
+        }
+
+        [Test]
+        public void Get_tutorial_information_should_return_null_nextTutorial_if_last_tutorial_in_section()
+        {
+            // Given
+            const int candidateId = 1;
+            const int customisationId = 1379;
+            const int sectionId = 74;
+            const int tutorialId = 52;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_tutorial_information_should_return_null_nextSection_if_last_section_in_course()
+        {
+            // Given
+            const int candidateId = 1;
+            const int customisationId = 1379;
+            const int sectionId = 82;
+            const int tutorialId = 94;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextSectionId.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextTutorial_should_skip_tutorials_not_in_customisation()
+        {
+            // Given
+            const int candidateId = 210934;
+            const int customisationId = 18366;
+            const int sectionId = 973;
+            const int tutorialId = 4257;
+
+            // The next tutorial ID in this section is 4258, but the next tutorial selected in CustomisationTutorials is 4263
+            const int nextTutorialId = 4263;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextSection_should_skip_empty_sections()
+        {
+            // Given
+            const int candidateId = 210934;
+            const int customisationId = 18366;
+            const int sectionId = 974;
+            const int tutorialId = 4262;
+
+            // The next section ID in this Application is 975, but the next section with a tutorial selected in
+            // CustomisationTutorials is 978
+            const int nextSectionId = 978;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextSectionId.Should().Be(nextSectionId);
         }
 
         [Test]
@@ -127,7 +205,10 @@
                 "<ul><li>use the Go To feature to jump to a particular page</li><li>browse a document by a specific element</li></ul></body></html>",
                 "/MOST/Word07Core/swf/1_1_02_Navigate_documents.swf",
                 "/MOST/Word07Core/MOST_Word07_1_1_02.dcr",
-                "/MOST/Word07Core/support.html?popup=1&item=navigateDocs"
+                "/MOST/Word07Core/support.html?popup=1&item=navigateDocs",
+                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/Assess/L2_Word_2007_Post_1.dcr",
+                51,
+                75
             ));
         }
 

--- a/DigitalLearningSolutions.Data/Models/TutorialContent/TutorialInformation.cs
+++ b/DigitalLearningSolutions.Data/Models/TutorialContent/TutorialInformation.cs
@@ -16,6 +16,9 @@
         public string? VideoPath { get; }
         public string? TutorialPath { get; }
         public string? SupportingMaterialPath { get; }
+        public string? PostLearningAssessmentPath { get; }
+        public int? NextTutorialId { get; }
+        public int? NextSectionId { get; }
 
         public TutorialInformation(
             int id,
@@ -32,7 +35,10 @@
             string? objectives,
             string? videoPath,
             string? tutorialPath,
-            string? supportingMaterialPath
+            string? supportingMaterialPath,
+            string? postLearningAssessmentPath,
+            int? nextTutorialId,
+            int? nextSectionId
         )
         {
             Id = id;
@@ -49,6 +55,9 @@
             VideoPath = videoPath;
             TutorialPath = tutorialPath;
             SupportingMaterialPath = supportingMaterialPath;
+            PostLearningAssessmentPath = postLearningAssessmentPath;
+            NextTutorialId = nextTutorialId;
+            NextSectionId = nextSectionId;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -49,16 +49,38 @@
                          Tutorials.Objectives,
                          Tutorials.VideoPath,
                          Tutorials.TutorialPath,
-                         Tutorials.SupportingMatsPath AS SupportingMaterialPath
+                         Tutorials.SupportingMatsPath AS SupportingMaterialPath,
+                         Sections.PLAssessPath AS PostLearningAssessmentPath,
+                         MIN(SubsequentTutorials.TutorialID) AS NextTutorialID,
+                         MIN(SubsequentSections.SectionID) AS NextSectionID
                     FROM Tutorials
                          INNER JOIN CustomisationTutorials
                          ON CustomisationTutorials.TutorialID = Tutorials.TutorialID
+
+                         INNER JOIN Sections
+                         ON Tutorials.SectionID = Sections.SectionID
 
                          INNER JOIN Customisations
                          ON CustomisationTutorials.CustomisationID = Customisations.CustomisationID
 
                          INNER JOIN Applications
                          ON Customisations.ApplicationId = Applications.ApplicationId
+
+                         LEFT JOIN CustomisationTutorials AS SubsequentCustomisationTutorials
+                         ON SubsequentCustomisationTutorials.CustomisationID = Customisations.CustomisationID
+                            AND SubsequentCustomisationTutorials.Status = 1
+
+                         LEFT JOIN Tutorials AS SubsequentTutorials
+                         ON SubsequentTutorials.SectionID = Sections.SectionID
+                            AND Tutorials.OrderByNumber < SubsequentTutorials.OrderByNumber
+                            AND SubsequentCustomisationTutorials.TutorialID = SubsequentTutorials.TutorialID
+
+                         LEFT JOIN Tutorials AS SubsequentSectionsTutorials
+                         ON  SubsequentCustomisationTutorials.TutorialID = SubsequentSectionsTutorials.TutorialID
+
+                         LEFT JOIN Sections AS SubsequentSections
+                         ON SubsequentSectionsTutorials.SectionID = SubsequentSections.SectionID
+                            AND Sections.SectionNumber < SubsequentSections.SectionNumber
 
                          LEFT JOIN Progress
                          ON CustomisationTutorials.CustomisationID = Progress.CustomisationID
@@ -76,7 +98,23 @@
                      AND Tutorials.SectionId = @sectionId
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
-                     AND CustomisationTutorials.Status = 1;",
+                     AND CustomisationTutorials.Status = 1
+                   GROUP BY Tutorials.TutorialID,
+                            Tutorials.TutorialName,
+                            Applications.ApplicationName,
+                            Customisations.CustomisationName,
+                            TutStatus.Status,
+                            aspProgress.TutTime,
+                            Tutorials.AverageTutMins,
+                            aspProgress.DiagLast,
+                            Tutorials.DiagAssessOutOf,
+                            CustomisationTutorials.DiagStatus,
+                            aspProgress.DiagAttempts,
+                            Tutorials.Objectives,
+                            Tutorials.VideoPath,
+                            Tutorials.TutorialPath,
+                            Tutorials.SupportingMatsPath,
+                            Sections.PLAssessPath;",
             new { candidateId, customisationId, sectionId, tutorialId });
         }
 

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -35,6 +35,11 @@
         )
         {
             return connection.QueryFirstOrDefault<TutorialInformation>(
+                // NextTutorialID is the ID of the next tutorial in the section, according to Tutorials.OrderBy
+                // or null if the last in the section.
+
+                // Similar for sections, using Sections.SectionNumber
+
                 @"SELECT Tutorials.TutorialID AS Id,
                          Tutorials.TutorialName AS Name,
                          Applications.ApplicationName,
@@ -51,8 +56,8 @@
                          Tutorials.TutorialPath,
                          Tutorials.SupportingMatsPath AS SupportingMaterialPath,
                          Sections.PLAssessPath AS PostLearningAssessmentPath,
-                         MIN(SubsequentTutorials.TutorialID) AS NextTutorialID,
-                         MIN(SubsequentSections.SectionID) AS NextSectionID
+                         MIN(NextTutorials.TutorialID) AS NextTutorialID,
+                         MIN(NextSections.SectionID) AS NextSectionID
                     FROM Tutorials
                          INNER JOIN CustomisationTutorials
                          ON CustomisationTutorials.TutorialID = Tutorials.TutorialID
@@ -66,21 +71,21 @@
                          INNER JOIN Applications
                          ON Customisations.ApplicationId = Applications.ApplicationId
 
-                         LEFT JOIN CustomisationTutorials AS SubsequentCustomisationTutorials
-                         ON SubsequentCustomisationTutorials.CustomisationID = Customisations.CustomisationID
-                            AND SubsequentCustomisationTutorials.Status = 1
+                         LEFT JOIN CustomisationTutorials AS NextCustomisationTutorials
+                         ON NextCustomisationTutorials.CustomisationID = Customisations.CustomisationID
+                            AND NextCustomisationTutorials.Status = 1
 
-                         LEFT JOIN Tutorials AS SubsequentTutorials
-                         ON SubsequentTutorials.SectionID = Sections.SectionID
-                            AND Tutorials.OrderByNumber < SubsequentTutorials.OrderByNumber
-                            AND SubsequentCustomisationTutorials.TutorialID = SubsequentTutorials.TutorialID
+                         LEFT JOIN Tutorials AS NextTutorials
+                         ON NextTutorials.SectionID = Sections.SectionID
+                            AND Tutorials.OrderByNumber < NextTutorials.OrderByNumber
+                            AND NextCustomisationTutorials.TutorialID = NextTutorials.TutorialID
 
-                         LEFT JOIN Tutorials AS SubsequentSectionsTutorials
-                         ON  SubsequentCustomisationTutorials.TutorialID = SubsequentSectionsTutorials.TutorialID
+                         LEFT JOIN Tutorials AS NextSectionsTutorials
+                         ON  NextCustomisationTutorials.TutorialID = NextSectionsTutorials.TutorialID
 
-                         LEFT JOIN Sections AS SubsequentSections
-                         ON SubsequentSectionsTutorials.SectionID = SubsequentSections.SectionID
-                            AND Sections.SectionNumber < SubsequentSections.SectionNumber
+                         LEFT JOIN Sections AS NextSections
+                         ON NextSectionsTutorials.SectionID = NextSections.SectionID
+                            AND Sections.SectionNumber < NextSections.SectionNumber
 
                          LEFT JOIN Progress
                          ON CustomisationTutorials.CustomisationID = Progress.CustomisationID

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -54,7 +54,11 @@
 
                          LEFT JOIN Tutorials AS NextTutorials
                          ON NextTutorials.SectionID = Tutorials.SectionID
-                            AND Tutorials.OrderByNumber < NextTutorials.OrderByNumber
+                            AND Tutorials.OrderByNumber <= NextTutorials.OrderByNumber
+                            AND (
+                                 Tutorials.OrderByNumber < NextTutorials.OrderByNumber
+                                 OR Tutorials.TutorialID < NextTutorials.TutorialID
+                            )
                             AND NextCustomisationTutorials.TutorialID = NextTutorials.TutorialID
 
                          LEFT JOIN Tutorials AS NextSectionsTutorials
@@ -62,7 +66,11 @@
 
                          LEFT JOIN Sections AS NextSections
                          ON NextSectionsTutorials.SectionID = NextSections.SectionID
-                            AND CurrentSection.SectionNumber < NextSections.SectionNumber
+                            AND CurrentSection.SectionNumber <= NextSections.SectionNumber
+                            AND (
+                                 CurrentSection.SectionNumber < NextSections.SectionNumber
+                                 OR CurrentSection.SectionID < NextSections.SectionID
+                            )
                    WHERE Tutorials.SectionId = @sectionId
                      AND Tutorials.TutorialID = @tutorialId
                    GROUP BY Tutorials.TutorialID
@@ -105,10 +113,18 @@
                          LEFT JOIN Tutorials AS NextTutorial
                          ON NextTutorialAndSectionNumbers.NextTutorialOrderByNumber = NextTutorial.OrderByNumber
                             AND Sections.SectionID = NextTutorial.SectionID
+                            AND (
+                                 Tutorials.OrderByNumber < NextTutorialAndSectionNumbers.NextTutorialOrderByNumber
+                                 OR Tutorials.TutorialID < NextTutorial.TutorialID
+                            )
 
                          LEFT JOIN Sections AS NextSection
                          ON NextTutorialAndSectionNumbers.NextSectionNumber = NextSection.SectionNumber
                             AND Customisations.ApplicationID = NextSection.ApplicationID
+                            AND (
+                                 Sections.SectionNumber < NextTutorialAndSectionNumbers.NextSectionNumber
+                                 OR Sections.SectionID < NextSection.SectionID
+                            )
 
                          LEFT JOIN Progress
                          ON CustomisationTutorials.CustomisationID = Progress.CustomisationID
@@ -126,7 +142,8 @@
                      AND Tutorials.SectionId = @sectionId
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
-                     AND CustomisationTutorials.Status = 1;",
+                     AND CustomisationTutorials.Status = 1
+                   ORDER BY NextTutorial.TutorialID, NextSection.SectionID;",
             new { candidateId, customisationId, sectionId, tutorialId });
         }
 

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/TutorialContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/TutorialContentHelper.cs
@@ -19,7 +19,10 @@
             string? objectives = "objectives",
             string? videoPath = "video",
             string? tutorialPath = "tutorial",
-            string? supportingMaterialPath = "material"
+            string? supportingMaterialPath = "material",
+            string? postLearningAssessmentPath = "/postLearningAssessment",
+            int? subsequentTutorialId = 2,
+            int? subsequentSectionId = 45
         )
         {
             return new TutorialInformation(
@@ -37,7 +40,10 @@
                 objectives,
                 videoPath,
                 tutorialPath,
-                supportingMaterialPath
+                supportingMaterialPath,
+                postLearningAssessmentPath,
+                subsequentTutorialId,
+                subsequentSectionId
             );
         }
 


### PR DESCRIPTION
## Changes
Amend `GetTutorialInformation` query and data model to get the next
tutorial ID, the next section ID, and the post-learning assessment
path.

## Testing
- Add test for course contents section test: test a course which has some sections where none of the section's
tutorials are in the CustomisationTutorial table (based on some checks I did this morning)
- Amend `GetTutorialInformation` tests, and add tests for edge cases like being the last tutorial
in a section, and check tutorials not in CustomisationTutorials are skipped.
