### PR TITLE
HEEDLS-320 Add single diagnostic assessment front end

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -473,11 +473,11 @@
             var tutorial = SectionContentHelper.CreateDefaultSectionTutorial(id: tutorialId);
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: false,
                 plAssessPath: null,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = false;
             expectedSectionContent.Tutorials.Add(tutorial);
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -507,11 +507,11 @@
             var tutorial = SectionContentHelper.CreateDefaultSectionTutorial(id: tutorialId);
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: null,
+                diagStatus: true,
                 plAssessPath: null,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             expectedSectionContent.Tutorials.Add(tutorial);
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -570,12 +570,12 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: false,
                 plAssessPath: "some/post-learning/path.html",
                 isAssessed: true,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = false;
             // expectedSectionContent.Tutorials is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -602,12 +602,12 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: null,
+                diagStatus: true,
                 plAssessPath: "some/post-learning/path.html",
                 isAssessed: true,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             // expectedSectionContent.Tutorials; viewable tutorials, is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -634,11 +634,11 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: true,
                 plAssessPath: null,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             // expectedSectionContent.Tutorials is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -665,12 +665,12 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: true,
                 plAssessPath: "some/post-learning/path.html",
                 isAssessed: false,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             // expectedSectionContent.Tutorials is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -697,12 +697,12 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: true,
                 plAssessPath: null,
                 isAssessed: true,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             // expectedSectionContent.Tutorials; viewable tutorials, is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -731,11 +731,11 @@
             var tutorial = SectionContentHelper.CreateDefaultSectionTutorial(id: tutorialId);
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: true,
                 plAssessPath: null,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             expectedSectionContent.Tutorials.Add(tutorial);
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -760,12 +760,12 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: true,
                 plAssessPath: "some/post-learning/path.html",
                 isAssessed: true,
                 consolidationPath: null,
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             // expectedSectionContent.Tutorials; viewable tutorials, is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
@@ -948,11 +948,11 @@
             const int sectionId = 456;
             var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
                 diagAssessPath: "some/diagnostic/path.html",
+                diagStatus: true,
                 plAssessPath: null,
                 consolidationPath: "some/consolidation/path.pdf",
                 otherSectionsExist: true
             );
-            expectedSectionContent.DiagnosticStatus = true;
             // expectedSectionContent.Tutorials; viewable tutorials, is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -627,6 +627,101 @@
         }
 
         [Test]
+        public void Sections_should_redirect_to_diagnostic_assessment_if_only_diagnostic_in_section()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: "some/diagnostic/path.html",
+                plAssessPath: null,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = true;
+            // expectedSectionContent.Tutorials is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("Diagnostic")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
+        public void Sections_should_redirect_to_diagnostic_assessment_if_there_is_post_learning_path_but_is_not_assessed()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: "some/diagnostic/path.html",
+                plAssessPath: "some/post-learning/path.html",
+                isAssessed: false,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = true;
+            // expectedSectionContent.Tutorials is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("Diagnostic")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
+        public void Sections_should_redirect_to_diagnostic_assessment_if_is_assessed_but_there_is_no_post_learning_path()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: "some/diagnostic/path.html",
+                plAssessPath: null,
+                isAssessed: true,
+                consolidationPath: null,
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = true;
+            // expectedSectionContent.Tutorials; viewable tutorials, is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithControllerName("LearningMenu")
+                .WithActionName("Diagnostic")
+                .WithRouteValue("customisationId", customisationId)
+                .WithRouteValue("sectionId", sectionId);
+        }
+
+        [Test]
         public void Sections_should_return_section_page_if_there_is_diagnostic_and_tutorial()
         {
             // Given
@@ -787,7 +882,7 @@
         }
 
         [Test]
-        public void Sections_should_return_section_page_if_there_is_consolidation()
+        public void Sections_should_return_section_page_if_there_is_one_tutorial_and_consolidation()
         {
             // Given
             const int customisationId = 123;
@@ -801,6 +896,64 @@
                 otherSectionsExist: true
             );
             expectedSectionContent.Tutorials.Add(tutorial);
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            var expectedModel = new SectionContentViewModel(config, expectedSectionContent, customisationId, sectionId);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should().BeViewResult()
+                .Model.Should().BeEquivalentTo(expectedModel);
+        }
+
+        [Test]
+        public void Sections_should_return_section_page_if_there_is_post_learning_assessment_and_consolidation()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: null,
+                plAssessPath: "some/post-learning/path.html",
+                isAssessed: true,
+                consolidationPath: "some/consolidation/path.pdf",
+                otherSectionsExist: true
+            );
+            // expectedSectionContent.Tutorials; viewable tutorials, is empty
+
+            A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
+                .Returns(expectedSectionContent);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
+
+            var expectedModel = new SectionContentViewModel(config, expectedSectionContent, customisationId, sectionId);
+
+            // When
+            var result = controller.Section(customisationId, sectionId);
+
+            // Then
+            result.Should().BeViewResult()
+                .Model.Should().BeEquivalentTo(expectedModel);
+        }
+
+        [Test]
+        public void Sections_should_return_section_page_if_there_is_diagnostic_assessment_and_consolidation()
+        {
+            // Given
+            const int customisationId = 123;
+            const int sectionId = 456;
+            var expectedSectionContent = SectionContentHelper.CreateDefaultSectionContent(
+                diagAssessPath: "some/diagnostic/path.html",
+                plAssessPath: null,
+                consolidationPath: "some/consolidation/path.pdf",
+                otherSectionsExist: true
+            );
+            expectedSectionContent.DiagnosticStatus = true;
+            // expectedSectionContent.Tutorials; viewable tutorials, is empty
 
             A.CallTo(() => sectionContentService.GetSectionContent(customisationId, CandidateId, sectionId))
                 .Returns(expectedSectionContent);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System;
     using DigitalLearningSolutions.Data.Models.DiagnosticAssessment;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
@@ -317,6 +318,128 @@
 
             // Then
             diagnosticAssessmentViewModel.Tutorials.Should().BeEquivalentTo<DiagnosticTutorial>(tutorials);
+        }
+
+        [TestCase(false, false, true)]
+        [TestCase(false, true, false)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, false)]
+        public void Diagnostic_assessment_should_have_onlyItemInOnlySection(
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool expectedOnlyItemInOnlySection
+        )
+        {
+            // Given
+            var diagnosticAssessment = DiagnosticAssessmentTestHelper.CreateDefaultDiagnosticAssessment(
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.OnlyItemInOnlySection.Should().Be(expectedOnlyItemInOnlySection);
+        }
+
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        public void Diagnostic_assessment_should_have_onlyItemInThisSection(
+            bool otherItemsInSectionExist,
+            bool expectedOnlyItemInThisSection
+        )
+        {
+            // Given
+            var diagnosticAssessment = DiagnosticAssessmentTestHelper.CreateDefaultDiagnosticAssessment(
+                otherItemsInSectionExist: otherItemsInSectionExist
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.OnlyItemInThisSection.Should().Be(expectedOnlyItemInThisSection);
+        }
+
+        [TestCase(false, false, false, false)]
+        [TestCase(false, false, true, true)]
+        [TestCase(false, true, false, false)]
+        [TestCase(false, true, true, false)]
+        [TestCase(true, false, false, false)]
+        [TestCase(true, false, true, false)]
+        [TestCase(true, true, false, false)]
+        [TestCase(true, true, true, false)]
+        public void Diagnostic_assessment_should_have_showCompletionSummary(
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool includeCertification,
+            bool expectedShowCompletionSummary
+        )
+        {
+            // Given
+            var diagnosticAssessment = DiagnosticAssessmentTestHelper.CreateDefaultDiagnosticAssessment(
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist,
+                includeCertification: includeCertification
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.ShowCompletionSummary.Should().Be(expectedShowCompletionSummary);
+        }
+
+        [TestCase(2, "2020-12-25T15:00:00Z", 1, true, 75, 80, 85)]
+        [TestCase(3, null, 0, true, 75, 80, 85)]
+        [TestCase(4, null, 3, true, 75, 80, 85)]
+        [TestCase(5, null, 3, false, 75, 80, 85)]
+        [TestCase(6, null, 3, false, 75, 80, 0)]
+        [TestCase(7, null, 3, false, 75, 0, 85)]
+        [TestCase(8, null, 3, false, 75, 0, 0)]
+        public void Diagnostic_assessment_should_have_completion_summary_card_view_model(
+            int customisationId,
+            string? completed,
+            int maxPostLearningAssessmentAttempts,
+            bool isAssessed,
+            int postLearningAssessmentPassThreshold,
+            int diagnosticAssessmentCompletionThreshold,
+            int tutorialsCompletionThreshold
+        )
+        {
+            // Given
+            var completedDateTime = completed != null ? DateTime.Parse(completed) : (DateTime?)null;
+
+            var diagnosticAssessment = DiagnosticAssessmentTestHelper.CreateDefaultDiagnosticAssessment(
+                completed: completedDateTime,
+                maxPostLearningAssessmentAttempts: maxPostLearningAssessmentAttempts,
+                isAssessed: isAssessed,
+                postLearningAssessmentPassThreshold: postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold: diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold: tutorialsCompletionThreshold
+            );
+
+            var expectedCompletionSummaryViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                completedDateTime,
+                maxPostLearningAssessmentAttempts,
+                isAssessed,
+                postLearningAssessmentPassThreshold,
+                diagnosticAssessmentCompletionThreshold,
+                tutorialsCompletionThreshold
+            );
+
+            // When
+            var diagnosticAssessmentViewModel =
+                new DiagnosticAssessmentViewModel(diagnosticAssessment, customisationId, SectionId);
+
+            // Then
+            diagnosticAssessmentViewModel.CompletionSummaryCardViewModel
+                .Should().BeEquivalentTo(expectedCompletionSummaryViewModel);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -126,13 +126,18 @@
                 return RedirectToAction("Tutorial", "LearningMenu", new { customisationId, sectionId, tutorialId });
             }
 
-            if (sectionContent.Tutorials.Count == 0
-                && !hasDiagnosticAssessment
-                && hasPostLearningAssessment
-                && !hasConsolidationMaterial
-            )
+            var justHasAssessments = sectionContent.Tutorials.Count == 0
+                                     && !hasConsolidationMaterial
+                                     && (hasDiagnosticAssessment || hasPostLearningAssessment);
+
+            if (justHasAssessments && !hasDiagnosticAssessment)
             {
                 return RedirectToAction("PostLearning", "LearningMenu", new { customisationId, sectionId });
+            }
+
+            if (justHasAssessments && !hasPostLearningAssessment)
+            {
+                return RedirectToAction("Diagnostic", "LearningMenu", new { customisationId, sectionId });
             }
 
             var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId.Value);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/DiagnosticAssessmentViewModel.cs
@@ -18,6 +18,10 @@
         public int CustomisationId { get; }
         public int SectionId { get; }
         public IEnumerable<DiagnosticTutorial> Tutorials { get; }
+        public bool OnlyItemInOnlySection { get; }
+        public bool OnlyItemInThisSection { get; }
+        public bool ShowCompletionSummary { get; }
+        public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
 
         public DiagnosticAssessmentViewModel(DiagnosticAssessment diagnosticAssessment, int customisationId, int sectionId)
         {
@@ -40,6 +44,18 @@
             CustomisationId = customisationId;
             SectionId = sectionId;
             Tutorials = diagnosticAssessment.Tutorials;
+            OnlyItemInOnlySection = !diagnosticAssessment.OtherItemsInSectionExist && !diagnosticAssessment.OtherSectionsExist;
+            OnlyItemInThisSection = !diagnosticAssessment.OtherItemsInSectionExist;
+            ShowCompletionSummary = OnlyItemInOnlySection && diagnosticAssessment.IncludeCertification;
+            CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(
+                customisationId,
+                diagnosticAssessment.Completed,
+                diagnosticAssessment.MaxPostLearningAssessmentAttempts,
+                diagnosticAssessment.IsAssessed,
+                diagnosticAssessment.PostLearningAssessmentPassThreshold,
+                diagnosticAssessment.DiagnosticAssessmentCompletionThreshold,
+                diagnosticAssessment.TutorialsCompletionThreshold
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -26,7 +26,19 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item">Diagnostic assessment</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Return to section</a></p>
+
+      @if (Model.OnlyItemInOnlySection)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+      }
+      else if (Model.OnlyItemInThisSection)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
+      }
+      else
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Return to section</a></p>
+      }
     </div>
   </nav>
 }
@@ -82,4 +94,14 @@
   </fieldset>
 </form>
 
-<partial name="Diagnostic/_DiagnosticNextLink" model="Model" />
+@if (!Model.OnlyItemInOnlySection)
+{
+  <partial name="Diagnostic/_DiagnosticNextLink" model="Model" />
+}
+
+@if (Model.ShowCompletionSummary)
+{
+  <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible thick">
+
+  <partial name="Shared/_CompletionSummaryCard" model="Model.CompletionSummaryCardViewModel" />
+}


### PR DESCRIPTION
## Changes
* Amend section action to redirect to the diagnostic assessment page if the course only has a diagnostic assessment.
* Add completion data to diagnostic assessment view model, to be shown if it is the only item in the course, and flags to record whether this is the only section, and only item in the section.
* Hide the next button if this is the only item in the section.
* Modify the mobile-only back breadcrumb to have a more helpful name, depending on if there are other sections in the course or not.

## Testing
Add unit tests, tested in Google Chrome

## Screenshots
### Diagnostic, only item in section, among other sections, wide viewport
![single_diagnostic_section_among_other_sections](https://user-images.githubusercontent.com/3650110/105381511-fe3e7f80-5c06-11eb-97de-2c5d976070aa.png)
### Diagnostic, only item in section, among other sections, narrow viewport
![single_diagnostic_section_among_other_sections_narrow](https://user-images.githubusercontent.com/3650110/105381509-fe3e7f80-5c06-11eb-8fa1-a55b18e3fe36.png)
### Diagnostic, only item in course, wide viewport
![single_diagnostic_course](https://user-images.githubusercontent.com/3650110/105381508-fd0d5280-5c06-11eb-9b50-1900c25af791.png)
### Diagnostic, only item in course, narrow viewport
![single_diagnostic_course_narrow](https://user-images.githubusercontent.com/3650110/105381501-fbdc2580-5c06-11eb-94d1-4ada99ee47ae.png)
### Diagnostic, only item in course, wide viewport, with completion summary
![single_diagnostic_course_with_completion](https://user-images.githubusercontent.com/3650110/105381505-fc74bc00-5c06-11eb-8859-db26846e73a4.png)