### PR TITLE
Add single post learning assessment front end

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -532,7 +532,102 @@
         }
 
         [Test]
-        public void Sections_should_not_redirect_to_tutorial_page_if_there_is_diagnostic()
+        public void Sections_should_redirect_to_post_learning_assessment_if_only_post_learning_in_section()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: null,
+                plAssessPath: "some/post-learning/path.html",
+                isAssessed: true,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            // expectedSectionContent.Tutorials is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("PostLearning")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
+        public void Sections_should_redirect_to_post_learning_assessment_if_there_is_diagnostic_path_but_no_diagnostic_tutorials()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: "some/diagnostic/path.html",
+                plAssessPath: "some/post-learning/path.html",
+                isAssessed: true,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = false;
+            // expectedSectionContent.Tutorials is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("PostLearning")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
+        public void Sections_should_redirect_to_post_learning_assessment_if_there_is_diagnostic_tutorial_but_no_path()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: null,
+                plAssessPath: "some/post-learning/path.html",
+                isAssessed: true,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = true;
+            // expectedSectionContent.Tutorials; viewable tutorials, is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("PostLearning")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
+        public void Sections_should_return_section_page_if_there_is_diagnostic_and_tutorial()
         {
             // Given
             const int customisationId = 123;
@@ -563,7 +658,37 @@
         }
 
         [Test]
-        public void Sections_should_not_redirect_to_tutorial_page_if_there_is_post_learning_assessment()
+        public void Sections_should_return_section_page_if_there_is_diagnostic_and_post_learning_assessments()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: "some/diagnostic/path.html",
+                plAssessPath: "some/post-learning/path.html",
+                isAssessed: true,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = true;
+            // expectedSectionContent.Tutorials; viewable tutorials, is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            var expectedModel = new SectionContentViewModel(config, expectedSectionContent, customisationId, sectionId);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should().BeViewResult()
+                .Model.Should().BeEquivalentTo(expectedModel);
+        }
+
+        [Test]
+        public void Sections_should_return_section_page_if_there_is_post_learning_assessment_and_tutorial()
         {
             // Given
             const int customisationId = 123;
@@ -662,7 +787,7 @@
         }
 
         [Test]
-        public void Sections_should_not_redirect_to_tutorial_page_if_there_is_consolidation()
+        public void Sections_should_return_section_page_if_there_is_consolidation()
         {
             // Given
             const int customisationId = 123;
@@ -692,7 +817,7 @@
         }
 
         [Test]
-        public void Sections_should_not_redirect_to_tutorial_page_if_more_than_one_tutorial_in_section()
+        public void Sections_should_return_section_page_if_more_than_one_tutorial_in_section()
         {
             // Given
             const int customisationId = 123;

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -259,7 +259,7 @@
         public void Post_learning_assessment_should_have_onlyItemInOnlySection(
             bool otherSectionsExist,
             bool otherItemsInSectionExist,
-            bool onlyItemInOnlySection
+            bool expectedOnlyItemInOnlySection
         )
         {
             // Given
@@ -273,14 +273,14 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().Be(onlyItemInOnlySection);
+            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().Be(expectedOnlyItemInOnlySection);
         }
 
         [TestCase(false, true)]
         [TestCase(true, false)]
         public void Post_learning_assessment_should_have_onlyItemInThisSection(
             bool otherItemsInSectionExist,
-            bool onlyItemInThisSection
+            bool expectedOnlyItemInThisSection
         )
         {
             // Given
@@ -293,18 +293,22 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().Be(onlyItemInThisSection);
+            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().Be(expectedOnlyItemInThisSection);
         }
 
-        [TestCase(false, false, true, true)]
         [TestCase(false, false, false, false)]
-        [TestCase(true, false, true, false)]
+        [TestCase(false, false, true, true)]
+        [TestCase(false, true, false, false)]
         [TestCase(false, true, true, false)]
+        [TestCase(true, false, false, false)]
+        [TestCase(true, false, true, false)]
+        [TestCase(true, true, false, false)]
+        [TestCase(true, true, true, false)]
         public void Post_learning_assessment_should_have_showCompletionSummary(
             bool otherSectionsExist,
             bool otherItemsInSectionExist,
             bool includeCertification,
-            bool showCompletionSummary
+            bool expectedShowCompletionSummary
         )
         {
             // Given
@@ -319,7 +323,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.ShowCompletionSummary.Should().Be(showCompletionSummary);
+            postLearningAssessmentViewModel.ShowCompletionSummary.Should().Be(expectedShowCompletionSummary);
         }
 
         [TestCase(2, "2020-12-25T15:00:00Z", 1, true, 75, 80, 85)]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FluentAssertions;
@@ -249,6 +250,210 @@
 
             // Then
             postLearningAssessmentViewModel.NextSectionId.Should().BeNull();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_not_have_onlyItemInOnlyCourse_when_other_sections_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: true,
+                otherItemsInSectionExist: false
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.OnlyItemInOnlyCourse.Should().BeFalse();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_not_have_onlyItemInOnlyCourse_when_other_items_in_section_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: false,
+                otherItemsInSectionExist: true
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.OnlyItemInOnlyCourse.Should().BeFalse();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_have_onlyItemInOnlyCourse()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: false,
+                otherItemsInSectionExist: false
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.OnlyItemInOnlyCourse.Should().BeTrue();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_have_noOtherItemsInSectionExist_when_no_other_sections_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherItemsInSectionExist: false
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.NoOtherItemsInSectionExist.Should().BeTrue();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_not_have_noOtherItemsInSectionExist_when_other_sections_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherItemsInSectionExist: true
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.NoOtherItemsInSectionExist.Should().BeFalse();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_show_completion_summary_when_include_certification_and_only_tutorial_and_section()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: false,
+                otherItemsInSectionExist: false,
+                includeCertification: true
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeTrue();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_not_show_completion_summary_when_include_certification_is_false()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: false,
+                otherItemsInSectionExist: false,
+                includeCertification: false
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeFalse();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_not_show_completion_summary_when_other_sections_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: true,
+                otherItemsInSectionExist: false,
+                includeCertification: true
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeFalse();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_not_show_completion_summary_when_other_items_in_section_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherSectionsExist: false,
+                otherItemsInSectionExist: true,
+                includeCertification: true
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+
+            // Then
+            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeFalse();
+        }
+
+        [TestCase(2, "2020-12-25T15:00:00Z", 1, true, 75, 80, 85)]
+        [TestCase(3, null, 0, true, 75, 80, 85)]
+        [TestCase(4, null, 3, true, 75, 80, 85)]
+        [TestCase(5, null, 3, false, 75, 80, 85)]
+        [TestCase(6, null, 3, false, 75, 80, 0)]
+        [TestCase(7, null, 3, false, 75, 0, 85)]
+        [TestCase(8, null, 3, false, 75, 0, 0)]
+        public void Post_learning_assessment_should_have_completion_summary_card_view_model(
+            int customisationId,
+            string? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold
+        )
+        {
+            // Given
+            var completedDateTime = completed != null ? DateTime.Parse(completed) : (DateTime?)null;
+
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                completed: completedDateTime,
+                maxPostLearningAssessmentAttempts: maxPostLearningAssessmentAttempts,
+                isAssessed: isAssessed,
+                postLearningAssessmentPassThreshold: postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold: diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold: tutorialsCompletionThreshold
+            );
+
+            var expectedCompletionSummaryViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                completedDateTime,
+                maxPostLearningAssessmentAttempts,
+                isAssessed,
+                postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, customisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.CompletionSummaryCardViewModel
+                .Should().BeEquivalentTo(expectedCompletionSummaryViewModel);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -304,7 +304,7 @@
         }
 
         [Test]
-        public void Post_learning_assessment_should_have_noOtherItemsInSectionExist_when_no_other_sections_exist()
+        public void Post_learning_assessment_should_be_only_item_in_only_section_when_no_other_sections_exist()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -316,11 +316,11 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.NoOtherItemsInSectionExist.Should().BeTrue();
+            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeTrue();
         }
 
         [Test]
-        public void Post_learning_assessment_should_not_have_noOtherItemsInSectionExist_when_other_sections_exist()
+        public void Post_learning_assessment_should_be_only_item_in_only_section_when_other_sections_exist()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -332,7 +332,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.NoOtherItemsInSectionExist.Should().BeFalse();
+            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeFalse();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -252,13 +252,20 @@
             postLearningAssessmentViewModel.NextSectionId.Should().BeNull();
         }
 
-        [Test]
-        public void Post_learning_assessment_should_not_be_only_item_in_only_section_when_other_sections_exist()
+        [TestCase(false, false, true)]
+        [TestCase(false, true, false)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, false)]
+        public void Post_learning_assessment_should_have_onlyItemInOnlySection(
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool onlyItemInOnlySection
+        )
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: true,
-                otherItemsInSectionExist: false
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist
             );
 
             // When
@@ -266,16 +273,19 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeFalse();
+            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().Be(onlyItemInOnlySection);
         }
 
-        [Test]
-        public void Post_learning_assessment_should_not_be_only_item_in_only_section_when_other_items_in_section_exist()
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        public void Post_learning_assessment_should_have_onlyItemInThisSection(
+            bool otherItemsInSectionExist,
+            bool onlyItemInThisSection
+        )
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: true
+                otherItemsInSectionExist: otherItemsInSectionExist
             );
 
             // When
@@ -283,16 +293,25 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeFalse();
+            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().Be(onlyItemInThisSection);
         }
 
-        [Test]
-        public void Post_learning_assessment_should_be_only_item_in_only_section()
+        [TestCase(false, false, true, true)]
+        [TestCase(false, false, false, false)]
+        [TestCase(true, false, true, false)]
+        [TestCase(false, true, true, false)]
+        public void Post_learning_assessment_should_have_showCompletionSummary(
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool includeCertification,
+            bool showCompletionSummary
+        )
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: false
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist,
+                includeCertification: includeCertification
             );
 
             // When
@@ -300,112 +319,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeTrue();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_be_only_item_in_this_section_when_no_other_sections_exist()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherItemsInSectionExist: false
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-            // Then
-            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().BeTrue();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_not_be_only_item_in_this_section_when_other_sections_exist()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherItemsInSectionExist: true
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-            // Then
-            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().BeFalse();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_show_completion_summary_when_include_certification_and_only_item_and_section()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: false,
-                includeCertification: true
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-            // Then
-            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeTrue();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_not_show_completion_summary_when_include_certification_is_false()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: false,
-                includeCertification: false
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-            // Then
-            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeFalse();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_not_show_completion_summary_when_other_sections_exist()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: true,
-                otherItemsInSectionExist: false,
-                includeCertification: true
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-            // Then
-            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeFalse();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_not_show_completion_summary_when_other_items_in_section_exist()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: true,
-                includeCertification: true
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-
-            // Then
-            postLearningAssessmentViewModel.ShowCompletionSummary.Should().BeFalse();
+            postLearningAssessmentViewModel.ShowCompletionSummary.Should().Be(showCompletionSummary);
         }
 
         [TestCase(2, "2020-12-25T15:00:00Z", 1, true, 75, 80, 85)]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -253,7 +253,7 @@
         }
 
         [Test]
-        public void Post_learning_assessment_should_not_have_onlyItemInOnlyCourse_when_other_sections_exist()
+        public void Post_learning_assessment_should_not_be_only_item_in_only_section_when_other_sections_exist()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -266,11 +266,11 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlyCourse.Should().BeFalse();
+            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeFalse();
         }
 
         [Test]
-        public void Post_learning_assessment_should_not_have_onlyItemInOnlyCourse_when_other_items_in_section_exist()
+        public void Post_learning_assessment_should_not_be_only_item_in_only_section_when_other_items_in_section_exist()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -283,31 +283,15 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlyCourse.Should().BeFalse();
+            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeFalse();
         }
 
         [Test]
-        public void Post_learning_assessment_should_have_onlyItemInOnlyCourse()
+        public void Post_learning_assessment_should_have_be_only_item_in_only_section()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
                 otherSectionsExist: false,
-                otherItemsInSectionExist: false
-            );
-
-            // When
-            var postLearningAssessmentViewModel =
-                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
-
-            // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlyCourse.Should().BeTrue();
-        }
-
-        [Test]
-        public void Post_learning_assessment_should_be_only_item_in_only_section_when_no_other_sections_exist()
-        {
-            // Given
-            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
                 otherItemsInSectionExist: false
             );
 
@@ -320,7 +304,23 @@
         }
 
         [Test]
-        public void Post_learning_assessment_should_be_only_item_in_only_section_when_other_sections_exist()
+        public void Post_learning_assessment_should_be_only_item_in_this_section_when_no_other_sections_exist()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                otherItemsInSectionExist: false
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().BeTrue();
+        }
+
+        [Test]
+        public void Post_learning_assessment_should_be_only_item_in_this_section_when_other_sections_exist()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -332,7 +332,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.OnlyItemInOnlySection.Should().BeFalse();
+            postLearningAssessmentViewModel.OnlyItemInThisSection.Should().BeFalse();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -287,7 +287,7 @@
         }
 
         [Test]
-        public void Post_learning_assessment_should_have_be_only_item_in_only_section()
+        public void Post_learning_assessment_should_be_only_item_in_only_section()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -320,7 +320,7 @@
         }
 
         [Test]
-        public void Post_learning_assessment_should_be_only_item_in_this_section_when_other_sections_exist()
+        public void Post_learning_assessment_should_not_be_only_item_in_this_section_when_other_sections_exist()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
@@ -336,7 +336,7 @@
         }
 
         [Test]
-        public void Post_learning_assessment_should_show_completion_summary_when_include_certification_and_only_tutorial_and_section()
+        public void Post_learning_assessment_should_show_completion_summary_when_include_certification_and_only_item_and_section()
         {
             // Given
             var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -112,15 +112,27 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
+            var hasDiagnosticAssessment = sectionContent.DiagnosticAssessmentPath != null && sectionContent.DiagnosticStatus;
+            var hasPostLearningAssessment = sectionContent.PostLearningAssessmentPath != null && sectionContent.IsAssessed;
+            var hasConsolidationMaterial = sectionContent.ConsolidationPath != null;
 
             if (sectionContent.Tutorials.Count == 1
-                && (sectionContent.DiagnosticAssessmentPath == null || !sectionContent.DiagnosticStatus)
-                && (sectionContent.PostLearningAssessmentPath == null || !sectionContent.IsAssessed)
-                && sectionContent.ConsolidationPath == null
+                && !hasDiagnosticAssessment
+                && !hasPostLearningAssessment
+                && !hasConsolidationMaterial
             )
             {
                 var tutorialId = sectionContent.Tutorials.First().Id;
                 return RedirectToAction("Tutorial", "LearningMenu", new { customisationId, sectionId, tutorialId });
+            }
+
+            if (sectionContent.Tutorials.Count == 0
+                && !hasDiagnosticAssessment
+                && hasPostLearningAssessment
+                && !hasConsolidationMaterial
+            )
+            {
+                return RedirectToAction("PostLearning", "LearningMenu", new { customisationId, sectionId });
             }
 
             var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId.Value);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -13,7 +13,7 @@
         public int SectionId { get; }
         public int? NextSectionId { get; }
         public bool OnlyItemInOnlyCourse { get; }
-        public bool NoOtherItemsInSectionExist { get; }
+        public bool OnlyItemInOnlySection { get; }
         public bool ShowCompletionSummary { get; }
         public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
 
@@ -37,7 +37,7 @@
             }
 
             OnlyItemInOnlyCourse = !postLearningAssessment.OtherItemsInSectionExist && !postLearningAssessment.OtherSectionsExist;
-            NoOtherItemsInSectionExist = !postLearningAssessment.OtherItemsInSectionExist;
+            OnlyItemInOnlySection = !postLearningAssessment.OtherItemsInSectionExist;
             ShowCompletionSummary = OnlyItemInOnlyCourse && postLearningAssessment.IncludeCertification;
 
             CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -12,8 +12,8 @@
         public int CustomisationId { get; }
         public int SectionId { get; }
         public int? NextSectionId { get; }
-        public bool OnlyItemInOnlyCourse { get; }
         public bool OnlyItemInOnlySection { get; }
+        public bool OnlyItemInThisSection { get; }
         public bool ShowCompletionSummary { get; }
         public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
 
@@ -36,9 +36,9 @@
                 ScoreInformation = GetScoreInformation(postLearningAssessment);
             }
 
-            OnlyItemInOnlyCourse = !postLearningAssessment.OtherItemsInSectionExist && !postLearningAssessment.OtherSectionsExist;
-            OnlyItemInOnlySection = !postLearningAssessment.OtherItemsInSectionExist;
-            ShowCompletionSummary = OnlyItemInOnlyCourse && postLearningAssessment.IncludeCertification;
+            OnlyItemInOnlySection = !postLearningAssessment.OtherItemsInSectionExist && !postLearningAssessment.OtherSectionsExist;
+            OnlyItemInThisSection = !postLearningAssessment.OtherItemsInSectionExist;
+            ShowCompletionSummary = OnlyItemInOnlySection && postLearningAssessment.IncludeCertification;
 
             CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(
                 customisationId,

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -12,6 +12,10 @@
         public int CustomisationId { get; }
         public int SectionId { get; }
         public int? NextSectionId { get; }
+        public bool OnlyItemInOnlyCourse { get; }
+        public bool NoOtherItemsInSectionExist { get; }
+        public bool ShowCompletionSummary { get; }
+        public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
 
         public PostLearningAssessmentViewModel(PostLearningAssessment postLearningAssessment, int customisationId, int sectionId)
         {
@@ -31,6 +35,20 @@
                 AssessmentStatus = GetPassStatus(postLearningAssessment);
                 ScoreInformation = GetScoreInformation(postLearningAssessment);
             }
+
+            OnlyItemInOnlyCourse = !postLearningAssessment.OtherItemsInSectionExist && !postLearningAssessment.OtherSectionsExist;
+            NoOtherItemsInSectionExist = !postLearningAssessment.OtherItemsInSectionExist;
+            ShowCompletionSummary = OnlyItemInOnlyCourse && postLearningAssessment.IncludeCertification;
+
+            CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                postLearningAssessment.Completed,
+                postLearningAssessment.MaxPostLearningAssessmentAttempts,
+                postLearningAssessment.IsAssessed,
+                postLearningAssessment.PostLearningAssessmentPassThreshold,
+                postLearningAssessment.DiagnosticAssessmentCompletionThreshold,
+                postLearningAssessment.TutorialsCompletionThreshold
+            );
         }
 
         private string GetScoreInformation(PostLearningAssessment postLearningAssessment)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -32,7 +32,7 @@
       {
         <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
       }
-      else if (Model.NoOtherItemsInSectionExist)
+      else if (Model.OnlyItemInOnlySection)
       {
         <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
       }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -28,11 +28,11 @@
         <li class="nhsuk-breadcrumb__item">Post learning assessment</li>
       </ol>
 
-      @if (Model.OnlyItemInOnlyCourse)
+      @if (Model.OnlyItemInOnlySection)
       {
         <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
       }
-      else if (Model.OnlyItemInOnlySection)
+      else if (Model.OnlyItemInThisSection)
       {
         <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
       }
@@ -83,7 +83,7 @@
   }
 </div>
 
-@if (!Model.OnlyItemInOnlyCourse)
+@if (!Model.OnlyItemInOnlySection)
 {
   <partial name="PostLearning/_PostLearningNextLink" model="Model"/>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -27,7 +27,19 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item">Post learning assessment</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Return to section</a></p>
+
+      @if (Model.OnlyItemInOnlyCourse)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+      }
+      else if (Model.NoOtherItemsInSectionExist)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
+      }
+      else
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Return to section</a></p>
+      }
     </div>
   </nav>
 }
@@ -71,4 +83,14 @@
   }
 </div>
 
-<partial name="PostLearning/_PostLearningNextLink" model="Model"/>
+@if (!Model.OnlyItemInOnlyCourse)
+{
+  <partial name="PostLearning/_PostLearningNextLink" model="Model"/>
+}
+
+@if (Model.ShowCompletionSummary)
+{
+  <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible thick">
+
+  <partial name="Shared/_CompletionSummaryCard" model="Model.CompletionSummaryCardViewModel" />
+}


### PR DESCRIPTION
## Changes
* Amend section action to redirect to the post learning assessment page if the course only has a post learning assessment.
* Add completion data to post learning assessment view model, to be shown if it is the item in the course, and flags to record whether this is the only section, and only item in the section.
* Hide the next button if this is the only item in the section.
* Modify the mobile-only back breadcrumb to have a more helpful name,
depending on if there are other sections in the course or not.

## Testing
Amend tests for this new information, and new learning menu controller behaviour. Tested in Chrome and IE11 using a screen reader and no JS.

## Screenshots
### Single post learning assessment, without a completion summary
![single_pl_no_completion](https://user-images.githubusercontent.com/3650110/105365516-3f7a6380-5bf6-11eb-8a01-a444ae517d96.png)

### Single post learning assessment using a narrow viewport, without a completion summary
![single_pl_no_completion_narrow](https://user-images.githubusercontent.com/3650110/105365514-3ee1cd00-5bf6-11eb-9fe3-d384093e4ac3.png)

### Single post learning assessment, with a completion summary
![single_pl_with_completion](https://user-images.githubusercontent.com/3650110/105365511-3db0a000-5bf6-11eb-9f8d-e9b76f62f296.png)

### Section with post learning assessment and consolidation exercise
![pl_and_consolidation](https://user-images.githubusercontent.com/3650110/105365507-3c7f7300-5bf6-11eb-9b66-d368004545be.png)