### PR TITLE
HEEDLS-307 - Section Page Show Diagnostic Recommendation Status Fix

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -3,13 +3,10 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="@(Model.ShowRecommendationStatus || Model.ShowLearnStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-full")">
+      <div class="@(Model.ShowRecommendationStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-full")">
         <h3 class="nhsuk-card__heading card-with-status-heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
-        <div class="nhsuk-u-margin-bottom-4">
-          <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
-        </div>
       </div>
       <div class="nhsuk-grid-column-one-third">
         @if (Model.ShowRecommendationStatus)
@@ -18,6 +15,15 @@
             @Model.RecommendationStatus
           </strong>
         }
+      </div>
+    </div>
+    <div class="nhsuk-grid-row">
+      <div class="@(Model.ShowLearnStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-full")">
+        <div class="nhsuk-u-margin-bottom-4">
+          <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary" />
+        </div>
+      </div>
+      <div class="nhsuk-grid-column-one-third">
         @if (Model.ShowLearnStatus)
         {
           <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">


### PR DESCRIPTION
Fixing a bug where the completion status and recommendation tag were on the same line if recommendation status was "Optional"

Normal view:

![image](https://user-images.githubusercontent.com/44266225/105183447-1c807e80-5b26-11eb-812c-6ad24144f217.png)

Mobile view:

![image](https://user-images.githubusercontent.com/44266225/105183626-52256780-5b26-11eb-8681-dd335e9b8554.png)
