### PR TITLE
HEEDLS-331 Reword section card learning completion

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionCardViewModelTest.cs
@@ -42,7 +42,7 @@
             var sectionCardViewModel = new SectionCardViewModel(section, CustomisationId, showPercentageCourseSetting);
 
             // Then
-            sectionCardViewModel.PercentComplete.Should().Be($"{percentComplete}% Complete");
+            sectionCardViewModel.PercentComplete.Should().Be($"{percentComplete}% learning complete");
         }
 
         [Test]
@@ -97,7 +97,7 @@
             var sectionCardViewModel = new SectionCardViewModel(section, CustomisationId, showPercentageCourseSetting);
 
             // Then
-            sectionCardViewModel.PercentComplete.Should().Be($"{percentCompleteRounded}% Complete");
+            sectionCardViewModel.PercentComplete.Should().Be($"{percentCompleteRounded}% learning complete");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningMenu/SectionCardViewModel.cs
@@ -15,7 +15,7 @@
             Title = section.Title;
             SectionId = section.Id;
             PercentComplete = section.HasLearning && showPercentageCourseSetting
-                ? $"{Convert.ToInt32(Math.Floor(section.PercentComplete))}% Complete"
+                ? $"{Convert.ToInt32(Math.Floor(section.PercentComplete))}% learning complete"
                 : "";
             CustomisationId = customisationId;
         }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -4,12 +4,12 @@
 <div class="nhsuk-card nhsuk-u-margin-bottom-3 learning-menu-card">
   <div class="nhsuk-card__content">
     <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-three-quarters">
+      <div class="nhsuk-grid-column-two-thirds">
         <h3 class="nhsuk-card__heading" id="@Model.SectionId-name">
           @Model.Title
         </h3>
       </div>
-      <div class="nhsuk-grid-column-one-quarter">
+      <div class="nhsuk-grid-column-one-third">
         <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
           @Model.PercentComplete
         </h3>


### PR DESCRIPTION
## Changes
- Tweak the formatting of the learning completion text in the view model
- Tweak styling to accommodate longer learning completion text.

## Testing
Amend relevant unit tests, tested in Chrome, Firefox, Edge and IE11, using a screenreader and high zoom.

## Screenshots
### Section page (wide viewport)
![learning_complete_wide](https://user-images.githubusercontent.com/3650110/106131203-4b1bdc00-615a-11eb-86dd-0386c717cf84.png)
### Section page (narrow viewport)
![learning_complete_narrow](https://user-images.githubusercontent.com/3650110/106131200-4a834580-615a-11eb-944b-e6350a58a338.png)