### PR TITLE
HEEDLS-256 Add name to aria text of launch section link

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -5,7 +5,7 @@
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-three-quarters">
-        <h3 class="nhsuk-card__heading">
+        <h3 class="nhsuk-card__heading" id="@Model.SectionId-name">
           @Model.Title
         </h3>
       </div>
@@ -17,7 +17,11 @@
     </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
-        <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0" asp-action="Section" asp-route-sectionId="@Model.SectionId" asp-route-customisationId="@Model.CustomisationId">
+        <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"
+           aria-describedby="@Model.SectionId-name"
+           asp-action="Section"
+           asp-route-sectionId="@Model.SectionId"
+           asp-route-customisationId="@Model.CustomisationId">
           Launch section
         </a>
       </div>


### PR DESCRIPTION
## Changes
Add section id to heading text of section card, and use that for an `aria-describedby` on the Launch section button.

## Tested
Tested with a screen reader in Chrome, Firefox, Edge and IE11. No visual changes occured.