### PR TITLE
HEEDLS-356 - Created Migration that adds new ResetPassword table and …

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202103161535_AddResetPasswordTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202103161535_AddResetPasswordTable.cs
@@ -9,22 +9,24 @@
         {
             Create.Table("ResetPassword")
                 .WithColumn("ID").AsInt32().NotNullable().PrimaryKey().Identity()
-                .WithColumn("ResetPasswordHash").AsCustom("text").NotNullable()
-                .WithColumn("PasswordResetDateTime").AsCustom("timestamp").NotNullable();
+                .WithColumn("ResetPasswordHash").AsString(64).NotNullable()
+                .WithColumn("PasswordResetDateTime").AsDateTime().NotNullable().WithDefault(SystemMethods.CurrentUTCDateTime); ;
 
             Alter.Table("AdminUsers")
-                .AddColumn("ResetPasswordID").AsInt32().Nullable();
+                .AddColumn("ResetPasswordID").AsInt32().Nullable().ForeignKey("FK_AdminUsers_ResetPasswordID_ResetPassword_ID", "ResetPassword", "ID");
 
             Alter.Table("Candidates")
-                .AddColumn("ResetPasswordID").AsInt32().Nullable();
+                .AddColumn("ResetPasswordID").AsInt32().Nullable().ForeignKey("FK_Candidates_ResetPasswordID_ResetPassword_ID", "ResetPassword", "ID"); ;
 
         }
 
         public override void Down()
         {
-            Delete.Table("ResetPassword");
+            Delete.ForeignKey("FK_AdminUsers_ResetPasswordID_ResetPassword_ID").OnTable("AdminUsers");
+            Delete.ForeignKey("FK_Candidates_ResetPasswordID_ResetPassword_ID").OnTable("Candidates");
             Delete.Column("ResetPasswordID").FromTable("AdminUsers");
             Delete.Column("ResetPasswordID").FromTable("Candidates");
+            Delete.Table("ResetPassword");
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202103161535_AddResetPasswordTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202103161535_AddResetPasswordTable.cs
@@ -1,0 +1,30 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202103161535)]
+    public class AddResetPasswordTable : Migration
+    {
+        public override void Up()
+        {
+            Create.Table("ResetPassword")
+                .WithColumn("ID").AsInt32().NotNullable().PrimaryKey().Identity()
+                .WithColumn("ResetPasswordHash").AsCustom("text").NotNullable()
+                .WithColumn("PasswordResetDateTime").AsCustom("timestamp").NotNullable();
+
+            Alter.Table("AdminUsers")
+                .AddColumn("ResetPasswordID").AsInt32().Nullable();
+
+            Alter.Table("Candidates")
+                .AddColumn("ResetPasswordID").AsInt32().Nullable();
+
+        }
+
+        public override void Down()
+        {
+            Delete.Table("ResetPassword");
+            Delete.Column("ResetPasswordID").FromTable("AdminUsers");
+            Delete.Column("ResetPasswordID").FromTable("Candidates");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/MigrationHelperMethods.cs
+++ b/DigitalLearningSolutions.Web/Helpers/MigrationHelperMethods.cs
@@ -30,7 +30,8 @@
                         typeof(CandidateAssessmentSubmittedDate).Assembly,
                         typeof(ChangesForDigitalCapability).Assembly,
                         typeof(FixFilteredSPs).Assembly,
-                        typeof(AddAssessAttemptsIndex).Assembly
+                        typeof(AddAssessAttemptsIndex).Assembly,
+                        typeof(AddResetPasswordTable).Assembly
                     ).For.Migrations()
                 ).AddLogging(lb => lb
                     .AddFluentMigratorConsole()


### PR DESCRIPTION
…adds new ResetPasswordID columns to AdminUsers table and Candidates table.

Tested the Up Migration through the usual means of running the Web project - everything that needed to be added to the database was added successfully.
Tested the Down Migration through the process described in the "Reversing the Migration" section in the readme - all the new columns and the new table were deleted successfully.