### PR TITLE
HEEDLS-267 Hide average duration on initial menu if n/a

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -141,7 +141,7 @@
         }
 
         [Test]
-        public void Initial_menu_should_have_not_applicable_for_null_duration()
+        public void Initial_menu_should_have_null_duration_for_null_duration()
         {
             // Given
             int? averageDuration = null;
@@ -153,7 +153,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.AverageDuration.Should().Be("Not applicable");
+            initialMenuViewModel.AverageDuration.Should().BeNull();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -10,7 +10,7 @@
     {
         public int Id { get; }
         public string Title { get; }
-        public string AverageDuration { get; }
+        public string? AverageDuration { get; }
         public string CentreName { get; }
         public string? BannerText { get; }
         public bool ShouldShowCompletionSummary { get; }
@@ -41,11 +41,11 @@
             );
         }
 
-        private static string FormatDuration(int? duration)
+        private static string? FormatDuration(int? duration)
         {
             if (duration == null)
             {
-                return "Not applicable";
+                return null;
             }
 
             if (duration < 60)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -19,7 +19,12 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.Title</h1>
-    <h2 class="nhsuk-u-secondary-text-color nhsuk-heading-l">Average Course Time: @Model.AverageDuration</h2>
+
+    @if (Model.AverageDuration != null)
+    {
+      <h2 class="nhsuk-u-secondary-text-color nhsuk-heading-l">Average Course Time: @Model.AverageDuration</h2>
+    }
+
     <p class="nhsuk-u-margin-bottom-0">@Model.CentreName</p>
     <p class="nhsuk-u-secondary-text-color">@Model.BannerText</p>
   </div>


### PR DESCRIPTION
## Changes
Hide average duration on initial menu if n/a. On Jira I've added my thoughts on why this is the only line that needs changing.

## Testing
Amend unit tests, and tested on course 6940 (one with an n/a duration).

## Screenshots
### A course with an n/a duration
![invalid_duration_hidden](https://user-images.githubusercontent.com/3650110/103669510-540cf980-4f70-11eb-90c3-5238e6950218.png)
