### PR TITLE
HEEDLS-332 Change tutorial next link to button

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -733,7 +733,7 @@
             tutorialViewModel.ShowNextButton.Should().Be(expectedShowNextButton);
         }
 
-    [Test]
+        [Test]
         public void Tutorial_should_show_completion_summary_when_include_certification_and_only_tutorial_and_section()
         {
             // Given

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -669,7 +669,7 @@
         [TestCase(true, false, true, false)]
         [TestCase(true, true, false, false)]
         [TestCase(true, true, true, false)]
-        public void tutorial_should_have_showCompletionSummary(
+        public void Tutorial_should_have_showCompletionSummary(
             bool otherSectionsExist,
             bool otherItemsInSectionExist,
             bool includeCertification,
@@ -695,7 +695,45 @@
             tutorialViewModel.ShowCompletionSummary.Should().Be(expectedShowCompletionSummary);
         }
 
-        [Test]
+        [TestCase("Not started", false, false, false)]
+        [TestCase("Not started", false, true, false)]
+        [TestCase("Not started", true, false, false)]
+        [TestCase("Not started", true, true, false)]
+        [TestCase("Started", false, false, false)]
+        [TestCase("Started", false, true, false)]
+        [TestCase("Started", true, false, false)]
+        [TestCase("Started", true, true, false)]
+        [TestCase("Complete", false, false, false)]
+        [TestCase("Complete", false, true, true)]
+        [TestCase("Complete", true, false, true)]
+        [TestCase("Complete", true, true, true)]
+        public void Tutorial_should_have_showNextButton(
+            string status,
+            bool otherSectionsExist,
+            bool otherItemsInSectionExist,
+            bool expectedShowNextButton
+        )
+        {
+            // Given
+            var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
+                status: status,
+                otherSectionsExist: otherSectionsExist,
+                otherItemsInSectionExist: otherItemsInSectionExist
+            );
+
+            // When
+            var tutorialViewModel = new TutorialViewModel(
+                config,
+                expectedTutorialInformation,
+                CustomisationId,
+                SectionId
+            );
+
+            // Then
+            tutorialViewModel.ShowNextButton.Should().Be(expectedShowNextButton);
+        }
+
+    [Test]
         public void Tutorial_should_show_completion_summary_when_include_certification_and_only_tutorial_and_section()
         {
             // Given

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -40,15 +40,15 @@ hr.thick {
       @extend .nhsuk-u-margin-0;
     }
 
-    @include mq($until: large-desktop) {
+    @include mq($until: 1030px) {
       margin-top: nhsuk-spacing(3);
       margin-right: nhsuk-spacing(0);
       display: block;
     }
 
-    @include mq($from: large-desktop) {
+    @include mq($from: 1030px) {
       margin-top: nhsuk-spacing(0);
-      margin-right: nhsuk-spacing(3);
+      margin-right: nhsuk-spacing(2);
       display: inline;
     }
   }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/TutorialViewModel.cs
@@ -31,6 +31,7 @@
         public CompletionSummaryCardViewModel CompletionSummaryCardViewModel { get; }
         public string TutorialStartButtonAdditionalStyling { get; }
         public string TutorialStartButtonText { get; }
+        public bool ShowNextButton { get; }
 
         public TutorialViewModel(
             IConfiguration config,
@@ -93,6 +94,7 @@
             );
             TutorialStartButtonAdditionalStyling = tutorialInformation.Status == "Complete" ? "nhsuk-button--secondary" : "";
             TutorialStartButtonText = tutorialInformation.Status == "Complete" ? "Restart tutorial" : "Start tutorial";
+            ShowNextButton = tutorialInformation.Status == "Complete" && !OnlyItemInOnlySection;
         }
 
         private bool GetCanShowProgress(bool showLearnStatus, bool canShowDiagnosticStatus, int attemptCount)

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -113,12 +113,13 @@
       </a>
     </div>
   }
-</div>
 
-@if (!Model.OnlyItemInOnlySection)
-{
-  <partial name="Tutorial/_TutorialNextLink" model="Model.NextLinkViewModel" />
-}
+  @if (Model.ShowNextButton) {
+    <div>
+      <partial name="Tutorial/_TutorialNextLink" model="Model.NextLinkViewModel" />
+    </div>
+  }
+</div>
 
 @if (Model.ShowCompletionSummary)
 {

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/_TutorialNextLink.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/_TutorialNextLink.cshtml
@@ -3,57 +3,45 @@
 
 @if (Model.NextTutorialId != null)
 {
-  <a class="nhsuk-back-link__link next-link"
+  <a class="nhsuk-button"
      asp-controller="LearningMenu"
      asp-action="Tutorial"
      asp-route-customisationId="@Model.CustomisationId"
      asp-route-sectionId="@Model.SectionId"
      asp-route-tutorialId="@Model.NextTutorialId">
 
-    Go to next tutorial
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-    </svg>
+    Next tutorial
   </a>
 }
 else if (Model.PostLearningAssessmentPath != null)
 {
-  <a class="nhsuk-back-link__link next-link"
+  <a class="nhsuk-button"
      asp-controller="LearningMenu"
      asp-action="PostLearning"
      asp-route-customisationId="@Model.CustomisationId"
      asp-route-sectionId="@Model.SectionId">
 
-    Go to post learning assessment
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-    </svg>
+    Post learning assessment
   </a>
 }
 else if (Model.NextSectionId != null)
 {
-  <a class="nhsuk-back-link__link next-link"
+  <a class="nhsuk-button"
      asp-controller="LearningMenu"
      asp-action="Section"
      asp-route-customisationId="@Model.CustomisationId"
      asp-route-sectionId="@Model.NextSectionId">
 
-    Go to next section
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-    </svg>
+    Next section
   </a>
 }
 else
 {
-  <a class="nhsuk-back-link__link next-link"
+  <a class="nhsuk-button"
      asp-controller="LearningMenu"
      asp-action="Index"
      asp-route-customisationId="@Model.CustomisationId">
 
     Finish
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="next-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-    </svg>
   </a>
 }


### PR DESCRIPTION
## Changes
- Change tutorial next link to button
- Only show this next button if the tutorial has been completed.
- Tweak some CSS to deal with the long row of buttons. We can't use the NHS width classes unfortunately because we need to switch to the vertical list of buttons when the screen is narrower than ~1030px but the widest NHS width class (`large-desktop`) is only 990px wide. 

## Testing
Add some unit tests, tested in Chrome, Firefox, Edge and IE11, using a screenreader and high zoom.

## Screenshots
### Not started button row
![not_started_buttons](https://user-images.githubusercontent.com/3650110/106127050-0ee67c80-6156-11eb-8af8-2fcd31ec3c95.png)
### Started button row
![started_buttons](https://user-images.githubusercontent.com/3650110/106127048-0ee67c80-6156-11eb-9959-4ce82e2add31.png)
### Next tutorial button
![next_tutorial_button](https://user-images.githubusercontent.com/3650110/106127046-0e4de600-6156-11eb-9e86-6a6637342868.png)
### Finish button
![finish_button](https://user-images.githubusercontent.com/3650110/106127039-0d1cb900-6156-11eb-8ae8-fdd33d80a7a4.png)
### Post learning assessment button (wide viewport)
![post_learning_button](https://user-images.githubusercontent.com/3650110/106127045-0db54f80-6156-11eb-9ef7-1bfeef9042c6.png)
### Post learning assessment button (narrow viewport)
![narrow_viewport_buttons](https://user-images.githubusercontent.com/3650110/106127043-0db54f80-6156-11eb-9a25-111b50f89517.png)