### PR TITLE
HEEDLS-253 Content viewer fix tracking url

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
@@ -223,7 +223,7 @@
             const int customisationId = 24861;
             var expectedHtmlUrl = "https://www.dls.nhs.uk/CMS/CMSContent/Course508/Section1904/Tutorials/Intro to Social Media/itspplayer.html"
                                 + "?CentreID=101&CustomisationID=24861&CandidateID=254480&Version=2&ProgressID=276837&type=learn"
-                                + $"&TrackURL={BaseUrl}/tracking";
+                                + $"&TrackURL={BaseUrl}/tracking/tracker";
 
             // Given
             var expectedTutorialContent = TutorialContentHelper.CreateDefaultTutorialContent(

--- a/DigitalLearningSolutions.Web/Helpers/ConfigHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ConfigHelper.cs
@@ -39,7 +39,7 @@
 
         public static string GetTrackingUrl(this IConfiguration config)
         {
-            return $"{config[CurrentSystemBaseUrlName]}/tracking";
+            return $"{config[CurrentSystemBaseUrlName]}/tracking/tracker";
         }
 
         public static string GetScormPlayerUrl(this IConfiguration config)


### PR DESCRIPTION
Change the tracking URL.

Change a test using the tracking URL.

Ran and passed all unit tests, manually tested on Firefox and inspected the correct URL used in the iframe.