### PR TITLE
HEEDLS-330 Post learning assessment fullscreen

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/postLearningContentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/postLearningContentViewer.ts
@@ -1,6 +1,8 @@
+import { setupFullscreen } from './fullscreen';
+
 function postLearningCloseMpe(): void {
   // Extract the current domain, customisationId and sectionId out of the URL
-  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/PostLearning\/Content$/);
+  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/PostLearning\/Content#?$/);
 
   if (!matches || matches.length < 4) {
     return;
@@ -11,3 +13,4 @@ function postLearningCloseMpe(): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).closeMpe = postLearningCloseMpe;
+setupFullscreen();

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/postLearningContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/postLearningContentViewer.spec.ts
@@ -27,6 +27,18 @@ describe('closeMpe', () => {
       expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/PostLearning');
     });
 
+  it('should redirect to post learning assessment after entering fullscreen',
+    () => {
+      // Given
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/PostLearning/Content#';
+
+      // When
+      window.closeMpe();
+
+      // Then
+      expect(window.location.href).toBe('https://localhost:44363/test/LearningMenu/123/456/PostLearning');
+    });
+
   it('should do nothing on unexpected page',
     () => {
       // Given

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/DiagnosticContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/DiagnosticContent.cshtml
@@ -4,6 +4,7 @@
 @model DiagnosticContentViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/learningMenu/contentViewer.css")" asp-append-version="true">
 
 @{
   ViewData["HeaderPrefix"] = "";
@@ -39,11 +40,10 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
-    
-    @{ var contentType = "assessment"; }
-    <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
-
-    <iframe src="@Model.ContentSource" class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block" height="800">
-    </iframe>
   </div>
 </div>
+
+@{ var contentType = "assessment"; }
+<partial name="Shared/_JavaScriptDisabledError" model="contentType" />
+
+<partial name="Shared/_IFrameWithFullscreen" model="@Model.ContentSource"/>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
@@ -4,6 +4,7 @@
 @model PostLearningContentViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/index.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/learningMenu/contentViewer.css")" asp-append-version="true">
 
 @{
   ViewData["HeaderPrefix"] = "";
@@ -39,11 +40,25 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
-
-    @{ var contentType = "assessment"; }
-    <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
-
-    <iframe src="@Model.ContentSource" class="nhsuk-grid-column-full nhsuk-u-margin-bottom-6 js-only-block" height="800">
-    </iframe>
   </div>
 </div>
+
+@{ var contentType = "assessment"; }
+<partial name="Shared/_JavaScriptDisabledError" model="contentType" />
+
+<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper js-only-block" id="content-viewer_iframe-wrapper">
+  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 content-viewer_iframe">
+  </iframe>
+</div>
+
+<a class="nhsuk-button js-only-inline"
+   id="content-viewer_enter-fullscreen-button"
+   href="#">
+  Fullscreen
+</a>
+
+<a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
+   id="content-viewer_exit-fullscreen-button"
+   href="#">
+  Exit fullscreen
+</a>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
@@ -46,19 +46,4 @@
 @{ var contentType = "assessment"; }
 <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
 
-<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper js-only-block" id="content-viewer_iframe-wrapper">
-  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 content-viewer_iframe">
-  </iframe>
-</div>
-
-<a class="nhsuk-button js-only-inline"
-   id="content-viewer_enter-fullscreen-button"
-   href="#">
-  Fullscreen
-</a>
-
-<a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
-   id="content-viewer_exit-fullscreen-button"
-   href="#">
-  Exit fullscreen
-</a>
+<partial name="Shared/_IFrameWithFullscreen" model="@Model.ContentSource" />

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_IFrameWithFullscreen.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Shared/_IFrameWithFullscreen.cshtml
@@ -1,0 +1,18 @@
+﻿@model string
+
+<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper js-only-block" id="content-viewer_iframe-wrapper">
+  <iframe src="@Model" class="nhsuk-u-margin-bottom-6 content-viewer_iframe">
+  </iframe>
+</div>
+
+<a class="nhsuk-button js-only-inline"
+   id="content-viewer_enter-fullscreen-button"
+   href="#">
+  Fullscreen
+</a>
+
+<a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
+   id="content-viewer_exit-fullscreen-button"
+   href="#">
+  Exit fullscreen
+</a>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -45,19 +45,4 @@
 @{ var contentType = "tutorial"; }
 <partial name="Shared/_JavaScriptDisabledError" model="contentType" />
 
-<div class="nhsuk-u-margin-bottom-6 content-viewer_iframe-wrapper js-only-block" id="content-viewer_iframe-wrapper">
-  <iframe src="@Model.ContentSource" class="nhsuk-u-margin-bottom-6 content-viewer_iframe">
-  </iframe>
-</div>
-
-<a class="nhsuk-button js-only-inline"
-   id="content-viewer_enter-fullscreen-button"
-   href="#">
-  Fullscreen
-</a>
-
-<a class="nhsuk-button nhsuk-button--secondary exit-fullscreen-button hidden"
-   id="content-viewer_exit-fullscreen-button"
-   href="#">
-  Exit fullscreen
-</a>
+<partial name="Shared/_IFrameWithFullscreen" model="@Model.ContentSource" />


### PR DESCRIPTION
Add fullscreen functionality to post learning content page.

The add responsive resizing; maintaining a 4:3 ratio.

Modify typescript to work after entering fullscreen.

Add tests for close page function after entering fullscreen.

Issue with padding on sides is also fixed.

Ran and passed all unit tests, screenshots taken in Google Chrome.

There is an issue on Firefox where the height of content inside the iframe is too big.

Browser
![image](https://user-images.githubusercontent.com/36454654/105702511-cd5e9300-5f03-11eb-9f06-11ef93d50e19.png)

Browser fullscreen
![image](https://user-images.githubusercontent.com/36454654/105702552-dd767280-5f03-11eb-83f1-d43849e9a639.png)

Mobile
![image](https://user-images.githubusercontent.com/36454654/105702586-e9facb00-5f03-11eb-8cb2-1850349555b9.png)

Mobile fullscreen
![image](https://user-images.githubusercontent.com/36454654/105702604-eff0ac00-5f03-11eb-9b61-dce738121e28.png)
