### PR TITLE
HEEDLS-279 Add section customisation back end

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Models/CourseSettingsTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Models/CourseSettingsTests.cs
@@ -20,6 +20,58 @@
         }
 
         [Test]
+        public void CourseSettings_should_have_default_settings_when_json_is_empty_string()
+        {
+            // Given
+            var defaultSettings = new CourseSettings(null);
+
+            // When
+            var courseSettings = new CourseSettings("");
+
+            // Then
+            courseSettings.Should().BeEquivalentTo(defaultSettings);
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_settings_when_json_is_empty_whitespace()
+        {
+            // Given
+            var defaultSettings = new CourseSettings(null);
+
+            // When
+            var courseSettings = new CourseSettings("   ");
+
+            // Then
+            courseSettings.Should().BeEquivalentTo(defaultSettings);
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_settings_when_json_is_empty_object()
+        {
+            // Given
+            var defaultSettings = new CourseSettings(null);
+
+            // When
+            var courseSettings = new CourseSettings("{}");
+
+            // Then
+            courseSettings.Should().BeEquivalentTo(defaultSettings);
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_settings_when_json_is_empty_list()
+        {
+            // Given
+            var defaultSettings = new CourseSettings(null);
+
+            // When
+            var courseSettings = new CourseSettings("[]");
+
+            // Then
+            courseSettings.Should().BeEquivalentTo(defaultSettings);
+        }
+
+        [Test]
         public void CourseSettings_should_take_ShowPercentage_from_json()
         {
             // When
@@ -77,6 +129,66 @@
 
             // Then
             courseSettings.ShowTime.Should().BeTrue();
+        }
+
+        [Test]
+        public void CourseSettings_should_take_ShowLearnStatus_from_json()
+        {
+            // When
+            var courseSettings = new CourseSettings("{\"lm.sl\":false}");
+
+            // Then
+            courseSettings.ShowLearnStatus.Should().BeFalse();
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_ShowLearnStatus_when_not_in_json()
+        {
+            // When
+            var courseSettings = new CourseSettings(null);
+
+            // Then
+            courseSettings.ShowLearnStatus.Should().BeTrue();
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_ShowLearnStatus_when_wrong_type()
+        {
+            // When
+            var courseSettings = new CourseSettings("{\"lm.sl\":\"Line Manager\"}");
+
+            // Then
+            courseSettings.ShowLearnStatus.Should().BeTrue();
+        }
+
+        [Test]
+        public void CourseSettings_should_take_ConsolidationExercise_from_json()
+        {
+            // When
+            var courseSettings = new CourseSettings("{\"lm:ce\":\"Consolidation exercise\"}");
+
+            // Then
+            courseSettings.ConsolidationExercise.Should().Be("Consolidation exercise");
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_ConsolidationExercise_when_not_in_json()
+        {
+            // When
+            var courseSettings = new CourseSettings(null);
+
+            // Then
+            courseSettings.ConsolidationExercise.Should().BeNull();
+        }
+
+        [Test]
+        public void CourseSettings_should_have_default_ConsolidationExercise_when_wrong_type()
+        {
+            // When
+            var courseSettings = new CourseSettings("{\"lm:ce\":false}");
+
+            // Then
+            courseSettings.ConsolidationExercise.Should().BeNull();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/SectionContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SectionContentServiceTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Transactions;
+    using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.SectionContent;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
@@ -50,6 +51,7 @@
                 1,
                 true,
                 true,
+                null,
                 null
             );
             expectedSectionContent.Tutorials.AddRange(
@@ -63,7 +65,7 @@
             );
             result.Should().BeEquivalentTo(expectedSectionContent);
         }
-        
+
         [Test]
         public void Get_section_content_should_return_null_if_customisation_id_is_invalid()
         {
@@ -114,6 +116,7 @@
                 0,
                 true,
                 true,
+                null,
                 null
             );
             expectedSectionContent.Tutorials.AddRange(
@@ -158,6 +161,7 @@
                 0,
                 true,
                 true,
+                null,
                 null
             );
             expectedSectionContent.Tutorials.AddRange(
@@ -226,7 +230,8 @@
                 0,
                 true,
                 false,
-                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip"
+                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip",
+                null
             );
             // Will have no tutorials as CustomisationTutorial.Status is 0 for all tutorials in this section
 
@@ -257,7 +262,8 @@
                 0,
                 false,
                 true,
-                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip"
+                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip",
+                null
             );
             // Will have no tutorials as CustomisationTutorial.Status is 0 for all tutorials in this section
 
@@ -288,7 +294,8 @@
                 0,
                 false,
                 false,
-                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip"
+                "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip",
+                null
             );
             expectedSectionContent.Tutorials.AddRange(
                 new[]
@@ -406,6 +413,7 @@
                 1,
                 true,
                 true,
+                null,
                 null
             );
             expectedSectionContent.Tutorials.AddRange(
@@ -423,6 +431,48 @@
 
             // Then
             result.Should().BeEquivalentTo(expectedSectionContent);
+        }
+
+        [Test]
+        public void Get_section_content_should_parse_course_settings()
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                const int customisationId = 15853;
+                const int candidateId = 1;
+                const int sectionId = 382;
+                const string courseSettingsText =
+                    "{\"lm.sp\":false,\"lm.st\":false,\"lm.sl\":false,\"df.sd\":false,"
+                   + "\"df.sm\":false,\"df.ss\":false,\"lm:ce\":\"consolidation/exercise\"}";
+                var expectedCourseSettings = new CourseSettings(courseSettingsText);
+
+                courseContentTestHelper.AddCourseSettings(customisationId, courseSettingsText);
+
+                // When
+                var result = sectionContentService.GetSectionContent(customisationId, candidateId, sectionId);
+
+                // Then
+                result.Should().NotBeNull();
+                result!.CourseSettings.Should().BeEquivalentTo(expectedCourseSettings);
+            }
+        }
+
+        [Test]
+        public void Get_section_content_should_have_default_course_settings_when_json_is_null()
+        {
+            // Given
+            const int customisationId = 15853;
+            const int candidateId = 1;
+            const int sectionId = 382;
+            var defaultSettings = new CourseSettings(null);
+
+            // When
+            var result = sectionContentService.GetSectionContent(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Should().NotBeNull();
+            result!.CourseSettings.Should().BeEquivalentTo(defaultSettings);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CourseSettings.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseSettings.cs
@@ -7,6 +7,8 @@
     {
         public bool ShowPercentage { get; } = true;
         public bool ShowTime { get; } = true;
+        public bool ShowLearnStatus { get; } = true;
+        public string? ConsolidationExercise { get; } = null;
 
         public CourseSettings(string? settingsText)
         {
@@ -19,6 +21,11 @@
             {
                 var settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(settingsText);
 
+                if (settings == null)
+                {
+                    return;
+                }
+
                 if (settings.ContainsKey("lm.sp") && settings["lm.sp"] is bool)
                 {
                     ShowPercentage = (bool)settings["lm.sp"];
@@ -27,6 +34,16 @@
                 if (settings.ContainsKey("lm.st") && settings["lm.st"] is bool)
                 {
                     ShowTime = (bool)settings["lm.st"];
+                }
+
+                if (settings.ContainsKey("lm.sl") && settings["lm.sl"] is bool)
+                {
+                    ShowLearnStatus = (bool)settings["lm.sl"];
+                }
+
+                if (settings.ContainsKey("lm:ce") && settings["lm:ce"] is string)
+                {
+                    ConsolidationExercise = (string)settings["lm:ce"];
                 }
             }
             catch (JsonException)

--- a/DigitalLearningSolutions.Data/Models/SectionContent/SectionContent.cs
+++ b/DigitalLearningSolutions.Data/Models/SectionContent/SectionContent.cs
@@ -17,6 +17,7 @@
         public bool DiagnosticStatus { get; }
         public bool IsAssessed { get; }
         public string? ConsolidationPath { get; }
+        public CourseSettings CourseSettings { get; }
         public List<SectionTutorial> Tutorials { get; } = new List<SectionTutorial>();
 
         public SectionContent(
@@ -33,7 +34,9 @@
             int plPasses,
             bool diagStatus,
             bool isAssessed,
-            string? consolidationPath)
+            string? consolidationPath,
+            string? courseSettings
+        )
         {
             CourseTitle = $"{applicationName} - {customisationName}";
             SectionName = sectionName;
@@ -48,6 +51,7 @@
             DiagnosticStatus = diagStatus;
             IsAssessed = isAssessed;
             ConsolidationPath = consolidationPath;
+            CourseSettings = new CourseSettings(courseSettings);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/SectionContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SectionContentService.cs
@@ -36,13 +36,14 @@
                         COALESCE (aspProgress.DiagAttempts, 0) AS DiagAttempts,
                         COALESCE (aspProgress.DiagLast, 0) AS DiagLast,
                         Tutorials.DiagAssessOutOf,
-                        Sections.DiagAssessPath, 
+                        Sections.DiagAssessPath,
                         Sections.PLAssessPath,
                         COALESCE (Attempts.AttemptsPL, 0) AS AttemptsPL,
                         COALESCE (Attempts.PLPasses, 0) AS PLPasses,
                         CustomisationTutorials.DiagStatus,
                         Customisations.IsAssessed,
                         Sections.ConsolidationPath,
+                        Applications.CourseSettings,
                         Tutorials.TutorialName,
                         COALESCE (aspProgress.TutStat, 0) AS TutStat,
                         COALESCE (TutStatus.Status, 'Not started') AS CompletionStatus,
@@ -102,7 +103,7 @@
                     {
                         sectionContent.Tutorials.Add(tutorial);
                     }
-                    
+
                     return sectionContent;
                 },
                 new { customisationId, candidateId, sectionId },

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
@@ -18,7 +18,8 @@
             int plPasses = 1,
             bool diagStatus = true,
             bool isAssessed = true,
-            string? consolidationPath = "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip"
+            string? consolidationPath = "https://www.dls.nhs.uk/tracking/MOST/Word07Core/cons/WC07-Exercise_1.zip",
+            string? courseSettings = null
         )
         {
             return new SectionContent(
@@ -35,7 +36,8 @@
                 plPasses,
                 diagStatus,
                 isAssessed,
-                consolidationPath
+                consolidationPath,
+                courseSettings
             );
         }
     }


### PR DESCRIPTION
## Changes
* Add some more fields to the course settings object
* Get course settings when getting section content
* Cover some more edge cases for course settings JSON

## Testing
Add some more unit tests for: new course settings fields, 
section content getting the settings, and more course
settings edge cases, such as when the JSON is valid but
unexpected, such as the empty string, the empty list, etc.