### PR TITLE
HEEDLS 294 Fix archived tutorials in course and tutorials services

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/TutorialContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/TutorialContentTestHelper.cs
@@ -1,0 +1,26 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
+{
+    using Dapper;
+    using Microsoft.Data.SqlClient;
+
+    public class TutorialContentTestHelper
+    {
+        private SqlConnection connection;
+
+        public TutorialContentTestHelper(SqlConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public void ArchiveTutorial(int tutorialId)
+        {
+            connection.Execute(
+                @"UPDATE Tutorials
+                     SET ArchivedDate = GETDATE()
+
+                   WHERE Tutorials.TutorialID = @tutorialId;",
+                new { tutorialId }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseCompletionServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseCompletionServiceTests.cs
@@ -92,6 +92,24 @@
         }
 
         [Test]
+        public void Get_course_completion_should_not_use_archived_tutorials_in_percentageTutorialsCompleted()
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                const int candidateId = 11;
+                const int customisationId = 15937;
+                courseCompletionTestHelper.AddCertificationToCourse(customisationId);
+
+                // When
+                var result = courseCompletionService.GetCourseCompletion(candidateId, customisationId);
+
+                // Then
+                result.PercentageTutorialsCompleted.Should().Be(100.0 * 36 / 196);
+            }
+        }
+
+        [Test]
         public void Get_course_completion_of_evaluated_course_should_return_course_completion()
         {
             using (new TransactionScope())

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseCompletionServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseCompletionServiceTests.cs
@@ -101,11 +101,14 @@
                 const int customisationId = 15937;
                 courseCompletionTestHelper.AddCertificationToCourse(customisationId);
 
+                const int tutorialsComplete = 36;
+                const int tutorialsAvailable = 196;
+
                 // When
                 var result = courseCompletionService.GetCourseCompletion(candidateId, customisationId);
 
                 // Then
-                result.PercentageTutorialsCompleted.Should().Be(100.0 * 36 / 196);
+                result.PercentageTutorialsCompleted.Should().Be(100.0 * tutorialsComplete / tutorialsAvailable);
             }
         }
 

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -589,13 +589,16 @@
             const int candidateId = 11;
             const int customisationId = 15937;
 
+            const int tutorialsComplete = 3;
+            const int tutorialsAvailable = 14;
+
             // When
             var result = courseContentService.GetCourseContent(candidateId, customisationId);
 
             // Then
             result.Should().NotBeNull();
             result!.Sections.First(section => section.Id == 392)
-                .PercentComplete.Should().Be(100.0 * 3 / 14);
+                .PercentComplete.Should().Be(100.0 * tutorialsComplete / tutorialsAvailable);
         }
 
         [Test]
@@ -620,13 +623,16 @@
             const int candidateId = 22966;
             const int customisationId = 7669;
 
+            const int tutorialsComplete = 2;
+            const int tutorialsAvailable = 12;
+
             // When
             var result = courseContentService.GetCourseContent(candidateId, customisationId);
 
             // Then
             result.Should().NotBeNull();
             result!.Sections.First(section => section.Id == 96)
-                .PercentComplete.Should().Be(100.0 * 2 / 12);
+                .PercentComplete.Should().Be(100.0 * tutorialsComplete / tutorialsAvailable);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -149,6 +149,25 @@
         }
 
         [Test]
+        public void Get_tutorial_information_nextTutorial_skips_archived_tutorial()
+        {
+            // Given
+            const int candidateId = 11;
+            const int customisationId = 15937;
+            const int sectionId = 392;
+            const int tutorialId = 1535;
+
+            const int nextTutorialId = 1583; // Skipping over archived 1536, 1537, 1581
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextTutorialId.Should().Be(nextTutorialId);
+        }
+
+        [Test]
         public void Get_tutorial_information_nextSection_can_return_smaller_sectionId()
         {
             // Given
@@ -373,6 +392,22 @@
         }
 
         [Test]
+        public void Get_tutorial_information_should_return_null_if_tutorial_is_archived()
+        {
+            // Given
+            const int candidateId = 23031;
+            const int customisationId = 14212;
+            const int sectionId = 249;
+            const int tutorialId = 1142;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().BeNull();
+        }
+
+        [Test]
         public void Get_tutorial_content_should_return_tutorial_content()
         {
             // Given
@@ -461,6 +496,21 @@
             const int customisationId = 1530;
             const int sectionId = 74;
             const int tutorialId = 49;
+
+            // When
+            var tutorialContent = tutorialContentService.GetTutorialContent(customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorialContent.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_tutorial_content_should_return_null_if_tutorial_is_archived()
+        {
+            // Given
+            const int customisationId = 14212;
+            const int sectionId = 249;
+            const int tutorialId = 1142;
 
             // When
             var tutorialContent = tutorialContentService.GetTutorialContent(customisationId, sectionId, tutorialId);
@@ -572,6 +622,21 @@
             const int customisationId = 4207;
             const int sectionId = 152;
             const int tutorialId = 642;
+
+            // When
+            var tutorialVideo = tutorialContentService.GetTutorialVideo(customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorialVideo.Should().BeNull();
+        }
+
+        [Test]
+        public void Get_tutorial_video_should_return_null_if_tutorial_is_archived()
+        {
+            // Given
+            const int customisationId = 14212;
+            const int sectionId = 249;
+            const int tutorialId = 1142;
 
             // When
             var tutorialVideo = tutorialContentService.GetTutorialVideo(customisationId, sectionId, tutorialId);

--- a/DigitalLearningSolutions.Data/Services/CourseCompletionService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseCompletionService.cs
@@ -72,6 +72,7 @@
 
                    WHERE Customisations.CustomisationID = @customisationId
                          AND Sections.ArchivedDate IS NULL
+                         AND Tutorials.ArchivedDate IS NULL
                    GROUP BY Progress.ProgressID
                   )
 

--- a/DigitalLearningSolutions.Data/Services/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseContentService.cs
@@ -47,6 +47,7 @@
                             INNER JOIN Tutorials ON CustomisationTutorials.TutorialID = Tutorials.TutorialID
                             WHERE CustomisationTutorials.CustomisationID = @customisationId
                                   AND CustomisationTutorials.Status = 1
+                                  AND Tutorials.ArchivedDate IS NULL
                        ) AS TutorialDurations
                    GROUP BY CustomisationID
                   )
@@ -86,6 +87,7 @@
                    WHERE Customisations.CustomisationID = @customisationId
                      AND Customisations.Active = 1
                      AND Sections.ArchivedDate IS NULL
+                     AND Tutorials.ArchivedDate IS NULL
                      AND (CustomisationTutorials.Status = 1 OR CustomisationTutorials.DiagStatus = 1 OR Customisations.IsAssessed = 1)
                    GROUP BY
                          Sections.SectionID,

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -64,10 +64,12 @@
 
                          LEFT JOIN Tutorials AS NextSectionsTutorials
                          ON NextCustomisationTutorials.TutorialID = NextSectionsTutorials.TutorialID
+                            AND NextSectionsTutorials.ArchivedDate IS NULL
 
                          LEFT JOIN Sections AS NextSections
                          ON NextSectionsTutorials.SectionID = NextSections.SectionID
                             AND CurrentSection.SectionNumber <= NextSections.SectionNumber
+                            AND NextSections.ArchivedDate IS NULL
                             AND (
                                  CurrentSection.SectionNumber < NextSections.SectionNumber
                                  OR CurrentSection.SectionID < NextSections.SectionID
@@ -148,6 +150,7 @@
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
                      AND CustomisationTutorials.Status = 1
+                     AND Sections.ArchivedDate IS NULL
                      AND Tutorials.ArchivedDate IS NULL
                    ORDER BY NextTutorial.TutorialID, NextSection.SectionID;",
             new { candidateId, customisationId, sectionId, tutorialId });
@@ -179,6 +182,7 @@
                          AND Tutorials.TutorialId = @tutorialId
                          AND Customisations.Active = 1
                          AND CustomisationTutorials.Status = 1
+                         AND Sections.ArchivedDate IS NULL
                          AND Tutorials.ArchivedDate IS NULL;",
                 new { customisationId, sectionId, tutorialId });
         }
@@ -209,6 +213,7 @@
                          AND Sections.SectionID = @sectionId
                          AND Tutorials.TutorialId = @tutorialId
                          AND Customisations.Active = 1
+                         AND Sections.ArchivedDate IS NULL
                          AND CustomisationTutorials.Status = 1
                          AND Tutorials.ArchivedDate IS NULL;",
                     new { customisationId, sectionId, tutorialId });

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -54,6 +54,7 @@
 
                          LEFT JOIN Tutorials AS NextTutorials
                          ON NextTutorials.SectionID = Tutorials.SectionID
+                            AND NextTutorials.ArchivedDate IS NULL
                             AND Tutorials.OrderByNumber <= NextTutorials.OrderByNumber
                             AND (
                                  Tutorials.OrderByNumber < NextTutorials.OrderByNumber
@@ -147,6 +148,7 @@
                      AND Tutorials.TutorialID = @tutorialId
                      AND Customisations.Active = 1
                      AND CustomisationTutorials.Status = 1
+                     AND Tutorials.ArchivedDate IS NULL
                    ORDER BY NextTutorial.TutorialID, NextSection.SectionID;",
             new { candidateId, customisationId, sectionId, tutorialId });
         }
@@ -176,7 +178,8 @@
                          AND Sections.SectionID = @sectionId
                          AND Tutorials.TutorialId = @tutorialId
                          AND Customisations.Active = 1
-                         AND CustomisationTutorials.Status = 1;",
+                         AND CustomisationTutorials.Status = 1
+                         AND Tutorials.ArchivedDate IS NULL;",
                 new { customisationId, sectionId, tutorialId });
         }
 
@@ -206,7 +209,8 @@
                          AND Sections.SectionID = @sectionId
                          AND Tutorials.TutorialId = @tutorialId
                          AND Customisations.Active = 1
-                         AND CustomisationTutorials.Status = 1;",
+                         AND CustomisationTutorials.Status = 1
+                         AND Tutorials.ArchivedDate IS NULL;",
                     new { customisationId, sectionId, tutorialId });
             }
             catch (DataException e)


### PR DESCRIPTION
### Changes
Ignore archived tutorials and sections in data services by adding filters to `WHERE` clauses in various queries. Service changed for this ticket:
* Tutorial content
* Course content
* Course completion

This includes changes from review comments in #152.

### Testing
Remove tests that depend on the old stored procedures, and replace them with new tests. Add tests to check correcting ignoring of archived sections and tutorials.