### PR TITLE
Change post learning start button text

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -191,6 +191,74 @@
             postLearningAssessmentViewModel.AssessmentStatusStyling.Should().Be("not-passed-text");
         }
 
+        [TestCase(0)]
+        [TestCase(1)]
+        public void Post_learning_assessment_start_button_should_be_grey_if_it_has_been_attempted(int postLearningPasses)
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: 1,
+                plPasses: postLearningPasses
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.StartButtonAdditionalStyling.Should().Be("nhsuk-button--secondary");
+        }
+
+        [Test]
+        public void Post_learning_assessment_start_button_should_have_no_extra_colour_if_it_has_not_been_attempted()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: 0
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.StartButtonAdditionalStyling.Should().Be("");
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        public void Post_learning_assessment_start_button_should_say_restart_if_it_has_been_attempted(int postLearningPasses)
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: 1,
+                plPasses: postLearningPasses
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.StartButtonText.Should().Be("Restart assessment");
+        }
+
+        [Test]
+        public void Post_learning_assessment_start_button_should_say_start_if_it_has_not_been_attempted()
+        {
+            // Given
+            var postLearningAssessment = PostLearningAssessmentHelper.CreateDefaultPostLearningAssessment(
+                attemptsPl: 0
+            );
+
+            // When
+            var postLearningAssessmentViewModel =
+                new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
+
+            // Then
+            postLearningAssessmentViewModel.StartButtonText.Should().Be("Start assessment");
+        }
+
         [Test]
         public void Post_learning_assessment_assessment_status_with_no_attempts_should_have_no_score_information()
         {

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -8,6 +8,8 @@
         public string SectionName { get; }
         public string AssessmentStatus { get; }
         public string AssessmentStatusStyling { get; }
+        public string StartButtonText { get; }
+        public string StartButtonAdditionalStyling { get; }
         public string? ScoreInformation { get; }
         public bool PostLearningLocked { get; }
         public int CustomisationId { get; }
@@ -30,11 +32,15 @@
             if (postLearningAssessment.PostLearningAttempts == 0)
             {
                 AssessmentStatus = "Not attempted";
+                StartButtonText = "Start assessment";
+                StartButtonAdditionalStyling = "";
             }
             else
             {
                 AssessmentStatus = GetPassStatus(postLearningAssessment);
                 ScoreInformation = GetScoreInformation(postLearningAssessment);
+                StartButtonText = "Restart assessment";
+                StartButtonAdditionalStyling = "nhsuk-button--secondary";
             }
             AssessmentStatusStyling = GetPassStatusStyling(postLearningAssessment);
 

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/PostLearningAssessmentViewModel.cs
@@ -32,17 +32,21 @@
             if (postLearningAssessment.PostLearningAttempts == 0)
             {
                 AssessmentStatus = "Not attempted";
-                StartButtonText = "Start assessment";
-                StartButtonAdditionalStyling = "";
             }
             else
             {
                 AssessmentStatus = GetPassStatus(postLearningAssessment);
                 ScoreInformation = GetScoreInformation(postLearningAssessment);
-                StartButtonText = "Restart assessment";
-                StartButtonAdditionalStyling = "nhsuk-button--secondary";
             }
             AssessmentStatusStyling = GetPassStatusStyling(postLearningAssessment);
+
+            StartButtonText = postLearningAssessment.PostLearningAttempts == 0
+                ? "Start assessment"
+                : "Restart assessment";
+            StartButtonAdditionalStyling = postLearningAssessment.PostLearningAttempts == 0
+                ? ""
+                : "nhsuk-button--secondary";
+
 
             OnlyItemInOnlySection = !postLearningAssessment.OtherItemsInSectionExist && !postLearningAssessment.OtherSectionsExist;
             OnlyItemInThisSection = !postLearningAssessment.OtherItemsInSectionExist;

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -73,11 +73,11 @@
   else
   {
       <a
-        class="nhsuk-button nhsuk-u-margin-bottom-0"
+        class="nhsuk-button nhsuk-u-margin-bottom-0 @Model.StartButtonAdditionalStyling"
         asp-action="PostLearningContent"
         asp-route-customisationId="@Model.CustomisationId"
         asp-route-sectionId="@Model.SectionId">
-        Start assessment
+        @Model.StartButtonText
       </a>
   }
 </div>


### PR DESCRIPTION
## Changes
Change post learning assessment start button to say restart instead of start when the assessment has already been attempted.

## Testing
Add some more unit tests. Tested in Chrome, Firefox, Edge and IE11, using high zoom and a screen reader.

## Screenshots
### Not attempted assessment page
![not_attempted_assessment_button](https://user-images.githubusercontent.com/3650110/105692699-a483d100-5ef6-11eb-99f9-4535de2246ad.png)
### Passed assessment page
![passed_assessment_button](https://user-images.githubusercontent.com/3650110/105692702-a51c6780-5ef6-11eb-84c3-adc9a4f9cd3a.png)
### Failed assessment page
![failed_assessment_button](https://user-images.githubusercontent.com/3650110/105692698-a352a400-5ef6-11eb-90f3-54a3f9950501.png)