### PR TITLE
HEEDLS-324 Add some missed styling to title text

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -50,7 +50,9 @@
 
     @if (Model.ShowPostLearning)
     {
-      <h3 class="nhsuk-u-secondary-text-color nhsuk-u-margin-bottom-3">Post learning assessment @Model.PostLearningStatus.ToLower()</h3>
+      <h3 class="nhsuk-u-margin-bottom-3 @Model.PostLearningStatusStyling">
+        Post learning assessment @Model.PostLearningStatus.ToLower()
+      </h3>
     }
   </div>
 </div>


### PR DESCRIPTION
## Changes
Add green styling to the post learning status displayed in headings at the top of the course.

## Testing
Tested in Chrome, using a screen reader and no JS.

## Screenshots
### Not attempted post learning heading
![not_attempted_title](https://user-images.githubusercontent.com/3650110/105700280-8cb14a80-5f00-11eb-8406-b0ba4f7cbf67.png)
### Passed post learning heading
![passed_title](https://user-images.githubusercontent.com/3650110/105700282-8cb14a80-5f00-11eb-9716-4a7cfe39a2b5.png)
### Failed post learning heading
![failed_title](https://user-images.githubusercontent.com/3650110/105700278-8c18b400-5f00-11eb-8d90-12a793340842.png)