### PR TITLE
HEEDLS-322 Tutorial content viewer close not working after fullscreen

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/contentViewer.ts
@@ -2,7 +2,7 @@ import { setupFullscreen } from './fullscreen';
 
 function closeMpe(): void {
   // Extract the current domain, customisationId, sectionId and tutorialId out of the URL
-  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial$/);
+  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/(\d+)\/Tutorial#?$/);
 
   if (!matches || matches.length < 5) {
     return;

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/contentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/contentViewer.spec.ts
@@ -27,6 +27,18 @@ describe('closeMpe', () => {
       expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/789');
     });
 
+  it('should redirect to tutorial overview after accessing fullscreen',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/789/Tutorial#';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/789');
+    });
+
   it('should do nothing on unexpected page',
     () => {
       // Given


### PR DESCRIPTION
Small modification to the regex to account for URL after enabling fullscreen.

Add test for URL after enabling fullscreen.

Ran and passed all unit tests, manually tested on Firefox by using `closeMpe()` in fullscreen and after exiting fullscreen.