### PR TITLE
HEEDLS-254 Content Closing page

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <None Remove="Scripts\helpers\constants.ts" />
     <None Remove="Scripts\index.d.ts" />
+    <None Remove="Scripts\learningMenu\contentViewer.ts" />
     <None Remove="Scripts\learningPortal\dlscommon.ts" />
     <None Remove="Scripts\learningPortal\sortCourses.ts" />
     <None Remove="Scripts\nhsuk.ts" />
@@ -59,6 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <TypeScriptCompile Include="Scripts\learningMenu\contentViewer.ts" />
     <TypeScriptCompile Include="Scripts\learningPortal\available.ts" />
     <TypeScriptCompile Include="Scripts\learningPortal\completed.ts" />
     <TypeScriptCompile Include="Scripts\learningPortal\current.ts" />

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
@@ -2,12 +2,11 @@ function closeMpe(): void {
   // Extract the customisationId and sectionId out of the URL
   const matches = window.location.href.match(/.*\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
 
-  if (matches == null || matches.length < 3) {
+  if (!matches || matches.length < 4) {
     return;
   }
 
-  window.location.href = `/LearningMenu/${matches[1]}/${matches[2]}`;
+  window.location.href = `/LearningMenu/${matches[1]}/${matches[2]}/${matches[3]}`;
 }
 
 window.closeMpe = closeMpe;
-// export default closeMpe;

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
@@ -1,5 +1,5 @@
 function closeMpe(): void {
-  // Extract the customisationId and sectionId out of the URL
+  // Extract the customisationId, sectionId and tutorialId out of the URL
   const matches = window.location.href.match(/.*\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
 
   if (!matches || matches.length < 4) {

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
@@ -1,0 +1,13 @@
+function closeMpe(): void {
+  // Extract the customisationId and sectionId out of the URL
+  const matches = window.location.href.match(/.*\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
+
+  if (matches == null || matches.length < 3) {
+    return;
+  }
+
+  window.location.href = `/LearningMenu/${matches[1]}/${matches[2]}`;
+}
+
+window.closeMpe = closeMpe;
+// export default closeMpe;

--- a/DigitalLearningSolutions.Web/Scripts/spec/contentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/contentViewer.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '../learningMenu/contentViewer';
+
+beforeAll(() => {
+  global.window = Object.create(window);
+  const url = 'https://example.com';
+  Object.defineProperty(global.window, 'location', {
+    value: {
+      href: url,
+    },
+  });
+});
+
+describe('closeMpe', () => {
+  it('should redirect to tutorial overview',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/LearningMenu/123/456/789/Tutorial';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('/LearningMenu/123/456/789');
+    });
+
+  it('should do nothing on unexpected page',
+    () => {
+      // Given
+      const url = 'https://localhost:44363/LearningMenu/123/456';
+      window.location.href = url;
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toEqual(url);
+    });
+});

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -15,6 +15,10 @@
   <partial name="Shared/_NavMenuItems" />
 }
 
+@section scripts {
+  <script src="@Url.Content("~/js/learningMenu/contentViewer.js")" asp-append-version="true"></script>
+}
+
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.TutorialName</h1>


### PR DESCRIPTION
I don't think this is ready to go yet, and I've got a questions section below. I thought the easiest way for me to explain what I had done so far was a PR, and I can add any changes needed to it

## Changes
- Add `closeMpe` function for Content Viewer in a new TypeScript file
- Add this script to the `ContentViewer` view

## Questions
- I've added no tests. How should I test this, in particular is there a good way of mocking up a `window` object? Also, where should I put these tests?
- I've exposed this as a global function using `window.closeMpe = closeMpe` to make sure it's still accessible after webpack runs. Is there a better way of doing this?
- The `closeMpe` function needs the `customisationId` and `sectionId` for it to redirect. Currently I'm extracting this from the URL using `window.location.href`, is this the best way of doing this or is there a better way of getting those IDs into the function?
- How can I test this in action? Do you happen to have a tutorial that you know of that calls this function?