### PR TITLE
HEEDLS-301 Extract completion summary card into partial

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CompletionSummaryCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CompletionSummaryCardViewModelTests.cs
@@ -1,0 +1,199 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
+{
+    using System;
+    using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    class CompletionSummaryCardViewModelTests
+    {
+        private const int CustomisationId = 1;
+        private readonly DateTime? Completed = null;
+        private const int MaxPostLearningAssessmentAttempts = 0;
+        private const bool IsAssessed = true;
+        private const int PostLearningAssessmentPassThreshold = 100;
+        private const int DiagnosticAssessmentCompletionThreshold = 85;
+        private const int TutorialsCompletionThreshold = 0;
+
+        [Test]
+        public void Completion_summary_card_should_have_customisationId()
+        {
+            // Given
+            const int customisationId = 121;
+
+            // When
+            var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                Completed,
+                MaxPostLearningAssessmentAttempts,
+                IsAssessed,
+                PostLearningAssessmentPassThreshold,
+                DiagnosticAssessmentCompletionThreshold,
+                TutorialsCompletionThreshold
+            );
+
+            // Then
+            completionSummaryCardViewModel.CustomisationId.Should().Be(customisationId);
+        }
+
+        [Test]
+        public void Completion_summary_card_completion_status_for_completed_should_be_complete()
+        {
+            // When
+            var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                CustomisationId,
+                DateTime.Now,
+                MaxPostLearningAssessmentAttempts,
+                IsAssessed,
+                PostLearningAssessmentPassThreshold,
+                DiagnosticAssessmentCompletionThreshold,
+                TutorialsCompletionThreshold
+            );
+
+            // Then
+            completionSummaryCardViewModel.CompletionStatus.Should().Be("Complete");
+        }
+
+        [Test]
+        public void Completion_summary_card_completion_status_for_null_completed_should_be_incomplete()
+        {
+            // When
+            var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                CustomisationId,
+                null,
+                MaxPostLearningAssessmentAttempts,
+                IsAssessed,
+                PostLearningAssessmentPassThreshold,
+                DiagnosticAssessmentCompletionThreshold,
+                TutorialsCompletionThreshold
+            );
+
+            // Then
+            completionSummaryCardViewModel.CompletionStatus.Should().Be("Incomplete");
+        }
+
+        [Test]
+        public void Completion_summary_card_completion_styling_for_completed_should_be_complete()
+        {
+            // When
+            var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                CustomisationId,
+                DateTime.Now,
+                MaxPostLearningAssessmentAttempts,
+                IsAssessed,
+                PostLearningAssessmentPassThreshold,
+                DiagnosticAssessmentCompletionThreshold,
+                TutorialsCompletionThreshold
+            );
+
+            // Then
+            completionSummaryCardViewModel.CompletionStyling.Should().Be("complete");
+        }
+
+        [Test]
+        public void Completion_summary_card_completion_styling_for_null_completed_should_be_incomplete()
+        {
+            // When
+            var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                CustomisationId,
+                null,
+                MaxPostLearningAssessmentAttempts,
+                IsAssessed,
+                PostLearningAssessmentPassThreshold,
+                DiagnosticAssessmentCompletionThreshold,
+                TutorialsCompletionThreshold
+            );
+
+            // Then
+            completionSummaryCardViewModel.CompletionStyling.Should().Be("incomplete");
+        }
+
+        [TestCase(
+            "2020-12-25T15:00:00Z",
+            1,
+            true,
+            75,
+            80,
+            85,
+            "You completed this course on 25 December 2020."
+        )]
+        [TestCase(
+            null,
+            0,
+            true,
+            75,
+            80,
+            85,
+            "To complete this course, you must pass all post learning assessments with a score of 75% or higher."
+        )]
+        [TestCase(
+            null,
+            3,
+            true,
+            75,
+            80,
+            85,
+            "To complete this course, you must pass all post learning assessments with a score of 75% or higher. Failing an assessment 3 times will lock your progress."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            80,
+            85,
+            "To complete this course, you must achieve 80% in the diagnostic assessment and complete 85% of the learning material."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            80,
+            0,
+            "To complete this course, you must achieve 80% in the diagnostic assessment."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            0,
+            85,
+            "To complete this course, you must complete 85% of the learning material."
+        )]
+        [TestCase(
+            null,
+            3,
+            false,
+            75,
+            0,
+            0,
+            "There are no requirements to complete this course."
+        )]
+        public void Completion_summary_card_completion_should_have_formatted_completion_summary(
+            string? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold,
+            string expectedSummary
+        )
+        {
+            // When
+            var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                CustomisationId,
+                completed != null ? DateTime.Parse(completed) : (DateTime?)null,
+                maxPostLearningAssessmentAttempts,
+                isAssessed,
+                postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold
+            );
+
+            // Then
+            completionSummaryCardViewModel.CompletionSummary.Should().Be(expectedSummary);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CompletionSummaryCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CompletionSummaryCardViewModelTests.cs
@@ -8,7 +8,6 @@
     class CompletionSummaryCardViewModelTests
     {
         private const int CustomisationId = 1;
-        private readonly DateTime? Completed = null;
         private const int MaxPostLearningAssessmentAttempts = 0;
         private const bool IsAssessed = true;
         private const int PostLearningAssessmentPassThreshold = 100;
@@ -24,7 +23,7 @@
             // When
             var completionSummaryCardViewModel = new CompletionSummaryCardViewModel(
                 customisationId,
-                Completed,
+                null,
                 MaxPostLearningAssessmentAttempts,
                 IsAssessed,
                 PostLearningAssessmentPassThreshold,

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -224,142 +224,29 @@
             initialMenuViewModel.Sections.Should().BeEquivalentTo(expectedSectionList);
         }
 
-        [Test]
-        public void Get_completion_status_for_completed_should_return_complete()
-        {
-            // Given
-            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: DateTime.Now
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
-
-            // Then
-            initialMenuViewModel.CompletionStatus.Should().Be("Complete");
-        }
-
-        [Test]
-        public void Get_completion_status_for_null_completed_should_return_incomplete()
-        {
-            // Given
-            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: null
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
-
-            // Then
-            initialMenuViewModel.CompletionStatus.Should().Be("Incomplete");
-        }
-
-        [Test]
-        public void Get_completion_styling_for_completed_should_return_complete()
-        {
-            // Given
-            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: DateTime.Now
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
-
-            // Then
-            initialMenuViewModel.CompletionStyling.Should().Be("complete");
-        }
-
-        [Test]
-        public void Get_completion_styling_for_null_completed_should_return_incomplete()
-        {
-            // Given
-            var courseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: null
-            );
-
-            // When
-            var initialMenuViewModel = new InitialMenuViewModel(courseContent);
-
-            // Then
-            initialMenuViewModel.CompletionStyling.Should().Be("incomplete");
-        }
-
-        [TestCase(
-            "2020-12-25T15:00:00Z",
-            1,
-            true,
-            75,
-            80,
-            85,
-            "You completed this course on 25 December 2020."
-        )]
-        [TestCase(
-            null,
-            0,
-            true,
-            75,
-            80,
-            85,
-            "To complete this course, you must pass all post learning assessments with a score of 75% or higher."
-        )]
-        [TestCase(
-            null,
-            3,
-            true,
-            75,
-            80,
-            85,
-            "To complete this course, you must pass all post learning assessments with a score of 75% or higher. Failing an assessment 3 times will lock your progress."
-        )]
-        [TestCase(
-            null,
-            3,
-            false,
-            75,
-            80,
-            85,
-            "To complete this course, you must achieve 80% in the diagnostic assessment and complete 85% of the learning material."
-        )]
-        [TestCase(
-            null,
-            3,
-            false,
-            75,
-            80,
-            0,
-            "To complete this course, you must achieve 80% in the diagnostic assessment."
-        )]
-        [TestCase(
-            null,
-            3,
-            false,
-            75,
-            0,
-            85,
-            "To complete this course, you must complete 85% of the learning material."
-        )]
-        [TestCase(
-            null,
-            3,
-            false,
-            75,
-            0,
-            0,
-            "There are no requirements to complete this course."
-        )]
-        public void Initial_menu_should_have_formatted_completion_summary(
+        [TestCase(2, "2020-12-25T15:00:00Z", 1, true, 75, 80, 85)]
+        [TestCase(3, null, 0, true, 75, 80, 85)]
+        [TestCase(4, null, 3, true, 75, 80, 85)]
+        [TestCase(5, null, 3, false, 75, 80, 85)]
+        [TestCase(6, null, 3, false, 75, 80, 0)]
+        [TestCase(7, null, 3, false, 75, 0, 85)]
+        [TestCase(8, null, 3, false, 75, 0, 0)]
+        public void Initial_menu_should_have_completion_summary_card_view_model(
+            int customisationId,
             string? completed,
             int maxPostLearningAssessmentAttempts,
             bool isAssessed,
             int postLearningAssessmentPassThreshold,
             int diagnosticAssessmentCompletionThreshold,
-            int tutorialsCompletionThreshold,
-            string expectedSummary
+            int tutorialsCompletionThreshold
         )
         {
             // Given
+            var completedDateTime = completed != null ? DateTime.Parse(completed) : (DateTime?)null;
+
             var courseContent = CourseContentHelper.CreateDefaultCourseContent(
-                completed: completed != null ? DateTime.Parse(completed) : (DateTime?) null,
+                customisationId: customisationId,
+                completed: completedDateTime,
                 maxPostLearningAssessmentAttempts: maxPostLearningAssessmentAttempts,
                 isAssessed: isAssessed,
                 postLearningAssessmentPassThreshold: postLearningAssessmentPassThreshold,
@@ -367,11 +254,22 @@
                 tutorialsCompletionThreshold: tutorialsCompletionThreshold
             );
 
+            var expectedCompletionSummaryViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                completedDateTime,
+                maxPostLearningAssessmentAttempts,
+                isAssessed,
+                postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold
+            );
+
             // When
             var initialMenuViewModel = new InitialMenuViewModel(courseContent);
 
             // Then
-            initialMenuViewModel.CompletionSummary.Should().Be(expectedSummary);
+            initialMenuViewModel.CompletionSummaryCardViewModel
+                .Should().BeEquivalentTo(expectedCompletionSummaryViewModel);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/CompletionSummaryCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/CompletionSummaryCardViewModel.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningMenu
+{
+    using System;
+    using DigitalLearningSolutions.Web.Helpers;
+
+    public class CompletionSummaryCardViewModel
+    {
+        public int CustomisationId { get; }
+        public string CompletionStatus { get; }
+        public string CompletionStyling { get; }
+        public string CompletionSummary { get; }
+
+        public CompletionSummaryCardViewModel(
+            int customisationId,
+            DateTime? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold
+        )
+        {
+            CustomisationId = customisationId;
+            CompletionStatus = completed == null ? "Incomplete" : "Complete";
+            CompletionStyling = completed == null ? "incomplete" : "complete";
+            CompletionSummary = CompletionSummaryHelper.GetCompletionSummary(
+                completed,
+                maxPostLearningAssessmentAttempts,
+                isAssessed,
+                postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/InitialMenuViewModel.cs
@@ -15,9 +15,7 @@
         public string? BannerText { get; }
         public bool ShouldShowCompletionSummary { get; }
         public IEnumerable<SectionCardViewModel> Sections { get; }
-        public string CompletionStatus { get; }
-        public string CompletionStyling { get; }
-        public string CompletionSummary { get; }
+        public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
         public bool ShowTime { get; }
 
         public InitialMenuViewModel(CourseContent courseContent)
@@ -34,10 +32,8 @@
                 Id,
                 courseContent.CourseSettings.ShowPercentage
             ));
-
-            CompletionStatus = courseContent.Completed == null ? "Incomplete" : "Complete";
-            CompletionStyling = courseContent.Completed == null ? "incomplete" : "complete";
-            CompletionSummary = CompletionSummaryHelper.GetCompletionSummary(
+            CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                courseContent.Id,
                 courseContent.Completed,
                 courseContent.MaxPostLearningAssessmentAttempts,
                 courseContent.IsAssessed,

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -54,31 +54,5 @@
 {
   <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible thick">
 
-  <div class="nhsuk-card nhsuk-card--clickable learning-menu-card">
-    <div class="nhsuk-card__content">
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-three-quarters">
-          <h2 class="nhsuk-card__heading nhsuk-heading-m completion-card-heading">
-            <a class="nhsuk-card__link"
-               asp-action="CompletionSummary"
-               asp-controller="LearningMenu"
-               asp-route-customisationId="@Model.Id">
-              Course Completion Summary
-            </a>
-          </h2>
-        </div>
-        <div class="nhsuk-grid-column-one-quarter">
-          <strong class="status-tag @Model.CompletionStyling">
-            @Model.CompletionStatus
-          </strong>
-        </div>
-      </div>
-
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-full">
-          <p class="nhsuk-u-secondary-text-color nhsuk-u-margin-0">@Model.CompletionSummary</p>
-        </div>
-      </div>
-    </div>
-  </div>
+  <partial name="Shared/_CompletionSummaryCard" model="@Model.CompletionSummaryCardViewModel" />
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_CompletionSummaryCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_CompletionSummaryCard.cshtml
@@ -1,0 +1,30 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningMenu
+@model CompletionSummaryCardViewModel
+
+<div class="nhsuk-card nhsuk-card--clickable learning-menu-card">
+  <div class="nhsuk-card__content">
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-three-quarters">
+        <h2 class="nhsuk-card__heading nhsuk-heading-m completion-card-heading">
+          <a class="nhsuk-card__link"
+             asp-action="CompletionSummary"
+             asp-controller="LearningMenu"
+             asp-route-customisationId="@Model.CustomisationId">
+            Course Completion Summary
+          </a>
+        </h2>
+      </div>
+      <div class="nhsuk-grid-column-one-quarter">
+        <strong class="status-tag @Model.CompletionStyling">
+          @Model.CompletionStatus
+        </strong>
+      </div>
+    </div>
+
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-full">
+        <p class="nhsuk-u-secondary-text-color nhsuk-u-margin-0">@Model.CompletionSummary</p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Changes
Refactor the completion summary card out of the initial menu view and
view model, into its own partial view.

## Testing
Rearrange some tests to reflect the refactoring. Tested in Chrome, UI should appear the same as before the PR.

## Screenshots
### Course with a completion summary
![course_with_completion_summary](https://user-images.githubusercontent.com/3650110/104743387-8de5b900-5743-11eb-8f10-b4ae654e9b2c.png)
### Course without a completion summary
![course_without_completion_summary](https://user-images.githubusercontent.com/3650110/104743384-8d4d2280-5743-11eb-94f5-9051de770c7c.png)