### PR TITLE
HEEDLS-242 Assessment page diagnostic back end

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/DiagnosticAssessmentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/DiagnosticAssessmentTestHelper.cs
@@ -1,0 +1,31 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
+{
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Linq;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
+    using DigitalLearningSolutions.Data.Models.TutorialContent;
+    using Microsoft.Data.SqlClient;
+
+    public class DiagnosticAssessmentTestHelper
+    {
+        private SqlConnection connection;
+
+        public DiagnosticAssessmentTestHelper(SqlConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public IEnumerable<OldTutorial> TutorialsFromOldStoredProcedure(int progressId, int sectionId)
+        {
+            return connection.Query<OldTutorial>("uspReturnProgressDetail_V3", new { progressId, sectionId }, commandType: CommandType.StoredProcedure);
+        }
+
+        public IEnumerable<OldScores> ScoresFromOldStoredProcedure(int progressId, int sectionId)
+        {
+            return connection.Query<OldScores>("uspReturnSectionsForCandCust_V2", new { progressId }, commandType: CommandType.StoredProcedure)
+                .Where(section => section.SectionId == sectionId);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
@@ -1,0 +1,95 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.Helpers;
+    using FakeItEasy;
+    using FluentAssertions;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+
+    internal class DiagnosticAssessmentServiceTests
+    {
+        private DiagnosticAssessmentService diagnosticAssessmentService;
+
+        [SetUp]
+        public void Setup()
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            var logger = A.Fake<ILogger<SectionContentService>>();
+            diagnosticAssessmentService = new DiagnosticAssessmentService(connection, logger);
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_should_return_diagnostic_assessment()
+        {
+            // Given
+            const int customisationId = 9684;
+            const int candidateId = 22044;
+            const int sectionId = 135;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            var expectedDiagnosticAssessment = new DiagnosticAssessment(
+                "Level 2 - Microsoft Outlook 2010",
+                "Pre- Reg Pharmacists Diagnostics",
+                "Introducing Outlook",
+                1,
+                41,
+                44,
+                "https://www.dls.nhs.uk/tracking/MOST/Outlook10Core/Assess/L2_Outlook_2010_Diag_1.dcr",
+                false
+            );
+            expectedDiagnosticAssessment.Tutorials.AddRange(
+                new[]
+                {
+                    new DiagnosticTutorial("Explore the Outlook modules", 535),
+                    new DiagnosticTutorial("Use the Navigation Pane", 536),
+                    new DiagnosticTutorial("Use the To-Do Bar", 537),
+                    new DiagnosticTutorial("Create an email", 538),
+                    new DiagnosticTutorial("View and read emails", 539),
+                    new DiagnosticTutorial("Respond to emails", 540),
+                    new DiagnosticTutorial("Categorise items", 541),
+                    new DiagnosticTutorial("Flag an email", 542)
+        }
+            );
+            result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_should_return_diagnostic_assessment_if_not_enrolled()
+        {
+            // Given
+            const int customisationId = 18438;
+            const int candidateId = 83744;
+            const int sectionId = 993;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            var expectedDiagnosticAssessment = new DiagnosticAssessment(
+                "5 Jan Test",
+                "New",
+                "Working with Microsoft Office applications",
+                0,
+                0,
+                13,
+                "https://www.dls.nhs.uk/CMS/CMSContent/Course120/Diagnostic/01-Diag-Working-with-Microsoft-Office-applications/itspplayer.html",
+                true
+            );
+            expectedDiagnosticAssessment.Tutorials.AddRange(
+                new[]
+                {
+                    new DiagnosticTutorial("Introduction to applications", 4340),
+                    new DiagnosticTutorial("Common screen elements", 4341),
+                    new DiagnosticTutorial("Using ribbon tabs", 4342),
+                    new DiagnosticTutorial("Getting help", 4343)
+                }
+            );
+            result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
@@ -24,36 +24,34 @@
         public void Get_diagnostic_assessment_should_return_diagnostic_assessment()
         {
             // Given
-            const int customisationId = 9684;
-            const int candidateId = 22044;
-            const int sectionId = 135;
+            const int customisationId = 5148;
+            const int candidateId = 95318;
+            const int sectionId = 115;
 
             // When
             var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
 
             // Then
             var expectedDiagnosticAssessment = new DiagnosticAssessment(
-                "Level 2 - Microsoft Outlook 2010",
-                "Pre- Reg Pharmacists Diagnostics",
-                "Introducing Outlook",
-                1,
-                41,
-                44,
-                "https://www.dls.nhs.uk/tracking/MOST/Outlook10Core/Assess/L2_Outlook_2010_Diag_1.dcr",
-                false
+                "Level 2 - Microsoft Excel 2010",
+                "Using Formulas",
+                "Using formulas",
+                4,
+                7,
+                10,
+                "https://www.dls.nhs.uk/tracking/MOST/Excel10Core/Assess/L2_Excel_2010_Diag_4.dcr",
+                true
             );
             expectedDiagnosticAssessment.Tutorials.AddRange(
                 new[]
                 {
-                    new DiagnosticTutorial("Explore the Outlook modules", 535),
-                    new DiagnosticTutorial("Use the Navigation Pane", 536),
-                    new DiagnosticTutorial("Use the To-Do Bar", 537),
-                    new DiagnosticTutorial("Create an email", 538),
-                    new DiagnosticTutorial("View and read emails", 539),
-                    new DiagnosticTutorial("Respond to emails", 540),
-                    new DiagnosticTutorial("Categorise items", 541),
-                    new DiagnosticTutorial("Flag an email", 542)
-        }
+                    new DiagnosticTutorial("Create and edit simple formulas", 383, true),
+                    new DiagnosticTutorial("Understand and enforce simple precedence in formulas", 384, true),
+                    new DiagnosticTutorial("Nest parentheses in formulas", 385, true),
+                    new DiagnosticTutorial("Use relative and absolute cell references", 386, true),
+                    new DiagnosticTutorial("Refer to other worksheets", 387, true),
+                    new DiagnosticTutorial("Link other workbooks", 388, true)
+                }
             );
             result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
         }
@@ -83,13 +81,111 @@
             expectedDiagnosticAssessment.Tutorials.AddRange(
                 new[]
                 {
-                    new DiagnosticTutorial("Introduction to applications", 4340),
-                    new DiagnosticTutorial("Common screen elements", 4341),
-                    new DiagnosticTutorial("Using ribbon tabs", 4342),
-                    new DiagnosticTutorial("Getting help", 4343)
+                    new DiagnosticTutorial("Introduction to applications", 4340, true),
+                    new DiagnosticTutorial("Common screen elements", 4341, true),
+                    new DiagnosticTutorial("Using ribbon tabs", 4342, true),
+                    new DiagnosticTutorial("Getting help", 4343, true)
                 }
             );
             result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_returns_assessment_if_only_is_assessed_is_true()
+        {
+            // Given
+            const int customisationId = 2684;
+            const int candidateId = 196;
+            const int sectionId = 74;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            var expectedDiagnosticAssessment = new DiagnosticAssessment(
+                "Level 2 - Microsoft Word 2007",
+                "Styles and Working with References",
+                "Working with documents",
+                0,
+                0,
+                18,
+                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/Assess/L2_Word_2007_Diag_1.dcr",
+                true
+            );
+            result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_can_return_no_tutorials()
+        {
+            // Given
+            const int customisationId = 9850;
+            const int candidateId = 254480;
+            const int sectionId = 170;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Tutorials.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_should_return_null_if_customisation_id_is_invalid()
+        {
+            // Given
+            const int customisationId = 0;
+            const int candidateId = 254480;
+            const int sectionId = 994;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_should_return_null_if_section_id_is_invalid()
+        {
+            // Given
+            const int customisationId = 18438;
+            const int candidateId = 254480;
+            const int sectionId = 0;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_should_return_null_if_archived_date_is_null()
+        {
+            // When
+            const int customisationId = 14212;
+            const int candidateId = 23031;
+            const int sectionId = 261;
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_diagnostic_assessment_should_return_null_if_diag_status_and_status_and_is_assessed_are_false()
+        {
+            // Given
+            const int customisationId = 1530;
+            const int candidateId = 23573;
+            const int sectionId = 74;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Should().BeNull();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
@@ -16,7 +16,7 @@
         public void Setup()
         {
             var connection = ServiceTestHelper.GetDatabaseConnection();
-            var logger = A.Fake<ILogger<SectionContentService>>();
+            var logger = A.Fake<ILogger<DiagnosticAssessmentService>>();
             diagnosticAssessmentService = new DiagnosticAssessmentService(connection, logger);
         }
 

--- a/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
+    using System.Linq;
+    using System.Transactions;
     using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
@@ -11,6 +13,7 @@
     internal class DiagnosticAssessmentServiceTests
     {
         private DiagnosticAssessmentService diagnosticAssessmentService;
+        private DiagnosticAssessmentTestHelper diagnosticAssessmentTestHelper;
 
         [SetUp]
         public void Setup()
@@ -18,6 +21,7 @@
             var connection = ServiceTestHelper.GetDatabaseConnection();
             var logger = A.Fake<ILogger<DiagnosticAssessmentService>>();
             diagnosticAssessmentService = new DiagnosticAssessmentService(connection, logger);
+            diagnosticAssessmentTestHelper = new DiagnosticAssessmentTestHelper(connection);
         }
 
         [Test]
@@ -186,6 +190,70 @@
 
             // Then
             result.Should().BeNull();
+        }
+
+        [TestCase(70093, 3452, 110, 38227)]
+        [TestCase(84238, 6062, 105, 55672)]
+        [TestCase(83361, 5263, 161, 98818)]
+        [TestCase(173505, 11347, 178, 156377)]
+        [TestCase(121301, 5903, 169, 180362)]
+        [TestCase(181938, 5263, 153, 198839)]
+        [TestCase(269044, 10059, 212, 237170)]
+        public void Get_diagnostic_assessment_should_have_same_tutorials_as_stored_procedure(
+            int candidateId,
+            int customisationId,
+            int sectionId,
+            int progressId
+        )
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                var tutorialIdsReturnedFromOldStoredProcedure = diagnosticAssessmentTestHelper
+                    .TutorialsFromOldStoredProcedure(progressId, sectionId)
+                    .Select(tutorial => tutorial.TutorialId);
+
+                // When
+                var sectionIdsInCourseContent = diagnosticAssessmentService
+                    .GetDiagnosticAssessment(customisationId, candidateId, sectionId)?
+                    .Tutorials
+                    .Select(section => section.Id);
+
+                // Then
+                sectionIdsInCourseContent.Should().Equal(tutorialIdsReturnedFromOldStoredProcedure);
+            }
+        }
+
+        [TestCase(70093, 3452, 110, 38227)]
+        [TestCase(84238, 6062, 105, 55672)]
+        [TestCase(83361, 5263, 161, 98818)]
+        [TestCase(173505, 11347, 178, 156377)]
+        [TestCase(121301, 5903, 169, 180362)]
+        [TestCase(181938, 5263, 153, 198839)]
+        [TestCase(269044, 10059, 212, 237170)]
+        public void Get_diagnostic_assessment_should_have_same_scores_as_stored_procedure(
+            int candidateId,
+            int customisationId,
+            int sectionId,
+            int progressId
+        )
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                var scoresReturnedFromOldStoredProcedure = diagnosticAssessmentTestHelper
+                    .ScoresFromOldStoredProcedure(progressId, sectionId)
+                    .FirstOrDefault();
+
+                // When
+                var sectionInCourseContent = diagnosticAssessmentService
+                    .GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+                // Then
+                sectionInCourseContent.SectionScore.Should().Be(scoresReturnedFromOldStoredProcedure.SecScore);
+                sectionInCourseContent.MaxSectionScore.Should().Be(scoresReturnedFromOldStoredProcedure.SecOutOf);
+                sectionInCourseContent.DiagnosticAttempts.Should().Be(scoresReturnedFromOldStoredProcedure.DiagAttempts);
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticAssessment.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Data.Models.DiagnosticAssessment
+{
+    using System.Collections.Generic;
+
+    public class DiagnosticAssessment
+    {
+        public string CourseTitle { get; }
+        public string SectionName { get; }
+        public int DiagnosticAttempts { get; set; }
+        public int SectionScore { get; set; }
+        public int MaxSectionScore { get; set; }
+        public string DiagnosticAssessmentPath { get; }
+        public bool SelectTutorials { get; }
+        public List<DiagnosticTutorial> Tutorials { get; } = new List<DiagnosticTutorial>();
+
+        public DiagnosticAssessment(
+            string applicationName,
+            string customisationName,
+            string sectionName,
+            int diagAttempts,
+            int diagLast,
+            int diagAssessOutOf,
+            string diagAssessPath,
+            bool diagObjSelect
+        )
+        {
+            CourseTitle = $"{applicationName} - {customisationName}";
+            SectionName = sectionName;
+            DiagnosticAttempts = diagAttempts;
+            SectionScore = diagLast;
+            MaxSectionScore = diagAssessOutOf;
+            DiagnosticAssessmentPath = diagAssessPath;
+            SelectTutorials = diagObjSelect;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticAssessment.cs
@@ -10,7 +10,7 @@
         public int SectionScore { get; set; }
         public int MaxSectionScore { get; set; }
         public string DiagnosticAssessmentPath { get; }
-        public bool SelectTutorials { get; }
+        public bool CanSelectTutorials { get; }
         public List<DiagnosticTutorial> Tutorials { get; } = new List<DiagnosticTutorial>();
 
         public DiagnosticAssessment(
@@ -30,7 +30,7 @@
             SectionScore = diagLast;
             MaxSectionScore = diagAssessOutOf;
             DiagnosticAssessmentPath = diagAssessPath;
-            SelectTutorials = diagObjSelect;
+            CanSelectTutorials = diagObjSelect;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticTutorial.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticTutorial.cs
@@ -1,0 +1,14 @@
+﻿namespace DigitalLearningSolutions.Data.Models.DiagnosticAssessment
+{
+    public class DiagnosticTutorial
+    {
+        public string TutorialName { get; }
+        public int Id { get; }
+
+        public DiagnosticTutorial(string tutorialName, int id)
+        {
+            TutorialName = tutorialName;
+            Id = id;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticTutorial.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticTutorial.cs
@@ -4,11 +4,13 @@
     {
         public string TutorialName { get; }
         public int Id { get; }
+        public bool IsDisplayed { get; }
 
-        public DiagnosticTutorial(string tutorialName, int id)
+        public DiagnosticTutorial(string tutorialName, int id, bool status)
         {
             TutorialName = tutorialName;
             Id = id;
+            IsDisplayed = status;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/OldScores.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/OldScores.cs
@@ -1,0 +1,10 @@
+﻿namespace DigitalLearningSolutions.Data.Models.DiagnosticAssessment
+{
+    public class OldScores
+    {
+        public int SectionId { get; set; }
+        public int SecScore { get; set; }
+        public int SecOutOf { get; set; }
+        public int DiagAttempts { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/OldTutorial.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/OldTutorial.cs
@@ -1,0 +1,7 @@
+﻿namespace DigitalLearningSolutions.Data.Models.DiagnosticAssessment
+{
+    public class OldTutorial
+    {
+        public int TutorialId { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentService.cs
@@ -15,9 +15,9 @@
     public class DiagnosticAssessmentService : IDiagnosticAssessmentService
     {
         private readonly IDbConnection connection;
-        private readonly ILogger<SectionContentService> logger;
+        private readonly ILogger<DiagnosticAssessmentService> logger;
 
-        public DiagnosticAssessmentService(IDbConnection connection, ILogger<SectionContentService> logger)
+        public DiagnosticAssessmentService(IDbConnection connection, ILogger<DiagnosticAssessmentService> logger)
         {
             this.connection = connection;
             this.logger = logger;

--- a/DigitalLearningSolutions.Data/Services/SectionContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SectionContentService.cs
@@ -82,13 +82,12 @@
                         AND (Sections.ArchivedDate IS NULL)
                         AND (CustomisationTutorials.DiagStatus = 1 OR Customisations.IsAssessed = 1 OR CustomisationTutorials.Status = 1)
                     ORDER BY Tutorials.OrderByNumber, Tutorials.TutorialID",
-                    (section, tutorial) =>
+                (section, tutorial) =>
                 {
                     if (sectionContent == null)
                     {
                         sectionContent = section;
                     }
-
                     else
                     {
                         sectionContent.DiagnosticAttempts = Math.Max(sectionContent.DiagnosticAttempts, section.DiagnosticAttempts);

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/DiagnosticAssessmentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/DiagnosticAssessmentHelper.cs
@@ -1,0 +1,31 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.TestHelpers
+{
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
+
+    public static class DiagnosticAssessmentHelper
+    {
+        public static DiagnosticAssessment CreateDefaultDiagnosticAssessment(
+            string applicationName = "application name",
+            string customisationName = "customisation name",
+            string sectionName = "section name",
+            int diagAttempts = 1,
+            int diagLast = 2,
+            int diagAssessOutOf = 3,
+            string diagAssessPath = "https://www.dls.nhs.uk/tracking/MOST/Word10Core/Assess/L2_Word_2010_Diag_1.dcr",
+            bool diagObjSelect = true
+        )
+        {
+            return new DiagnosticAssessment(
+                applicationName,
+                customisationName,
+                sectionName,
+                diagAttempts,
+                diagLast,
+                diagAssessOutOf,
+                diagAssessPath,
+                diagObjSelect
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTest.cs
@@ -1,0 +1,190 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
+    using DigitalLearningSolutions.Web.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class DiagnosticAssessmentTest
+    {
+        private const int CustomisationId = 5;
+        private const int SectionId = 5;
+
+        [Test]
+        public void Diagnostic_assessment_should_have_title()
+        {
+            // Given
+            const string applicationName = "Application name";
+            const string customisationName = "Customisation name";
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                applicationName: applicationName,
+                customisationName: customisationName
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+        }
+
+        [Test]
+        public void Diagnostic_assessment_should_have_section_name()
+        {
+            // Given
+            const string sectionName = "Section name";
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                sectionName: sectionName
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.SectionName.Should().Be(sectionName);
+        }
+
+        [Test]
+        public void Diagnostic_assessment_should_have_path()
+        {
+            // Given
+            const string diagnosticAssessmentPath =
+                "https://www.dls.nhs.uk/tracking/MOST/Excel07Core/Assess/L2_Excel_2007_Diag_7.dcr";
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                diagAssessPath: diagnosticAssessmentPath
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.DiagnosticAssessmentPath.Should().Be(diagnosticAssessmentPath);
+        }
+
+        [Test]
+        public void Diagnostic_assessment_select_tutorials_can_be_true()
+        {
+            // Given
+            const bool selectTutorials = true;
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                diagObjSelect: selectTutorials
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.SelectTutorials.Should().BeTrue();
+        }
+
+        [Test]
+        public void Diagnostic_assessment_select_tutorials_can_be_false()
+        {
+            // Given
+            const bool selectTutorials = false;
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                diagObjSelect: selectTutorials
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.SelectTutorials.Should().BeFalse();
+        }
+
+        [Test]
+        public void Diagnostic_assessment_attempts_information_with_no_attempts_should_be_not_attempted()
+        {
+            // Given
+            const int diagnosticAttempts = 0;
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                diagAttempts: diagnosticAttempts
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.AttemptsInformation.Should().Be("Not attempted");
+        }
+
+        [Test]
+        public void Diagnostic_assessment_attempts_information_with_attempts_should_be_not_last_score()
+        {
+            // Given
+            const int diagnosticAttempts = 3;
+            const int sectionScore = 10;
+            const int maxSectionScore = 20;
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                diagAttempts: diagnosticAttempts,
+                diagLast: sectionScore,
+                diagAssessOutOf: maxSectionScore
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.AttemptsInformation.Should().Be("10/20 - 3 attempts");
+        }
+
+        [Test]
+        public void Diagnostic_assessment_should_have_customisation_id()
+        {
+            // Given
+            const int customisationId = 11;
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment();
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, customisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.CustomisationId.Should().Be(customisationId);
+        }
+
+        [Test]
+        public void Diagnostic_assessment_should_have_section_id()
+        {
+            // Given
+            const int sectionId = 22;
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment();
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, sectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.SectionId.Should().Be(sectionId);
+        }
+
+        [Test]
+        public void Diagnostic_assessment_should_have_tutorials()
+        {
+            // Given
+            var tutorials = new[]
+            {
+                new DiagnosticTutorial("Tutorial 1", 1),
+                new DiagnosticTutorial("Tutorial 2", 2)
+            };
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment();
+            diagnosticAssessment.Tutorials.AddRange(tutorials);
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.Tutorials.Should().BeEquivalentTo<DiagnosticTutorial>(tutorials);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
@@ -6,7 +6,7 @@
     using FluentAssertions;
     using NUnit.Framework;
 
-    public class DiagnosticAssessmentTest
+    public class DiagnosticAssessmentViewModelTests
     {
         private const int CustomisationId = 5;
         private const int SectionId = 5;
@@ -79,7 +79,7 @@
                 new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
 
             // Then
-            diagnosticAssessmentViewModel.SelectTutorials.Should().BeTrue();
+            diagnosticAssessmentViewModel.CanSelectTutorials.Should().BeTrue();
         }
 
         [Test]
@@ -96,7 +96,7 @@
                 new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
 
             // Then
-            diagnosticAssessmentViewModel.SelectTutorials.Should().BeFalse();
+            diagnosticAssessmentViewModel.CanSelectTutorials.Should().BeFalse();
         }
 
         [Test]
@@ -117,7 +117,7 @@
         }
 
         [Test]
-        public void Diagnostic_assessment_attempts_information_with_attempts_should_be_not_last_score()
+        public void Diagnostic_assessment_attempts_information_with_attempts_should_be_last_score()
         {
             // Given
             const int diagnosticAttempts = 3;
@@ -173,8 +173,8 @@
             // Given
             var tutorials = new[]
             {
-                new DiagnosticTutorial("Tutorial 1", 1),
-                new DiagnosticTutorial("Tutorial 2", 2)
+                new DiagnosticTutorial("Tutorial 1", 1, true),
+                new DiagnosticTutorial("Tutorial 2", 2, true)
             };
             var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment();
             diagnosticAssessment.Tutorials.AddRange(tutorials);

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -96,6 +96,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ISessionDataService, SessionDataService>();
             services.AddScoped<ISessionService, SessionService>();
             services.AddScoped<ISectionContentService, SectionContentService>();
+            services.AddScoped<IDiagnosticAssessmentService, DiagnosticAssessmentService>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
@@ -9,7 +9,7 @@
         public string CourseTitle { get; }
         public string SectionName { get; }
         public string DiagnosticAssessmentPath { get; }
-        public bool SelectTutorials { get; }
+        public bool CanSelectTutorials { get; }
         public string AttemptsInformation { get; }
         public int CustomisationId { get; }
         public int SectionId { get; }
@@ -20,10 +20,15 @@
             CourseTitle = diagnosticAssessment.CourseTitle;
             SectionName = diagnosticAssessment.SectionName;
             DiagnosticAssessmentPath = diagnosticAssessment.DiagnosticAssessmentPath;
-            SelectTutorials = diagnosticAssessment.SelectTutorials;
-            AttemptsInformation = diagnosticAssessment.DiagnosticAttempts == 0
-                ? "Not attempted"
-                : $"{diagnosticAssessment.SectionScore}/{diagnosticAssessment.MaxSectionScore} - {diagnosticAssessment.DiagnosticAttempts} attempts";
+            CanSelectTutorials = diagnosticAssessment.CanSelectTutorials;
+            AttemptsInformation = diagnosticAssessment.DiagnosticAttempts switch
+            {
+                0 => "Not attempted",
+                1 => $"{diagnosticAssessment.SectionScore}/{diagnosticAssessment.MaxSectionScore} " +
+                     $"- {diagnosticAssessment.DiagnosticAttempts} attempt",
+                _ => $"{diagnosticAssessment.SectionScore}/{diagnosticAssessment.MaxSectionScore} " +
+                     $"- {diagnosticAssessment.DiagnosticAttempts} attempts"
+            };
             CustomisationId = customisationId;
             SectionId = sectionId;
             Tutorials = diagnosticAssessment.Tutorials;

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
@@ -1,0 +1,32 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
+
+    public class DiagnosticAssessmentViewModel
+    {
+
+        public string CourseTitle { get; }
+        public string SectionName { get; }
+        public string DiagnosticAssessmentPath { get; }
+        public bool SelectTutorials { get; }
+        public string AttemptsInformation { get; }
+        public int CustomisationId { get; }
+        public int SectionId { get; }
+        public IEnumerable<DiagnosticTutorial> Tutorials { get; }
+
+        public DiagnosticAssessmentViewModel(DiagnosticAssessment diagnosticAssessment, int customisationId, int sectionId)
+        {
+            CourseTitle = diagnosticAssessment.CourseTitle;
+            SectionName = diagnosticAssessment.SectionName;
+            DiagnosticAssessmentPath = diagnosticAssessment.DiagnosticAssessmentPath;
+            SelectTutorials = diagnosticAssessment.SelectTutorials;
+            AttemptsInformation = diagnosticAssessment.DiagnosticAttempts == 0
+                ? "Not attempted"
+                : $"{diagnosticAssessment.SectionScore}/{diagnosticAssessment.MaxSectionScore} - {diagnosticAssessment.DiagnosticAttempts} attempts";
+            CustomisationId = customisationId;
+            SectionId = sectionId;
+            Tutorials = diagnosticAssessment.Tutorials;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -1,24 +1,25 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningMenu
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
+@model DiagnosticAssessmentViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
 
 @{
   ViewData["HeaderPrefix"] = "";
-  ViewData["Application"] = "CMS Demonstration Course - Vimetube test";
-  ViewData["Title"] = "CMS Demonstration Course - Vimetube test";
-  ViewData["CustomisationId"] = 18438;
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{18438}";
-  ViewData["HeaderPathName"] = "CMS Demonstration Course - Vimetube test";
+  ViewData["Application"] = Model.CourseTitle;
+  ViewData["Title"] = Model.CourseTitle;
+  ViewData["CustomisationId"] = Model.CustomisationId;
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.CustomisationId}";
+  ViewData["HeaderPathName"] = Model.CourseTitle;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading" class="nhsuk-heading-xl">Working with Microsoft Office applications</h1>
-    <h2 class="nhsuk-u-secondary-text-color">Not attempted</h2>
+    <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
+    <h2 class="nhsuk-u-secondary-text-color">@Model.AttemptsInformation</h2>
   </div>
 </div>
 
@@ -34,50 +35,36 @@
 
 <form class="nhsuk-form-group">
   <fieldset class="nhsuk-fieldset">
-    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-      Which areas do you want to assess?
-    </legend>
+    @if (Model.SelectTutorials)
+    {
+      <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+        Which areas do you want to assess?
+      </legend>
 
-    <div class="nhsuk-hint" id="contact-hint">
-      Select all areas that you want to test.
-    </div>
+      <div class="nhsuk-hint">
+        Select all areas that you want to test.
+      </div>
+      
+      <div class="nhsuk-u-margin-bottom-3">
+        @foreach (var tutorial in Model.Tutorials) {
+          <div class="nhsuk-checkboxes__item">
+            <input class="nhsuk-checkboxes__input" type="checkbox" checked="checked" id="@tutorial.Id" value="@tutorial.Id">
+            <label class="nhsuk-label nhsuk-checkboxes__label" for="@tutorial.Id">
+              @tutorial.TutorialName
+            </label>
+          </div>
+        }
+      </div>
+    }
 
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" type="checkbox" checked="checked" id="1" value="1">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="1">
-        Introduction to applications
-      </label>
-    </div>
-
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" type="checkbox" checked="checked" id="2" value="2">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="2">
-        Common screen elements
-      </label>
-    </div>
-
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" type="checkbox" checked="checked" id="3" value="3">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="3">
-        Using ribbon tabs
-      </label>
-    </div>
-
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" type="checkbox" checked="checked" id="4" value="4">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="4">
-        Getting help
-      </label>
-    </div>
-
-    <button class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-0" type="submit">
+    <button class="nhsuk-button nhsuk-u-margin-bottom-0" type="submit">
       Start assessment
     </button>
   </fieldset>
 </form>
 
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-action="Section" asp-controller="LearningMenu" asp-route-customisationId="18438" asp-route-sectionId="993">
+  <a class="nhsuk-back-link__link" asp-action="Section" asp-controller="LearningMenu" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
     </svg>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -35,7 +35,7 @@
 
 <form class="nhsuk-form-group">
   <fieldset class="nhsuk-fieldset">
-    @if (Model.SelectTutorials)
+    @if (Model.CanSelectTutorials)
     {
       <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
         Which areas do you want to assess?


### PR DESCRIPTION
Create query for diagnostic assessment information.

Create view model.

Replace hardcoded values in view.

Add logic to controller.

Add service, view model and controller tests.

Ran and passed all unit tests, manually tested on Firefox to check webpage was displaying correct information from backend.

Screenshot shows a page where the user does not have the option to select assessment areas.
![image](https://user-images.githubusercontent.com/36454654/102623537-8fb75f00-413a-11eb-9a41-0d460c1b5be7.png)
