### PR TITLE
HEEDLS-299 Add tutorial customisation front end

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -387,8 +387,7 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 canShowDiagnosticStatus: true,
-                attemptCount: 1,
-                courseSettings: null
+                attemptCount: 1
             );
 
             // When
@@ -409,8 +408,7 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 canShowDiagnosticStatus: true,
-                attemptCount: 0,
-                courseSettings: null
+                attemptCount: 0
             );
 
             // When
@@ -431,8 +429,7 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 canShowDiagnosticStatus: false,
-                attemptCount: 1,
-                courseSettings: null
+                attemptCount: 1
             );
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -198,9 +198,8 @@
         public void Tutorial_should_have_showLearnStatus_from_courseSetting()
         {
             // Given
-            const bool showLearnStatus = false;
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
-                courseSettings: "{\"lm.sl\":" + showLearnStatus.ToString().ToLower() + "}"
+                courseSettings: "{\"lm.sl\":false}"
             );
 
             // When
@@ -212,7 +211,7 @@
             );
 
             // Then
-            tutorialViewModel.ShowLearnStatus.Should().Be(showLearnStatus);
+            tutorialViewModel.ShowLearnStatus.Should().BeFalse();
         }
 
         [Test]
@@ -232,7 +231,7 @@
             );
 
             // Then
-            tutorialViewModel.ShowLearnStatus.Should().Be(true);
+            tutorialViewModel.ShowLearnStatus.Should().BeTrue();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -154,6 +154,88 @@
         }
 
         [Test]
+        public void Tutorial_should_have_supportingMaterialsLabel_from_courseSetting()
+        {
+            // Given
+            const string supportingMaterialsText = "Different supporting information description";
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                courseSettings: "{\"lm:si\":\"" + supportingMaterialsText + "\"}"
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.SupportingMaterialsLabel.Should().Be(supportingMaterialsText);
+        }
+
+        [Test]
+        public void Tutorial_should_have_default_supportingMaterialsLabel_when_courseSetting_is_empty()
+        {
+            // Given
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                courseSettings: null
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.SupportingMaterialsLabel.Should().Be("Download supporting materials");
+        }
+
+        [Test]
+        public void Tutorial_should_have_showLearnStatus_from_courseSetting()
+        {
+            // Given
+            const bool showLearnStatus = false;
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                courseSettings: "{\"lm.sl\":" + showLearnStatus.ToString().ToLower() + "}"
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.ShowLearnStatus.Should().Be(showLearnStatus);
+        }
+
+        [Test]
+        public void Tutorial_should_have_default_showLearnStatus_when_courseSetting_is_empty()
+        {
+            // Given
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                courseSettings: null
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.ShowLearnStatus.Should().Be(true);
+        }
+
+        [Test]
         public void Tutorial_should_have_customisationId()
         {
             // Given
@@ -239,38 +321,12 @@
             tutorialViewModel.NextLinkViewModel.Should().BeEquivalentTo(expectedNextLinkViewModel);
         }
 
-        [Test]
-        public void Tutorial_should_have_timeSummary()
-        {
-            // Given
-            const int averageTutorialDuration = 73;
-            const int timeSpent = 41;
-
-            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
-                timeSpent: timeSpent,
-                averageTutorialDuration: averageTutorialDuration
-            );
-            // TODO: Test different customisations settings when found as part of HEEDLS-196
-            var expectedTimeSummary = new TutorialTimeSummaryViewModel(timeSpent, averageTutorialDuration, true, true);
-
-            // When
-            var tutorialViewModel = new TutorialViewModel(
-                config,
-                expectedTutorialInformation,
-                CustomisationId,
-                SectionId
-            );
-
-            // Then
-            tutorialViewModel.TimeSummary.Should().BeEquivalentTo(expectedTimeSummary);
-        }
-
         [TestCase(0, 1, true, true)]
-        [TestCase(1, 30, true, true)]
-        [TestCase(30, 120, true, true)]
-        [TestCase(120, 61, true, true)]
+        [TestCase(1, 30, true, false)]
+        [TestCase(30, 120, false, true)]
+        [TestCase(120, 61, false, false)]
         [TestCase(61, 195, true, true)]
-        [TestCase(195, 0, true, true)]
+        [TestCase(195, 0, true, false)]
         public void Tutorial_should_have_timeSummary(
             int timeSpent,
             int averageTutorialDuration,
@@ -281,7 +337,10 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 timeSpent: timeSpent,
-                averageTutorialDuration: averageTutorialDuration
+                averageTutorialDuration: averageTutorialDuration,
+                courseSettings: "{\"lm.st\":" + showTime.ToString().ToLower()
+                             + ", \"lm.sl\":" + showLearnStatus.ToString().ToLower() + "}"
+
             );
             var expectedTimeSummary = new TutorialTimeSummaryViewModel(
                 timeSpent,
@@ -329,7 +388,8 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 canShowDiagnosticStatus: true,
-                attemptCount: 1
+                attemptCount: 1,
+                courseSettings: null
             );
 
             // When
@@ -350,7 +410,8 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 canShowDiagnosticStatus: true,
-                attemptCount: 0
+                attemptCount: 0,
+                courseSettings: null
             );
 
             // When
@@ -371,7 +432,30 @@
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 canShowDiagnosticStatus: false,
-                attemptCount: 1
+                attemptCount: 1,
+                courseSettings: null
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.CanShowProgress.Should().BeFalse();
+        }
+
+        [Test]
+        public void Tutorial_should_not_decide_to_show_progress_when_showLearnStatus_courseSetting_is_false()
+        {
+            // Given
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                canShowDiagnosticStatus: true,
+                attemptCount: 1,
+                courseSettings: "{\"lm.sl\":false}"
             );
 
             // When

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -14,6 +14,8 @@
         public string? TutorialPath { get; }
         public string? VideoPath { get; }
         public string? Objectives { get; }
+        public bool ShowLearnStatus { get; }
+        public string SupportingMaterialsLabel { get; }
         public int CustomisationId { get; }
         public int SectionId { get; }
         public int TutorialId { get; }
@@ -37,22 +39,28 @@
             TutorialPath = tutorialInformation.TutorialPath;
             VideoPath = tutorialInformation.VideoPath;
             Status = tutorialInformation.Status;
+            ShowLearnStatus = tutorialInformation.CourseSettings.ShowLearnStatus;
+            SupportingMaterialsLabel =
+                tutorialInformation.CourseSettings.SupportingInformation ?? "Download supporting materials";
 
             CustomisationId = customisationId;
             SectionId = sectionId;
             TutorialId = tutorialInformation.Id;
             Objectives = ParseObjectives(tutorialInformation.Objectives);
 
-            CanShowProgress =
-                GetCanShowProgress(tutorialInformation.CanShowDiagnosticStatus, tutorialInformation.AttemptCount);
+            CanShowProgress = GetCanShowProgress(
+                tutorialInformation.CourseSettings.ShowLearnStatus,
+                tutorialInformation.CanShowDiagnosticStatus,
+                tutorialInformation.AttemptCount
+            );
             TutorialRecommendation =
                 GetTutorialRecommendation(tutorialInformation.CurrentScore, tutorialInformation.PossibleScore);
             ScoreSummary = GetScoreSummary(tutorialInformation.CurrentScore, tutorialInformation.PossibleScore);
             TimeSummary = new TutorialTimeSummaryViewModel(
                 tutorialInformation.TimeSpent,
                 tutorialInformation.AverageTutorialDuration,
-                true,
-                true
+                tutorialInformation.CourseSettings.ShowTime,
+                tutorialInformation.CourseSettings.ShowLearnStatus
             );
             SupportingMaterialPath =
                 ContentUrlHelper.GetNullableContentPath(config, tutorialInformation.SupportingMaterialPath);
@@ -65,9 +73,9 @@
             );
         }
 
-        private bool GetCanShowProgress(bool canShowDiagnosticStatus, int attemptCount)
+        private bool GetCanShowProgress(bool showLearnStatus, bool canShowDiagnosticStatus, int attemptCount)
         {
-            return canShowDiagnosticStatus && attemptCount > 0;
+            return showLearnStatus && canShowDiagnosticStatus && attemptCount > 0;
         }
 
         private string GetTutorialRecommendation(int currentScore, int possibleScore)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -7,7 +7,9 @@
         <h3 class="nhsuk-card__heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
-        <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
+        <div class="nhsuk-u-margin-bottom-4">
+          <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
+        </div>
       </div>
       @if (Model.ShowLearnStatus)
       {

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_TutorialTimeSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_TutorialTimeSummary.cshtml
@@ -3,7 +3,7 @@
 
 @if (Model.ShowTime)
 {
-<p class="nhsuk-u-secondary-text-color">
+<p class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">
   @Model.TimeSpentSummary spent
   <span class="visually-hidden">on this tutorial</span>
   (average tutorial time @Model.AverageTimeSummary)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -35,14 +35,17 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.TutorialName</h1>
-    <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">@Model.Status @Model.ScoreSummary</h2>
+    @if (Model.ShowLearnStatus)
+    {
+      <h2 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-0">@Model.Status @Model.ScoreSummary</h2>
+    }
     <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
   </div>
 </div>
 
 @if (Model.CanShowProgress)
 {
-  <div class="nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
+  <div class="nhsuk-inset-text nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">
     <span class="nhsuk-u-visually-hidden">Information: </span>
     <p>Based on your diagnostic assessment outcome, this tutorial is <b>@Model.TutorialRecommendation</b>.</p>
   </div>
@@ -50,7 +53,7 @@
 
 @if (Model.Objectives != null)
 {
-  <div class="nhsuk-care-card nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4 objectives-card">
+  <div class="nhsuk-care-card nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0 objectives-card">
     <div class="nhsuk-care-card__heading-container">
       <h3 class="nhsuk-care-card__heading"><span role="text">Objectives</span></h3>
       <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
@@ -61,7 +64,7 @@
   </div>
 }
 
-<div class="button-row">
+<div class="button-row nhsuk-u-margin-top-4">
   @if (Model.TutorialPath != null)
   {
     <div>
@@ -94,7 +97,7 @@
   {
     <div>
       <a class="nhsuk-button nhsuk-button--secondary" href="@Model.SupportingMaterialPath" download>
-        Download supporting materials
+        @Model.SupportingMaterialsLabel
       </a>
     </div>
   }


### PR DESCRIPTION
## Changes
Change tutorial time summary styling to make spacing consistent when
information is hidden. Tweak tutorial card styling to work around these
changes (there should be no discernable difference in tutorial card
styling after this PR).

## Testing
Add some tests for this new data. Tested in Chrome and IE11, using high zoom and a screenreader.

## Screenshots of tutorial page
### Tutorial with `showTime = false` and custom supporting materials text 
![show_time_false_and_custom_materials_tutorial](https://user-images.githubusercontent.com/3650110/104584588-bfcf2080-565a-11eb-97ec-5770491cc05c.png)
### Tutorial with `showLearnStatus  = false`
![show_learn_false_tutorial](https://user-images.githubusercontent.com/3650110/104584587-bfcf2080-565a-11eb-9c0e-d0a573ddd3f6.png)
### Tutorial with all course settings as `true`
![show_all_tutorial](https://user-images.githubusercontent.com/3650110/104584582-be9df380-565a-11eb-8b8e-b2d012687a22.png)

## Screenshots of section page
These should be the same as last time, but some changes were required to keep them the same
### Section with `showTime = false`
![show_time_false_section](https://user-images.githubusercontent.com/3650110/104585077-6e736100-565b-11eb-9a32-c057cee421ee.png)
### Section with `showLearnStatus  = false`
![show_learn_false_section](https://user-images.githubusercontent.com/3650110/104585076-6ddaca80-565b-11eb-8a87-9a6921b9f459.png)
### Section with all course settings as `true`
![show_all_section](https://user-images.githubusercontent.com/3650110/104585074-6d423400-565b-11eb-8dce-f2e98545b8cf.png)