### PR TITLE
HEEDLS-288 Ignore archived tutorials in data services

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CourseCompletionServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseCompletionServiceTests.cs
@@ -92,6 +92,24 @@
         }
 
         [Test]
+        public void Get_course_completion_should_not_use_archived_tutorials_in_percentageTutorialsCompleted()
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                const int candidateId = 11;
+                const int customisationId = 15937;
+                courseCompletionTestHelper.AddCertificationToCourse(customisationId);
+
+                // When
+                var result = courseCompletionService.GetCourseCompletion(candidateId, customisationId);
+
+                // Then
+                result.PercentageTutorialsCompleted.Should().Be(100.0 * 36 / 196);
+            }
+        }
+
+        [Test]
         public void Get_course_completion_of_evaluated_course_should_return_course_completion()
         {
             using (new TransactionScope())

--- a/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DiagnosticAssessmentServiceTests.cs
@@ -398,7 +398,7 @@
         }
 
         [Test]
-        public void Get_diagnostic_content_should_not_return_tutorials_where_archived_date_is_null()
+        public void Get_diagnostic_content_should_not_return_archived_tutorials()
         {
             // Given
             const int customisationId = 14212;

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -149,6 +149,25 @@
         }
 
         [Test]
+        public void Get_tutorial_information_nextTutorial_skips_archived_tutorial()
+        {
+            // Given
+            const int candidateId = 11;
+            const int customisationId = 15937;
+            const int sectionId = 392;
+            const int tutorialId = 1535;
+
+            const int nextTutorialId = 1583; // Skipping over archived 1536, 1537, 1581
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
+        }
+
+        [Test]
         public void Get_tutorial_information_nextSection_can_return_smaller_sectionId()
         {
             // Given
@@ -373,6 +392,22 @@
         }
 
         [Test]
+        public void Get_tutorial_information_should_return_null_if_tutorial_is_archived()
+        {
+            // Given
+            const int candidateId = 23031;
+            const int customisationId = 14212;
+            const int sectionId = 249;
+            const int tutorialId = 1142;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().BeNull();
+        }
+
+        [Test]
         public void Get_tutorial_content_should_return_tutorial_content()
         {
             // Given
@@ -461,6 +496,21 @@
             const int customisationId = 1530;
             const int sectionId = 74;
             const int tutorialId = 49;
+
+            // When
+            var tutorialContent = tutorialContentService.GetTutorialContent(customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorialContent.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_tutorial_content_should_return_null_if_tutorial_is_archived()
+        {
+            // Given
+            const int customisationId = 14212;
+            const int sectionId = 249;
+            const int tutorialId = 1142;
 
             // When
             var tutorialContent = tutorialContentService.GetTutorialContent(customisationId, sectionId, tutorialId);
@@ -572,6 +622,21 @@
             const int customisationId = 4207;
             const int sectionId = 152;
             const int tutorialId = 642;
+
+            // When
+            var tutorialVideo = tutorialContentService.GetTutorialVideo(customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorialVideo.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_tutorial_video_should_return_null_if_tutorial_is_archived()
+        {
+            // Given
+            const int customisationId = 14212;
+            const int sectionId = 249;
+            const int tutorialId = 1142;
 
             // When
             var tutorialVideo = tutorialContentService.GetTutorialVideo(customisationId, sectionId, tutorialId);

--- a/DigitalLearningSolutions.Data/Services/CourseCompletionService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseCompletionService.cs
@@ -72,6 +72,7 @@
 
                    WHERE Customisations.CustomisationID = @customisationId
                          AND Sections.ArchivedDate IS NULL
+                         AND Tutorials.ArchivedDate IS NULL
                    GROUP BY Progress.ProgressID
                   )
 

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -47,6 +47,7 @@
                             INNER JOIN Tutorials ON CustomisationTutorials.TutorialID = Tutorials.TutorialID
                             WHERE CustomisationTutorials.CustomisationID = @customisationId
                                   AND CustomisationTutorials.Status = 1
+                                  AND Tutorials.ArchivedDate IS NULL
                        ) AS TutorialDurations
                    GROUP BY CustomisationID
                   )
@@ -86,6 +87,7 @@
                    WHERE Customisations.CustomisationID = @customisationId
                      AND Customisations.Active = 1
                      AND Sections.ArchivedDate IS NULL
+                     AND Tutorials.ArchivedDate IS NULL
                      AND (CustomisationTutorials.Status = 1 OR CustomisationTutorials.DiagStatus = 1 OR Customisations.IsAssessed = 1)
                    GROUP BY
                          Sections.SectionID,

--- a/DigitalLearningSolutions.Data/Services/SectionContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SectionContentService.cs
@@ -82,9 +82,10 @@
                     WHERE
                         CustomisationTutorials.CustomisationID = @customisationId
                         AND Sections.SectionID = @sectionId
-                        AND (Sections.ArchivedDate IS NULL)
+                        AND Sections.ArchivedDate IS NULL
                         AND (CustomisationTutorials.DiagStatus = 1 OR Customisations.IsAssessed = 1 OR CustomisationTutorials.Status = 1)
                         AND Customisations.Active = 1
+                        AND Tutorials.ArchivedDate IS NULL
                         ORDER BY Tutorials.OrderByNumber, Tutorials.TutorialID",
                     (section, tutorial) =>
                         {

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -54,6 +54,7 @@
 
                          LEFT JOIN Tutorials AS NextTutorials
                          ON NextTutorials.SectionID = Tutorials.SectionID
+                            AND NextTutorials.ArchivedDate IS NULL
                             AND Tutorials.OrderByNumber <= NextTutorials.OrderByNumber
                             AND (
                                  Tutorials.OrderByNumber < NextTutorials.OrderByNumber
@@ -147,6 +148,7 @@
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
                      AND CustomisationTutorials.Status = 1
+                     AND Tutorials.ArchivedDate IS NULL
                    ORDER BY NextTutorial.TutorialID, NextSection.SectionID;",
             new { candidateId, customisationId, sectionId, tutorialId });
         }
@@ -176,7 +178,8 @@
                          AND Sections.SectionID = @sectionId
                          AND Tutorials.TutorialId = @tutorialId
                          AND Customisations.Active = 1
-                         AND CustomisationTutorials.Status = 1;",
+                         AND CustomisationTutorials.Status = 1
+                         AND Tutorials.ArchivedDate IS NULL;",
                 new { customisationId, sectionId, tutorialId });
         }
 
@@ -206,7 +209,8 @@
                          AND Sections.SectionID = @sectionId
                          AND Tutorials.TutorialId = @tutorialId
                          AND Customisations.Active = 1
-                         AND CustomisationTutorials.Status = 1;",
+                         AND CustomisationTutorials.Status = 1
+                         AND Tutorials.ArchivedDate IS NULL;",
                     new { customisationId, sectionId, tutorialId });
             }
             catch (DataException e)


### PR DESCRIPTION
### Changes
Ignore archived tutorials in data services by adding filters
to `WHERE` clauses in various queries.

### Testing
* Test that archived tutorials are ignored (both in lists of tutorials, and when aggregating scores over tutorials).
* Rewrite the tests comparing to the old stored procedures because these services now diverge from the stored procedures (they would include archived tutorials).