### PR TITLE
HEEDLS-307-Section Page Show DIagnostic Recommendation Status Frontend

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -63,3 +63,13 @@ hr.thick {
   right: -8px;
   left: auto;
 }
+
+.float-right-additional-information{
+  @include mq($until: desktop) {
+    float: none;
+  }
+
+  @include mq($from: desktop) {
+    float: right;
+  }
+}

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -5,7 +5,7 @@
   border: none;
 }
 
-.completion-card-heading {
+.card-with-status-heading {
   @extend .nhsuk-u-margin-bottom-3;
 
   // Add padding to match border and padding of status tag
@@ -62,14 +62,4 @@ hr.thick {
 #next-arrow {
   right: -8px;
   left: auto;
-}
-
-.float-right-additional-information{
-  @include mq($until: desktop) {
-    float: none;
-  }
-
-  @include mq($from: desktop) {
-    float: right;
-  }
 }

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/section.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/section.scss
@@ -1,0 +1,11 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+.float-right-additional-information {
+  @include mq($until: desktop) {
+    float: none;
+  }
+
+  @include mq($from: desktop) {
+    float: right;
+  }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -4,6 +4,7 @@
 @model SectionContentViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/learningMenu/section.css")" asp-append-version="true">
 
 @{
   ViewData["HeaderPrefix"] = "";

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_DiagnosticAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_DiagnosticAssessmentCard.cshtml
@@ -9,7 +9,7 @@
         </h3>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
-        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
+        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
           @Model.DiagnosticCompletionStatus
         </h3>
       </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_PostLearningAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_PostLearningAssessmentCard.cshtml
@@ -9,7 +9,7 @@
         </h3>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
-        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
+        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
           @Model.PostLearningStatus
         </h3>
       </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -3,15 +3,15 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-three-quarters">
-        <h3 class="nhsuk-card__heading completion-card-heading" id="@Model.Id-name">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h3 class="nhsuk-card__heading card-with-status-heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
         <div class="nhsuk-u-margin-bottom-4">
           <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
         </div>
       </div>
-      <div class="nhsuk-grid-column-one-quarter">
+      <div class="nhsuk-grid-column-one-third">
         <strong class="status-tag nhsuk-tag--orange float-right-additional-information">
           Recommended
         </strong>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -15,13 +15,14 @@
         <strong class="status-tag nhsuk-tag--orange float-right-additional-information">
           Recommended
         </strong>
-        @if (Model.ShowLearnStatus) {
+        @if (Model.ShowLearnStatus)
+        {
           <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
             @Model.CompletionStatus
           </h3>
         }
       </div>
-      </div>
+    </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
         <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -3,23 +3,25 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="@(Model.ShowLearnStatus ? "nhsuk-grid-column-three-quarters" : "nhsuk-grid-column-full")">
-        <h3 class="nhsuk-card__heading" id="@Model.Id-name">
+      <div class="nhsuk-grid-column-three-quarters">
+        <h3 class="nhsuk-card__heading completion-card-heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
         <div class="nhsuk-u-margin-bottom-4">
           <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
         </div>
       </div>
-      @if (Model.ShowLearnStatus)
-      {
-        <div class="nhsuk-grid-column-one-quarter">
-          <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
+      <div class="nhsuk-grid-column-one-quarter">
+        <strong class="status-tag nhsuk-tag--orange float-right-additional-information">
+          Recommended
+        </strong>
+        @if (Model.ShowLearnStatus) {
+          <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
             @Model.CompletionStatus
           </h3>
-        </div>
-      }
-    </div>
+        }
+      </div>
+      </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
         <a class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_CompletionSummaryCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_CompletionSummaryCard.cshtml
@@ -5,7 +5,7 @@
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-three-quarters">
-        <h2 class="nhsuk-card__heading nhsuk-heading-m completion-card-heading">
+        <h2 class="nhsuk-card__heading nhsuk-heading-m card-with-status-heading">
           <a class="nhsuk-card__link"
              asp-action="CompletionSummary"
              asp-controller="LearningMenu"
@@ -15,7 +15,7 @@
         </h2>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
-        <strong class="status-tag @Model.CompletionStyling">
+        <strong class="status-tag @Model.CompletionStyling float-right-additional-information">
           @Model.CompletionStatus
         </strong>
       </div>


### PR DESCRIPTION
Regular view
![image](https://user-images.githubusercontent.com/44266225/104904713-6415d780-5979-11eb-8eea-310fb9c93a21.png)

Mobile view
![image](https://user-images.githubusercontent.com/44266225/104904757-742db700-5979-11eb-8c03-7fee29a1fd2f.png)

Had to use float: right as the normal methods had some problems with text overflowing during resizing. I checked with kevin and david and they were happy with how it looked
