### PR TITLE
HEEDLS-NONE Remove interface access modifiers

### DIFF
--- a/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentDataService.cs
@@ -9,8 +9,8 @@
 
     public interface IDiagnosticAssessmentDataService
     {
-        public DiagnosticAssessment? GetDiagnosticAssessment(int customisationId, int candidateId, int sectionId);
-        public DiagnosticContent? GetDiagnosticContent(int customisationId, int sectionId);
+        DiagnosticAssessment? GetDiagnosticAssessment(int customisationId, int candidateId, int sectionId);
+        DiagnosticContent? GetDiagnosticContent(int customisationId, int sectionId);
     }
 
     public class DiagnosticAssessmentDataService : IDiagnosticAssessmentDataService

--- a/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/DiagnosticAssessmentService.cs
@@ -8,8 +8,8 @@
 
     public interface IDiagnosticAssessmentService
     {
-        public DiagnosticAssessment? GetDiagnosticAssessment(int customisationId, int candidateId, int sectionId);
-        public DiagnosticContent? GetDiagnosticContent(int customisationId, int sectionId, List<int> checkedTutorials);
+        DiagnosticAssessment? GetDiagnosticAssessment(int customisationId, int candidateId, int sectionId);
+        DiagnosticContent? GetDiagnosticContent(int customisationId, int sectionId, List<int> checkedTutorials);
     }
 
     public class DiagnosticAssessmentService : IDiagnosticAssessmentService

--- a/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/TutorialContentService.cs
@@ -4,7 +4,6 @@
     using Dapper;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.TutorialContent;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     public interface ITutorialContentService
     {


### PR DESCRIPTION
Remove `public` from some interface methods.

Ran and passed all unit tests.