### PR TITLE
HEEDLS-284 - Section Page Show Diagnostic Recommendation Status Fix

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/SectionContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SectionContentServiceTests.cs
@@ -68,10 +68,10 @@
             expectedSectionContent.Tutorials.AddRange(
                 new[]
                 {
-                    new SectionTutorial("Introduction to applications", 0, "Not started", 0, 17, 1461, true, 0 , 2),
-                    new SectionTutorial("Common screen elements", 0, "Not started", 0, 11, 1462, true, 0, 4),
-                    new SectionTutorial("Using ribbon tabs", 0, "Not started", 0, 6, 1463, true, 0, 2),
-                    new SectionTutorial("Getting help", 0, "Not started", 0, 11, 1464, true, 0, 5)
+                    new SectionTutorial("Introduction to applications", 0, "Not started", 0, 17, 1461, true, 0 , 2, true, 0),
+                    new SectionTutorial("Common screen elements", 0, "Not started", 0, 11, 1462, true, 0, 4, true, 0),
+                    new SectionTutorial("Using ribbon tabs", 0, "Not started", 0, 6, 1463, true, 0, 2, true, 0),
+                    new SectionTutorial("Getting help", 0, "Not started", 0, 11, 1464, true, 0, 5, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedSectionContent);
@@ -154,14 +154,14 @@
             expectedSectionContent.Tutorials.AddRange(
                 new[]
                 {
-                    new SectionTutorial("Entering data in the Worksheet", 0, "Not started", 0, 9, 4453, true, 0, 5),
-                    new SectionTutorial("Copying, moving and Auto-Filling data", 2, "Complete", 3, 14, 4454, true, 0, 5),
-                    new SectionTutorial("Define names for cells and cell ranges", 0, "Not started", 0, 10, 4455, true, 0, 4),
-                    new SectionTutorial("Using absolute and relative addresses", 0, "Not started", 0, 12, 4456, true, 0, 3),
-                    new SectionTutorial("Insert and delete rows, columns and cells", 0, "Not started", 0, 5, 4457, true, 0, 4),
-                    new SectionTutorial("Hide and unhide rows or columns", 2, "Complete", 1, 3, 4458, true, 0, 2),
-                    new SectionTutorial("Use pick lists", 0, "Not started", 0, 8, 4459, true, 0, 1),
-                    new SectionTutorial("Use comments", 0, "Not started", 0, 21, 4460, true, 0, 6)
+                    new SectionTutorial("Entering data in the Worksheet", 0, "Not started", 0, 9, 4453, true, 0, 5, true, 0),
+                    new SectionTutorial("Copying, moving and Auto-Filling data", 2, "Complete", 3, 14, 4454, true, 0, 5, true, 0),
+                    new SectionTutorial("Define names for cells and cell ranges", 0, "Not started", 0, 10, 4455, true, 0, 4, true, 0),
+                    new SectionTutorial("Using absolute and relative addresses", 0, "Not started", 0, 12, 4456, true, 0, 3, true, 0),
+                    new SectionTutorial("Insert and delete rows, columns and cells", 0, "Not started", 0, 5, 4457, true, 0, 4, true, 0),
+                    new SectionTutorial("Hide and unhide rows or columns", 2, "Complete", 1, 3, 4458, true, 0, 2, true, 0),
+                    new SectionTutorial("Use pick lists", 0, "Not started", 0, 8, 4459, true, 0, 1, true, 0),
+                    new SectionTutorial("Use comments", 0, "Not started", 0, 21, 4460, true, 0, 6, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedSectionContent);
@@ -207,14 +207,14 @@
             expectedSectionContent.Tutorials.AddRange(
                 new[]
                 {
-                    new SectionTutorial("Entering data in the Worksheet", 0, "Not started", 0, 9, 4453, true, 0, 5),
-                    new SectionTutorial("Copying, moving and Auto-Filling data", 0, "Not started", 0, 14, 4454, true, 0, 5),
-                    new SectionTutorial("Define names for cells and cell ranges", 0, "Not started", 0, 10, 4455, true, 0, 4),
-                    new SectionTutorial("Using absolute and relative addresses", 0, "Not started", 0, 12, 4456, true, 0, 3),
-                    new SectionTutorial("Insert and delete rows, columns and cells", 0, "Not started", 0, 5, 4457, true, 0, 4),
-                    new SectionTutorial("Hide and unhide rows or columns", 0, "Not started", 0, 3, 4458, true, 0, 2),
-                    new SectionTutorial("Use pick lists", 0, "Not started", 0, 8, 4459, true, 0, 1),
-                    new SectionTutorial("Use comments", 0, "Not started", 0, 21, 4460, true, 0, 6)
+                    new SectionTutorial("Entering data in the Worksheet", 0, "Not started", 0, 9, 4453, true, 0, 5, true, 0),
+                    new SectionTutorial("Copying, moving and Auto-Filling data", 0, "Not started", 0, 14, 4454, true, 0, 5, true, 0),
+                    new SectionTutorial("Define names for cells and cell ranges", 0, "Not started", 0, 10, 4455, true, 0, 4, true, 0),
+                    new SectionTutorial("Using absolute and relative addresses", 0, "Not started", 0, 12, 4456, true, 0, 3, true, 0),
+                    new SectionTutorial("Insert and delete rows, columns and cells", 0, "Not started", 0, 5, 4457, true, 0, 4, true, 0),
+                    new SectionTutorial("Hide and unhide rows or columns", 0, "Not started", 0, 3, 4458, true, 0, 2, true, 0),
+                    new SectionTutorial("Use pick lists", 0, "Not started", 0, 8, 4459, true, 0, 1, true, 0),
+                    new SectionTutorial("Use comments", 0, "Not started", 0, 21, 4460, true, 0, 6, true, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedSectionContent);
@@ -364,10 +364,10 @@
             expectedSectionContent.Tutorials.AddRange(
                 new[]
                 {
-                    new SectionTutorial("View documents", 0, "Not started", 0, 9, 49, true, 0, 10),
-                    new SectionTutorial("Navigate documents", 0, "Not started", 0, 5, 50, true, 0, 3),
-                    new SectionTutorial("Use document properties", 2, "Complete", 1, 2, 51, true, 0, 2),
-                    new SectionTutorial("Save documents", 2, "Complete", 2, 4, 52, true, 0, 3)
+                    new SectionTutorial("View documents", 0, "Not started", 0, 9, 49, true, 0, 10, false, 0),
+                    new SectionTutorial("Navigate documents", 0, "Not started", 0, 5, 50, true, 0, 3, false, 0),
+                    new SectionTutorial("Use document properties", 2, "Complete", 1, 2, 51, true, 0, 2, false, 0),
+                    new SectionTutorial("Save documents", 2, "Complete", 2, 4, 52, true, 0, 3, false, 0)
                 }
             );
             result.Should().BeEquivalentTo(expectedSectionContent);
@@ -578,10 +578,10 @@
             expectedSectionContent.Tutorials.AddRange(
                 new[]
                 {
-                    new SectionTutorial("Introduction to applications", 0, "Not started", 0, 17, 1461, true, 0 , 2),
-                    new SectionTutorial("Common screen elements", 0, "Not started", 0, 11, 1462, true, 0, 4),
-                    new SectionTutorial("Using ribbon tabs", 0, "Not started", 0, 6, 1463, true, 0, 2),
-                    new SectionTutorial("Getting help", 0, "Not started", 0, 11, 1464, true, 0, 5)
+                    new SectionTutorial("Introduction to applications", 0, "Not started", 0, 17, 1461, true, 0, 2, true, 0),
+                    new SectionTutorial("Common screen elements", 0, "Not started", 0, 11, 1462, true, 0, 4, true, 0),
+                    new SectionTutorial("Using ribbon tabs", 0, "Not started", 0, 6, 1463, true, 0, 2, true, 0),
+                    new SectionTutorial("Getting help", 0, "Not started", 0, 11, 1464, true, 0, 5, true, 0)
                 }
             );
 

--- a/DigitalLearningSolutions.Data/Models/SectionContent/SectionTutorial.cs
+++ b/DigitalLearningSolutions.Data/Models/SectionContent/SectionTutorial.cs
@@ -11,6 +11,8 @@
         public bool CustomisationTutorialStatus { get; }
         public int CurrentScore { get; }
         public int PossibleScore { get; }
+        public bool TutorialDiagnosticStatus { get; }
+        public int TutorialDiagnosticAttempts { get; }
 
         public SectionTutorial(
             string tutorialName,
@@ -21,7 +23,9 @@
             int id,
             bool status,
             int currentScore,
-            int possibleScore
+            int possibleScore,
+            bool tutorialDiagnosticStatus,
+            int tutorialDiagnosticAttempts
         )
         {
             TutorialName = tutorialName;
@@ -33,6 +37,8 @@
             CustomisationTutorialStatus = status;
             CurrentScore = currentScore;
             PossibleScore = possibleScore;
+            TutorialDiagnosticStatus = tutorialDiagnosticStatus;
+            TutorialDiagnosticAttempts = tutorialDiagnosticAttempts;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/SectionContentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SectionContentService.cs
@@ -101,7 +101,9 @@
                         Tutorials.TutorialID AS id,
                         CustomisationTutorials.Status,
                         COALESCE (aspProgress.DiagLast, 0) AS CurrentScore,
-                        Tutorials.DiagAssessOutOf AS PossibleScore
+                        Tutorials.DiagAssessOutOf AS PossibleScore,
+                        CustomisationTutorials.DiagStatus AS TutorialDiagnosticStatus,
+                        COALESCE (aspProgress.DiagAttempts, 0) AS TutorialDiagnosticAttempts
                     FROM Tutorials
                         INNER JOIN CustomisationTutorials
                             ON CustomisationTutorials.TutorialID = Tutorials.TutorialID

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionContentHelper.cs
@@ -67,7 +67,9 @@
             int id = 1,
             bool status = true,
             int currentScore = 5,
-            int possibleScore = 7
+            int possibleScore = 7,
+            bool tutorialDiagnosticStatus = true,
+            int tutorialDiagnosticAttempts = 1
         )
         {
             return new SectionTutorial(
@@ -79,7 +81,9 @@
                 id,
                 status,
                 currentScore,
-                possibleScore
+                possibleScore,
+                tutorialDiagnosticStatus,
+                tutorialDiagnosticAttempts
             );
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionTutorialHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SectionTutorialHelper.cs
@@ -13,7 +13,9 @@
             int tutorialId = 1,
             bool customisationTutorialStatus = true,
             int currentScore = 3,
-            int possibleScore = 5
+            int possibleScore = 5,
+            bool tutorialDiagnosticStatus = true,
+            int tutorialDiagnosticAttempts = 1
         )
         {
             return new SectionTutorial(
@@ -25,7 +27,9 @@
                 tutorialId,
                 customisationTutorialStatus,
                 currentScore,
-                possibleScore
+                possibleScore,
+                tutorialDiagnosticStatus,
+                tutorialDiagnosticAttempts
             );
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
@@ -45,9 +45,7 @@
                 showTime,
                 showLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -66,9 +64,7 @@
                 showTime: true,
                 showLearnStatus: true,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -87,9 +83,7 @@
                 showTime: true,
                 showLearnStatus: false,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -108,9 +102,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -129,9 +121,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -142,7 +132,10 @@
         public void Tutorial_card_should_show_recommendation_status_if_all_conditions_are_met()
         {
             // Given
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
+                tutorialDiagnosticStatus: true,
+                tutorialDiagnosticAttempts: 2
+            );
 
             // When
             var tutorialCardViewModel = new TutorialCardViewModel(
@@ -150,9 +143,7 @@
                 ShowTime,
                 showLearnStatus: true,
                 CustomisationId,
-                SectionId,
-                diagnosticStatus: true,
-                diagnosticAttempts: 2
+                SectionId
             );
 
             // Then
@@ -163,7 +154,9 @@
         public void Tutorial_card_should_not_show_recommendation_status_if_diagnostic_status_is_false()
         {
             // Given
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
+                tutorialDiagnosticStatus: false
+            );
 
             // When
             var tutorialCardViewModel = new TutorialCardViewModel(
@@ -171,9 +164,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                diagnosticStatus: false,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -192,9 +183,7 @@
                 ShowTime,
                 showLearnStatus: false,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -205,7 +194,9 @@
         public void Tutorial_card_should_not_show_recommendation_status_if_diagnostic_attempts_is_zero()
         {
             // Given
-            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial();
+            var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
+                tutorialDiagnosticAttempts: 0
+            );
 
             // When
             var tutorialCardViewModel = new TutorialCardViewModel(
@@ -213,9 +204,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                diagnosticAttempts: 0
+                SectionId
             );
 
             // Then
@@ -237,9 +226,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -261,9 +248,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -285,9 +270,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then
@@ -309,9 +292,7 @@
                 ShowTime,
                 ShowLearnStatus,
                 CustomisationId,
-                SectionId,
-                DiagnosticStatus,
-                DiagnosticAttempts
+                SectionId
             );
 
             // Then

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialCardViewModelTests.cs
@@ -155,7 +155,8 @@
         {
             // Given
             var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
-                tutorialDiagnosticStatus: false
+                tutorialDiagnosticStatus: false,
+                tutorialDiagnosticAttempts: 2
             );
 
             // When
@@ -195,7 +196,8 @@
         {
             // Given
             var sectionTutorial = SectionTutorialHelper.CreateDefaultSectionTutorial(
-                tutorialDiagnosticAttempts: 0
+                tutorialDiagnosticAttempts: 0,
+                tutorialDiagnosticStatus: true
             );
 
             // When

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
@@ -54,9 +54,7 @@
                 sectionContent.CourseSettings.ShowTime,
                 sectionContent.CourseSettings.ShowLearnStatus,
                 sectionId,
-                customisationId,
-                sectionContent.DiagnosticStatus,
-                sectionContent.DiagnosticAttempts
+                customisationId
             ));
 
             DisplayDiagnosticSeparator = ShowDiagnostic && (sectionContent.Tutorials.Any() || ShowPostLearning || ShowConsolidation);

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialCardViewModel.cs
@@ -20,9 +20,7 @@
             bool showTime,
             bool showLearnStatus,
             int sectionId,
-            int customisationId,
-            bool diagnosticStatus,
-            int diagnosticAttempts
+            int customisationId
         )
         {
             Id = tutorial.Id;
@@ -39,7 +37,7 @@
             CustomisationId = customisationId;
             RecommendationStatus = tutorial.CurrentScore < tutorial.PossibleScore ? "Recommended" : "Optional";
             StatusTagColour = tutorial.CurrentScore < tutorial.PossibleScore ? "nhsuk-tag--orange" : "nhsuk-tag--green";
-            ShowRecommendationStatus = diagnosticAttempts > 0 && showLearnStatus && diagnosticStatus;
+            ShowRecommendationStatus = tutorial.TutorialDiagnosticAttempts > 0 && showLearnStatus && tutorial.TutorialDiagnosticStatus;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -3,34 +3,33 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="@(Model.ShowRecommendationStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-column-full")">
+      <div class="@(Model.ShowRecommendationStatus || Model.ShowLearnStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-column-full")">
         <h3 class="nhsuk-card__heading card-with-status-heading" id="@Model.Id-name">
           @Model.TutorialName
         </h3>
       </div>
-      <div class="nhsuk-grid-column-one-third">
-        @if (Model.ShowRecommendationStatus)
-        {
+      @if (Model.ShowRecommendationStatus) {
+        <div class="nhsuk-grid-column-one-third">
           <strong class="status-tag @Model.StatusTagColour float-right-additional-information">
+            <span class="nhsuk-u-visually-hidden">This tutorial is</span>
             @Model.RecommendationStatus
           </strong>
-        }
-      </div>
-    </div>
-    <div class="nhsuk-grid-row">
-      <div class="@(Model.ShowLearnStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-column-full")">
-        <div class="nhsuk-u-margin-bottom-4">
-          <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary" />
         </div>
-      </div>
-      <div class="nhsuk-grid-column-one-third">
-        @if (Model.ShowLearnStatus)
-        {
+      }
+      @if (Model.TimeSummary.ShowTime || Model.ShowRecommendationStatus) {
+        <div class="@(Model.ShowLearnStatus ? "nhsuk-grid-column-two-thirds" : "nhsuk-grid-column-full")">
+          <div class="nhsuk-u-margin-bottom-4">
+            <partial name="Shared/_TutorialTimeSummary" model="@Model.TimeSummary"/>
+          </div>
+        </div>
+      }
+      @if (Model.ShowLearnStatus) {
+        <div class="nhsuk-grid-column-one-third">
           <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
             @Model.CompletionStatus
           </h3>
-        }
-      </div>
+        </div>
+      }
     </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">


### PR DESCRIPTION
No new tests have been added, all the diffs in the test files are to fix existing tests under the new section tutorial constructor. 

Diagnostic Status and diagnostic attempts are now using the per tutorial values rather than per section values which means the status tag will be displayed/removed in the correct situations. 

For the view, changes have been made so that in the case where there is no time information and no recommendation status, the learn status will appear on the same row as the title. Unfortunately due to the nature of float right it would require a lot of messy logic to have the learn status replace the recommendation status (if recommendation status is not shown and time information is) so in that case there will be white space where the recommendation status would have been.

Something I realised is that the recommendation status is based on if the learn status is true, this means that all the whitespace problems could be fixed by swapping the location of the recommendation status and the learn status (as if the learn status isn't visible, then neither will the recommendation status meaning no top white space). There would be some formatting challenges with the status tag that would require some extra css but it would be plausible. Let me know if you think this is a change we want to do or if we're happy leaving it with the white space in that scenario