### PR TITLE
HEEDLS-249 Remove times from section cards in initial menu

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -52,19 +52,19 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Viewing workbooks", 112, true, 12.5, 0, 28),
-                    new CourseSection("Manipulating worksheets", 113, true, 20, 2, 28),
-                    new CourseSection("Manipulating information", 114, true, 25, 5, 28),
-                    new CourseSection("Using formulas", 115, true, 100 / 3.0, 10, 28),
-                    new CourseSection("Using functions", 116, true, 400 / 7.0, 43, 28),
-                    new CourseSection("Managing formulas and functions", 117, true, 0, 0, 28),
-                    new CourseSection("Working with data", 118, true, 0, 0, 28),
-                    new CourseSection("Formatting cells and worksheets", 119, true, 0, 0, 28),
-                    new CourseSection("Formatting numbers", 120, true, 0, 0, 28),
-                    new CourseSection("Working with charts", 121, true, 0, 0, 28),
-                    new CourseSection("Working with illustrations", 122, true, 0, 0, 28),
-                    new CourseSection("Collaborating with others", 123, true, 0, 0, 28),
-                    new CourseSection("Preparing to print", 124, true, 0, 0, 28)
+                    new CourseSection("Viewing workbooks", 112, true, 12.5),
+                    new CourseSection("Manipulating worksheets", 113, true, 20),
+                    new CourseSection("Manipulating information", 114, true, 25),
+                    new CourseSection("Using formulas", 115, true, 100 / 3.0),
+                    new CourseSection("Using functions", 116, true, 400 / 7.0),
+                    new CourseSection("Managing formulas and functions", 117, true, 0),
+                    new CourseSection("Working with data", 118, true, 0),
+                    new CourseSection("Formatting cells and worksheets", 119, true, 0),
+                    new CourseSection("Formatting numbers", 120, true, 0),
+                    new CourseSection("Working with charts", 121, true, 0),
+                    new CourseSection("Working with illustrations", 122, true, 0),
+                    new CourseSection("Collaborating with others", 123, true, 0),
+                    new CourseSection("Preparing to print", 124, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -97,19 +97,19 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Viewing workbooks", 112, true, 0, 0, 28),
-                    new CourseSection("Manipulating worksheets", 113, true, 0, 0, 28),
-                    new CourseSection("Manipulating information", 114, true, 0, 0, 28),
-                    new CourseSection("Using formulas", 115, true, 0, 0, 28),
-                    new CourseSection("Using functions", 116, true, 0, 0, 28),
-                    new CourseSection("Managing formulas and functions", 117, true, 0, 0, 28),
-                    new CourseSection("Working with data", 118, true, 0, 0, 28),
-                    new CourseSection("Formatting cells and worksheets", 119, true, 0, 0, 28),
-                    new CourseSection("Formatting numbers", 120, true, 0, 0, 28),
-                    new CourseSection("Working with charts", 121, true, 0, 0, 28),
-                    new CourseSection("Working with illustrations", 122, true, 0, 0, 28),
-                    new CourseSection("Collaborating with others", 123, true, 0, 0, 28),
-                    new CourseSection("Preparing to print", 124, true, 0, 0, 28)
+                    new CourseSection("Viewing workbooks", 112, true, 0),
+                    new CourseSection("Manipulating worksheets", 113, true, 0),
+                    new CourseSection("Manipulating information", 114, true, 0),
+                    new CourseSection("Using formulas", 115, true, 0),
+                    new CourseSection("Using functions", 116, true, 0),
+                    new CourseSection("Managing formulas and functions", 117, true, 0),
+                    new CourseSection("Working with data", 118, true, 0),
+                    new CourseSection("Formatting cells and worksheets", 119, true, 0),
+                    new CourseSection("Formatting numbers", 120, true, 0),
+                    new CourseSection("Working with charts", 121, true, 0),
+                    new CourseSection("Working with illustrations", 122, true, 0),
+                    new CourseSection("Collaborating with others", 123, true, 0),
+                    new CourseSection("Preparing to print", 124, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -142,16 +142,16 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Working in PowerPoint", 125, false, 0, 0, 28),
-                    new CourseSection("Creating a presentation", 126, false, 0, 0, 28),
-                    new CourseSection("Formatting slides", 127, false, 0, 0, 28),
-                    new CourseSection("Working with text", 128, false, 0, 0, 28),
-                    new CourseSection("Working with graphics and multimedia", 129, true, 20.0, 4, 28),
-                    new CourseSection("Working with tables and charts", 130, false, 0, 0, 28),
-                    new CourseSection("Using animations and transitions", 131, false, 0, 0, 28),
-                    new CourseSection("Collaborating on presentations", 132, false, 0, 0, 28),
-                    new CourseSection("Preparing presentations", 133, false, 0, 0, 28),
-                    new CourseSection("Delivering presentations", 134, false, 0, 0, 28)
+                    new CourseSection("Working in PowerPoint", 125, false, 0),
+                    new CourseSection("Creating a presentation", 126, false, 0),
+                    new CourseSection("Formatting slides", 127, false, 0),
+                    new CourseSection("Working with text", 128, false, 0),
+                    new CourseSection("Working with graphics and multimedia", 129, true, 20.0),
+                    new CourseSection("Working with tables and charts", 130, false, 0),
+                    new CourseSection("Using animations and transitions", 131, false, 0),
+                    new CourseSection("Collaborating on presentations", 132, false, 0),
+                    new CourseSection("Preparing presentations", 133, false, 0),
+                    new CourseSection("Delivering presentations", 134, false, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -184,16 +184,16 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Working in PowerPoint", 125, false, 0, 0, 28),
-                    new CourseSection("Creating a presentation", 126, false, 0, 0, 28),
-                    new CourseSection("Formatting slides", 127, false, 0, 0, 28),
-                    new CourseSection("Working with text", 128, false, 0, 0, 28),
-                    new CourseSection("Working with graphics and multimedia", 129, true, 0, 0, 28),
-                    new CourseSection("Working with tables and charts", 130, false, 0, 0, 28),
-                    new CourseSection("Using animations and transitions", 131, false, 0, 0, 28),
-                    new CourseSection("Collaborating on presentations", 132, false, 0, 0, 28),
-                    new CourseSection("Preparing presentations", 133, false, 0, 0, 28),
-                    new CourseSection("Delivering presentations", 134, false, 0, 0, 28)
+                    new CourseSection("Working in PowerPoint", 125, false, 0),
+                    new CourseSection("Creating a presentation", 126, false, 0),
+                    new CourseSection("Formatting slides", 127, false, 0),
+                    new CourseSection("Working with text", 128, false, 0),
+                    new CourseSection("Working with graphics and multimedia", 129, true, 0),
+                    new CourseSection("Working with tables and charts", 130, false, 0),
+                    new CourseSection("Using animations and transitions", 131, false, 0),
+                    new CourseSection("Collaborating on presentations", 132, false, 0),
+                    new CourseSection("Preparing presentations", 133, false, 0),
+                    new CourseSection("Delivering presentations", 134, false, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -230,19 +230,19 @@
                 expectedCourse.Sections.AddRange(
                     new[]
                     {
-                        new CourseSection("Viewing workbooks", 112, true, 100.0, 17, 28),
-                        new CourseSection("Manipulating worksheets", 113, true, 100.0, 22, 28),
-                        new CourseSection("Manipulating information", 114, true, 100.0, 25, 28),
-                        new CourseSection("Using formulas", 115, true, 100.0, 37, 28),
-                        new CourseSection("Using functions", 116, true, 100.0, 98, 28),
-                        new CourseSection("Managing formulas and functions", 117, true, 100.0, 11, 28),
-                        new CourseSection("Working with data", 118, true, 100.0, 98, 28),
-                        new CourseSection("Formatting cells and worksheets", 119, true, 100.0, 39, 28),
-                        new CourseSection("Formatting numbers", 120, true, 100.0, 50, 28),
-                        new CourseSection("Working with charts", 121, true, 100.0, 51, 28),
-                        new CourseSection("Working with illustrations", 122, true, 100.0, 15, 28),
-                        new CourseSection("Collaborating with others", 123, true, 100.0, 53, 28),
-                        new CourseSection("Preparing to print", 124, true, 100.0, 22, 28)
+                        new CourseSection("Viewing workbooks", 112, true, 100.0),
+                        new CourseSection("Manipulating worksheets", 113, true, 100.0),
+                        new CourseSection("Manipulating information", 114, true, 100.0),
+                        new CourseSection("Using formulas", 115, true, 100.0),
+                        new CourseSection("Using functions", 116, true, 100.0),
+                        new CourseSection("Managing formulas and functions", 117, true, 100.0),
+                        new CourseSection("Working with data", 118, true, 100.0),
+                        new CourseSection("Formatting cells and worksheets", 119, true, 100.0),
+                        new CourseSection("Formatting numbers", 120, true, 100.0),
+                        new CourseSection("Working with charts", 121, true, 100.0),
+                        new CourseSection("Working with illustrations", 122, true, 100.0),
+                        new CourseSection("Collaborating with others", 123, true, 100.0),
+                        new CourseSection("Preparing to print", 124, true, 100.0)
                     }
                 );
                 result.Should().BeEquivalentTo(expectedCourse);
@@ -279,19 +279,19 @@
                 expectedCourse.Sections.AddRange(
                     new[]
                     {
-                        new CourseSection("Viewing workbooks", 112, true, 12.5, 0, 28),
-                        new CourseSection("Manipulating worksheets", 113, true, 20, 2, 28),
-                        new CourseSection("Manipulating information", 114, true, 25, 5, 28),
-                        new CourseSection("Using formulas", 115, true, 100 / 3.0, 10, 28),
-                        new CourseSection("Using functions", 116, true, 400 / 7.0, 43, 28),
-                        new CourseSection("Managing formulas and functions", 117, true, 0, 0, 28),
-                        new CourseSection("Working with data", 118, true, 0, 0, 28),
-                        new CourseSection("Formatting cells and worksheets", 119, true, 0, 0, 28),
-                        new CourseSection("Formatting numbers", 120, true, 0, 0, 28),
-                        new CourseSection("Working with charts", 121, true, 0, 0, 28),
-                        new CourseSection("Working with illustrations", 122, true, 0, 0, 28),
-                        new CourseSection("Collaborating with others", 123, true, 0, 0, 28),
-                        new CourseSection("Preparing to print", 124, true, 0, 0, 28)
+                        new CourseSection("Viewing workbooks", 112, true, 12.5),
+                        new CourseSection("Manipulating worksheets", 113, true, 20),
+                        new CourseSection("Manipulating information", 114, true, 25),
+                        new CourseSection("Using formulas", 115, true, 100 / 3.0),
+                        new CourseSection("Using functions", 116, true, 400 / 7.0),
+                        new CourseSection("Managing formulas and functions", 117, true, 0),
+                        new CourseSection("Working with data", 118, true, 0),
+                        new CourseSection("Formatting cells and worksheets", 119, true, 0),
+                        new CourseSection("Formatting numbers", 120, true, 0),
+                        new CourseSection("Working with charts", 121, true, 0),
+                        new CourseSection("Working with illustrations", 122, true, 0),
+                        new CourseSection("Collaborating with others", 123, true, 0),
+                        new CourseSection("Preparing to print", 124, true, 0)
                     }
                 );
                 result.Should().BeEquivalentTo(expectedCourse);
@@ -330,15 +330,15 @@
                 expectedCourse.Sections.AddRange(
                     new[]
                     {
-                        new CourseSection("Working with documents", 103, true, 0, 0, 28),
-                        new CourseSection("Formatting content", 104, true, 0, 0, 28),
-                        new CourseSection("Formatting documents", 105, true, 0, 0, 28),
-                        new CourseSection("Illustrations and graphics", 106, true, 0, 0, 28),
-                        new CourseSection("Using tables", 107, true, 0, 0, 28),
-                        new CourseSection("Working with references", 108, true, 0, 0, 28),
-                        new CourseSection("Proofing and working on documents with others", 109, true, 0, 0, 28),
-                        new CourseSection("Sharing documents", 110, true, 0, 0, 28),
-                        new CourseSection("Mass-mailing documents", 111, true, 0, 0, 28)
+                        new CourseSection("Working with documents", 103, true, 0),
+                        new CourseSection("Formatting content", 104, true, 0),
+                        new CourseSection("Formatting documents", 105, true, 0),
+                        new CourseSection("Illustrations and graphics", 106, true, 0),
+                        new CourseSection("Using tables", 107, true, 0),
+                        new CourseSection("Working with references", 108, true, 0),
+                        new CourseSection("Proofing and working on documents with others", 109, true, 0),
+                        new CourseSection("Sharing documents", 110, true, 0),
+                        new CourseSection("Mass-mailing documents", 111, true, 0)
                     }
                 );
                 result.Should().BeEquivalentTo(expectedCourse);
@@ -388,15 +388,15 @@
             expectedCourse.Sections.AddRange(
                 new[]
                 {
-                    new CourseSection("Working with documents", 103, true, 0, 0, 28),
-                    new CourseSection("Formatting content", 104, true, 0, 0, 28),
-                    new CourseSection("Formatting documents", 105, true, 0, 0, 28),
-                    new CourseSection("Illustrations and graphics", 106, true, 0, 0, 28),
-                    new CourseSection("Using tables", 107, true, 0, 0, 28),
-                    new CourseSection("Working with references", 108, true, 0, 0, 28),
-                    new CourseSection("Proofing and working on documents with others", 109, true, 0, 0, 28),
-                    new CourseSection("Sharing documents", 110, true, 0, 0, 28),
-                    new CourseSection("Mass-mailing documents", 111, true, 0, 0, 28)
+                    new CourseSection("Working with documents", 103, true, 0),
+                    new CourseSection("Formatting content", 104, true, 0),
+                    new CourseSection("Formatting documents", 105, true, 0),
+                    new CourseSection("Illustrations and graphics", 106, true, 0),
+                    new CourseSection("Using tables", 107, true, 0),
+                    new CourseSection("Working with references", 108, true, 0),
+                    new CourseSection("Proofing and working on documents with others", 109, true, 0),
+                    new CourseSection("Sharing documents", 110, true, 0),
+                    new CourseSection("Mass-mailing documents", 111, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedCourse);
@@ -434,19 +434,19 @@
                 expectedCourse.Sections.AddRange(
                     new[]
                     {
-                        new CourseSection("Viewing workbooks", 112, true, 0, 0, 28),
-                        new CourseSection("Manipulating worksheets", 113, true, 0, 0, 28),
-                        new CourseSection("Manipulating information", 114, true, 0, 0, 28),
-                        new CourseSection("Using formulas", 115, true, 0, 0, 28),
-                        new CourseSection("Using functions", 116, true, 0, 0, 28),
-                        new CourseSection("Managing formulas and functions", 117, true, 0, 0, 28),
-                        new CourseSection("Working with data", 118, true, 0, 0, 28),
-                        new CourseSection("Formatting cells and worksheets", 119, true, 0, 0, 28),
-                        new CourseSection("Formatting numbers", 120, true, 0, 0, 28),
-                        new CourseSection("Working with charts", 121, true, 0, 0, 28),
-                        new CourseSection("Working with illustrations", 122, true, 0, 0, 28),
-                        new CourseSection("Collaborating with others", 123, true, 0, 0, 28),
-                        new CourseSection("Preparing to print", 124, true, 0, 0, 28)
+                        new CourseSection("Viewing workbooks", 112, true, 0),
+                        new CourseSection("Manipulating worksheets", 113, true, 0),
+                        new CourseSection("Manipulating information", 114, true, 0),
+                        new CourseSection("Using formulas", 115, true, 0),
+                        new CourseSection("Using functions", 116, true, 0),
+                        new CourseSection("Managing formulas and functions", 117, true, 0),
+                        new CourseSection("Working with data", 118, true, 0),
+                        new CourseSection("Formatting cells and worksheets", 119, true, 0),
+                        new CourseSection("Formatting numbers", 120, true, 0),
+                        new CourseSection("Working with charts", 121, true, 0),
+                        new CourseSection("Working with illustrations", 122, true, 0),
+                        new CourseSection("Collaborating with others", 123, true, 0),
+                        new CourseSection("Preparing to print", 124, true, 0)
                     }
                 );
                 result.Should().BeEquivalentTo(expectedCourse);
@@ -484,7 +484,7 @@
                 expectedCourse.Sections.AddRange(
                     new[]
                     {
-                        new CourseSection("Dementia Awareness", 245, true, 0, 0, 28),
+                        new CourseSection("Dementia Awareness", 245, true, 0),
                     }
                 );
                 result.Should().BeEquivalentTo(expectedCourse);

--- a/DigitalLearningSolutions.Data/Models/CourseContent/CourseSection.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseContent/CourseSection.cs
@@ -6,24 +6,18 @@
         public int Id { get; }
         public bool HasLearning { get; }
         public double PercentComplete { get; }
-        public int TimeMins { get; }
-        public int AverageSectionTime { get; }
 
         public CourseSection(
             string sectionName,
             int id,
             bool hasLearning,
-            double percentComplete,
-            int timeMins,
-            int averageSectionTime
+            double percentComplete
         )
         {
             Title = sectionName;
             Id = id;
             HasLearning = hasLearning;
             PercentComplete = percentComplete;
-            TimeMins = timeMins;
-            AverageSectionTime = averageSectionTime;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -56,9 +56,7 @@
                                  OR dbo.CheckCustomisationSectionHasLearning(Customisations.CustomisationID, Sections.SectionID) = 0
                             THEN 0
                             ELSE CAST(SUM(aspProgress.TutStat) * 100 AS FLOAT) / (COUNT(Tutorials.TutorialID) * 2)
-                         END) AS PercentComplete,
-                         COALESCE(SUM(aspProgress.TutTime), 0) as TimeMins,
-                         Sections.AverageSectionMins as AverageSectionTime
+                         END) AS PercentComplete
                   FROM Applications
                   INNER JOIN Customisations ON Applications.ApplicationID = Customisations.ApplicationID
                   INNER JOIN Sections ON Sections.ApplicationID = Applications.ApplicationID
@@ -89,8 +87,7 @@
                          Sections.SectionName,
                          Sections.SectionID,
                          Sections.SectionNumber,
-                         Progress.CandidateID,
-                         Sections.AverageSectionMins
+                         Progress.CandidateID
                   ORDER BY Sections.SectionNumber;",
                 (course, section) =>
                 {

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseSectionHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseSectionHelper.cs
@@ -8,18 +8,14 @@
             int id = 1,
             string sectionName = "SectionName",
             bool hasLearning = true,
-            double percentComplete = 15.0,
-            int timeMins = 1,
-            int averageSectionTime = 2
+            double percentComplete = 15.0
         )
         {
             return new CourseSection(
                 sectionName,
                 id,
                 hasLearning,
-                percentComplete,
-                timeMins,
-                averageSectionTime
+                percentComplete
             );
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -73,23 +73,5 @@
             // Then
             sectionCardViewModel.PercentComplete.Should().Be($"{percentCompleteRounded}% Complete");
         }
-
-        [Test]
-        public void Section_should_return_time_information()
-        {
-            // Given
-            const int timeMins = 10;
-            const int averageSectionTime = 20;
-            var section = CourseSectionHelper.CreateDefaultCourseSection(
-                timeMins: timeMins,
-                averageSectionTime: averageSectionTime
-            );
-
-            // When
-            var sectionCardViewModel = new SectionCardViewModel(section, CustomisationId);
-
-            // Then
-            sectionCardViewModel.TimeInformation.Should().Be("10m (average time 20m)");
-        }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -8,7 +8,6 @@
         public int SectionId { get; }
         public string PercentComplete { get; }
         public int CustomisationId { get; }
-        public string TimeInformation { get; }
 
         public SectionCardViewModel(CourseSection section, int customisationId)
         {
@@ -16,7 +15,6 @@
             SectionId = section.Id;
             PercentComplete = section.HasLearning ? $"{section.PercentComplete:f0}% Complete" : "";
             CustomisationId = customisationId;
-            TimeInformation = $"{section.TimeMins}m (average time {section.AverageSectionTime}m)";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -8,9 +8,6 @@
         <h3 class="nhsuk-card__heading">
           @Model.Title
         </h3>
-        <p class="nhsuk-u-secondary-text-color">
-          @Model.TimeInformation
-        </p>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
         <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">


### PR DESCRIPTION
## Changes
- Remove times from section cards in initial menu
- Tidy up the view model and tests.

## Testing
Tested in Chrome and IE11 using a high zoom, screen reader, and narrow viewport.

## Screenshots
### Wide viewport
![times_removed](https://user-images.githubusercontent.com/3650110/102631867-2f2e1f00-4146-11eb-8ad6-ec150bbe4618.png)
### Narrow viewport
![times_removed_narrow_viewport](https://user-images.githubusercontent.com/3650110/102631865-2f2e1f00-4146-11eb-9fb3-db273ebd5229.png)