### PR TITLE
Fix tutorial next link back end bug

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -238,6 +238,23 @@
         }
 
         [Test]
+        public void Get_tutorial_information_should_return_null_postLearningAssessmentPath_when_isAssessed_is_false()
+        {
+            // Given
+            const int candidateId = 11;
+            const int customisationId = 24224;
+            const int sectionId = 245;
+            const int tutorialId = 4407;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.PostLearningAssessmentPath.Should().BeNull();
+        }
+
+        [Test]
         public void Get_tutorial_information_should_return_null_if_customisation_id_invalid()
         {
             // Given

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -91,7 +91,10 @@
                          Tutorials.VideoPath,
                          Tutorials.TutorialPath,
                          Tutorials.SupportingMatsPath AS SupportingMaterialPath,
-                         Sections.PLAssessPath AS PostLearningAssessmentPath,
+                         CASE
+                              WHEN Customisations.IsAssessed = 0 THEN NULL
+                              ELSE Sections.PLAssessPath
+                         END AS PostLearningAssessmentPath,
                          NextTutorial.TutorialID AS NextTutorialID,
                          NextSection.SectionID AS NextSectionID
                     FROM Tutorials


### PR DESCRIPTION
*Bug description*:
If a course as a post learning assessment, but it has been disabled by
`IsAssessed`, then the next link should not link to that post learning
assessment.

## Changes
Amend query to discard post learning assessment path if `IsAssessed` is `false`

## Testing
Add a regression test for the example @FridaTveit found whilst testing.