### PR TITLE
HEEDLS-325 Change post learning page status text to green

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -137,6 +137,61 @@
         }
 
         [Test]
+        public void Post_learning_assessment_assessment_status_with_no_attempts_should_have_not_passed_styling()
+        {
+            // Given
+            const int postLearningAttempts = 0;
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: postLearningAttempts
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.AssessmentStatusStyling.Should().Be("not-passed-text");
+        }
+
+        [Test]
+        public void Post_learning_assessment_assessment_status_with_passes_should_have_passed_styling()
+        {
+            // Given
+            const int postLearningAttempts = 4;
+            const int postLearningPasses = 2;
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: postLearningAttempts,
+                plPasses: postLearningPasses
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.AssessmentStatusStyling.Should().Be("passed-text");
+        }
+
+        [Test]
+        public void Post_learning_assessment_assessment_status_with_attempts_but_no_passes_should_have_not_passed_styling()
+        {
+            // Given
+            const int postLearningAttempts = 5;
+            const int postLearningPasses = 0;
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: postLearningAttempts,
+                plPasses: postLearningPasses
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.AssessmentStatusStyling.Should().Be("not-passed-text");
+        }
+
+        [Test]
         public void Post_learning_assessment_assessment_status_with_no_attempts_should_have_no_score_information()
         {
             // Given

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -63,3 +63,11 @@ hr.thick {
   right: -8px;
   left: auto;
 }
+
+.passed-text {
+  color: $color_nhsuk-green;
+}
+
+.not-passed-text {
+  @extend .nhsuk-u-secondary-text-color;
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -7,6 +7,7 @@
         public string CourseTitle { get; }
         public string SectionName { get; }
         public string AssessmentStatus { get; }
+        public string AssessmentStatusStyling { get; }
         public string? ScoreInformation { get; }
         public bool PostLearningLocked { get; }
         public int CustomisationId { get; }
@@ -29,10 +30,12 @@
             if (postLearningAssessment.PostLearningAttempts == 0)
             {
                 AssessmentStatus = "Not attempted";
+                AssessmentStatusStyling = "not-passed-text";
             }
             else
             {
                 AssessmentStatus = GetPassStatus(postLearningAssessment);
+                AssessmentStatusStyling = GetPassStatusStyling(postLearningAssessment);
                 ScoreInformation = GetScoreInformation(postLearningAssessment);
             }
 
@@ -63,6 +66,13 @@
              return postLearningAssessment.PostLearningPassed
                 ? "Passed"
                 : "Failed";
+        }
+
+        private string GetPassStatusStyling(PostLearningAssessment postLearningAssessment)
+        {
+             return postLearningAssessment.PostLearningPassed
+                ? "passed-text"
+                : "not-passed-text";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -30,14 +30,13 @@
             if (postLearningAssessment.PostLearningAttempts == 0)
             {
                 AssessmentStatus = "Not attempted";
-                AssessmentStatusStyling = "not-passed-text";
             }
             else
             {
                 AssessmentStatus = GetPassStatus(postLearningAssessment);
-                AssessmentStatusStyling = GetPassStatusStyling(postLearningAssessment);
                 ScoreInformation = GetScoreInformation(postLearningAssessment);
             }
+            AssessmentStatusStyling = GetPassStatusStyling(postLearningAssessment);
 
             OnlyItemInOnlySection = !postLearningAssessment.OtherItemsInSectionExist && !postLearningAssessment.OtherSectionsExist;
             OnlyItemInThisSection = !postLearningAssessment.OtherItemsInSectionExist;
@@ -70,7 +69,7 @@
 
         private string GetPassStatusStyling(PostLearningAssessment postLearningAssessment)
         {
-             return postLearningAssessment.PostLearningPassed
+             return postLearningAssessment.PostLearningAttempts > 0 && postLearningAssessment.PostLearningPassed
                 ? "passed-text"
                 : "not-passed-text";
         }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -50,7 +50,7 @@
       <span class="nhsuk-caption-l">Post learning assessment</span>
       @Model.SectionName
     </h1>
-    <h2 class="nhsuk-u-secondary-text-color">
+    <h2 class="@Model.AssessmentStatusStyling">
       <span class="nhsuk-u-visually-hidden">Your status: </span>
       @Model.AssessmentStatus
       @if (Model.ScoreInformation != null)


### PR DESCRIPTION
## Changes
Change post learning status text on the post learning page to green
when the assessment has been completed successfully.

The text size does not need to be changed, already it is 24px on the
narrowest of displays.

## Testing
Add some unit tests, tested in Chrome, Firefox, Edge and IE11, and using a screenreader.

## Screenshots
### Not attempted post learning assessment
![not_attempted_post_learning](https://user-images.githubusercontent.com/3650110/105515080-3065e500-5ccc-11eb-8445-af4725266958.png)
### Failed post learning assessment
![failed_post_learning_assessment](https://user-images.githubusercontent.com/3650110/105515075-2fcd4e80-5ccc-11eb-8f4c-f26ce9cb9c5c.png)
### Completed post learning assessment
![green_post_learning_status](https://user-images.githubusercontent.com/3650110/105515084-30fe7b80-5ccc-11eb-87ad-d0b8e8594c34.png)