### PR TITLE
HEEDLS-324 Post learning card status text colour

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -476,6 +476,45 @@
         }
 
         [Test]
+        public void Post_learning_status_styling_should_have_not_passed_styling_if_pl_attempts_is_zero()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(attemptsPl: 0);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.PostLearningStatusStyling.Should().Be("not-passed-text");
+        }
+
+        [Test]
+        public void Post_learning_status_should_have_not_passed_styling_if_pl_attempts_is_more_than_zero_and_pl_passes_is_zero()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(attemptsPl: 3, plPasses: 0);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.PostLearningStatusStyling.Should().Be("not-passed-text");
+        }
+
+        [Test]
+        public void Post_learning_status_should_have_passed_styling_if_pl_attempts_is_more_than_zero_and_pl_passes_is_more_than_zero()
+        {
+            // Given
+            var sectionContent = SectionContentHelper.CreateDefaultSectionContent(attemptsPl: 3, plPasses: 1);
+
+            // When
+            var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
+
+            // Then
+            sectionContentViewModel.PostLearningStatusStyling.Should().Be("passed-text");
+        }
+
+        [Test]
         public void Diagnostic_assessment_completion_status_is_not_attempted_if_diag_attempts_is_zero()
         {
             // Given

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionContentViewModel.cs
@@ -17,6 +17,7 @@
         public int SectionId { get; }
         public bool ShowPostLearning { get; }
         public string PostLearningStatus { get; }
+        public string PostLearningStatusStyling { get; }
         public bool ShowDiagnostic { get; }
         public string DiagnosticCompletionStatus { get; }
         public string? ConsolidationExercisePath { get; }
@@ -41,6 +42,7 @@
             SectionId = sectionId;
             ShowPostLearning = sectionContent.PostLearningAssessmentPath != null && sectionContent.IsAssessed;
             PostLearningStatus = GetPostLearningStatus(sectionContent);
+            PostLearningStatusStyling = GetPostLearningStatusStyling(sectionContent);
             ShowDiagnostic = sectionContent.DiagnosticAssessmentPath != null && sectionContent.DiagnosticStatus;
             DiagnosticCompletionStatus = GetDiagnosticCompletionStatus(sectionContent);
             ConsolidationExercisePath = sectionContent.ConsolidationPath == null
@@ -103,6 +105,13 @@
             }
 
             return "";
+        }
+
+        private static string GetPostLearningStatusStyling(SectionContent sectionContent)
+        {
+            return sectionContent.PostLearningAttempts > 0 && sectionContent.PostLearningPassed
+                ? "passed-text"
+                : "not-passed-text";
         }
 
         private static string GetDiagnosticCompletionStatus(SectionContent sectionContent)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_DiagnosticAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_DiagnosticAssessmentCard.cshtml
@@ -3,12 +3,12 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-three-quarters">
+      <div class="nhsuk-grid-column-two-thirds">
         <h3 class="nhsuk-card__heading" id="diagnostic-name">
           Diagnostic Assessment
         </h3>
       </div>
-      <div class="nhsuk-grid-column-one-quarter">
+      <div class="nhsuk-grid-column-one-third">
         <h3 class="nhsuk-u-secondary-text-color float-right-additional-information">
           @Model.DiagnosticCompletionStatus
         </h3>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_DiagnosticAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_DiagnosticAssessmentCard.cshtml
@@ -9,7 +9,7 @@
         </h3>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
-        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
+        <h3 class="nhsuk-u-secondary-text-color float-right-additional-information">
           @Model.DiagnosticCompletionStatus
         </h3>
       </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_PostLearningAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_PostLearningAssessmentCard.cshtml
@@ -9,7 +9,7 @@
         </h3>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
-        <h3 class="nhsuk-u-secondary-text-color float-right-additional-information">
+        <h3 class="@Model.PostLearningStatusStyling float-right-additional-information">
           @Model.PostLearningStatus
         </h3>
       </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_PostLearningAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_PostLearningAssessmentCard.cshtml
@@ -9,7 +9,7 @@
         </h3>
       </div>
       <div class="nhsuk-grid-column-one-quarter">
-        <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
+        <h3 class="nhsuk-u-secondary-text-color float-right-additional-information">
           @Model.PostLearningStatus
         </h3>
       </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/_TutorialCard.cshtml
@@ -25,7 +25,7 @@
       }
       @if (Model.ShowLearnStatus) {
         <div class="nhsuk-grid-column-one-third">
-          <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color float-right-additional-information">
+          <h3 class="nhsuk-u-secondary-text-color float-right-additional-information">
             @Model.CompletionStatus
           </h3>
         </div>


### PR DESCRIPTION
## Changes
* Make all section card status text larger
* Change post learning status text in the post learning card on the section page to green when the assessment has been completed successfully.
*  Fix text wrapping issues for completed diagnostic assessments, in the diagnostic assessment card on the section page.

## Testing
Add some unit tests, tested in Chrome, Firefox, Edge and IE11, and using a screenreader.

## Screenshots
### Not attempted assessment
![not_attempted_assessment](https://user-images.githubusercontent.com/3650110/105521149-6eb2d280-5cd3-11eb-8649-6926fa714024.png)
### Failed assessment
![failed_assessment](https://user-images.githubusercontent.com/3650110/105521147-6eb2d280-5cd3-11eb-9a5c-605dff82b4ef.png)
### Passed assessment
![passed_assessment](https://user-images.githubusercontent.com/3650110/105521145-6e1a3c00-5cd3-11eb-8b6c-3eda04fa6690.png)
### Diagnostic card assessment and tutorials with recommendations
![diagnostic_and_recommendations](https://user-images.githubusercontent.com/3650110/105521144-6e1a3c00-5cd3-11eb-9e82-b20d3e176af6.png)
### Post learning assessment card and tutorials with recommendations
![pl_and_recommendations](https://user-images.githubusercontent.com/3650110/105521141-6d81a580-5cd3-11eb-8c1e-3a92af6dc86e.png)