### PR TITLE
HEEDLS-282 Fix the tutorial page next button back end

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/TutorialContentTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/TutorialContentTestHelper.cs
@@ -22,5 +22,16 @@
                 new { tutorialId }
             );
         }
+
+        public void UpdatePLAssessPath(int sectionId, string? newPath)
+        {
+            connection.Execute(
+                @"UPDATE Sections
+                     SET PLAssessPath = @newPath
+
+                   WHERE SectionID = @sectionId;",
+                new { sectionId, newPath }
+            );
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -243,14 +243,14 @@
             const int sectionId = 150;
             const int tutorialId = 634;
 
-            const int nextSectionId = 151; // All tutorials are CustomisationTutorials.Status = 0, though some DiagStatus = 1
+            const int expectedNextSectionId = 151; // All tutorials are CustomisationTutorials.Status = 0, though some DiagStatus = 1
 
             // When
             var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
 
             // Then
             tutorial.Should().NotBeNull();
-            tutorial!.NextSectionId.Should().Be(nextSectionId);
+            tutorial!.NextSectionId.Should().Be(expectedNextSectionId);
         }
 
         [Test]
@@ -262,8 +262,8 @@
             const int sectionId = 104;
             const int tutorialId = 331;
 
-            const int expectedNextSectionId = 105;
-
+            const int expectedNextSectionId = 105; // All tutorials are CustomisationTutorials.Status and DiagStatus = 0
+                                                   // Customisations.IsAssessed = 1 and Sections.PLAssessPath is not null
             // When
             var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
 
@@ -272,7 +272,7 @@
         }
 
         [Test]
-        public void Get_tutorial_information_nextSection_skips_section_with_only_post_learning_assessment_but_no_path()
+        public void Get_tutorial_information_nextSection_skips_assessed_section_with_no_assessment_path()
         {
             using (new TransactionScope())
             {
@@ -282,7 +282,8 @@
                 const int sectionId = 104;
                 const int tutorialId = 331;
 
-                const int originalNextSectionId = 105;
+                const int originalNextSectionId = 105; // All tutorials are CustomisationTutorials.Status and DiagStatus = 0
+                                                       // Customisations.IsAssessed = 1
                 tutorialContentTestHelper.UpdatePLAssessPath(originalNextSectionId, null);
                 const int expectedNextSectionId = 106;
 

--- a/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TutorialContentServiceTests.cs
@@ -235,6 +235,66 @@
         }
 
         [Test]
+        public void Get_tutorial_information_nextSection_returns_section_with_only_diagnostic_assessment()
+        {
+            // Given
+            const int candidateId = 74411;
+            const int customisationId = 5852;
+            const int sectionId = 150;
+            const int tutorialId = 634;
+
+            const int nextSectionId = 151; // All tutorials are CustomisationTutorials.Status = 0, though some DiagStatus = 1
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            // Then
+            tutorial.Should().NotBeNull();
+            tutorial!.NextSectionId.Should().Be(nextSectionId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextSection_returns_section_with_only_post_learning_assessment()
+        {
+            // Given
+            const int customisationId = 10820;
+            const int candidateId = 1;
+            const int sectionId = 104;
+            const int tutorialId = 331;
+
+            const int expectedNextSectionId = 105;
+
+            // When
+            var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+            //Then
+            tutorial.NextSectionId.Should().Be(expectedNextSectionId);
+        }
+
+        [Test]
+        public void Get_tutorial_information_nextSection_skips_section_with_only_post_learning_assessment_but_no_path()
+        {
+            using (new TransactionScope())
+            {
+                // Given
+                const int customisationId = 10820;
+                const int candidateId = 1;
+                const int sectionId = 104;
+                const int tutorialId = 331;
+
+                const int originalNextSectionId = 105;
+                tutorialContentTestHelper.UpdatePLAssessPath(originalNextSectionId, null);
+                const int expectedNextSectionId = 106;
+
+                // When
+                var tutorial = tutorialContentService.GetTutorialInformation(candidateId, customisationId, sectionId, tutorialId);
+
+                //Then
+                tutorial.NextSectionId.Should().Be(expectedNextSectionId);
+            }
+        }
+
+        [Test]
         public void Get_tutorial_information_nextTutorial_returns_smaller_tutorialId_for_shared_orderByNumber()
         {
             // Given

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -48,6 +48,9 @@
                          INNER JOIN Sections AS CurrentSection
                          ON Tutorials.SectionID = CurrentSection.SectionID
 
+                         INNER JOIN Customisations
+                         ON Customisations.CustomisationID = @customisationId
+
                          LEFT JOIN CustomisationTutorials AS NextCustomisationTutorials
                          ON NextCustomisationTutorials.CustomisationID = @customisationId
                             AND NextCustomisationTutorials.Status = 1
@@ -62,8 +65,16 @@
                             )
                             AND NextCustomisationTutorials.TutorialID = NextTutorials.TutorialID
 
+                         LEFT JOIN CustomisationTutorials AS NextSectionCustomisationTutorials
+                         ON NextSectionCustomisationTutorials.CustomisationID = @customisationId
+                            AND (
+                                 NextSectionCustomisationTutorials.Status = 1
+                                 OR NextSectionCustomisationTutorials.DiagStatus = 1
+                                 OR Customisations.IsAssessed = 1
+                            )
+
                          LEFT JOIN Tutorials AS NextSectionsTutorials
-                         ON NextCustomisationTutorials.TutorialID = NextSectionsTutorials.TutorialID
+                         ON NextSectionCustomisationTutorials.TutorialID = NextSectionsTutorials.TutorialID
                             AND NextSectionsTutorials.ArchivedDate IS NULL
 
                          LEFT JOIN Sections AS NextSections
@@ -74,6 +85,12 @@
                                  CurrentSection.SectionNumber < NextSections.SectionNumber
                                  OR CurrentSection.SectionID < NextSections.SectionID
                             )
+                            AND (
+                                 NextSectionCustomisationTutorials.Status = 1
+                                 OR NextSectionCustomisationTutorials.DiagStatus = 1
+                                 OR NextSections.PLAssessPath IS NOT NULL
+                            )
+
                    WHERE Tutorials.SectionId = @sectionId
                      AND Tutorials.TutorialID = @tutorialId
                    GROUP BY Tutorials.TutorialID


### PR DESCRIPTION
### Changes
Get next section IDs when sections just have diagnostic assessments,
or just have post learning assessments (previously it was only displayed
if there was tutorial learning for that next section).

### Testing
Add some unit tests to cover these cases.