### PR TITLE
HEEDLS-195 Add evaluate or show certificate link to button

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
@@ -209,6 +209,20 @@
         }
 
         [Test]
+        public void CourseCompletion_should_have_FinaliseUrl()
+        {
+            // Given
+            var expectedCourseCompletion = CourseCompletionHelper.CreateDefaultCourseCompletion();
+            var expectedFinaliseUrl = $"{BaseUrl}/tracking/finalise?ProgressID={ProgressId}";
+
+            // When
+            var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
+
+            // Then
+            courseCompletionViewModel.FinaliseUrl.Should().Be(expectedFinaliseUrl);
+        }
+
+        [Test]
         public void CourseCompletion_FinaliseText_should_be_null_when_completed_is_null()
         {
             // Given

--- a/DigitalLearningSolutions.Web/Helpers/ConfigHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ConfigHelper.cs
@@ -32,9 +32,10 @@
             return IsNullOrEmpty(environmentName) ? "appsettings.json" : $"appsettings.{environmentName}.json";
         }
 
-        public static string GetEvaluateUrl(this IConfiguration config, int progressId)
+        public static string GetEvaluateUrl(this IConfiguration config, int progressId, bool fromLearningPortal)
         {
-            return $"{config[CurrentSystemBaseUrlName]}/tracking/finalise?ProgressID={progressId}&lp=1";
+            return $"{config[CurrentSystemBaseUrlName]}/tracking/finalise?ProgressID={progressId}" +
+                (fromLearningPortal ? "&lp=1" : "");
         }
 
         public static string GetTrackingUrl(this IConfiguration config)

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/CourseCompletionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/CourseCompletionViewModel.cs
@@ -21,6 +21,7 @@
         public string? FinaliseAriaLabel { get; }
         public string SummaryText { get; }
         public string DownloadSummaryUrl { get; }
+        public string FinaliseUrl { get; }
 
         public CourseCompletionViewModel(IConfiguration config, CourseCompletion courseCompletion, int progressId)
         {
@@ -59,6 +60,7 @@
             );
 
             DownloadSummaryUrl = config.GetDownloadSummaryUrl(progressId);
+            FinaliseUrl = config.GetEvaluateUrl(progressId, false);
         }
 
         private string? GetEvaluationOrCertificateText(DateTime? completed, DateTime? evaluated, bool isAssessed)

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Completed/CompletedCourseViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Completed/CompletedCourseViewModel.cs
@@ -16,7 +16,7 @@
         {
             CompletedDate = course.Completed;
             EvaluatedDate = course.Evaluated;
-            EvaluateUrl = config.GetEvaluateUrl(course.ProgressID);
+            EvaluateUrl = config.GetEvaluateUrl(course.ProgressID, true);
         }
 
         public string FinaliseButtonText()

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Completion/Completion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Completion/Completion.cshtml
@@ -68,7 +68,7 @@
   @if (Model.FinaliseText != null)
   {
     <div>
-      <a class="nhsuk-button nhsuk-button" href="#" aria-label="@Model.FinaliseAriaLabel">
+      <a class="nhsuk-button nhsuk-button" target="_blank" href="@Model.FinaliseUrl" aria-label="@Model.FinaliseAriaLabel">
         @Model.FinaliseText
       </a>
     </div>


### PR DESCRIPTION
## Changes
* Add flag to existing finalise URL maker to show whether to redirect to
the learning portal or not, using query parameter `lp=1`.
* Add evaluate or show certificate link to button

## Testing
Amend unit tests, link tested in Google Chrome (that it goes to the right place), but not tested with old code, like HEEDLS-194.