### PR TITLE
HEEDLS-248 Make time summary partial for tutorial page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Helpers/DurationFormattingHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/DurationFormattingHelperTests.cs
@@ -1,0 +1,106 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
+{
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    class DurationFormattingHelperTests
+    {
+        [Test]
+        public void FormatDuration_should_have_averageDuration_for_0_minutes()
+        {
+            // Given
+            const int averageDuration = 0;
+
+            // When
+            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+
+            // Then
+            result.Should().Be("0 minutes");
+        }
+
+        [Test]
+        public void FormatDuration_should_have_averageDuration_for_1_minute()
+        {
+            // Given
+            const int averageDuration = 1;
+
+            // When
+            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+
+            // Then
+            result.Should().Be("1 minute");
+        }
+
+        [Test]
+        public void FormatDuration_should_have_averageDuration_for_under_an_hour()
+        {
+            // Given
+            const int averageDuration = 30;
+
+            // When
+            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+
+            // Then
+            result.Should().Be("30 minutes");
+        }
+
+        [Test]
+        public void FormatDuration_should_have_averageDuration_for_whole_number_of_hours()
+        {
+            // Given
+            const int averageDuration = 120;
+
+            // When
+            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+
+            // Then
+            result.Should().Be("2 hours");
+        }
+
+        [Test]
+        public void FormatDuration_should_have_averageDuration_for_one_hour_one_minute()
+        {
+            // Given
+            const int averageDuration = 61;
+
+            // When
+            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+
+            // Then
+            result.Should().Be("1 hour 1 minute");
+        }
+
+
+        [Test]
+        public void FormatDuration_should_have_averageDuration_for_multiple_hours()
+        {
+            // Given
+            const int averageDuration = 195;
+
+            // When
+            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+
+            // Then
+            result.Should().Be("3 hours 15 minutes");
+        }
+
+        [TestCase(0, "0 minutes")]
+        [TestCase(1, "1 minute")]
+        [TestCase(30, "30 minutes")]
+        [TestCase(120, "2 hours")]
+        [TestCase(61, "1 hour 1 minute")]
+        [TestCase(195, "3 hours 15 minutes")]
+        [TestCase(null, null)]
+        public void FormatNullableDuration_should_format_durations(int? averageDuration, string? expectedResult)
+        {
+            // When
+            var result = DurationFormattingHelper.FormatNullableDuration(averageDuration);
+
+            // Then
+            result.Should().Be(expectedResult);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Helpers/DurationFormattingHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/DurationFormattingHelperTests.cs
@@ -1,73 +1,71 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
 {
     using DigitalLearningSolutions.Web.Helpers;
-    using DigitalLearningSolutions.Web.Tests.TestHelpers;
-    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FluentAssertions;
     using NUnit.Framework;
 
     class DurationFormattingHelperTests
     {
         [Test]
-        public void FormatDuration_should_have_averageDuration_for_0_minutes()
+        public void FormatDuration_should_have_duration_for_0_minutes()
         {
             // Given
-            const int averageDuration = 0;
+            const int duration = 0;
 
             // When
-            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatDuration(duration);
 
             // Then
             result.Should().Be("0 minutes");
         }
 
         [Test]
-        public void FormatDuration_should_have_averageDuration_for_1_minute()
+        public void FormatDuration_should_have_duration_for_1_minute()
         {
             // Given
-            const int averageDuration = 1;
+            const int duration = 1;
 
             // When
-            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatDuration(duration);
 
             // Then
             result.Should().Be("1 minute");
         }
 
         [Test]
-        public void FormatDuration_should_have_averageDuration_for_under_an_hour()
+        public void FormatDuration_should_have_duration_for_under_an_hour()
         {
             // Given
-            const int averageDuration = 30;
+            const int duration = 30;
 
             // When
-            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatDuration(duration);
 
             // Then
             result.Should().Be("30 minutes");
         }
 
         [Test]
-        public void FormatDuration_should_have_averageDuration_for_whole_number_of_hours()
+        public void FormatDuration_should_have_duration_for_whole_number_of_hours()
         {
             // Given
-            const int averageDuration = 120;
+            const int duration = 120;
 
             // When
-            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatDuration(duration);
 
             // Then
             result.Should().Be("2 hours");
         }
 
         [Test]
-        public void FormatDuration_should_have_averageDuration_for_one_hour_one_minute()
+        public void FormatDuration_should_have_duration_for_one_hour_one_minute()
         {
             // Given
-            const int averageDuration = 61;
+            const int duration = 61;
 
             // When
-            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatDuration(duration);
 
             // Then
             result.Should().Be("1 hour 1 minute");
@@ -75,13 +73,13 @@
 
 
         [Test]
-        public void FormatDuration_should_have_averageDuration_for_multiple_hours()
+        public void FormatDuration_should_have_duration_for_multiple_hours()
         {
             // Given
-            const int averageDuration = 195;
+            const int duration = 195;
 
             // When
-            var result = DurationFormattingHelper.FormatDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatDuration(duration);
 
             // Then
             result.Should().Be("3 hours 15 minutes");
@@ -94,10 +92,10 @@
         [TestCase(61, "1 hour 1 minute")]
         [TestCase(195, "3 hours 15 minutes")]
         [TestCase(null, null)]
-        public void FormatNullableDuration_should_format_durations(int? averageDuration, string? expectedResult)
+        public void FormatNullableDuration_should_format_durations(int? duration, string? expectedResult)
         {
             // When
-            var result = DurationFormattingHelper.FormatNullableDuration(averageDuration);
+            var result = DurationFormattingHelper.FormatNullableDuration(duration);
 
             // Then
             result.Should().Be(expectedResult);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -43,117 +43,23 @@
             initialMenuViewModel.Id.Should().Be(customisationId);
         }
 
-        [Test]
-        public void Initial_menu_should_have_averageDuration_for_0_minutes()
+        [TestCase(0, "0 minutes")]
+        [TestCase(1, "1 minute")]
+        [TestCase(30, "30 minutes")]
+        [TestCase(120, "2 hours")]
+        [TestCase(61, "1 hour 1 minute")]
+        [TestCase(195, "3 hours 15 minutes")]
+        [TestCase(null, null)]
+        public void Initial_menu_formats_average_duration(int? averageDuration, string? expectedFormattedTime)
         {
             // Given
-            const int averageDuration = 0;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(averageDuration: averageDuration);
 
             // When
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.AverageDuration.Should().Be("0 minutes");
-        }
-
-        [Test]
-        public void Initial_menu_should_have_averageDuration_for_1_minute()
-        {
-            // Given
-            const int averageDuration = 1;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.AverageDuration.Should().Be("1 minute");
-        }
-
-        [Test]
-        public void Initial_menu_should_have_averageDuration_for_under_an_hour()
-        {
-            // Given
-            const int averageDuration = 30;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.AverageDuration.Should().Be("30 minutes");
-        }
-
-        [Test]
-        public void Initial_menu_should_have_averageDuration_for_whole_number_of_hours()
-        {
-            // Given
-            const int averageDuration = 120;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.AverageDuration.Should().Be("2 hours");
-        }
-
-        [Test]
-        public void Initial_menu_should_have_averageDuration_for_one_hour_one_minute()
-        {
-            // Given
-            const int averageDuration = 61;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.AverageDuration.Should().Be("1 hour 1 minute");
-        }
-
-
-        [Test]
-        public void Initial_menu_should_have_averageDuration_for_multiple_hours()
-        {
-            // Given
-            const int averageDuration = 195;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.AverageDuration.Should().Be("3 hours 15 minutes");
-        }
-
-        [Test]
-        public void Initial_menu_should_have_null_duration_for_null_duration()
-        {
-            // Given
-            int? averageDuration = null;
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(
-                averageDuration: averageDuration
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
-
-            // Then
-            initialMenuViewModel.AverageDuration.Should().BeNull();
+            initialMenuViewModel.AverageDuration.Should().Be(expectedFormattedTime);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
@@ -13,148 +13,36 @@
         private const bool ShowLearnStatus = true;
 
         [Test]
-        public void Tutorial_card_average_time_spent_string_should_have_plural_if_value_is_not_one()
+        public void Tutorial_card_should_have_timeSummary()
         {
             // Given
-            const int averageTime = 10;
+            const int averageTutorialDuration = 73;
+            const int timeSpent = 41;
+            const bool showTime = true;
+            const bool showLearnStatus = false;
+
             var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
-                averageTutMins: averageTime
+                tutTime: timeSpent,
+                averageTutMins: averageTutorialDuration
+            );
+            var expectedTimeSummary = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTutorialDuration,
+                showTime,
+                showLearnStatus
             );
 
             // When
             var tutorialCardViewModel = new TutorialCardViewModel(
                 sectionTutorial,
-                ShowTime,
-                ShowLearnStatus,
+                showTime,
+                showLearnStatus,
                 CustomisationId,
                 SectionId
             );
 
             // Then
-            tutorialCardViewModel.AverageTimeInformation.Should().Be($"(average tutorial time {averageTime} minutes)");
-        }
-
-        [Test]
-        public void Tutorial_card_average_time_spent_string_should_not_have_plural_if_value_is_one()
-        {
-            // Given
-            const int averageTime = 1;
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
-                averageTutMins: averageTime
-            );
-
-            // When
-            var tutorialCardViewModel = new TutorialCardViewModel(
-                sectionTutorial,
-                ShowTime,
-                ShowLearnStatus,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialCardViewModel.AverageTimeInformation.Should().Be($"(average tutorial time {averageTime} minute)");
-        }
-
-        [Test]
-        public void Tutorial_card_time_spent_string_should_have_plural_if_value_is_not_one()
-        {
-            // Given
-            const int tutTime = 10;
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
-                tutTime: tutTime
-            );
-
-            // When
-            var tutorialCardViewModel = new TutorialCardViewModel(
-                sectionTutorial,
-                ShowTime,
-                ShowLearnStatus,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialCardViewModel.TimeSpentInformation.Should().Be($"{tutTime} minutes spent");
-        }
-
-        [Test]
-        public void Tutorial_card_time_spent_string_should_not_have_plural_if_value_is_one()
-        {
-            // Given
-            const int tutTime = 1;
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
-                tutTime: tutTime
-            );
-
-            // When
-            var tutorialCardViewModel = new TutorialCardViewModel(
-                sectionTutorial,
-                ShowTime,
-                ShowLearnStatus,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialCardViewModel.TimeSpentInformation.Should().Be($"{tutTime} minute spent");
-        }
-
-        [Test]
-        public void Tutorial_card_should_show_time_if_courseSettings_are_true()
-        {
-            // Given
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
-
-            // When
-            var tutorialCardViewModel = new TutorialCardViewModel(
-                sectionTutorial,
-                showTime: true,
-                showLearnStatus: true,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialCardViewModel.ShowTime.Should().BeTrue();
-        }
-
-        [Test]
-        public void Tutorial_card_should_not_show_time_if_showTime_courseSetting_is_false()
-        {
-            // Given
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
-
-            // When
-            var tutorialCardViewModel = new TutorialCardViewModel(
-                sectionTutorial,
-                showTime: false,
-                showLearnStatus: true,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialCardViewModel.ShowTime.Should().BeFalse();
-        }
-
-        [Test]
-        public void Tutorial_card_should_not_show_time_if_showLearnStatus_is_false()
-        {
-            // Given
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
-
-            // When
-            var tutorialCardViewModel = new TutorialCardViewModel(
-                sectionTutorial,
-                showTime: true,
-                showLearnStatus: false,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialCardViewModel.ShowTime.Should().BeFalse();
+            tutorialCardViewModel.TimeSummary.Should().BeEquivalentTo(expectedTimeSummary);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
@@ -12,15 +12,20 @@
         private const bool ShowTime = true;
         private const bool ShowLearnStatus = true;
 
-        [Test]
-        public void Tutorial_card_should_have_timeSummary()
+        [TestCase(0, 1, true, true)]
+        [TestCase(1, 30, true, false)]
+        [TestCase(30, 120, false, true)]
+        [TestCase(120, 61, false, false)]
+        [TestCase(61, 195, true, true)]
+        [TestCase(195, 0, true, false)]
+        public void Tutorial_card_should_have_timeSummary(
+            int timeSpent,
+            int averageTutorialDuration,
+            bool showTime,
+            bool showLearnStatus
+        )
         {
             // Given
-            const int averageTutorialDuration = 73;
-            const int timeSpent = 41;
-            const bool showTime = true;
-            const bool showLearnStatus = false;
-
             var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
                 tutTime: timeSpent,
                 averageTutMins: averageTutorialDuration

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialTimeSummaryViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialTimeSummaryViewModelTests.cs
@@ -1,0 +1,144 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
+{
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    class TutorialTimeSummaryViewModelTests
+    {
+        private const bool ShowTime = true;
+        private const bool ShowLearnStatus = true;
+
+        [Test]
+        public void Tutorial_card_average_time_spent_string_should_have_plural_if_value_is_not_one()
+        {
+            // Given
+            const int timeSpent = 1;
+            const int averageTime = 10;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                ShowTime,
+                ShowLearnStatus
+            );
+
+            // Then
+            tutorialTimeSummaryViewModel.AverageTimeSummary.Should().Be($"(average tutorial time {averageTime} minutes)");
+        }
+
+        [Test]
+        public void Tutorial_card_average_time_spent_string_should_not_have_plural_if_value_is_one()
+        {
+            // Given
+            const int timeSpent = 10;
+            const int averageTime = 1;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                ShowTime,
+                ShowLearnStatus
+            );
+
+            // Then
+            tutorialTimeSummaryViewModel.AverageTimeSummary.Should().Be($"(average tutorial time {averageTime} minute)");
+        }
+
+        [Test]
+        public void Tutorial_card_time_spent_string_should_have_plural_if_value_is_not_one()
+        {
+            // Given
+            const int timeSpent = 10;
+            const int averageTime = 1;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                ShowTime,
+                ShowLearnStatus
+            );
+
+            // Then
+            tutorialTimeSummaryViewModel.TimeSpentSummary.Should().Be($"{timeSpent} minutes spent");
+        }
+
+        [Test]
+        public void Tutorial_card_time_spent_string_should_not_have_plural_if_value_is_one()
+        {
+            // Given
+            const int timeSpent = 1;
+            const int averageTime = 10;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                ShowTime,
+                ShowLearnStatus
+            );
+
+            // Then
+            tutorialTimeSummaryViewModel.TimeSpentSummary.Should().Be($"{timeSpent} minute spent");
+        }
+
+        [Test]
+        public void Tutorial_card_should_show_time_if_courseSettings_are_true()
+        {
+            // Given
+            const int timeSpent = 10;
+            const int averageTime = 10;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                showTimeSetting: true,
+                showLearnStatusSetting: true
+            );
+
+            tutorialTimeSummaryViewModel.ShowTime.Should().BeTrue();
+        }
+
+        [Test]
+        public void Tutorial_card_should_not_show_time_if_showTime_courseSetting_is_false()
+        {
+            // Given
+            const int timeSpent = 10;
+            const int averageTime = 10;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                showTimeSetting: false,
+                showLearnStatusSetting: true
+            );
+
+            // Then
+            tutorialTimeSummaryViewModel.ShowTime.Should().BeFalse();
+        }
+
+        [Test]
+        public void Tutorial_card_should_not_show_time_if_showLearnStatus_is_false()
+        {
+            // Given
+            const int timeSpent = 10;
+            const int averageTime = 10;
+
+            // When
+            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTime,
+                showTimeSetting: true,
+                showLearnStatusSetting: false
+            );
+
+            // Then
+            tutorialTimeSummaryViewModel.ShowTime.Should().BeFalse();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialTimeSummaryViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialTimeSummaryViewModelTests.cs
@@ -9,12 +9,16 @@
         private const bool ShowTime = true;
         private const bool ShowLearnStatus = true;
 
-        [Test]
-        public void Tutorial_card_average_time_spent_string_should_have_plural_if_value_is_not_one()
+        [TestCase(0, "0 minutes")]
+        [TestCase(1, "1 minute")]
+        [TestCase(30, "30 minutes")]
+        [TestCase(120, "2 hours")]
+        [TestCase(61, "1 hour 1 minute")]
+        [TestCase(195, "3 hours 15 minutes")]
+        public void TutorialTimeSummary_formats_average_time_spent(int averageTime, string expectedFormattedTime)
         {
             // Given
             const int timeSpent = 1;
-            const int averageTime = 10;
 
             // When
             var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
@@ -25,14 +29,18 @@
             );
 
             // Then
-            tutorialTimeSummaryViewModel.AverageTimeSummary.Should().Be($"(average tutorial time {averageTime} minutes)");
+            tutorialTimeSummaryViewModel.AverageTimeSummary.Should().Be(expectedFormattedTime);
         }
 
-        [Test]
-        public void Tutorial_card_average_time_spent_string_should_not_have_plural_if_value_is_one()
+        [TestCase(0, "0 minutes")]
+        [TestCase(1, "1 minute")]
+        [TestCase(30, "30 minutes")]
+        [TestCase(120, "2 hours")]
+        [TestCase(61, "1 hour 1 minute")]
+        [TestCase(195, "3 hours 15 minutes")]
+        public void TutorialTimeSummary_formats_user_time_spent(int timeSpent, string expectedFormattedTime)
         {
             // Given
-            const int timeSpent = 10;
             const int averageTime = 1;
 
             // When
@@ -44,49 +52,11 @@
             );
 
             // Then
-            tutorialTimeSummaryViewModel.AverageTimeSummary.Should().Be($"(average tutorial time {averageTime} minute)");
+            tutorialTimeSummaryViewModel.TimeSpentSummary.Should().Be(expectedFormattedTime);
         }
 
         [Test]
-        public void Tutorial_card_time_spent_string_should_have_plural_if_value_is_not_one()
-        {
-            // Given
-            const int timeSpent = 10;
-            const int averageTime = 1;
-
-            // When
-            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
-                timeSpent,
-                averageTime,
-                ShowTime,
-                ShowLearnStatus
-            );
-
-            // Then
-            tutorialTimeSummaryViewModel.TimeSpentSummary.Should().Be($"{timeSpent} minutes spent");
-        }
-
-        [Test]
-        public void Tutorial_card_time_spent_string_should_not_have_plural_if_value_is_one()
-        {
-            // Given
-            const int timeSpent = 1;
-            const int averageTime = 10;
-
-            // When
-            var tutorialTimeSummaryViewModel = new TutorialTimeSummaryViewModel(
-                timeSpent,
-                averageTime,
-                ShowTime,
-                ShowLearnStatus
-            );
-
-            // Then
-            tutorialTimeSummaryViewModel.TimeSpentSummary.Should().Be($"{timeSpent} minute spent");
-        }
-
-        [Test]
-        public void Tutorial_card_should_show_time_if_courseSettings_are_true()
+        public void TutorialTimeSummary_should_show_time_if_courseSettings_are_true()
         {
             // Given
             const int timeSpent = 10;
@@ -104,7 +74,7 @@
         }
 
         [Test]
-        public void Tutorial_card_should_not_show_time_if_showTime_courseSetting_is_false()
+        public void TutorialTimeSummary_should_not_show_time_if_showTime_courseSetting_is_false()
         {
             // Given
             const int timeSpent = 10;
@@ -123,7 +93,7 @@
         }
 
         [Test]
-        public void Tutorial_card_should_not_show_time_if_showLearnStatus_is_false()
+        public void TutorialTimeSummary_should_not_show_time_if_showLearnStatus_is_false()
         {
             // Given
             const int timeSpent = 10;

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -244,6 +244,43 @@
             tutorialViewModel.TimeSummary.Should().BeEquivalentTo(expectedTimeSummary);
         }
 
+        [TestCase(0, 1, true, true)]
+        [TestCase(1, 30, true, true)]
+        [TestCase(30, 120, true, true)]
+        [TestCase(120, 61, true, true)]
+        [TestCase(61, 195, true, true)]
+        [TestCase(195, 0, true, true)]
+        public void Tutorial_should_have_timeSummary(
+            int timeSpent,
+            int averageTutorialDuration,
+            bool showTime,
+            bool showLearnStatus
+        )
+        {
+            // Given
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                timeSpent: timeSpent,
+                averageTutorialDuration: averageTutorialDuration
+            );
+            var expectedTimeSummary = new TutorialTimeSummaryViewModel(
+                timeSpent,
+                averageTutorialDuration,
+                showTime,
+                showLearnStatus
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.TimeSummary.Should().BeEquivalentTo(expectedTimeSummary);
+        }
+
         [Test]
         public void Tutorial_should_summarise_score()
         {

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -219,13 +219,18 @@
         }
 
         [Test]
-        public void Tutorial_should_summarise_duration()
+        public void Tutorial_should_have_timeSummary()
         {
             // Given
+            const int averageTutorialDuration = 73;
+            const int timeSpent = 41;
+
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
-                averageTutorialDuration: 73,
-                timeSpent: 41
+                timeSpent: timeSpent,
+                averageTutorialDuration: averageTutorialDuration
             );
+            // TODO: Test different customisations settings when found as part of HEEDLS-196
+            var expectedTimeSummary = new TutorialTimeSummaryViewModel(timeSpent, averageTutorialDuration, true, true);
 
             // When
             var tutorialViewModel = new TutorialViewModel(
@@ -236,7 +241,7 @@
             );
 
             // Then
-            tutorialViewModel.TimeSummary.Should().Be("41m (average time 1h 13m)");
+            tutorialViewModel.TimeSummary.Should().BeEquivalentTo(expectedTimeSummary);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Helpers/DurationFormattingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/DurationFormattingHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Web.Helpers
+{
+    public class DurationFormattingHelper
+    {
+        public static string FormatDuration(int duration)
+        {
+            if (duration < 60)
+            {
+                return FormatTimeUnits(duration, "minute");
+            }
+
+            var durationMinutes = duration % 60;
+            var formattedHours = FormatTimeUnits(duration / 60, "hour");
+            var formattedMinutes = FormatTimeUnits(durationMinutes, "minute");
+            return durationMinutes == 0 ? formattedHours : $"{formattedHours} {formattedMinutes}";
+
+        }
+
+        public static string? FormatNullableDuration(int? duration) =>
+            duration == null ? null : FormatDuration(duration.Value);
+
+        private static string FormatTimeUnits(int duration, string unit) =>
+            duration == 1 ? $"{duration} {unit}" : $"{duration} {unit}s";
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -24,7 +24,7 @@
         {
             Id = courseContent.Id;
             Title = courseContent.Title;
-            AverageDuration = FormatDuration(courseContent.AverageDuration);
+            AverageDuration = DurationFormattingHelper.FormatNullableDuration(courseContent.AverageDuration);
 
             CentreName = courseContent.CentreName;
             BannerText = courseContent.BannerText;
@@ -47,27 +47,5 @@
             );
             ShowTime = AverageDuration != null && courseContent.CourseSettings.ShowTime;
         }
-
-        private static string? FormatDuration(int? duration)
-        {
-            if (duration == null)
-            {
-                return null;
-            }
-
-            if (duration < 60)
-            {
-                return FormatTimeUnits(duration.Value, "minute");
-            }
-
-            var durationMinutes = duration.Value % 60;
-            var formattedHours = FormatTimeUnits(duration.Value / 60, "hour");
-            var formattedMinutes = FormatTimeUnits(durationMinutes, "minute");
-            return durationMinutes == 0 ? formattedHours : $"{formattedHours} {formattedMinutes}";
-
-        }
-
-        private static string FormatTimeUnits(int duration, string unit) =>
-            duration == 1 ? $"{duration} {unit}" : $"{duration} {unit}s";
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialCardViewModel.cs
@@ -7,12 +7,10 @@
         public int Id { get; }
         public string TutorialName { get; }
         public string CompletionStatus { get; }
-        public string TimeSpentInformation { get; }
-        public string AverageTimeInformation { get; }
         public int SectionId { get; }
         public int CustomisationId { get; }
-        public bool ShowTime { get; }
         public bool ShowLearnStatus { get; }
+        public TutorialTimeSummaryViewModel TimeSummary { get; }
 
         public TutorialCardViewModel(
             SectionTutorial tutorial,
@@ -25,14 +23,13 @@
             Id = tutorial.Id;
             TutorialName = tutorial.TutorialName;
             CompletionStatus = tutorial.CompletionStatus;
-            TimeSpentInformation = tutorial.TutorialTime == 1
-                ? $"{tutorial.TutorialTime} minute spent"
-                : $"{tutorial.TutorialTime} minutes spent";
-            AverageTimeInformation = tutorial.AverageTutorialTime == 1
-                ? $"(average tutorial time {tutorial.AverageTutorialTime} minute)"
-                : $"(average tutorial time {tutorial.AverageTutorialTime} minutes)";
-            ShowTime = showTime && showLearnStatus;
             ShowLearnStatus = showLearnStatus;
+            TimeSummary = new TutorialTimeSummaryViewModel(
+                tutorial.TutorialTime,
+                tutorial.AverageTutorialTime,
+                showTime,
+                showLearnStatus
+            );
             SectionId = sectionId;
             CustomisationId = customisationId;
         }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialTimeSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialTimeSummaryViewModel.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
+{
+    public class TutorialTimeSummaryViewModel
+    {
+        public string TimeSpentSummary { get; }
+        public string AverageTimeSummary { get; }
+        public bool ShowTime { get; }
+
+        public TutorialTimeSummaryViewModel(
+            int timeSpent,
+            int averageTimeSpent,
+            bool showTimeSetting,
+            bool showLearnStatusSetting
+        )
+        {
+            TimeSpentSummary = timeSpent == 1
+                ? $"{timeSpent} minute spent"
+                : $"{timeSpent} minutes spent";
+            AverageTimeSummary = averageTimeSpent == 1
+                ? $"(average tutorial time {averageTimeSpent} minute)"
+                : $"(average tutorial time {averageTimeSpent} minutes)";
+            ShowTime = showTimeSetting && showLearnStatusSetting;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialTimeSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialTimeSummaryViewModel.cs
@@ -1,5 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
 {
+    using DigitalLearningSolutions.Web.Helpers;
+
     public class TutorialTimeSummaryViewModel
     {
         public string TimeSpentSummary { get; }
@@ -13,12 +15,8 @@
             bool showLearnStatusSetting
         )
         {
-            TimeSpentSummary = timeSpent == 1
-                ? $"{timeSpent} minute spent"
-                : $"{timeSpent} minutes spent";
-            AverageTimeSummary = averageTimeSpent == 1
-                ? $"(average tutorial time {averageTimeSpent} minute)"
-                : $"(average tutorial time {averageTimeSpent} minutes)";
+            TimeSpentSummary = DurationFormattingHelper.FormatDuration(timeSpent);
+            AverageTimeSummary = DurationFormattingHelper.FormatDuration(averageTimeSpent);
             ShowTime = showTimeSetting && showLearnStatusSetting;
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -19,7 +19,7 @@
         public bool CanShowProgress { get; }
         public string TutorialRecommendation { get; }
         public string ScoreSummary { get; }
-        public string TimeSummary { get; }
+        public TutorialTimeSummaryViewModel TimeSummary { get; }
         public string? SupportingMaterialPath { get; }
         public TutorialNextLinkViewModel NextLinkViewModel { get; }
 
@@ -46,7 +46,12 @@
             TutorialRecommendation =
                 GetTutorialRecommendation(tutorialInformation.CurrentScore, tutorialInformation.PossibleScore);
             ScoreSummary = GetScoreSummary(tutorialInformation.CurrentScore, tutorialInformation.PossibleScore);
-            TimeSummary = GetTimeSummary(tutorialInformation.TimeSpent, tutorialInformation.AverageTutorialDuration);
+            TimeSummary = new TutorialTimeSummaryViewModel(
+                tutorialInformation.TimeSpent,
+                tutorialInformation.AverageTutorialDuration,
+                true,
+                true
+            );
             SupportingMaterialPath =
                 ContentUrlHelper.GetNullableContentPath(config, tutorialInformation.SupportingMaterialPath);
             NextLinkViewModel = new TutorialNextLinkViewModel(
@@ -71,21 +76,6 @@
         private string GetScoreSummary(int currentScore, int possibleScore)
         {
             return CanShowProgress ? $"(score: {currentScore} out of {possibleScore})" : "";
-        }
-
-        private string GetTimeSummary(int timeSpent, int averageTutorialDuration)
-        {
-            return $"{ParseMinutes(timeSpent)}" +
-                   $" (average time {ParseMinutes(averageTutorialDuration)})";
-        }
-
-        private static string ParseMinutes(int minutes)
-        {
-            if (minutes > 60)
-            {
-                return $"{minutes / 60}h {minutes % 60}m";
-            }
-            return $"{minutes}m";
         }
 
         private static string? ParseObjectives(string? objectives)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -7,15 +7,7 @@
         <h3 class="nhsuk-card__heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
-
-        @if (Model.ShowTime)
-        {
-          <p class="nhsuk-u-secondary-text-color">
-            @Model.TimeSpentInformation
-            <span class="visually-hidden">on this tutorial</span>
-            @Model.AverageTimeInformation
-          </p>
-        }
+        <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
       </div>
       @if (Model.ShowLearnStatus)
       {

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_TutorialTimeSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_TutorialTimeSummary.cshtml
@@ -3,9 +3,9 @@
 
 @if (Model.ShowTime)
 {
-  <p class="nhsuk-u-secondary-text-color">
-    @Model.TimeSpentSummary
-    <span class="visually-hidden">on this tutorial</span>
-    @Model.AverageTimeSummary
-  </p>
+<p class="nhsuk-u-secondary-text-color">
+  @Model.TimeSpentSummary spent
+  <span class="visually-hidden">on this tutorial</span>
+  (average tutorial time @Model.AverageTimeSummary)
+</p>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_TutorialTimeSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_TutorialTimeSummary.cshtml
@@ -1,0 +1,11 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningMenu
+@model TutorialTimeSummaryViewModel
+
+@if (Model.ShowTime)
+{
+  <p class="nhsuk-u-secondary-text-color">
+    @Model.TimeSpentSummary
+    <span class="visually-hidden">on this tutorial</span>
+    @Model.AverageTimeSummary
+  </p>
+}

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -22,7 +22,7 @@
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.TutorialName</h1>
     <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">@Model.Status @Model.ScoreSummary</h2>
-    <p class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-4">@Model.TimeSummary</p>
+    <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
   </div>
 </div>
 


### PR DESCRIPTION
## Changes
Take time summary used by tutorial card and put it in a partial, for
use in tutorial card and also tutorial page.

## Testing
Amend tests for these view models, move time summary tests into the
partial's view model tests.

Pages tested in Chrome, Firefox, Edge, and IE11, using a screen reader and a narrow viewport.

## Screenshot
![tutorial_time_improvement](https://user-images.githubusercontent.com/3650110/104042486-79993d80-51d2-11eb-8c4c-0a06a1ad9a57.png)