### PR TITLE
Add front end for tutorial overview next link

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/TutorialContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/TutorialContentHelper.cs
@@ -21,8 +21,8 @@
             string? tutorialPath = "tutorial",
             string? supportingMaterialPath = "material",
             string? postLearningAssessmentPath = "/postLearningAssessment",
-            int? subsequentTutorialId = 2,
-            int? subsequentSectionId = 45
+            int? nextTutorialId = 2,
+            int? nextSectionId = 45
         )
         {
             return new TutorialInformation(
@@ -42,8 +42,8 @@
                 tutorialPath,
                 supportingMaterialPath,
                 postLearningAssessmentPath,
-                subsequentTutorialId,
-                subsequentSectionId
+                nextTutorialId,
+                nextSectionId
             );
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialNextLinkViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialNextLinkViewModelTests.cs
@@ -1,0 +1,95 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    class TutorialNextLinkViewModelTests
+    {
+        private const int CustomisationId = 1;
+        private const int SectionId = 10;
+        const string PostLearningAssessmentPath = "/assessment";
+        const int NextTutorialId = 101;
+        const int NextSectionId = 102;
+
+        [Test]
+        public void Tutorial_should_have_customisationId()
+        {
+            // When
+            var nextLinkViewModel = new TutorialNextLinkViewModel(
+                CustomisationId,
+                SectionId,
+                PostLearningAssessmentPath,
+                NextTutorialId,
+                NextSectionId
+            );
+
+            // Then
+            nextLinkViewModel.CustomisationId.Should().Be(CustomisationId);
+        }
+
+        [Test]
+        public void Tutorial_should_have_sectionId()
+        {
+            // When
+            var nextLinkViewModel = new TutorialNextLinkViewModel(
+                CustomisationId,
+                SectionId,
+                PostLearningAssessmentPath,
+                NextTutorialId,
+                NextSectionId
+            );
+
+            // Then
+            nextLinkViewModel.SectionId.Should().Be(SectionId);
+        }
+
+        [Test]
+        public void Tutorial_should_have_postLearningAssessmentPath()
+        {
+            // When
+            var nextLinkViewModel = new TutorialNextLinkViewModel(
+                CustomisationId,
+                SectionId,
+                PostLearningAssessmentPath,
+                NextTutorialId,
+                NextSectionId
+            );
+
+            // Then
+            nextLinkViewModel.PostLearningAssessmentPath.Should().Be(PostLearningAssessmentPath);
+        }
+
+        [Test]
+        public void Tutorial_should_have_nextTutorialId()
+        {
+            // When
+            var nextLinkViewModel = new TutorialNextLinkViewModel(
+                CustomisationId,
+                SectionId,
+                PostLearningAssessmentPath,
+                NextTutorialId,
+                NextSectionId
+            );
+
+            // Then
+            nextLinkViewModel.NextTutorialId.Should().Be(NextTutorialId);
+        }
+
+        [Test]
+        public void Tutorial_should_have_nextSectionId()
+        {
+            // When
+            var nextLinkViewModel = new TutorialNextLinkViewModel(
+                CustomisationId,
+                SectionId,
+                PostLearningAssessmentPath,
+                NextTutorialId,
+                NextSectionId
+            );
+
+            // Then
+            nextLinkViewModel.NextSectionId.Should().Be(NextSectionId);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -187,6 +187,38 @@
         }
 
         [Test]
+        public void Tutorial_should_have_nextLinkViewModel()
+        {
+            // Given
+            const string postLearningAssessmentPath = "/assessment";
+            const int nextTutorialId = 101;
+            const int nextSectionId = 100;
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                nextTutorialId: nextTutorialId,
+                nextSectionId: nextSectionId,
+                postLearningAssessmentPath: postLearningAssessmentPath
+            );
+            var expectedNextLinkViewModel = new TutorialNextLinkViewModel(
+                CustomisationId,
+                SectionId,
+                postLearningAssessmentPath,
+                nextTutorialId,
+                nextSectionId
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.NextLinkViewModel.Should().BeEquivalentTo(expectedNextLinkViewModel);
+        }
+
+        [Test]
         public void Tutorial_should_summarise_duration()
         {
             // Given

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/tutorial.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/tutorial.scss
@@ -27,3 +27,18 @@
   width: 100%;
   height: auto;
 }
+
+.grid-column-85 {
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 85%;
+}
+
+.next-link {
+  float: right;
+}
+
+#next-arrow {
+  left: auto;
+  right: -24px
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialNextLinkViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialNextLinkViewModel.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
+{
+    public class TutorialNextLinkViewModel
+    {
+        public int CustomisationId { get; }
+        public int SectionId { get; }
+        public string? PostLearningAssessmentPath { get; }
+        public int? NextTutorialId { get; }
+        public int? NextSectionId { get; }
+        public TutorialNextLinkViewModel(
+            int customisationId,
+            int sectionId,
+            string? postLearningAssessmentPath,
+            int? nextTutorialId,
+            int? nextSectionId
+        )
+        {
+            CustomisationId = customisationId;
+            SectionId = sectionId;
+            PostLearningAssessmentPath = postLearningAssessmentPath;
+            NextTutorialId = nextTutorialId;
+            NextSectionId = nextSectionId;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialNextLinkViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialNextLinkViewModel.cs
@@ -7,6 +7,7 @@
         public string? PostLearningAssessmentPath { get; }
         public int? NextTutorialId { get; }
         public int? NextSectionId { get; }
+
         public TutorialNextLinkViewModel(
             int customisationId,
             int sectionId,

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -21,6 +21,7 @@
         public string ScoreSummary { get; }
         public string TimeSummary { get; }
         public string? SupportingMaterialPath { get; }
+        public TutorialNextLinkViewModel NextLinkViewModel { get; }
 
         public TutorialViewModel(
             IConfiguration config,
@@ -48,6 +49,13 @@
             TimeSummary = GetTimeSummary(tutorialInformation.TimeSpent, tutorialInformation.AverageTutorialDuration);
             SupportingMaterialPath =
                 ContentUrlHelper.GetNullableContentPath(config, tutorialInformation.SupportingMaterialPath);
+            NextLinkViewModel = new TutorialNextLinkViewModel(
+                customisationId,
+                sectionId,
+                tutorialInformation.PostLearningAssessmentPath,
+                tutorialInformation.NextTutorialId,
+                tutorialInformation.NextSectionId
+            );
         }
 
         private bool GetCanShowProgress(bool canShowDiagnosticStatus, int attemptCount)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -25,14 +25,16 @@
   </div>
 </div>
 
-@if (Model.CanShowProgress) {
+@if (Model.CanShowProgress)
+{
   <div class="nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
     <span class="nhsuk-u-visually-hidden">Information: </span>
     <p>Based on your diagnostic assessment outcome, this tutorial is <b>@Model.TutorialRecommendation</b>.</p>
   </div>
 }
 
-@if (Model.Objectives != null) {
+@if (Model.Objectives != null)
+{
   <details class="nhsuk-details nhsuk-u-margin-bottom-4">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text">
@@ -46,7 +48,8 @@
 }
 
 <div class="tutorial-actions-container">
-  @if (Model.TutorialPath != null) {
+  @if (Model.TutorialPath != null)
+  {
     <div>
       <a class="nhsuk-button"
          asp-action="ContentViewer"
@@ -59,7 +62,8 @@
     </div>
   }
 
-  @if (Model.VideoPath != null) {
+  @if (Model.VideoPath != null)
+  {
     <div>
       <a class="nhsuk-button nhsuk-button--secondary"
          asp-controller="LearningMenu"
@@ -72,7 +76,8 @@
     </div>
   }
 
-  @if (Model.SupportingMaterialPath != null) {
+  @if (Model.SupportingMaterialPath != null)
+  {
     <div>
       <a class="nhsuk-button nhsuk-button--secondary" href="@Model.SupportingMaterialPath" download>
         Download supporting materials
@@ -81,12 +86,15 @@
   }
 </div>
 
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-back-link grid-column-85">
+    <a class="nhsuk-back-link__link" asp-action="Section" asp-controller="LearningMenu" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">
+      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+      </svg>
+      Return to section
+    </a>
 
-<div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-action="Section" asp-controller="LearningMenu" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-    </svg>
-    Return to section
-  </a>
+    <partial name="Tutorial/_TutorialNextLink" model="Model.NextLinkViewModel" />
+  </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/_TutorialNextLink.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/_TutorialNextLink.cshtml
@@ -1,0 +1,56 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningMenu
+@model TutorialNextLinkViewModel
+
+@if (Model.NextTutorialId != null)
+{
+  <a class="nhsuk-back-link__link next-link"
+     asp-controller="LearningMenu"
+     asp-action="Tutorial"
+     asp-route-customisationId="@Model.CustomisationId"
+     asp-route-sectionId="@Model.SectionId"
+     asp-route-tutorialId="@Model.NextTutorialId">
+
+    Go to next tutorial
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+    </svg>
+  </a>
+}
+else if (Model.PostLearningAssessmentPath != null)
+{
+  <a class="nhsuk-back-link__link next-link"
+     href="">
+
+    Go to post learning assessment
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+    </svg>
+  </a>
+}
+else if (Model.NextSectionId != null)
+{
+  <a class="nhsuk-back-link__link next-link"
+     asp-controller="LearningMenu"
+     asp-action="Section"
+     asp-route-customisationId="@Model.CustomisationId"
+     asp-route-sectionId="@Model.NextSectionId">
+
+    Go to next section
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+    </svg>
+  </a>
+}
+else
+{
+  <a class="nhsuk-back-link__link next-link"
+     asp-controller="LearningMenu"
+     asp-action="Index"
+     asp-route-customisationId="@Model.CustomisationId">
+
+    Finish
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+    </svg>
+  </a>
+}


### PR DESCRIPTION
## Changes
- Add a partial for the next link, and a view model for the partial.
- Add some CSS to style the next link.

## Testing
Add view model tests for the new data. Tested in Chrome, Firefox, Edge and IE11 using high zoom, narrow viewports, a screen reader an no-JS.

## Screenshots
### Post learning assessment link with wide viewport
![postlearningassessment_link](https://user-images.githubusercontent.com/3650110/102489571-8f00c900-4065-11eb-80a1-ffdca7a921a2.png)

### Post learning assessment link with narrow viewport
![postlearningassessment_link_320px](https://user-images.githubusercontent.com/3650110/102489569-8f00c900-4065-11eb-9449-da88941897cb.png)

### Post learning assessment link with wide viewport and 5x zoom
![postlearningassessment_link_5x_zoom](https://user-images.githubusercontent.com/3650110/102489570-8f00c900-4065-11eb-853f-8757d88766c8.png)

### Next section link
![nextsection_link](https://user-images.githubusercontent.com/3650110/102489567-8e683280-4065-11eb-94a0-8ede57f99bba.png)

### Next tutorial link
![nexttutorial_link](https://user-images.githubusercontent.com/3650110/102489568-8e683280-4065-11eb-9985-28967d840cc4.png)

### Finish link
![finish_link](https://user-images.githubusercontent.com/3650110/102489565-8dcf9c00-4065-11eb-90ce-3266e05d03c9.png)