### PR TITLE
HEEDLS-297 Post learning assessment launch page close

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -24,6 +24,7 @@
     <None Remove="Scripts\index.d.ts" />
     <None Remove="Scripts\learningMenu\contentViewer.ts" />
     <None Remove="Scripts\learningMenu\diagnosticContentViewer.ts" />
+    <None Remove="Scripts\learningMenu\postLearningContentViewer.ts" />
     <None Remove="Scripts\learningPortal\dlscommon.ts" />
     <None Remove="Scripts\learningPortal\sortCourses.ts" />
     <None Remove="Scripts\nhsuk.ts" />
@@ -61,6 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <TypeScriptCompile Include="Scripts\learningMenu\postLearningContentViewer.ts" />
     <TypeScriptCompile Include="Scripts\learningMenu\diagnosticContentViewer.ts" />
     <TypeScriptCompile Include="Scripts\learningMenu\contentViewer.ts" />
     <TypeScriptCompile Include="Scripts\learningPortal\available.ts" />

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/postLearningContentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/postLearningContentViewer.ts
@@ -1,0 +1,12 @@
+function postLearningCloseMpe(): void {
+  // Extract the current domain, customisationId and sectionId out of the URL
+  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/PostLearning\/Content$/);
+
+  if (!matches || matches.length < 4) {
+    return;
+  }
+
+  window.location.href = `${matches[1]}/LearningMenu/${matches[2]}/${matches[3]}/PostLearning`;
+}
+
+window.closeMpe = postLearningCloseMpe;

--- a/DigitalLearningSolutions.Web/Scripts/spec/postLearningContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/postLearningContentViewer.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '../learningMenu/postLearningContentViewer';
+
+beforeAll(() => {
+  global.window = Object.create(window);
+  const url = 'https://example.com';
+  Object.defineProperty(global.window, 'location', {
+    value: {
+      href: url,
+    },
+  });
+});
+
+describe('closeMpe', () => {
+  it('should redirect to diagnostic assessment with no checked tutorials',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/PostLearning/Content';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/PostLearning');
+    });
+
+  it('should do nothing on unexpected page',
+    () => {
+      // Given
+      const url = 'https://localhost:44363/LearningMenu/123/456';
+      window.location.href = url;
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toEqual(url);
+    });
+});

--- a/DigitalLearningSolutions.Web/Scripts/spec/postLearningContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/postLearningContentViewer.spec.ts
@@ -15,7 +15,7 @@ beforeAll(() => {
 });
 
 describe('closeMpe', () => {
-  it('should redirect to diagnostic assessment with no checked tutorials',
+  it('should redirect to post learning assessment',
     () => {
       // Given
       window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/PostLearning/Content';

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
@@ -32,10 +32,14 @@
   </nav>
 }
 
+@section scripts {
+  <script src="@Url.Content("~/js/learningMenu/postLearningContentViewer.js")" asp-append-version="true"></script>
+}
+
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
-    
+
     @{ var contentType = "assessment"; }
     <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
 


### PR DESCRIPTION
Add TypeScript for automatic page close.

Add unit tests for TypeScript.

Ran and passed all unit tests, tested close function via console on Firefox.