### PR TITLE
HEEDLS-323 Content viewer smaller height on mobile

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/fullscreen.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/fullscreen.ts
@@ -11,7 +11,7 @@ export function setupFullscreen(): void {
 
 export function exitFullscreen(): void {
   getIFrameWrapper()?.classList.remove('fullscreen');
-  getIFrameWrapper()?.classList.add('content-viewer_wrapper');
+  getIFrameWrapper()?.classList.add('content-viewer_iframe-wrapper');
   getExitFullscreenButton()?.classList.add('hidden');
   getEnterFullscreenButton()?.classList.remove('hidden');
   getHeader()?.classList.remove('hidden');
@@ -20,7 +20,7 @@ export function exitFullscreen(): void {
 }
 
 export function enterFullscreen(): void {
-  getIFrameWrapper()?.classList.remove('content-viewer_wrapper');
+  getIFrameWrapper()?.classList.remove('content-viewer_iframe-wrapper');
   getIFrameWrapper()?.classList.add('fullscreen');
   getExitFullscreenButton()?.classList.remove('hidden');
   getEnterFullscreenButton()?.classList.add('hidden');
@@ -38,7 +38,7 @@ function getExitFullscreenButton(): HTMLElement | undefined {
 }
 
 function getIFrameWrapper(): HTMLElement | undefined {
-  return <HTMLElement>document.getElementById('content-viewer_wrapper');
+  return <HTMLElement>document.getElementById('content-viewer_iframe-wrapper');
 }
 
 function getHeader(): HTMLElement | undefined {

--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/fullscreen.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/fullscreen.ts
@@ -10,7 +10,8 @@ export function setupFullscreen(): void {
 }
 
 export function exitFullscreen(): void {
-  getIFrame()?.classList.remove('fullscreen');
+  getIFrameWrapper()?.classList.remove('fullscreen');
+  getIFrameWrapper()?.classList.add('content-viewer_wrapper');
   getExitFullscreenButton()?.classList.add('hidden');
   getEnterFullscreenButton()?.classList.remove('hidden');
   getHeader()?.classList.remove('hidden');
@@ -19,7 +20,8 @@ export function exitFullscreen(): void {
 }
 
 export function enterFullscreen(): void {
-  getIFrame()?.classList.add('fullscreen');
+  getIFrameWrapper()?.classList.remove('content-viewer_wrapper');
+  getIFrameWrapper()?.classList.add('fullscreen');
   getExitFullscreenButton()?.classList.remove('hidden');
   getEnterFullscreenButton()?.classList.add('hidden');
   getHeader()?.classList.add('hidden');
@@ -35,8 +37,8 @@ function getExitFullscreenButton(): HTMLElement | undefined {
   return <HTMLElement>document.getElementById('content-viewer_exit-fullscreen-button');
 }
 
-function getIFrame(): HTMLElement | undefined {
-  return <HTMLElement>document.getElementById('content-viewer_iframe');
+function getIFrameWrapper(): HTMLElement | undefined {
+  return <HTMLElement>document.getElementById('content-viewer_wrapper');
 }
 
 function getHeader(): HTMLElement | undefined {

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
@@ -111,8 +111,10 @@ describe('enterFullscreen', () => {
       <html>
       <head></head>
       <body>
-        <div class="nhsuk-u-margin-bottom-6 content-viewer_wrapper" id="content-viewer_wrapper">
-          <iframe src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe" id="content-viewer_iframe">
+        <div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper" id="content-viewer_iframe-wrapper">
+          <iframe
+            src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
+            class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
           </iframe>
         </div>
       </body>
@@ -123,7 +125,7 @@ describe('enterFullscreen', () => {
     enterFullscreen();
 
     // Then
-    const wrapper = document.getElementById('content-viewer_wrapper');
+    const wrapper = document.getElementById('content-viewer_iframe-wrapper');
     expect(wrapper!.classList).toContain('fullscreen');
   });
 });
@@ -237,8 +239,10 @@ describe('exitFullscreen', () => {
       <html>
       <head></head>
       <body>
-        <div class="nhsuk-u-margin-bottom-6 content-viewer_wrapper" id="content-viewer_wrapper">
-          <iframe src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe" id="content-viewer_iframe">
+        <div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper" id="content-viewer_iframe-wrapper">
+          <iframe
+            src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
+            class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
           </iframe>
         </div>
       </body>
@@ -249,7 +253,7 @@ describe('exitFullscreen', () => {
     exitFullscreen();
 
     // Then
-    const wrapper = document.getElementById('content-viewer_wrapper');
+    const wrapper = document.getElementById('content-viewer_iframe-wrapper');
     expect(wrapper!.classList).not.toContain('fullscreen');
   });
 });

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
@@ -105,18 +105,16 @@ describe('enterFullscreen', () => {
     expect(breadcrumbs!.classList).toContain('hidden');
   });
 
-  it('should make iframe fullscreen', () => {
+  it('should make wrapper fullscreen', () => {
     // Given
     global.document = new JSDOM(`
       <html>
       <head></head>
       <body>
-        <iframe
-          src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
-          class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block"
-          height="800"
-          id="content-viewer_iframe">
-        </iframe>
+        <div class="nhsuk-u-margin-bottom-6 content-viewer_wrapper" id="content-viewer_wrapper">
+          <iframe src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe" id="content-viewer_iframe">
+          </iframe>
+        </div>
       </body>
       </html>
     `).window.document;
@@ -125,8 +123,8 @@ describe('enterFullscreen', () => {
     enterFullscreen();
 
     // Then
-    const iframe = document.getElementById('content-viewer_iframe');
-    expect(iframe!.classList).toContain('fullscreen');
+    const wrapper = document.getElementById('content-viewer_wrapper');
+    expect(wrapper!.classList).toContain('fullscreen');
   });
 });
 
@@ -239,12 +237,10 @@ describe('exitFullscreen', () => {
       <html>
       <head></head>
       <body>
-        <iframe
-          src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
-          class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block fullscreen"
-          height="800"
-          id="content-viewer_iframe">
-        </iframe>
+        <div class="nhsuk-u-margin-bottom-6 content-viewer_wrapper" id="content-viewer_wrapper">
+          <iframe src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe" id="content-viewer_iframe">
+          </iframe>
+        </div>
       </body>
       </html>
     `).window.document;
@@ -253,7 +249,7 @@ describe('exitFullscreen', () => {
     exitFullscreen();
 
     // Then
-    const iframe = document.getElementById('content-viewer_iframe');
-    expect(iframe!.classList).not.toContain('fullscreen');
+    const wrapper = document.getElementById('content-viewer_wrapper');
+    expect(wrapper!.classList).not.toContain('fullscreen');
   });
 });

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
@@ -231,7 +231,7 @@ describe('exitFullscreen', () => {
     expect(breadcrumbs!.classList).not.toContain('hidden');
   });
 
-  it('should make iframe not fullscreen', () => {
+  it('should make wrapper not fullscreen', () => {
     // Given
     global.document = new JSDOM(`
       <html>

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/fullscreen.spec.ts
@@ -128,6 +128,30 @@ describe('enterFullscreen', () => {
     const wrapper = document.getElementById('content-viewer_iframe-wrapper');
     expect(wrapper!.classList).toContain('fullscreen');
   });
+
+  it('should remove the wrapper class', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper" id="content-viewer_iframe-wrapper">
+          <iframe
+            src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
+            class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
+          </iframe>
+        </div>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    enterFullscreen();
+
+    // Then
+    const wrapper = document.getElementById('content-viewer_iframe-wrapper');
+    expect(wrapper!.classList).not.toContain('content-viewer_iframe-wrapper');
+  });
 });
 
 describe('exitFullscreen', () => {
@@ -239,7 +263,7 @@ describe('exitFullscreen', () => {
       <html>
       <head></head>
       <body>
-        <div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper" id="content-viewer_iframe-wrapper">
+        <div class="nhsuk-u-margin-bottom-6 fullscreen" id="content-viewer_iframe-wrapper">
           <iframe
             src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
             class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
@@ -255,5 +279,29 @@ describe('exitFullscreen', () => {
     // Then
     const wrapper = document.getElementById('content-viewer_iframe-wrapper');
     expect(wrapper!.classList).not.toContain('fullscreen');
+  });
+
+  it('should add the wrapper class', () => {
+    // Given
+    global.document = new JSDOM(`
+      <html>
+      <head></head>
+      <body>
+        <div class="nhsuk-u-margin-bottom-6 fullscreen" id="content-viewer_iframe-wrapper">
+          <iframe
+            src="https://www.dls.nhs.uk/CMS/CMSContent/Course324/Section1058/Tutorials/01-01-CreateaPresentation/itspplayer.html?CentreID=101&amp;CustomisationID=19068&amp;TutorialID=4671&amp;CandidateID=254480&amp;Version=2&amp;ProgressID=285049&amp;type=learn&amp;TrackURL=https://localhost:44367/tracking/tracker"
+            class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
+          </iframe>
+        </div>
+      </body>
+      </html>
+    `).window.document;
+
+    // When
+    exitFullscreen();
+
+    // Then
+    const wrapper = document.getElementById('content-viewer_iframe-wrapper');
+    expect(wrapper!.classList).toContain('content-viewer_iframe-wrapper');
   });
 });

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/contentViewer.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/contentViewer.scss
@@ -8,7 +8,7 @@
   padding: 0 !important;
 }
 
-.content-viewer_wrapper {
+.content-viewer_iframe-wrapper {
   position: relative;
   padding-bottom: 75%;
   height: 0;

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/contentViewer.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/contentViewer.scss
@@ -8,6 +8,21 @@
   padding: 0 !important;
 }
 
+.content-viewer_wrapper {
+  position: relative;
+  padding-bottom: 75%;
+  height: 0;
+  overflow: hidden;
+}
+
+.content-viewer_iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .exit-fullscreen-button {
   position: absolute;
   bottom: 4px;

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -39,20 +39,22 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.TutorialName</h1>
-
-    @{ var contentType = "tutorial"; }
-    <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
-
-    <iframe src="@Model.ContentSource" class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block" height="800" id="content-viewer_iframe">
-    </iframe>
-
-    <a class="nhsuk-button js-only-inline"
-       id="content-viewer_enter-fullscreen-button"
-       href="#">
-      Fullscreen
-    </a>
   </div>
 </div>
+  
+@{ var contentType = "tutorial"; }
+<partial name="Shared/_JavaScriptDisabledError" model="contentType" />
+
+<div class="nhsuk-u-margin-bottom-6 content-viewer_wrapper" id="content-viewer_wrapper">
+  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe" id="content-viewer_iframe">
+  </iframe>
+</div>
+
+<a class="nhsuk-button js-only-inline"
+   id="content-viewer_enter-fullscreen-button"
+   href="#">
+  Fullscreen
+</a>
 
 <a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
    id="content-viewer_exit-fullscreen-button"

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -41,12 +41,12 @@
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.TutorialName</h1>
   </div>
 </div>
-  
+
 @{ var contentType = "tutorial"; }
 <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
 
-<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper" id="content-viewer_iframe-wrapper">
-  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
+<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper js-only-block" id="content-viewer_iframe-wrapper">
+  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 content-viewer_iframe">
   </iframe>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -45,8 +45,8 @@
 @{ var contentType = "tutorial"; }
 <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
 
-<div class="nhsuk-u-margin-bottom-6 content-viewer_wrapper" id="content-viewer_wrapper">
-  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe" id="content-viewer_iframe">
+<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper" id="content-viewer_iframe-wrapper">
+  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 js-only-block content-viewer_iframe">
   </iframe>
 </div>
 


### PR DESCRIPTION
Add wrapper for responsive sizing on iframe. The iframe now maintains a 4:3 ratio.

Change fullscreen scripts.

Modify fullscreen tests.

Issue with padding on sides is also resolved.

Ran and passed all unit tests, screenshots taken in Google Chrome.

Browser size
![image](https://user-images.githubusercontent.com/36454654/105521788-47103a00-5cd4-11eb-8774-d710299fac1c.png)

Mobile size
![image](https://user-images.githubusercontent.com/36454654/105522058-acfcc180-5cd4-11eb-935f-e49df9bf792d.png)

Issue on Firefox where the height of content inside the iframe is too big.
![image](https://user-images.githubusercontent.com/36454654/105522311-fc42f200-5cd4-11eb-9cff-56065582eaa1.png)
