### PR TITLE
HEEDLS-194 Add download summary link to button

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -1261,7 +1261,7 @@
             var result = controller.CompletionSummary(CustomisationId);
 
             // Then
-            var expectedModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var expectedModel = new CourseCompletionViewModel(config, expectedCourseCompletion, progressId);
 
             result.Should().BeViewResult()
                 .Model.Should().BeEquivalentTo(expectedModel);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
@@ -12,7 +12,7 @@
     {
         private IConfiguration config;
         private const string BaseUrl = "https://example.com";
-        const int ProgressId = 23;
+        private const int ProgressId = 23;
 
         [SetUp]
         public void SetUp()

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
@@ -3,11 +3,24 @@
     using System;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FakeItEasy;
     using FluentAssertions;
+    using Microsoft.Extensions.Configuration;
     using NUnit.Framework;
 
     class CourseCompletionViewModelTests
     {
+        private IConfiguration config;
+        private const string BaseUrl = "https://example.com";
+        const int ProgressId = 23;
+
+        [SetUp]
+        public void SetUp()
+        {
+            config = A.Fake<IConfiguration>();
+            A.CallTo(() => config["CurrentSystemBaseUrl"]).Returns(BaseUrl);
+        }
+
         [Test]
         public void CourseCompletion_should_have_customisationId()
         {
@@ -16,7 +29,7 @@
             var expectedCourseCompletion = CourseCompletionHelper.CreateDefaultCourseCompletion(customisationId);
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.CustomisationId.Should().Be(customisationId);
@@ -34,7 +47,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             var courseTitle = $"{applicationName} - {customisationName}";
@@ -51,7 +64,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.IsAssessed.Should().Be(isAssessed);
@@ -67,7 +80,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.DiagnosticScore.Should().Be(diagnosticScore);
@@ -83,7 +96,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.DiagnosticAttempts.Should().Be(diagnosticAttempts);
@@ -99,7 +112,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.PercentageTutorialsCompleted.Should().Be(44);
@@ -115,7 +128,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.PercentageTutorialsCompleted.Should().Be(67);
@@ -131,7 +144,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.PostLearningPasses.Should().Be(postLearningPasses);
@@ -147,7 +160,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.SectionCount.Should().Be(sectionCount);
@@ -162,7 +175,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.CompletionStatus.Should().Be("complete");
@@ -175,10 +188,24 @@
             var expectedCourseCompletion = CourseCompletionHelper.CreateDefaultCourseCompletion(completed: null);
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.CompletionStatus.Should().Be("incomplete");
+        }
+
+        [Test]
+        public void CourseCompletion_should_have_DownloadSummaryUrl()
+        {
+            // Given
+            var expectedCourseCompletion = CourseCompletionHelper.CreateDefaultCourseCompletion();
+            var expectedDownloadSummaryUrl = $"{BaseUrl}/tracking/summary?ProgressID={ProgressId}";
+
+            // When
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
+
+            // Then
+            courseCompletionViewModel.DownloadSummaryUrl.Should().Be(expectedDownloadSummaryUrl);
         }
 
         [Test]
@@ -188,7 +215,7 @@
             var expectedCourseCompletion = CourseCompletionHelper.CreateDefaultCourseCompletion(completed: null);
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseText.Should().BeNull();
@@ -201,7 +228,7 @@
             var expectedCourseCompletion = CourseCompletionHelper.CreateDefaultCourseCompletion(completed: null);
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseAriaLabel.Should().BeNull();
@@ -217,7 +244,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseText.Should().Be("Certificate");
@@ -233,7 +260,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseAriaLabel.Should().Be("View or print certificate");
@@ -250,7 +277,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseText.Should().Be("Certificate");
@@ -267,7 +294,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseAriaLabel.Should().Be("View or print certificate");
@@ -284,7 +311,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseText.Should().Be("Evaluate");
@@ -301,7 +328,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseAriaLabel.Should().Be("Evaluate course");
@@ -318,7 +345,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseText.Should().BeNull();
@@ -335,7 +362,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.FinaliseAriaLabel.Should().BeNull();
@@ -425,7 +452,7 @@
             );
 
             // When
-            var courseCompletionViewModel = new CourseCompletionViewModel(expectedCourseCompletion);
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
             courseCompletionViewModel.SummaryText.Should().Be(expectedSummary);

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -298,7 +298,7 @@
             sessionService.StartOrUpdateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
-            var model = new CourseCompletionViewModel(courseCompletion);
+            var model = new CourseCompletionViewModel(config, courseCompletion, progressId.Value);
             return View("Completion/Completion", model);
         }
     }

--- a/DigitalLearningSolutions.Web/Helpers/ConfigHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ConfigHelper.cs
@@ -46,5 +46,10 @@
         {
             return $"{config[CurrentSystemBaseUrlName]}/scoplayer/sco";
         }
+
+        public static string GetDownloadSummaryUrl(this IConfiguration config, int progressId)
+        {
+            return $"{config[CurrentSystemBaseUrlName]}/tracking/summary?ProgressID={progressId}";
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/CourseCompletionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/CourseCompletionViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using DigitalLearningSolutions.Data.Models.CourseCompletion;
     using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.Extensions.Configuration;
 
     public class CourseCompletionViewModel
     {
@@ -19,8 +20,9 @@
         public string? FinaliseText { get; }
         public string? FinaliseAriaLabel { get; }
         public string SummaryText { get; }
+        public string DownloadSummaryUrl { get; }
 
-        public CourseCompletionViewModel(CourseCompletion courseCompletion)
+        public CourseCompletionViewModel(IConfiguration config, CourseCompletion courseCompletion, int progressId)
         {
             CustomisationId = courseCompletion.Id;
             CourseTitle = courseCompletion.CourseTitle;
@@ -55,6 +57,8 @@
                 courseCompletion.DiagnosticAssessmentCompletionThreshold,
                 courseCompletion.TutorialsCompletionThreshold
             );
+
+            DownloadSummaryUrl = config.GetDownloadSummaryUrl(progressId);
         }
 
         private string? GetEvaluationOrCertificateText(DateTime? completed, DateTime? evaluated, bool isAssessed)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Completion/Completion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Completion/Completion.cshtml
@@ -74,7 +74,9 @@
     </div>
   }
   <div>
-    <a class="nhsuk-button nhsuk-button--secondary" href="#">Download summary</a>
+    <a class="nhsuk-button nhsuk-button--secondary" target="_blank" href="@Model.DownloadSummaryUrl">
+      Download summary
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
## Changes
Add progress ID and app configuration to the view model parameters to
generate the URL for the summary link.

## Testing
Update the unit tests to reflect these changes. Tested in Google Chrome, but not with the old code running (I often have issues getting the old system running with SQL requests timing out). It should be easier to test on the test site, and I doubt there will be any issues with it considering how small the change is.