### PR TITLE
HEEDLS-302 Add single section front end

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -99,6 +99,58 @@
         }
 
         [Test]
+        public void Index_should_redirect_to_section_page_if_one_section_in_course()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var section = CourseContentHelper.CreateDefaultCourseSection(id: sectionId);
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(customisationId);
+            expectedCourseContent.Sections.Add(section);
+
+            A.CallTo(() => courseContentService.GetCourseContent(CandidateId, customisationId))
+                .Returns(expectedCourseContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Index(customisationId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("Section")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
+        public void Index_should_not_redirect_to_section_page_if_more_than_one_section_in_course()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var section1 = CourseContentHelper.CreateDefaultCourseSection(id: sectionId + 1);
+            var section2 = CourseContentHelper.CreateDefaultCourseSection(id: sectionId + 2);
+            var section3 = CourseContentHelper.CreateDefaultCourseSection(id: sectionId + 3);
+
+            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(customisationId);
+            expectedCourseContent.Sections.AddRange(new[] { section1, section2, section3 });
+
+            A.CallTo(() => courseContentService.GetCourseContent(CandidateId, customisationId))
+                .Returns(expectedCourseContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Index(customisationId);
+
+            // Then
+            var expectedModel = new InitialMenuViewModel(expectedCourseContent);
+            result.Should().BeViewResult()
+                .Model.Should().BeEquivalentTo(expectedModel);
+        }
+
+        [Test]
         public void Index_should_return_404_if_unknown_course()
         {
             // Given

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CourseContentHelper.cs
@@ -39,5 +39,20 @@
                 courseSettings
             );
         }
+
+        public static CourseSection CreateDefaultCourseSection(
+            string sectionName = "Section",
+            int id = 1,
+            bool hasLearning = true,
+            double percentComplete = 25
+        )
+        {
+            return new CourseSection(
+                sectionName,
+                id,
+                hasLearning,
+                percentComplete
+            );
+        }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -159,7 +159,7 @@
         }
 
         [Test]
-        public void Initial_menu_show_completion_summary_should_be_include_certification_when_true()
+        public void Initial_menu_should_show_completion_summary_when_include_certification_is_true()
         {
             // Given
             const bool includeCertification = true;
@@ -175,7 +175,7 @@
         }
 
         [Test]
-        public void Initial_menu_show_completion_summary_should_be_include_certification_when_false()
+        public void Initial_menu_should_not_show_completion_summary_when_include_certification_is_false()
         {
             // Given
             const bool includeCertification = false;

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
@@ -647,6 +648,131 @@
 
             // Then
             sectionContentViewModel.NextSectionId.Should().BeNull();
+        }
+
+        [Test]
+        public void Section_content_should_have_otherSectionsExist_when_other_sections_exist()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                otherSectionsExist: true
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.OtherSectionsExist.Should().BeTrue();
+        }
+
+        [Test]
+        public void Section_content_should_not_have_otherSectionsExist_when_no_other_sections_exist()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                otherSectionsExist: false
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.OtherSectionsExist.Should().BeFalse();
+        }
+
+        [Test]
+        public void Section_content_should_show_completion_summary_when_include_certification_and_only_section()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                otherSectionsExist: false,
+                includeCertification: true
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ShowCompletionSummary.Should().BeTrue();
+        }
+
+        [Test]
+        public void Section_content_should_not_show_completion_summary_when_include_certification_is_false()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                otherSectionsExist: false,
+                includeCertification: false
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ShowCompletionSummary.Should().BeFalse();
+        }
+
+        [Test]
+        public void Section_content_should_not_show_completion_summary_when_other_sections_exist()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                otherSectionsExist: true,
+                includeCertification: true
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.ShowCompletionSummary.Should().BeFalse();
+        }
+
+        [TestCase(2, "2020-12-25T15:00:00Z", 1, true, 75, 80, 85)]
+        [TestCase(3, null, 0, true, 75, 80, 85)]
+        [TestCase(4, null, 3, true, 75, 80, 85)]
+        [TestCase(5, null, 3, false, 75, 80, 85)]
+        [TestCase(6, null, 3, false, 75, 80, 0)]
+        [TestCase(7, null, 3, false, 75, 0, 85)]
+        [TestCase(8, null, 3, false, 75, 0, 0)]
+        public void Section_content_should_have_completion_summary_card_view_model(
+            int customisationId,
+            string? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold
+        )
+        {
+            // Given
+            var completedDateTime = completed != null ? DateTime.Parse(completed) : (DateTime?)null;
+
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                completed: completedDateTime,
+                maxPostLearningAssessmentAttempts: maxPostLearningAssessmentAttempts,
+                isAssessed: isAssessed,
+                postLearningAssessmentPassThreshold: postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold: diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold: tutorialsCompletionThreshold
+            );
+
+            var expectedCompletionSummaryViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                completedDateTime,
+                maxPostLearningAssessmentAttempts,
+                isAssessed,
+                postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold
+            );
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, customisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.CompletionSummaryCardViewModel
+                .Should().BeEquivalentTo(expectedCompletionSummaryViewModel);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.LearningMenuController
 {
     using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
@@ -62,6 +63,12 @@
                     $"Candidate id: {candidateId}, customisation id: {customisationId}, " +
                     $"centre id: {centreId?.ToString() ?? "null"}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
+            }
+
+            if (courseContent.Sections.Count == 1)
+            {
+                var sectionId = courseContent.Sections.First().Id;
+                return RedirectToAction("Section", "LearningMenu", new { customisationId, sectionId });
             }
 
             var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId.Value);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
@@ -26,6 +26,9 @@
         public bool DisplayTutorialSeparator { get; }
         public bool DisplayPostLearningSeparator { get; }
         public int? NextSectionId { get; }
+        public bool ShowCompletionSummary { get; }
+        public bool OtherSectionsExist { get; }
+        public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
 
         public SectionContentViewModel(IConfiguration config, SectionContent sectionContent, int customisationId, int sectionId)
         {
@@ -57,6 +60,17 @@
             DisplayTutorialSeparator = sectionContent.Tutorials.Any() && (ShowPostLearning || ShowConsolidation);
             DisplayPostLearningSeparator = ShowConsolidation && ShowPostLearning;
             NextSectionId = sectionContent.NextSectionId;
+            ShowCompletionSummary = sectionContent.IncludeCertification && !sectionContent.OtherSectionsExist;
+            OtherSectionsExist = sectionContent.OtherSectionsExist;
+            CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                sectionContent.Completed,
+                sectionContent.MaxPostLearningAssessmentAttempts,
+                sectionContent.IsAssessed,
+                sectionContent.PostLearningAssessmentPassThreshold,
+                sectionContent.DiagnosticAssessmentCompletionThreshold,
+                sectionContent.TutorialsCompletionThreshold
+            );
         }
 
         private static string FormatPercentComplete(SectionContent sectionContent)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -46,7 +46,10 @@
   </div>
 </div>
 
-<partial name="Section/_SectionNextLink" model="Model" />
+@if (Model.OtherSectionsExist)
+{
+  <partial name="Section/_SectionNextLink" model="Model" />
+}
 
 @if (Model.ShowDiagnostic)
 {
@@ -81,4 +84,11 @@
 @if (Model.ShowConsolidation)
 {
   <partial name="Section/_ConsolidationExerciseCard" model="Model" />
+}
+
+@if (Model.ShowCompletionSummary)
+{
+  <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible thick">
+
+  <partial name="Shared/_CompletionSummaryCard" model="Model.CompletionSummaryCardViewModel" />
 }


### PR DESCRIPTION
## Changes 
* Amend initial menu action to redirect to the section page if the course has only one section.
* Add completion data to section view model, to be shown if it is the only section in the course, and to flag to record whether this is the only section or not. Also hide the next button in this case.

## Testing
Amend tests to reflect these changes to the initial menu action, and these additions to the section content view model. 

Tested in Chrome, IE11, using a screenreader. The tags are a bit weird with a screenreader in IE11 (the opening and closing `<strong>` tags get read), but this problem is present on the NHS design system website as well.

## Screenshots
### Single section page, with a completion summary
![one_section_with_completion](https://user-images.githubusercontent.com/3650110/104904277-e81b8f80-5978-11eb-8466-44fc6d723ddf.png)
### Single section page, without a completion summary
![one_section_without_completion](https://user-images.githubusercontent.com/3650110/104904271-e782f900-5978-11eb-87f6-e6aa38ecc330.png)
### One section among others, with a completion summary available (but not displayed because that is shown on the initial menu)
![one_section_of_multiple_with_completion](https://user-images.githubusercontent.com/3650110/104904274-e81b8f80-5978-11eb-8cdf-c0c3ae57a46c.png)