### PR TITLE
HEEDLS-314 Post learning assessment improve voice over fix

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -167,7 +167,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.ScoreInformation.Should().Be("(10% - 1 attempt)");
+            postLearningAssessmentViewModel.ScoreInformation.Should().Be("10% - 1 attempt");
         }
 
         [Test]
@@ -185,7 +185,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.ScoreInformation.Should().Be("(10% - 5 attempts)");
+            postLearningAssessmentViewModel.ScoreInformation.Should().Be("10% - 5 attempts");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -36,8 +36,8 @@
         private string GetScoreInformation(PostLearningAssessment postLearningAssessment)
         {
             return postLearningAssessment.PostLearningAttempts == 1
-                ? $"({postLearningAssessment.PostLearningScore}% - 1 attempt)"
-                : $"({postLearningAssessment.PostLearningScore}% - {postLearningAssessment.PostLearningAttempts} attempts)";
+                ? $"{postLearningAssessment.PostLearningScore}% - 1 attempt"
+                : $"{postLearningAssessment.PostLearningScore}% - {postLearningAssessment.PostLearningAttempts} attempts";
         }
 
         private string GetPassStatus(PostLearningAssessment postLearningAssessment)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -43,8 +43,7 @@
       @Model.AssessmentStatus
       @if (Model.ScoreInformation != null)
       {
-        <span class="nhsuk-u-visually-hidden">, your score: </span>
-        @Model.ScoreInformation
+        @:(<span class="nhsuk-u-visually-hidden">Your score: </span>@Model.ScoreInformation)
       }
     </h2>
   </div>


### PR DESCRIPTION
Move the hidden text to be within the parentheses.

Ran and passed all unit tests. Could not replicate the bug but there should no longer be a colon followed by a bracket.