### PR TITLE
HEEDLS-321 Change only tutorial or section mobile breadcrumbs

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -609,13 +609,20 @@
             tutorialViewModel.SupportingMaterialPath.Should().Be(expectedParsedPath);
         }
 
-        [Test]
-        public void Tutorial_should_show_next_button_when_other_sections_exist()
+        [TestCase(false, false, true)]
+        [TestCase(false, true, false)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, false)]
+        public void Tutorial_should_have_onlyItemInOnlySection(
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool expectedOnlyItemInOnlySection
+        )
         {
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
-                otherSectionsExist: true,
-                otherItemsInSectionExist: false
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist
             );
 
             // When
@@ -627,16 +634,19 @@
             );
 
             // Then
-            tutorialViewModel.ShowNextButton.Should().BeTrue();
+            tutorialViewModel.OnlyItemInOnlySection.Should().Be(expectedOnlyItemInOnlySection);
         }
 
-        [Test]
-        public void Tutorial_should_show_next_button_when_other_items_in_section_exist()
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        public void Tutorial_should_have_onlyItemInThisSection(
+            bool otherItemsInSectionExist,
+            bool expectedOnlyItemInThisSection
+        )
         {
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: true
+                otherItemsInSectionExist: otherItemsInSectionExist
             );
 
             // When
@@ -648,16 +658,29 @@
             );
 
             // Then
-            tutorialViewModel.ShowNextButton.Should().BeTrue();
+            tutorialViewModel.OnlyItemInThisSection.Should().Be(expectedOnlyItemInThisSection);
         }
 
-        [Test]
-        public void Tutorial_should_not_show_next_button_when_only_tutorial_and_section()
+        [TestCase(false, false, false, false)]
+        [TestCase(false, false, true, true)]
+        [TestCase(false, true, false, false)]
+        [TestCase(false, true, true, false)]
+        [TestCase(true, false, false, false)]
+        [TestCase(true, false, true, false)]
+        [TestCase(true, true, false, false)]
+        [TestCase(true, true, true, false)]
+        public void tutorial_should_have_showCompletionSummary(
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool includeCertification,
+            bool expectedShowCompletionSummary
+        )
         {
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
-                otherSectionsExist: false,
-                otherItemsInSectionExist: false
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist,
+                includeCertification: includeCertification
             );
 
             // When
@@ -669,7 +692,7 @@
             );
 
             // Then
-            tutorialViewModel.ShowNextButton.Should().BeFalse();
+            tutorialViewModel.ShowCompletionSummary.Should().Be(expectedShowCompletionSummary);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -25,7 +25,8 @@
         public TutorialTimeSummaryViewModel TimeSummary { get; }
         public string? SupportingMaterialPath { get; }
         public TutorialNextLinkViewModel NextLinkViewModel { get; }
-        public bool ShowNextButton { get; }
+        public bool OnlyItemInOnlySection { get; }
+        public bool OnlyItemInThisSection { get; }
         public bool ShowCompletionSummary { get; }
         public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
 
@@ -75,8 +76,9 @@
                 tutorialInformation.NextSectionId
             );
 
-            ShowNextButton = tutorialInformation.OtherItemsInSectionExist || tutorialInformation.OtherSectionsExist;
-            ShowCompletionSummary = !ShowNextButton && tutorialInformation.IncludeCertification;
+            OnlyItemInOnlySection = !tutorialInformation.OtherItemsInSectionExist && !tutorialInformation.OtherSectionsExist;
+            OnlyItemInThisSection = !tutorialInformation.OtherItemsInSectionExist;
+            ShowCompletionSummary = OnlyItemInOnlySection && tutorialInformation.IncludeCertification;
 
             CompletionSummaryCardViewModel = new CompletionSummaryCardViewModel(
                 customisationId,

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -26,7 +26,15 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.SectionName</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
+
+      @if (Model.OtherSectionsExist)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
+      }
+      else
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+      }
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -27,7 +27,19 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.TutorialName</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Return to section</a></p>
+
+      @if (Model.OnlyItemInOnlySection)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+      }
+      else if (Model.OnlyItemInThisSection)
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">Return to course menu</a></p>
+      }
+      else
+      {
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Return to section</a></p>
+      }
     </div>
   </nav>
 }
@@ -103,7 +115,7 @@
   }
 </div>
 
-@if (Model.ShowNextButton)
+@if (!Model.OnlyItemInOnlySection)
 {
   <partial name="Tutorial/_TutorialNextLink" model="Model.NextLinkViewModel" />
 }


### PR DESCRIPTION
## Changes
* Change mobile breadcrumbs' "Return ..." button to point to a page that won't redirect to the current page, either the initial menu or the current activities.
* Update the view models to help decide whether to change the breadcrumbs

## Testing
Update the unit tests, tested in Chrome using a screenreader.

## Screenshots
### Only section in course (wide)
![single_section_course_wide](https://user-images.githubusercontent.com/3650110/105480475-b3237b80-5c9d-11eb-96b6-2abfc37c888e.png)
### Only section in course (narrow)
![single_section_course_narrow](https://user-images.githubusercontent.com/3650110/105480472-b3237b80-5c9d-11eb-8966-84e671cfdd7c.png)
### Single tutorial in section, among other sections (wide)
![single_tutorial_section_among_sections_wide](https://user-images.githubusercontent.com/3650110/105480470-b28ae500-5c9d-11eb-9ccc-6b461c94e80c.png)
### Single tutorial in section, among other sections (narrow)
![single_tutorial_section_among_sections_narrow](https://user-images.githubusercontent.com/3650110/105480467-b1f24e80-5c9d-11eb-8a0b-fc4f1a42ac7e.png)
### Only tutorial in entire course (wide)
![single_tutorial_course_wide](https://user-images.githubusercontent.com/3650110/105480466-b159b800-5c9d-11eb-9cfa-a3bf6d504a7b.png)
### Only tutorial in entire course (narrow)
![single_tutorial_course_narrow](https://user-images.githubusercontent.com/3650110/105480463-b159b800-5c9d-11eb-890c-fc8e5e10cd01.png)
### One tutorial among other tutorials (narrow)
![one_tutorial_among_many_narrow](https://user-images.githubusercontent.com/3650110/105480457-b0288b00-5c9d-11eb-882f-90e64ac6a2fc.png)