### PR TITLE
HEEDLS-287 Use care cards for tutorial objectives

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/learningMenu/tutorial.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/tutorial.scss
@@ -1,5 +1,9 @@
 ﻿@import "~nhsuk-frontend/packages/core/all";
 
+.objectives-card {
+  @include nhsuk-typography-responsive(19);
+}
+
 .tutorial-video {
   width: 100%;
   height: auto;

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -50,16 +50,15 @@
 
 @if (Model.Objectives != null)
 {
-  <details class="nhsuk-details nhsuk-u-margin-bottom-4">
-    <summary class="nhsuk-details__summary">
-      <span class="nhsuk-details__summary-text">
-        Objectives
-      </span>
-    </summary>
-    <div class="nhsuk-details__text">
+  <div class="nhsuk-care-card nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4 objectives-card">
+    <div class="nhsuk-care-card__heading-container">
+      <h3 class="nhsuk-care-card__heading"><span role="text">Objectives</span></h3>
+      <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
+    </div>
+    <div class="nhsuk-care-card__content">
       @Html.Raw(Model.Objectives)
     </div>
-  </details>
+  </div>
 }
 
 <div class="button-row">


### PR DESCRIPTION
### Changes
Use care cards instead of a details expander to show objectives on the tutorial overview page.

### Testing
Tested in Chrome and IE11, using a screenreader and no JS.