### PR TITLE
HEEDLS-NONE Rename a test procedure

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -531,7 +531,7 @@
         [TestCase(207900, 274400)]
         [TestCase(213382, 4339)]
         [TestCase(286788, 23638)]
-        public void Get_course_content_should_have_same_sections_as_stored_procedure2(
+        public void Get_course_content_should_have_same_duration_as_stored_procedure(
             int candidateId,
             int customisationId
         )


### PR DESCRIPTION
Rename a test procedure added for HEEDLS-247. This procedure had a temporary name and ended up getting push up, sorry about that. I've renamed it to something more helpful here.