### PR TITLE
HEEDLS-281 Fix bug of hiding tutorials with status 0

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
@@ -49,12 +49,12 @@
             expectedDiagnosticAssessment.Tutorials.AddRange(
                 new[]
                 {
-                    new DiagnosticTutorial("Create and edit simple formulas", 383, true),
-                    new DiagnosticTutorial("Understand and enforce simple precedence in formulas", 384, true),
-                    new DiagnosticTutorial("Nest parentheses in formulas", 385, true),
-                    new DiagnosticTutorial("Use relative and absolute cell references", 386, true),
-                    new DiagnosticTutorial("Refer to other worksheets", 387, true),
-                    new DiagnosticTutorial("Link other workbooks", 388, true)
+                    new DiagnosticTutorial("Create and edit simple formulas", 383),
+                    new DiagnosticTutorial("Understand and enforce simple precedence in formulas", 384),
+                    new DiagnosticTutorial("Nest parentheses in formulas", 385),
+                    new DiagnosticTutorial("Use relative and absolute cell references", 386),
+                    new DiagnosticTutorial("Refer to other worksheets", 387),
+                    new DiagnosticTutorial("Link other workbooks", 388)
                 }
             );
             result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
@@ -85,28 +85,13 @@
             expectedDiagnosticAssessment.Tutorials.AddRange(
                 new[]
                 {
-                    new DiagnosticTutorial("Introduction to applications", 4340, true),
-                    new DiagnosticTutorial("Common screen elements", 4341, true),
-                    new DiagnosticTutorial("Using ribbon tabs", 4342, true),
-                    new DiagnosticTutorial("Getting help", 4343, true)
+                    new DiagnosticTutorial("Introduction to applications", 4340),
+                    new DiagnosticTutorial("Common screen elements", 4341),
+                    new DiagnosticTutorial("Using ribbon tabs", 4342),
+                    new DiagnosticTutorial("Getting help", 4343)
                 }
             );
             result.Should().BeEquivalentTo(expectedDiagnosticAssessment);
-        }
-
-        [Test]
-        public void Get_diagnostic_assessment_can_return_no_tutorials()
-        {
-            // Given
-            const int customisationId = 9850;
-            const int candidateId = 254480;
-            const int sectionId = 170;
-
-            // When
-            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
-
-            // Then
-            result.Tutorials.Should().BeEmpty();
         }
 
         [Test]
@@ -196,6 +181,24 @@
             var tutorialIds = result!.Tutorials.Select(tutorial => tutorial.Id).ToList();
             tutorialIds.Should().NotContain(541); // Tutorial with DiagStatus 0
             tutorialIds.Should().Equal(535, 536, 537, 538, 539, 540, 542);
+        }
+
+
+        [Test]
+        public void Get_diagnostic_assessment_can_have_tutorials_with_false_status()
+        {
+            // Given
+            const int customisationId = 5694;
+            const int candidateId = 1;
+            const int sectionId = 103;
+
+            // When
+            var result = diagnosticAssessmentService.GetDiagnosticAssessment(customisationId, candidateId, sectionId);
+
+            // Then
+            result.Should().NotBeNull();
+            var tutorialIds = result!.Tutorials.Select(tutorial => tutorial.Id).ToList();
+            tutorialIds.Should().Equal(319, 320, 322, 323, 321, 324); // All have CustomisationTutorials.Status = 0
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticTutorial.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticTutorial.cs
@@ -4,13 +4,11 @@
     {
         public string TutorialName { get; }
         public int Id { get; }
-        public bool IsDisplayed { get; }
 
-        public DiagnosticTutorial(string tutorialName, int id, bool status)
+        public DiagnosticTutorial(string tutorialName, int id)
         {
             TutorialName = tutorialName;
             Id = id;
-            IsDisplayed = status;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentService.cs
@@ -41,8 +41,7 @@
                         CASE WHEN Tutorials.OriginalTutorialID > 0
                              THEN Tutorials.OriginalTutorialID
                              ELSE Tutorials.TutorialID
-                        END AS id,
-                        CustomisationTutorials.Status
+                        END AS id
                     FROM Sections
                         INNER JOIN Customisations
                             ON Customisations.ApplicationID = Sections.ApplicationID
@@ -89,10 +88,7 @@
                         diagnosticAssessment.MaxSectionScore += diagnostic.MaxSectionScore;
                     }
 
-                    if (tutorial.IsDisplayed)
-                    {
-                            diagnosticAssessment.Tutorials.Add(tutorial);
-                    }
+                    diagnosticAssessment.Tutorials.Add(tutorial);
 
                     return diagnosticAssessment;
                 },

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
@@ -93,8 +93,8 @@
             // Given
             var tutorials = new[]
             {
-                new DiagnosticTutorial("Tutorial 1", 1, true),
-                new DiagnosticTutorial("Tutorial 2", 2, true)
+                new DiagnosticTutorial("Tutorial 1", 1),
+                new DiagnosticTutorial("Tutorial 2", 2)
             };
             var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment(
                 diagObjSelect: selectTutorials
@@ -200,8 +200,8 @@
             // Given
             var tutorials = new[]
             {
-                new DiagnosticTutorial("Tutorial 1", 1, true),
-                new DiagnosticTutorial("Tutorial 2", 2, true)
+                new DiagnosticTutorial("Tutorial 1", 1),
+                new DiagnosticTutorial("Tutorial 2", 2)
             };
             var diagnosticAssessment = DiagnosticAssessmentHelper.CreateDefaultDiagnosticAssessment();
             diagnosticAssessment.Tutorials.AddRange(tutorials);


### PR DESCRIPTION
### Changes
Remove change the C# code that was discarding tutorials with
`CustomisationTutorials.Status = 0` for the diagnostic assessment page.

Remove unneeded `CustomisationTutorials.Status` from `DiagnosticTutorial` object

### Testing
Amend tests due to type change, remove an incorrect test and add a regression test