### PR TITLE
HEEDLS-309 Implement fullscreen on tutorial content viewer

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -24,6 +24,7 @@
     <None Remove="Scripts\index.d.ts" />
     <None Remove="Scripts\learningMenu\contentViewer.ts" />
     <None Remove="Scripts\learningMenu\diagnosticContentViewer.ts" />
+    <None Remove="Scripts\learningMenu\fullscreen.ts" />
     <None Remove="Scripts\learningMenu\postLearningContentViewer.ts" />
     <None Remove="Scripts\learningPortal\dlscommon.ts" />
     <None Remove="Scripts\learningPortal\sortCourses.ts" />
@@ -62,6 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <TypeScriptCompile Include="Scripts\learningMenu\fullscreen.ts" />
     <TypeScriptCompile Include="Scripts\learningMenu\postLearningContentViewer.ts" />
     <TypeScriptCompile Include="Scripts\learningMenu\diagnosticContentViewer.ts" />
     <TypeScriptCompile Include="Scripts\learningMenu\contentViewer.ts" />

--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -29,6 +29,7 @@
     <None Remove="Scripts\learningPortal\dlscommon.ts" />
     <None Remove="Scripts\learningPortal\sortCourses.ts" />
     <None Remove="Scripts\nhsuk.ts" />
+    <None Remove="Scripts\spec\learningMenu\fullscreen.spec.ts" />
     <None Remove="Scripts\spec\setCompleteByDateSpec.ts" />
   </ItemGroup>
 
@@ -79,6 +80,7 @@
     <TypeScriptCompile Include="Scripts\learningPortal\selfAssessment.ts" />
     <TypeScriptCompile Include="Scripts\nhsuk.ts" />
     <TypeScriptCompile Include="Scripts\spec\getCourseCards.ts" />
+    <TypeScriptCompile Include="Scripts\spec\learningMenu\fullscreen.spec.ts" />
     <TypeScriptCompile Include="Scripts\spec\paginate.spec.ts" />
     <TypeScriptCompile Include="Scripts\spec\searchCourses.spec.ts" />
     <TypeScriptCompile Include="Scripts\spec\searchSortAndPaginate.spec.ts" />

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
@@ -1,3 +1,5 @@
+import { setupFullscreen } from './fullscreen';
+
 function closeMpe(): void {
   // Extract the current domain, customisationId, sectionId and tutorialId out of the URL
   const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
@@ -9,4 +11,6 @@ function closeMpe(): void {
   window.location.href = `${matches[1]}/LearningMenu/${matches[2]}/${matches[3]}/${matches[4]}`;
 }
 
-window.closeMpe = closeMpe;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).closeMpe = closeMpe;
+setupFullscreen();

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/diagnosticContentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/diagnosticContentViewer.ts
@@ -9,4 +9,5 @@ function diagnosticCloseMpe(): void {
   window.location.href = `${matches[1]}/LearningMenu/${matches[2]}/${matches[3]}/Diagnostic`;
 }
 
-window.closeMpe = diagnosticCloseMpe;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).closeMpe = diagnosticCloseMpe;

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/fullscreen.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/fullscreen.ts
@@ -1,0 +1,52 @@
+export function setupFullscreen(): void {
+  getExitFullscreenButton()?.addEventListener(
+    'click',
+    () => exitFullscreen()
+  );
+  getEnterFullscreenButton()?.addEventListener(
+    'click',
+    () => enterFullscreen()
+  );
+}
+
+export function exitFullscreen(): void {
+  getIFrame()?.classList.remove('fullscreen');
+  getExitFullscreenButton()?.classList.add('hidden');
+  getEnterFullscreenButton()?.classList.remove('hidden');
+  getHeader()?.classList.remove('hidden');
+  getFooter()?.classList.remove('hidden');
+  getBreadcrumbs()?.classList.remove('hidden');
+}
+
+export function enterFullscreen(): void {
+  getIFrame()?.classList.add('fullscreen');
+  getExitFullscreenButton()?.classList.remove('hidden');
+  getEnterFullscreenButton()?.classList.add('hidden');
+  getHeader()?.classList.add('hidden');
+  getFooter()?.classList.add('hidden');
+  getBreadcrumbs()?.classList.add('hidden');
+}
+
+function getEnterFullscreenButton(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementById('content-viewer_enter-fullscreen-button');
+}
+
+function getExitFullscreenButton(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementById('content-viewer_exit-fullscreen-button');
+}
+
+function getIFrame(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementById('content-viewer_iframe');
+}
+
+function getHeader(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementsByTagName('header')[0];
+}
+
+function getFooter(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementsByTagName('footer')[0];
+}
+
+function getBreadcrumbs(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementsByClassName('nhsuk-breadcrumb')[0];
+}

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/postLearningContentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/postLearningContentViewer.ts
@@ -9,4 +9,5 @@ function postLearningCloseMpe(): void {
   window.location.href = `${matches[1]}/LearningMenu/${matches[2]}/${matches[3]}/PostLearning`;
 }
 
-window.closeMpe = postLearningCloseMpe;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).closeMpe = postLearningCloseMpe;

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/contentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/contentViewer.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import '../learningMenu/contentViewer';
+import '../../learningMenu/contentViewer';
 
 beforeAll(() => {
   global.window = Object.create(window);

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/diagnosticContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/diagnosticContentViewer.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import '../learningMenu/diagnosticContentViewer';
+import '../../learningMenu/diagnosticContentViewer';
 
 beforeAll(() => {
   global.window = Object.create(window);

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
@@ -1,0 +1,259 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { JSDOM } from 'jsdom';
+import { exitFullscreen, enterFullscreen } from '../../learningMenu/fullscreen';
+
+describe('enterFullscreen', () => {
+  it('should show the exit fullscreen button', () => {
+    // Given
+    global.document = new JSDOM(`
+    <html>
+    <head></head>
+    <body>
+      <a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden" id="content-viewer_exit-fullscreen-button" href="#">
+        Exit fullscreen
+      </a>
+    </body>
+    </html>
+  `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const exitButton = document.getElementById('content-viewer_exit-fullscreen-button');
+    expect(exitButton!.classList).not.toContain('hidden');
+  });
+
+  it('should hide the enter fullscreen button', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <a class="nhsuk-button js-only-inline" id="content-viewer_enter-fullscreen-button" href="#">
+          Fullscreen
+        </a>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const fullscreenButton = document.getElementById('content-viewer_enter-fullscreen-button');
+    expect(fullscreenButton!.classList).toContain('hidden');
+  });
+
+  it('should hide the header', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white" role="banner">
+        </header>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const headerElement = document.getElementsByTagName('header')[0];
+    expect(headerElement!.classList).toContain('hidden');
+  });
+
+  it('should hide the footer', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <footer role="contentinfo" class>
+        </footer>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const footer = document.getElementsByTagName('footer')[0];
+    expect(footer!.classList).toContain('hidden');
+  });
+
+  it('should hide the breadcrumbs', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        </nav>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const breadcrumbs = document.getElementsByClassName('nhsuk-breadcrumb')[0];
+    expect(breadcrumbs!.classList).toContain('hidden');
+  });
+
+  it('should make iframe fullscreen', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <iframe
+          src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
+          class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block"
+          height="800"
+          id="content-viewer_iframe">
+        </iframe>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const iframe = document.getElementById('content-viewer_iframe');
+    expect(iframe!.classList).toContain('fullscreen');
+  });
+});
+
+describe('exitFullscreen', () => {
+  it('should hide the exit fullscreen button', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button" id="content-viewer_exit-fullscreen-button" href="#">
+          Exit fullscreen
+        </a>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const exitButton = document.getElementById('content-viewer_exit-fullscreen-button');
+    expect(exitButton!.classList).toContain('hidden');
+  });
+
+  it('should show the enter fullscreen button', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <a class="nhsuk-button js-only-inline hidden" id="content-viewer_enter-fullscreen-button" href="#">
+          Fullscreen
+        </a>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const fullscreenButton = document.getElementById('content-viewer_enter-fullscreen-button');
+    expect(fullscreenButton!.classList).not.toContain('hidden');
+  });
+
+  it('should show the header', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white hidden" role="banner">
+        </header>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const headerElement = document.getElementsByTagName('header')[0];
+    expect(headerElement!.classList).not.toContain('hidden');
+  });
+
+  it('should show the footer', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <footer role="contentinfo" class="hidden">
+        </footer>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const footer = document.getElementsByTagName('footer')[0];
+    expect(footer!.classList).not.toContain('hidden');
+  });
+
+  it('should show the breadcrumbs', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <nav class="nhsuk-breadcrumb hidden" aria-label="Breadcrumb">
+        </nav>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const breadcrumbs = document.getElementsByClassName('nhsuk-breadcrumb')[0];
+    expect(breadcrumbs!.classList).not.toContain('hidden');
+  });
+
+  it('should make iframe not fullscreen', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <iframe
+          src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
+          class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block fullscreen"
+          height="800"
+          id="content-viewer_iframe">
+        </iframe>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const iframe = document.getElementById('content-viewer_iframe');
+    expect(iframe!.classList).not.toContain('fullscreen');
+  });
+});

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/postLearningContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/postLearningContentViewer.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import '../learningMenu/postLearningContentViewer';
+import '../../learningMenu/postLearningContentViewer';
 
 beforeAll(() => {
   global.window = Object.create(window);

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/contentViewer.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/contentViewer.scss
@@ -1,0 +1,28 @@
+﻿.fullscreen {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0 !important;
+}
+
+.exit-fullscreen-button {
+  position: absolute;
+  bottom: 4px;
+  right: 0;
+  top: auto !important;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.js-only-inline {
+  display: none;
+}
+
+.js-enabled .js-only-inline {
+  display: inline;
+}

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -15,6 +15,8 @@
   <partial name="Shared/_NavMenuItems" />
 }
 
+<link rel="stylesheet" href="@Url.Content("~/css/learningMenu/contentViewer.css")" asp-append-version="true">
+
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
@@ -41,7 +43,19 @@
     @{ var contentType = "tutorial"; }
     <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
 
-    <iframe src="@Model.ContentSource" class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block" height="800">
+    <iframe src="@Model.ContentSource" class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block" height="800" id="content-viewer_iframe">
     </iframe>
+
+    <a class="nhsuk-button js-only-inline"
+       id="content-viewer_enter-fullscreen-button"
+       href="#">
+      Fullscreen
+    </a>
   </div>
 </div>
+
+<a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
+   id="content-viewer_exit-fullscreen-button"
+   href="#">
+  Exit fullscreen
+</a>


### PR DESCRIPTION
Added support for moving to and from fullscreen on the tutorial content viewer page. It will only work with js enabled.

Tested on Chrome, Firefox and IE11. Tested with voice over. Tested on mobile size screen.

Adding it to the assessment pages should be pretty simple, just calling the fullscreen setup function and adding the buttons in the cshtml files.

![image](https://user-images.githubusercontent.com/13311307/105075115-3c119b80-5a81-11eb-93e4-681c30493527.png)

![image](https://user-images.githubusercontent.com/13311307/105075170-4cc21180-5a81-11eb-8717-1e1a2bbd923c.png)
