### PR TITLE
HEEDLS-329 Diagnostic assessment fullscreen

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/diagnosticContentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/diagnosticContentViewer.ts
@@ -1,6 +1,8 @@
+import { setupFullscreen } from './fullscreen';
+
 function diagnosticCloseMpe(): void {
   // Extract the current domain, customisationId and sectionId out of the URL
-  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/Diagnostic\/Content(\?checkedTutorials=\d+(&checkedTutorials=\d+)*)?$/);
+  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/Diagnostic\/Content(\?checkedTutorials=\d+(&checkedTutorials=\d+)*)?#?$/);
 
   if (!matches || matches.length < 4) {
     return;
@@ -11,3 +13,4 @@ function diagnosticCloseMpe(): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).closeMpe = diagnosticCloseMpe;
+setupFullscreen();

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/contentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/contentViewer.spec.ts
@@ -27,7 +27,7 @@ describe('closeMpe', () => {
       expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/789');
     });
 
-  it('should redirect to tutorial overview after accessing fullscreen',
+  it('should redirect to tutorial overview after entering fullscreen',
     () => {
       // Given
       window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/789/Tutorial#';

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/diagnosticContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/diagnosticContentViewer.spec.ts
@@ -27,6 +27,18 @@ describe('closeMpe', () => {
       expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/Diagnostic');
     });
 
+  it('should redirect to diagnostic assessment with no checked tutorials after entering fullscreen',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content#';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/Diagnostic');
+    });
+
   it('should redirect to diagnostic assessment with one checked tutorial',
     () => {
       // Given
@@ -39,10 +51,34 @@ describe('closeMpe', () => {
       expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/Diagnostic');
     });
 
+  it('should redirect to diagnostic assessment with one checked tutorial after entering fullscreen',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content?checkedTutorials=1234#';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/Diagnostic');
+    });
+
   it('should redirect to diagnostic assessment with multiple checked tutorials',
     () => {
       // Given
       window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content?checkedTutorials=123&checkedTutorials=456';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/Diagnostic');
+    });
+
+  it('should redirect to diagnostic assessment with multiple checked tutorials after entering fullscreen',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content?checkedTutorials=123&checkedTutorials=456#';
 
       // When
       window.closeMpe();

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/DiagnosticContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/DiagnosticContent.cshtml
@@ -4,6 +4,7 @@
 @model DiagnosticContentViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/learningMenu/contentViewer.css")" asp-append-version="true">
 
 @{
   ViewData["HeaderPrefix"] = "";
@@ -39,11 +40,25 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
-    
-    @{ var contentType = "assessment"; }
-    <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
-
-    <iframe src="@Model.ContentSource" class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block" height="800">
-    </iframe>
   </div>
 </div>
+
+@{ var contentType = "assessment"; }
+<partial name="Shared/_JavaScriptDisabledError" model="contentType" />
+
+<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper js-only-block" id="content-viewer_iframe-wrapper">
+  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 content-viewer_iframe">
+  </iframe>
+</div>
+
+<a class="nhsuk-button js-only-inline"
+   id="content-viewer_enter-fullscreen-button"
+   href="#">
+  Fullscreen
+</a>
+
+<a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
+   id="content-viewer_exit-fullscreen-button"
+   href="#">
+  Exit fullscreen
+</a>


### PR DESCRIPTION
Add fullscreen functionality to diagnostic content page.

The add responsive resizing; maintaining a 4:3 ratio.

Modify typescript to work after entering fullscreen.

Add tests for close page function after entering fullscreen.

Issue with padding on sides is also fixed.

Ran and passed all unit tests, screenshots taken in Google Chrome.

There is an issue on Firefox where the height of content inside the iframe is too big.

Browser
![image](https://user-images.githubusercontent.com/36454654/105699085-bbc6bc80-5efe-11eb-881f-6dcc3ee84439.png)

Browser fullscreen
![image](https://user-images.githubusercontent.com/36454654/105698987-9b96fd80-5efe-11eb-8df4-4b4344713743.png)

Mobile
![image](https://user-images.githubusercontent.com/36454654/105699139-cbde9c00-5efe-11eb-9ecb-eb440c24acfc.png)

Mobile fullscreen
![image](https://user-images.githubusercontent.com/36454654/105699219-e9136a80-5efe-11eb-8d3e-2bc327a50866.png)
