### PR TITLE
HEEDLS-254 Bugfix: use absolute, not relative URLs in content close script

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
@@ -1,12 +1,12 @@
 function closeMpe(): void {
-  // Extract the customisationId, sectionId and tutorialId out of the URL
-  const matches = window.location.href.match(/.*\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
+  // Extract the current domain, customisationId, sectionId and tutorialId out of the URL
+  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
 
-  if (!matches || matches.length < 4) {
+  if (!matches || matches.length < 5) {
     return;
   }
 
-  window.location.href = `/LearningMenu/${matches[1]}/${matches[2]}/${matches[3]}`;
+  window.location.href = `${matches[1]}/LearningMenu/${matches[2]}/${matches[3]}/${matches[4]}`;
 }
 
 window.closeMpe = closeMpe;

--- a/DigitalLearningSolutions.Web/Scripts/spec/contentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/contentViewer.spec.ts
@@ -18,13 +18,13 @@ describe('closeMpe', () => {
   it('should redirect to tutorial overview',
     () => {
       // Given
-      window.location.href = 'https://localhost:44363/LearningMenu/123/456/789/Tutorial';
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/789/Tutorial';
 
       // When
       window.closeMpe();
 
       // Then
-      expect(window.location.href).toBe('/LearningMenu/123/456/789');
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/789');
     });
 
   it('should do nothing on unexpected page',


### PR DESCRIPTION
### Changes
Change the URLs to be absolute and not relative, to fix the issue with redirects found in testing.

### Testing
Amend the TypeScript unit tests to reflect this change. Checked running the function works from Chrome developer console, integration testing has not been done yet because it is easiest to do this on UAT when there are no cross-site scripting concerns.