### PR TITLE
HEEDLS-251 Improve completion summary link front end

### DIFF
--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -91,7 +91,7 @@
                          Sections.SectionNumber,
                          Progress.CandidateID,
                          Sections.AverageSectionMins
-                  ORDER BY Sections.SectionNumber;",
+                  ORDER BY Sections.SectionNumber, Sections.SectionID;",
                 (course, section) =>
                 {
                     courseContent ??= course;

--- a/DigitalLearningSolutions.Web.Tests/Helpers/CompletionSummaryHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/CompletionSummaryHelperTests.cs
@@ -1,0 +1,197 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
+{
+    using System;
+    using DigitalLearningSolutions.Web.Helpers;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    class CompletionSummaryHelperTests
+    {
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_complete_course()
+        {
+            // Given
+            DateTime? completedDate = DateTime.Parse("2020-12-25T15:00:00Z");
+            const int maxAssessments = 1;
+            const bool isAssessed = true;
+            const int postLearningThreshold = 75;
+            const int diagnosticThreshold = 80;
+            const int tutorialThreshold = 85;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be("You completed this course on 25 December 2020.");
+        }
+
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_assessed_course_without_threshold()
+        {
+            // Given
+            DateTime? completedDate = null;
+            const int maxAssessments = 0;
+            const bool isAssessed = true;
+            const int postLearningThreshold = 75;
+            const int diagnosticThreshold = 80;
+            const int tutorialThreshold = 85;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be($"To complete this course, you must pass all post learning assessments with a score " +
+                                $"of {postLearningThreshold}% or higher.");
+        }
+
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_assessed_course_with_threshold()
+        {
+            // Given
+            DateTime? completedDate = null;
+            const int maxAssessments = 3;
+            const bool isAssessed = true;
+            const int postLearningThreshold = 75;
+            const int diagnosticThreshold = 80;
+            const int tutorialThreshold = 85;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be(
+                $"To complete this course, you must pass all post learning assessments with a score of " +
+                $"{postLearningThreshold}% or higher. Failing an assessment " +
+                $"{maxAssessments} times will lock your progress.");
+        }
+
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_non_assessed_course_with_tutorial_and_post_learning_thresholds()
+        {
+            // Given
+            DateTime? completedDate = null;
+            const int maxAssessments = 3;
+            const bool isAssessed = false;
+            const int postLearningThreshold = 75;
+            const int diagnosticThreshold = 80;
+            const int tutorialThreshold = 85;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be(
+                $"To complete this course, you must achieve {diagnosticThreshold}% " +
+                $"in the diagnostic assessment and complete {tutorialThreshold}% of the learning " +
+                $"material.");
+        }
+
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_non_assessed_course_with_diagnostic_threshold()
+        {
+            // Given
+            DateTime? completedDate = null;
+            const int maxAssessments = 3;
+            const bool isAssessed = false;
+            const int postLearningThreshold = 75;
+            const int diagnosticThreshold = 80;
+            const int tutorialThreshold = 0;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be(
+                $"To complete this course, you must achieve {diagnosticThreshold}% in the diagnostic assessment."
+            );
+        }
+
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_non_assessed_course_with_tutorial_threshold()
+        {
+            // Given
+            DateTime? completedDate = null;
+            const int maxAssessments = 3;
+            const bool isAssessed = false;
+            const int postLearningThreshold = 75;
+            const int diagnosticThreshold = 0;
+            const int tutorialThreshold = 85;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be(
+                $"To complete this course, you must complete {tutorialThreshold}% of the learning " +
+                $"material."
+            );
+        }
+
+        [Test]
+        public void GetCompletionSummary_should_return_summary_of_course_with_no_requirements()
+        {
+            // Given
+            DateTime? completedDate = null;
+            const int maxAssessments = 3;
+            const bool isAssessed = false;
+            const int postLearningThreshold = 0;
+            const int diagnosticThreshold = 0;
+            const int tutorialThreshold = 0;
+
+            // When
+            var summary = CompletionSummaryHelper.GetCompletionSummary(
+                completedDate,
+                maxAssessments,
+                isAssessed,
+                postLearningThreshold,
+                diagnosticThreshold,
+                tutorialThreshold
+            );
+
+            // Then
+            summary.Should().Be("There are no requirements to complete this course.");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -221,5 +221,46 @@
             // Then
             initialMenuViewModel.CompletionStyling.Should().Be("incomplete");
         }
+
+        [TestCase("2020-12-25T15:00:00Z", 1, true, 75, 80, 85,
+            "You completed this course on 25 December 2020.")]
+        [TestCase(null, 0, true, 75, 80, 85,
+            "To complete this course, you must pass all post learning assessments with a score of 75% or higher.")]
+        [TestCase(null, 3, true, 75, 80, 85,
+            "To complete this course, you must pass all post learning assessments with a score of 75% or higher. Failing an assessment 3 times will lock your progress.")]
+        [TestCase(null, 3, false, 75, 80, 85,
+            "To complete this course, you must achieve 80% in the diagnostic assessment and complete 85% of the learning material.")]
+        [TestCase(null, 3, false, 75, 80, 0,
+            "To complete this course, you must achieve 80% in the diagnostic assessment.")]
+        [TestCase(null, 3, false, 75, 0, 85,
+            "To complete this course, you must complete 85% of the learning material.")]
+        [TestCase(null, 3, false, 75, 0, 0,
+            "There are no requirements to complete this course.")]
+        public void TutorialVideo_should_parse_path(
+            string? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold,
+            string expectedSummary
+        )
+        {
+            // Given
+            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
+                completed: completed != null ? DateTime.Parse(completed) : (DateTime?) null,
+                maxPostLearningAssessmentAttempts: maxPostLearningAssessmentAttempts,
+                isAssessed: isAssessed,
+                postLearningAssessmentPassThreshold: postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold: diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold: tutorialsCompletionThreshold
+            );
+
+            // When
+            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
+
+            // Then
+            initialMenuViewModel.CompletionSummary.Should().Be(expectedSummary);
+        }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -222,20 +222,69 @@
             initialMenuViewModel.CompletionStyling.Should().Be("incomplete");
         }
 
-        [TestCase("2020-12-25T15:00:00Z", 1, true, 75, 80, 85,
-            "You completed this course on 25 December 2020.")]
-        [TestCase(null, 0, true, 75, 80, 85,
-            "To complete this course, you must pass all post learning assessments with a score of 75% or higher.")]
-        [TestCase(null, 3, true, 75, 80, 85,
-            "To complete this course, you must pass all post learning assessments with a score of 75% or higher. Failing an assessment 3 times will lock your progress.")]
-        [TestCase(null, 3, false, 75, 80, 85,
-            "To complete this course, you must achieve 80% in the diagnostic assessment and complete 85% of the learning material.")]
-        [TestCase(null, 3, false, 75, 80, 0,
-            "To complete this course, you must achieve 80% in the diagnostic assessment.")]
-        [TestCase(null, 3, false, 75, 0, 85,
-            "To complete this course, you must complete 85% of the learning material.")]
-        [TestCase(null, 3, false, 75, 0, 0,
-            "There are no requirements to complete this course.")]
+        [TestCase(
+            "2020-12-25T15:00:00Z",
+            1,
+            true,
+            75,
+            80,
+            85,
+            "You completed this course on 25 December 2020."
+        )]
+        [TestCase(
+            null,
+            0,
+            true,
+            75,
+            80,
+            85,
+            "To complete this course, you must pass all post learning assessments with a score of 75% or higher."
+        )]
+        [TestCase(
+            null,
+            3,
+            true,
+            75,
+            80,
+            85,
+            "To complete this course, you must pass all post learning assessments with a score of 75% or higher. Failing an assessment 3 times will lock your progress."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            80,
+            85,
+            "To complete this course, you must achieve 80% in the diagnostic assessment and complete 85% of the learning material."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            80,
+            0,
+            "To complete this course, you must achieve 80% in the diagnostic assessment."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            0,
+            85,
+            "To complete this course, you must complete 85% of the learning material."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            0,
+            0,
+            "There are no requirements to complete this course."
+        )]
         public void TutorialVideo_should_parse_path(
             string? completed,
             int maxPostLearningAssessmentAttempts,

--- a/DigitalLearningSolutions.Web/Helpers/CompletionSummaryHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompletionSummaryHelper.cs
@@ -20,15 +20,12 @@
 
             if (isAssessed)
             {
-                if (maxPostLearningAssessmentAttempts == 0)
-                {
-                    return $"To complete this course, you must pass all post learning assessments with a score of " +
-                           $"{postLearningAssessmentPassThreshold}% or higher.";
-                }
-
-                return $"To complete this course, you must pass all post learning assessments with a score of " +
-                       $"{postLearningAssessmentPassThreshold}% or higher. Failing an assessment " +
-                       $"{maxPostLearningAssessmentAttempts} times will lock your progress.";
+                return maxPostLearningAssessmentAttempts == 0
+                    ? $"To complete this course, you must pass all post learning assessments with a score of " +
+                      $"{postLearningAssessmentPassThreshold}% or higher."
+                    : $"To complete this course, you must pass all post learning assessments with a score of " +
+                      $"{postLearningAssessmentPassThreshold}% or higher. Failing an assessment " +
+                      $"{maxPostLearningAssessmentAttempts} times will lock your progress.";
             }
 
             if (diagnosticAssessmentCompletionThreshold > 0 && tutorialsCompletionThreshold > 0)
@@ -50,7 +47,6 @@
                        $"the diagnostic assessment.";
             }
 
-            // There are no requirements to complete the course
             return "There are no requirements to complete this course.";
         }
     }

--- a/DigitalLearningSolutions.Web/Helpers/CompletionSummaryHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompletionSummaryHelper.cs
@@ -1,0 +1,57 @@
+﻿namespace DigitalLearningSolutions.Web.Helpers
+{
+    using System;
+
+    public static class CompletionSummaryHelper
+    {
+        public static string GetCompletionSummary(
+            DateTime? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold
+        )
+        {
+            if (completed != null)
+            {
+                return $"You completed this course on {completed:dd MMMM yyyy}.";
+            }
+
+            if (isAssessed)
+            {
+                if (maxPostLearningAssessmentAttempts == 0)
+                {
+                    return $"To complete this course, you must pass all post learning assessments with a score of " +
+                           $"{postLearningAssessmentPassThreshold}% or higher.";
+                }
+
+                return $"To complete this course, you must pass all post learning assessments with a score of " +
+                       $"{postLearningAssessmentPassThreshold}% or higher. Failing an assessment " +
+                       $"{maxPostLearningAssessmentAttempts} times will lock your progress.";
+            }
+
+            if (diagnosticAssessmentCompletionThreshold > 0 && tutorialsCompletionThreshold > 0)
+            {
+                return $"To complete this course, you must achieve {diagnosticAssessmentCompletionThreshold}% " +
+                       $"in the diagnostic assessment and complete {tutorialsCompletionThreshold}% of the learning " +
+                       $"material.";
+            }
+
+            if (tutorialsCompletionThreshold > 0)
+            {
+                return $"To complete this course, you must complete {tutorialsCompletionThreshold}% of the learning " +
+                       $"material.";
+            }
+
+            if (diagnosticAssessmentCompletionThreshold > 0)
+            {
+                return $"To complete this course, you must achieve {diagnosticAssessmentCompletionThreshold}% in " +
+                       $"the diagnostic assessment.";
+            }
+
+            // There are no requirements to complete the course
+            return "There are no requirements to complete this course.";
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -1,13 +1,32 @@
 ﻿@import "~nhsuk-frontend/packages/core/all";
+@import "~nhsuk-frontend/packages/components/tag/_tag";
 
 .learning-menu-card {
   border: none;
 }
 
-.incomplete {
-  border-left: 6px solid $color_nhsuk-red;
+.completion-card-heading {
+  @extend .nhsuk-u-margin-bottom-3;
+
+  // Add padding to match border and padding of status tag
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
-.complete {
-  border-left: 6px solid $color_nhsuk-green;
+.status-tag {
+  @extend .nhsuk-tag;
+  @extend .nhsuk-u-font-size-24;
+  @extend .nhsuk-u-margin-bottom-3;
+
+  &.incomplete {
+    @extend .nhsuk-tag--orange;
+  }
+
+  &.complete {
+    @extend .nhsuk-tag--green;
+  }
+}
+
+hr.thick {
+  border-bottom-width: 6pt;
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.CourseContent;
+    using DigitalLearningSolutions.Web.Helpers;
 
     public class InitialMenuViewModel
     {
@@ -16,6 +17,7 @@
         public IEnumerable<SectionCardViewModel> Sections { get; }
         public string CompletionStatus { get; }
         public string CompletionStyling { get; }
+        public string CompletionSummary { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
         {
@@ -28,6 +30,14 @@
             Sections = courseContent.Sections.Select(section => new SectionCardViewModel(section, Id));
             CompletionStatus = courseContent.Completed == null ? "Incomplete" : "Complete";
             CompletionStyling = courseContent.Completed == null ? "incomplete" : "complete";
+            CompletionSummary = CompletionSummaryHelper.GetCompletionSummary(
+                courseContent.Completed,
+                courseContent.MaxPostLearningAssessmentAttempts,
+                courseContent.IsAssessed,
+                courseContent.PostLearningAssessmentPassThreshold,
+                courseContent.DiagnosticAssessmentCompletionThreshold,
+                courseContent.TutorialsCompletionThreshold
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -41,17 +41,28 @@
   }
 </div>
 
-@if (Model.ShouldShowCompletionSummary) {
-  <div class="nhsuk-card learning-menu-card @Model.CompletionStyling">
+@if (Model.ShouldShowCompletionSummary)
+{
+  <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible thick">
+
+  <div class="nhsuk-card nhsuk-card--clickable learning-menu-card">
     <div class="nhsuk-card__content">
-      <h2 class="nhsuk-card__heading nhsuk-heading-m">
-        Course Completion Status: @Model.CompletionStatus
-      </h2>
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-three-quarters">
+          <h2 class="nhsuk-card__heading nhsuk-heading-m completion-card-heading">
+            <a class="nhsuk-card__link" href="#">Course Completion Summary</a>
+          </h2>
+        </div>
+        <div class="nhsuk-grid-column-one-quarter">
+          <strong class="status-tag @Model.CompletionStyling">
+            @Model.CompletionStatus
+          </strong>
+        </div>
+      </div>
+
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
-          <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
-            Show Summary
-          </a>
+          <p class="nhsuk-u-secondary-text-color nhsuk-u-margin-0">@Model.CompletionSummary</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes
- Add section tie break to ordering of initial menu
- Add completion summary text
- Add breakline to InitialMenu page between Section cards and course
completion status card
- Add completion requirements dummy text to CompletionCard
- Add status tag on the right of the card
- Convert summary card to a clickable card

## Testing
Added unit tests for summary text maker, and for changes to the view model. There is no easy way to test the sorting of sections because no two sections in a section course share a section number, but the change for that is so small I am quite confident it is right.

Tested UI in Chrome, Firefox, Edge and IE11, using no JS, high zoom, narrow viewports and a screenreader.

## Screenshots
### Incomplete course, wide viewport
![incomplete_course](https://user-images.githubusercontent.com/3650110/102629485-2425bf80-4143-11eb-8328-2b7f29cf2821.png)
### Incomplete course, narrow viewport
![completion_card_narrow_viewport](https://user-images.githubusercontent.com/3650110/102629484-238d2900-4143-11eb-8919-37f07237b798.png)
### Complete course, wide viewport
![complete_course](https://user-images.githubusercontent.com/3650110/102629480-22f49280-4143-11eb-97ab-5654fcd8d54d.png)

