### PR TITLE
HEEDLS-280 Add section customisation front end

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -75,22 +75,34 @@
         }
 
         [Test]
-        public void Section_content_should_have_setting_consolidation_path_when_courseSetting_exercise_is_not_null()
+        public void Section_content_should_have_consolidationExerciseLabel_from_courseSetting()
         {
             // Given
-            const string consolidationPath = "consolidation/path";
-            const string consolidationPathFromSettings = "consolidation/path/fromsetting";
+            const string consolidationText = "Different consolidation description";
             var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
-                consolidationPath: consolidationPath,
-                courseSettings: "{\"lm:ce\":\"" + consolidationPathFromSettings + "\"}"
+                courseSettings: "{\"lm:ce\":\"" + consolidationText + "\"}"
             );
-            var expectedConsolidationPath = ContentUrlHelper.GetContentPath(config, consolidationPathFromSettings);
 
             // When
             var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
 
             // Then
-            sectionContentViewModel.ConsolidationExercisePath.Should().Be(expectedConsolidationPath);
+            sectionContentViewModel.ConsolidationExerciseLabel.Should().Be(consolidationText);
+        }
+
+        [Test]
+        public void Section_content_should_have_default_consolidationExerciseLabel_when_courseSetting_is_empty()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                courseSettings: null
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ConsolidationExerciseLabel.Should().Be("Consolidation Exercise");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FakeItEasy;
@@ -56,24 +57,112 @@
         }
 
         [Test]
-        public void Section_content_without_has_learning_should_have_empty_percent_complete()
+        public void Section_content_should_have_consolidation_path_when_courseSetting_exercise_is_null()
         {
             // Given
-            const bool hasLearning = false;
+            const string consolidationPath = "consolidation/path";
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                consolidationPath: consolidationPath,
+                courseSettings: null
+            );
+            var expectedConsolidationPath = ContentUrlHelper.GetContentPath(config, consolidationPath);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ConsolidationExercisePath.Should().Be(expectedConsolidationPath);
+        }
+
+        [Test]
+        public void Section_content_should_have_setting_consolidation_path_when_courseSetting_exercise_is_not_null()
+        {
+            // Given
+            const string consolidationPath = "consolidation/path";
+            const string consolidationPathFromSettings = "consolidation/path/fromsetting";
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                consolidationPath: consolidationPath,
+                courseSettings: "{\"lm:ce\":\"" + consolidationPathFromSettings + "\"}"
+            );
+            var expectedConsolidationPath = ContentUrlHelper.GetContentPath(config, consolidationPathFromSettings);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ConsolidationExercisePath.Should().Be(expectedConsolidationPath);
+        }
+
+        [Test]
+        public void Section_content_with_has_learning_and_courseSetting_should_show_percent_complete()
+        {
+            // Given
+            const string courseSettings = "{\"lm.sp\":true}"; // ShowPercentage = true
             var tutorials = new[]
             {
                 SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 2),
                 SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 0),
                 SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 0)
             };
-            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(hasLearning: hasLearning);
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                hasLearning: true,
+                courseSettings: courseSettings
+            );
             sectionContent.Tutorials.AddRange(tutorials);
 
             // When
             var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
 
             // Then
-            sectionContentViewModel.PercentComplete.Should().Be("");
+            sectionContentViewModel.ShowPercentComplete.Should().BeTrue();
+        }
+
+        [Test]
+        public void Section_content_without_has_learning_should_not_show_percent_complete()
+        {
+            // Given
+            const string courseSettings = "{\"lm.sp\":true}"; // ShowPercentage = true
+            var tutorials = new[]
+            {
+                SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 2),
+                SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 0),
+                SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 0)
+            };
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                hasLearning: false,
+                courseSettings: courseSettings
+            );
+            sectionContent.Tutorials.AddRange(tutorials);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ShowPercentComplete.Should().BeFalse();
+        }
+
+        [Test]
+        public void Section_content_with_false_showPercentage_course_setting_should_not_show_percent_complete()
+        {
+            // Given
+            const string courseSettings = "{\"lm.sp\":false}"; // ShowPercentage = false
+            var tutorials = new[]
+            {
+                SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 2),
+                SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 0),
+                SectionTutorialHelper.CreateDefaultSectionTutorial(tutStat: 0)
+            };
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                hasLearning: true,
+                courseSettings: courseSettings
+            );
+            sectionContent.Tutorials.AddRange(tutorials);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ShowPercentComplete.Should().BeFalse();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
@@ -9,6 +9,8 @@
     {
         private const int CustomisationId = 5;
         private const int SectionId = 5;
+        private const bool ShowTime = true;
+        private const bool ShowLearnStatus = true;
 
         [Test]
         public void Tutorial_card_average_time_spent_string_should_have_plural_if_value_is_not_one()
@@ -20,7 +22,13 @@
             );
 
             // When
-            var tutorialCardViewModel = new TutorialCardViewModel(sectionTutorial, CustomisationId, SectionId);
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                ShowTime,
+                ShowLearnStatus,
+                CustomisationId,
+                SectionId
+            );
 
             // Then
             tutorialCardViewModel.AverageTimeInformation.Should().Be($"(average tutorial time {averageTime} minutes)");
@@ -36,7 +44,13 @@
             );
 
             // When
-            var tutorialCardViewModel = new TutorialCardViewModel(sectionTutorial, CustomisationId, SectionId);
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                ShowTime,
+                ShowLearnStatus,
+                CustomisationId,
+                SectionId
+            );
 
             // Then
             tutorialCardViewModel.AverageTimeInformation.Should().Be($"(average tutorial time {averageTime} minute)");
@@ -52,7 +66,13 @@
             );
 
             // When
-            var tutorialCardViewModel = new TutorialCardViewModel(sectionTutorial, CustomisationId, SectionId);
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                ShowTime,
+                ShowLearnStatus,
+                CustomisationId,
+                SectionId
+            );
 
             // Then
             tutorialCardViewModel.TimeSpentInformation.Should().Be($"{tutTime} minutes spent");
@@ -68,10 +88,111 @@
             );
 
             // When
-            var tutorialCardViewModel = new TutorialCardViewModel(sectionTutorial, CustomisationId, SectionId);
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                ShowTime,
+                ShowLearnStatus,
+                CustomisationId,
+                SectionId
+            );
 
             // Then
             tutorialCardViewModel.TimeSpentInformation.Should().Be($"{tutTime} minute spent");
+        }
+
+        [Test]
+        public void Tutorial_card_should_show_time_if_courseSettings_are_true()
+        {
+            // Given
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+
+            // When
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                showTime: true,
+                showLearnStatus: true,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialCardViewModel.ShowTime.Should().BeTrue();
+        }
+
+        [Test]
+        public void Tutorial_card_should_not_show_time_if_showTime_courseSetting_is_false()
+        {
+            // Given
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+
+            // When
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                showTime: false,
+                showLearnStatus: true,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialCardViewModel.ShowTime.Should().BeFalse();
+        }
+
+        [Test]
+        public void Tutorial_card_should_not_show_time_if_showLearnStatus_is_false()
+        {
+            // Given
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+
+            // When
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                showTime: true,
+                showLearnStatus: false,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialCardViewModel.ShowTime.Should().BeFalse();
+        }
+
+        [Test]
+        public void Tutorial_card_should_show_learning_status_if_showLearnStatus_is_true()
+        {
+            // Given
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+
+            // When
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                showTime: true,
+                showLearnStatus: true,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialCardViewModel.ShowLearnStatus.Should().BeTrue();
+        }
+
+        [Test]
+        public void Tutorial_card_should_not_show_learning_status_if_showLearnStatus_is_false()
+        {
+            // Given
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+
+            // When
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                showTime: true,
+                showLearnStatus: false,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialCardViewModel.ShowLearnStatus.Should().BeFalse();
         }
 
         [Test]
@@ -81,7 +202,13 @@
             var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
 
             // When
-            var tutorialCardViewModel = new TutorialCardViewModel(sectionTutorial, CustomisationId, SectionId);
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                ShowTime,
+                ShowLearnStatus,
+                CustomisationId,
+                SectionId
+            );
 
             // Then
             tutorialCardViewModel.CustomisationId.Should().Be(CustomisationId);
@@ -94,7 +221,13 @@
             var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
 
             // When
-            var tutorialCardViewModel = new TutorialCardViewModel(sectionTutorial, CustomisationId, SectionId);
+            var tutorialCardViewModel = new TutorialCardViewModel(
+                sectionTutorial,
+                ShowTime,
+                ShowLearnStatus,
+                CustomisationId,
+                SectionId
+            );
 
             // Then
             tutorialCardViewModel.SectionId.Should().Be(SectionId);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
@@ -20,6 +20,7 @@
         public string DiagnosticCompletionStatus { get; }
         public string? ConsolidationExercisePath { get; }
         public bool ShowConsolidation { get; }
+        public string ConsolidationExerciseLabel { get; }
         public IEnumerable<TutorialCardViewModel> Tutorials { get; }
         public bool DisplayDiagnosticSeparator { get; }
         public bool DisplayTutorialSeparator { get; }
@@ -37,11 +38,9 @@
             PostLearningStatus = GetPostLearningStatus(sectionContent);
             ShowDiagnostic = sectionContent.DiagnosticAssessmentPath != null && sectionContent.DiagnosticStatus;
             DiagnosticCompletionStatus = GetDiagnosticCompletionStatus(sectionContent);
-            ConsolidationExercisePath = ContentUrlHelper.GetNullableContentPath(
-                config,
-                sectionContent.CourseSettings.ConsolidationExercise ?? sectionContent.ConsolidationPath
-            );
+            ConsolidationExercisePath = ContentUrlHelper.GetNullableContentPath(config, sectionContent.ConsolidationPath);
             ShowConsolidation = ConsolidationExercisePath != null;
+            ConsolidationExerciseLabel = sectionContent.CourseSettings.ConsolidationExercise ?? "Consolidation Exercise";
 
             Tutorials = sectionContent.Tutorials.Select(tutorial => new TutorialCardViewModel(
                 tutorial,

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialCardViewModel.cs
@@ -11,8 +11,16 @@
         public string AverageTimeInformation { get; }
         public int SectionId { get; }
         public int CustomisationId { get; }
+        public bool ShowTime { get; }
+        public bool ShowLearnStatus { get; }
 
-        public TutorialCardViewModel(SectionTutorial tutorial, int sectionId, int customisationId)
+        public TutorialCardViewModel(
+            SectionTutorial tutorial,
+            bool showTime,
+            bool showLearnStatus,
+            int sectionId,
+            int customisationId
+        )
         {
             Id = tutorial.Id;
             TutorialName = tutorial.TutorialName;
@@ -23,6 +31,8 @@
             AverageTimeInformation = tutorial.AverageTutorialTime == 1
                 ? $"(average tutorial time {tutorial.AverageTutorialTime} minute)"
                 : $"(average tutorial time {tutorial.AverageTutorialTime} minutes)";
+            ShowTime = showTime && showLearnStatus;
+            ShowLearnStatus = showLearnStatus;
             SectionId = sectionId;
             CustomisationId = customisationId;
         }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -19,11 +19,15 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
-    <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">@Model.PercentComplete</h2>
+
+    @if (Model.ShowPercentComplete)
+    {
+      <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-3">@Model.PercentComplete</h2>
+    }
   </div>
 </div>
 
-<div class="nhsuk-back-link nhsuk-u-padding-top-3">
+<div class="nhsuk-back-link nhsuk-u-padding-top-0">
   <a class="nhsuk-back-link__link" asp-action="Index" asp-controller="LearningMenu" asp-route-customisationId="@Model.CustomisationId">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_ConsolidationExerciseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_ConsolidationExerciseCard.cshtml
@@ -6,7 +6,7 @@
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
         <h3 class="nhsuk-card__heading" id="consolidation-exercise-name">
-          Consolidation Exercise
+          @Model.ConsolidationExerciseLabel
         </h3>
       </div>
     </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -3,21 +3,28 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-three-quarters">
+      <div class="@(Model.ShowLearnStatus ? "nhsuk-grid-column-three-quarters" : "nhsuk-grid-column-full")">
         <h3 class="nhsuk-card__heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
-        <p class="nhsuk-u-secondary-text-color">
-          @Model.TimeSpentInformation
-          <span class="visually-hidden">on this tutorial</span>
-          @Model.AverageTimeInformation
-        </p>
+
+        @if (Model.ShowTime)
+        {
+          <p class="nhsuk-u-secondary-text-color">
+            @Model.TimeSpentInformation
+            <span class="visually-hidden">on this tutorial</span>
+            @Model.AverageTimeInformation
+          </p>
+        }
       </div>
-      <div class="nhsuk-grid-column-one-quarter">
-        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
-          @Model.CompletionStatus
-        </h3>
-      </div>
+      @if (Model.ShowLearnStatus)
+      {
+        <div class="nhsuk-grid-column-one-quarter">
+          <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
+            @Model.CompletionStatus
+          </h3>
+        </div>
+      }
     </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">


### PR DESCRIPTION
## Changes
Add show percentage, show learning status, and consolidation exercise
settings to section page.

## Testing
Add some unit tests, tested in Google Chrome

## Screenshots
### A section with show percentage and show time disabled
![show_percentage_and_show_time_disabled](https://user-images.githubusercontent.com/3650110/103891938-9b1afc00-50e2-11eb-86a0-d0f9b4a5372c.png)

### A section with learn status disabled
![learn_status_removed](https://user-images.githubusercontent.com/3650110/103891940-9bb39280-50e2-11eb-82f3-5dc83f33468f.png)
