### PR TITLE
HEELDS-188 Assessment page diagnostic bugfix

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
@@ -65,11 +65,13 @@
             diagnosticAssessmentViewModel.DiagnosticAssessmentPath.Should().Be(diagnosticAssessmentPath);
         }
 
-        [Test]
-        public void Diagnostic_assessment_select_tutorials_can_be_true()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Diagnostic_assessment_select_tutorials_with_no_tutorials_should_always_be_false(
+            bool selectTutorials
+        )
         {
             // Given
-            const bool selectTutorials = true;
             var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
                 diagObjSelect: selectTutorials
             );
@@ -79,7 +81,32 @@
                 new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
 
             // Then
-            diagnosticAssessmentViewModel.CanSelectTutorials.Should().BeTrue();
+            diagnosticAssessmentViewModel.CanSelectTutorials.Should().BeFalse();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Diagnostic_assessment_select_tutorials_with_no_tutorials_should_be_diagObjSelect(
+            bool selectTutorials
+        )
+        {
+            // Given
+            var tutorials = new[]
+            {
+                new DiagnosticTutorial("Tutorial 1", 1, true),
+                new DiagnosticTutorial("Tutorial 2", 2, true)
+            };
+            var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
+                diagObjSelect: selectTutorials
+            );
+            diagnosticAssessment.Tutorials.AddRange(tutorials);
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.CanSelectTutorials.Should().Be(selectTutorials);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
@@ -86,7 +86,7 @@
 
         [TestCase(true)]
         [TestCase(false)]
-        public void Diagnostic_assessment_select_tutorials_with_no_tutorials_should_be_diagObjSelect(
+        public void Diagnostic_assessment_select_tutorials_with_tutorials_should_be_diagObjSelect(
             bool selectTutorials
         )
         {

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
 {
     using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
 
     public class DiagnosticAssessmentViewModel
@@ -20,7 +21,7 @@
             CourseTitle = diagnosticAssessment.CourseTitle;
             SectionName = diagnosticAssessment.SectionName;
             DiagnosticAssessmentPath = diagnosticAssessment.DiagnosticAssessmentPath;
-            CanSelectTutorials = diagnosticAssessment.CanSelectTutorials;
+            CanSelectTutorials = diagnosticAssessment.CanSelectTutorials && diagnosticAssessment.Tutorials.Any();
             AttemptsInformation = diagnosticAssessment.DiagnosticAttempts switch
             {
                 0 => "Not attempted",

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -35,7 +35,7 @@
 
 <form class="nhsuk-form-group">
   <fieldset class="nhsuk-fieldset">
-    @if (Model.CanSelectTutorials && Model.Tutorials.Any())
+    @if (Model.CanSelectTutorials)
     {
       <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
         Which areas do you want to assess?

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -35,7 +35,7 @@
 
 <form class="nhsuk-form-group">
   <fieldset class="nhsuk-fieldset">
-    @if (Model.CanSelectTutorials)
+    @if (Model.CanSelectTutorials && Model.Tutorials.Any())
     {
       <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
         Which areas do you want to assess?


### PR DESCRIPTION
Add some logic to not display the selection prompt if there are no tutorials even if `diagObjSelect` is true.

Ran and passed all unit tests. Screenshot taken in Firefox.

![image](https://user-images.githubusercontent.com/36454654/103662781-43588580-4f68-11eb-9216-5f6301090d1d.png)