### PR TITLE
HEEDLS-354 - Reset Password email sending implemented.

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/EmailTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/EmailTestHelper.cs
@@ -1,0 +1,37 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
+{
+    using DigitalLearningSolutions.Data.Models.Email;
+    using MimeKit;
+
+    public static class EmailTestHelper
+    {
+        public const string DefaultHtmlBody = "<body style= 'font - family: Calibri; font - size: small;'>\r\n" +
+                                              "                                    <p>Test Body</p>\r\n" +
+                                              "                                </body>";
+
+        public static Email GetDefaultEmail
+        (
+            string[]? to = null,
+            string[]? cc = null,
+            string[]? bcc = null,
+            string subject = "Test Subject Line",
+            BodyBuilder? body = null
+        )
+        {
+            return new Email
+            (
+                to: to ?? new string[1] { "recipient@example.com" },
+                cc: cc ?? new string[1] { "cc@example.com" },
+                bcc: bcc ?? new string[1] { "bcc@example.com" },
+                subject: subject,
+                body: body ?? new BodyBuilder
+                {
+                    TextBody = "Test body",
+                    HtmlBody = @"<body style= 'font - family: Calibri; font - size: small;'>
+                                    <p>Test Body</p>
+                                </body>"
+                }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Helpers/EmailTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/EmailTestHelper.cs
@@ -5,9 +5,9 @@
 
     public static class EmailTestHelper
     {
-        public const string DefaultHtmlBody = "<body style= 'font - family: Calibri; font - size: small;'>\r\n" +
-                                              "                                    <p>Test Body</p>\r\n" +
-                                              "                                </body>";
+        public const string DefaultHtmlBody = "<body style= 'font - family: Calibri; font - size: small;'\r\n>" +
+                                              "   <p>Test Body</p>\r\n" +
+                                              "</body>";
 
         public static Email GetDefaultEmail
         (
@@ -27,9 +27,7 @@
                 body: body ?? new BodyBuilder
                 {
                     TextBody = "Test body",
-                    HtmlBody = @"<body style= 'font - family: Calibri; font - size: small;'>
-                                    <p>Test Body</p>
-                                </body>"
+                    HtmlBody = DefaultHtmlBody
                 }
             );
         }

--- a/DigitalLearningSolutions.Data.Tests/Helpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/UserTestHelper.cs
@@ -1,0 +1,45 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
+{
+    using DigitalLearningSolutions.Data.Models.User;
+
+    public static class UserTestHelper
+    {
+        public static DelegateUser GetDefaultDelegateUser
+        (
+            int id = 1,
+            string firstName = "Forename",
+            string surname = "Surname",
+            string emailAddress = "recipient@example.com",
+            int? resetPasswordId = null
+        )
+        {
+            return new DelegateUser
+            {
+                Id = id,
+                FirstName = firstName,
+                Surname = surname,
+                EmailAddress = emailAddress,
+                ResetPasswordId = resetPasswordId
+            };
+        }
+
+        public static AdminUser GetDefaultAdminUser
+        (
+            int id = 1,
+            string firstName = "Forename",
+            string surname = "Surname",
+            string emailAddress = "recipient@example.com",
+            int? resetPasswordId = null
+        )
+        {
+            return new AdminUser
+            {
+                Id = id,
+                FirstName = firstName,
+                Surname = surname,
+                EmailAddress = emailAddress,
+                ResetPasswordId = resetPasswordId
+            };
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/EmailServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/EmailServiceTests.cs
@@ -1,0 +1,296 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    using System.Threading;
+    using DigitalLearningSolutions.Data.Factories;
+    using DigitalLearningSolutions.Data.Models.Email;
+    using DigitalLearningSolutions.Data.Services;
+    using FakeItEasy;
+    using MailKit.Net.Smtp;
+    using MailKit.Security;
+    using MimeKit;
+    using NUnit.Framework;
+
+    public class EmailServiceTests
+    {
+        private EmailService emailService;
+        private IConfigService configService;
+        private ISmtpClient smtpClient;
+        private Email testEmail;
+        private Email multipleAddresseesTestEmail;
+
+        [SetUp]
+        public void Setup()
+        {
+            BodyBuilder emailTestBody = new BodyBuilder
+            {
+                TextBody = "Test body",
+                HtmlBody = @"<body style= 'font - family: Calibri; font - size: small;'>
+                                    <p>Test Body</p>
+                                </body>"
+            };
+
+            testEmail = new Email(
+                "recipient@example.com",
+                "Test Subject Line",
+                emailTestBody,
+                "cc@example.com",
+                "bcc@example.com");
+
+            multipleAddresseesTestEmail = new Email(
+                new string[2]{"recipient1@example.com", "recipient2@example.com"},
+                "Test Subject Line",
+                emailTestBody,
+                new string[2]{"cc1@example.com", "cc2@example.com"},
+                new string[2]{"bcc1@example.com","bcc2@example.com"});
+
+            configService = A.Fake<IConfigService>();
+            var smtpClientFactory = A.Fake<ISmtpClientFactory>();
+            smtpClient = A.Fake<ISmtpClient>();
+            A.CallTo(() => smtpClientFactory.GetSmtpClient()).Returns(smtpClient);
+
+            A.CallTo(() => configService.GetConfigValue(ConfigService.MailPort)).Returns("25");
+            A.CallTo(() => configService.GetConfigValue(ConfigService.MailUsername)).Returns("username");
+            A.CallTo(() => configService.GetConfigValue(ConfigService.MailPassword)).Returns("password");
+            A.CallTo(() => configService.GetConfigValue(ConfigService.MailServer)).Returns("smtp.example.com");
+            A.CallTo(() => configService.GetConfigValue(ConfigService.MailFromAddress)).Returns("test@example.com");
+
+            emailService = new EmailService(configService, smtpClientFactory);
+            // Going to want to copy the others over, but also perform it with string lists in the to/cc/bcc etc.
+        }
+
+        [Test]
+        public void Trying_to_send_mail_with_null_config_values_should_throw_an_exception()
+        {
+            // Given
+            A.CallTo(() => configService.GetConfigValue(ConfigService.MailPassword)).Returns(null);
+
+            // Then
+            Assert.Throws<ConfigValueMissingException>(() => emailService.SendEmail(testEmail));
+        }
+
+        [Test]
+        public void The_server_credentials_are_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Authenticate("username", "password", default(CancellationToken))
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_server_details_are_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Connect(
+                        "smtp.example.com",
+                        25,
+                        SecureSocketOptions.Auto,
+                        default(CancellationToken)
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_sender_email_address_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.From.ToString() == "test@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_email_subject_line_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.Subject.ToString() == "Test Subject Line"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_email_text_body_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.TextBody.ToString() == "Test body"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_email_HTML_body_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.HtmlBody.ToString() == "<body style= 'font - family: Calibri; font - size: small;'>\r\n" +
+                            "                                    <p>Test Body</p>\r\n" +
+                            "                                </body>"
+                        
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_recipient_email_address_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.To.ToString() == "recipient@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_recipient_email_addresses_are_correct()
+        {
+            // When
+            emailService.SendEmail(multipleAddresseesTestEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.To.ToString() == "recipient1@example.com, recipient2@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_cc_email_address_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.Cc.ToString() == "cc@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_cc_email_addresses_are_correct()
+        {
+            // When
+            emailService.SendEmail(multipleAddresseesTestEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.Cc.ToString() == "cc1@example.com, cc2@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_bcc_email_address_is_correct()
+        {
+            // When
+            emailService.SendEmail(testEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.Bcc.ToString() == "bcc@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+        [Test]
+        public void The_bcc_email_addresses_are_correct()
+        {
+            // When
+            emailService.SendEmail(multipleAddresseesTestEmail);
+
+            // Then
+            A.CallTo(() =>
+                    smtpClient.Send(
+                        A<MimeMessage>.That.Matches(m =>
+                            m.Bcc.ToString() == "bcc1@example.com, bcc2@example.com"
+                        ),
+                        default(CancellationToken),
+                        null
+                    )
+                )
+                .MustHaveHappened();
+        }
+
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/PasswordResetServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/PasswordResetServiceTests.cs
@@ -1,0 +1,81 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    using System.Data;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Exceptions;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.Email;
+    using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.Helpers;
+    using FakeItEasy;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+
+    public class PasswordResetServiceTests
+    {
+        private PasswordResetService passwordResetService;
+        private IDbConnection connection;
+        private IUserService userService;
+        private ILogger<PasswordResetService> logger;
+        private IConfigService configService;
+        private IEmailService emailService;
+
+        [SetUp]
+        public void Setup()
+        {
+            userService = A.Fake<IUserService>();
+            logger = A.Fake<ILogger<PasswordResetService>>();
+            configService = A.Fake<IConfigService>();
+            emailService = A.Fake<IEmailService>();
+            connection = ServiceTestHelper.GetDatabaseConnection();
+
+            A.CallTo(() => userService.GetUserByEmailAddress(A<string>._)).Returns(new DelegateUser
+            {
+                Id = 1,
+                FirstName = "Forename",
+                Surname = "Surname",
+                EmailAddress = "recipient@example.com",
+                ResetPasswordId = null
+            });
+
+            A.CallTo(() => configService.GetConfigValue(ConfigService.BaseUrl)).Returns("https://example.com");
+
+            passwordResetService = new PasswordResetService(userService, connection, logger, configService, emailService);
+        }
+
+
+        [Test]
+        public void Trying_get_null_user_should_throw_an_exception()
+        {
+            // Given
+            A.CallTo(() => userService.GetUserByEmailAddress(A<string>._)).Returns(null);
+
+            // Then
+            Assert.Throws<EmailAddressNotFoundException>(() => passwordResetService.SendResetPasswordEmail("recipient@example.com"));
+        }
+
+        [Test]
+        public void Trying_to_send_reset_password_email_with_null_config_values_should_throw_an_exception()
+        {
+            // Given
+            A.CallTo(() => configService.GetConfigValue(ConfigService.BaseUrl)).Returns(null);
+
+            // Then
+            Assert.Throws<ConfigValueMissingException>(() => passwordResetService.SendResetPasswordEmail("recipient@example.com"));
+        }
+
+        [Test]
+        public void Trying_to_send_password_reset_sends_email()
+        {
+            // When
+            passwordResetService.SendResetPasswordEmail("recipient@example.com");
+
+            // Then
+            A.CallTo(() =>
+                    emailService.SendEmail(A<Email>._)
+                )
+                .MustHaveHappened();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/UnlockServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/UnlockServiceTests.cs
@@ -1,13 +1,9 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
-    using System.Threading;
-    using DigitalLearningSolutions.Data.Factories;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Services;
     using FakeItEasy;
-    using MailKit.Net.Smtp;
-    using MailKit.Security;
-    using MimeKit;
     using NUnit.Framework;
 
     public class UnlockServiceTests
@@ -15,16 +11,14 @@
         private NotificationService notificationService;
         private INotificationDataService notificationDataService;
         private IConfigService configService;
-        private ISmtpClient smtpClient;
+        private IEmailService emailService;
 
         [SetUp]
         public void Setup()
         {
             notificationDataService = A.Fake<INotificationDataService>();
             configService = A.Fake<IConfigService>();
-            var smtpClientFactory = A.Fake<ISmtpClientFactory>();
-            smtpClient = A.Fake<ISmtpClient>();
-            A.CallTo(() => smtpClientFactory.GetSmtpClient()).Returns(smtpClient);
+            emailService = A.Fake<IEmailService>();
 
             A.CallTo(() => notificationDataService.GetUnlockData(A<int>._)).Returns(new UnlockData
             {
@@ -37,109 +31,39 @@
             });
 
             A.CallTo(() => configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl)).Returns("https://example.com");
-            A.CallTo(() => configService.GetConfigValue(ConfigService.MailPort)).Returns("25");
-            A.CallTo(() => configService.GetConfigValue(ConfigService.MailUsername)).Returns("username");
-            A.CallTo(() => configService.GetConfigValue(ConfigService.MailPassword)).Returns("password");
-            A.CallTo(() => configService.GetConfigValue(ConfigService.MailServer)).Returns("smtp.example.com");
-            A.CallTo(() => configService.GetConfigValue(ConfigService.MailFromAddress)).Returns("test@example.com");
 
-            notificationService = new NotificationService(notificationDataService, configService, smtpClientFactory);
+            notificationService = new NotificationService(notificationDataService, configService, emailService);
         }
 
         [Test]
-        public void Trying_to_send_mail_with_null_config_values_should_throw_an_exception()
+        public void Trying_get_null_unlock_data_should_throw_an_exception()
         {
             // Given
-            A.CallTo(() => configService.GetConfigValue(ConfigService.MailPassword)).Returns(null);
+            A.CallTo(() => notificationDataService.GetUnlockData(A<int>._)).Returns(null);
+
+            // Then
+            Assert.Throws<NotificationDataException>(() => notificationService.SendUnlockRequest(1));
+        }
+
+        [Test]
+        public void Trying_to_send_unlock_request_with_null_config_values_should_throw_an_exception()
+        {
+            // Given
+            A.CallTo(() => configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl)).Returns(null);
 
             // Then
             Assert.Throws<ConfigValueMissingException>(() => notificationService.SendUnlockRequest(1));
         }
 
         [Test]
-        public void The_sender_email_address_is_correct()
+        public void Trying_to_send_unlock_request_sends_email()
         {
             // When
             notificationService.SendUnlockRequest(1);
 
             // Then
             A.CallTo(() =>
-                    smtpClient.Send(
-                        A<MimeMessage>.That.Matches(m =>
-                            m.From.ToString() == "test@example.com"
-                        ),
-                        default(CancellationToken),
-                        null
-                    )
-                )
-                .MustHaveHappened();
-        }
-
-        [Test]
-        public void The_recipient_email_address_is_correct()
-        {
-            // When
-            notificationService.SendUnlockRequest(1);
-
-            // Then
-            A.CallTo(() =>
-                    smtpClient.Send(
-                        A<MimeMessage>.That.Matches(m =>
-                            m.To.ToString() == "recipient@example.com"
-                        ),
-                        default(CancellationToken),
-                        null
-                    )
-                )
-                .MustHaveHappened();
-        }
-
-        [Test]
-        public void The_cc_email_address_is_correct()
-        {
-            // When
-            notificationService.SendUnlockRequest(1);
-
-            // Then
-            A.CallTo(() =>
-                    smtpClient.Send(
-                        A<MimeMessage>.That.Matches(m =>
-                            m.Cc.ToString() == "cc@example.com"
-                        ),
-                        default(CancellationToken),
-                        null
-                    )
-                )
-                .MustHaveHappened();
-        }
-
-        [Test]
-        public void The_server_credentials_are_correct()
-        {
-            // When
-            notificationService.SendUnlockRequest(1);
-
-            // Then
-            A.CallTo(() =>
-                    smtpClient.Authenticate("username", "password", default(CancellationToken))
-                )
-                .MustHaveHappened();
-        }
-
-        [Test]
-        public void The_server_details_are_correct()
-        {
-            // When
-            notificationService.SendUnlockRequest(1);
-
-            // Then
-            A.CallTo(() =>
-                    smtpClient.Connect(
-                        "smtp.example.com",
-                        25,
-                        SecureSocketOptions.Auto,
-                        default(CancellationToken)
-                    )
+                    emailService.SendEmail(A<Email>._)
                 )
                 .MustHaveHappened();
         }

--- a/DigitalLearningSolutions.Data.Tests/Services/UnlockServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/UnlockServiceTests.cs
@@ -8,10 +8,10 @@
 
     public class UnlockServiceTests
     {
-        private NotificationService notificationService;
-        private INotificationDataService notificationDataService;
         private IConfigService configService;
         private IEmailService emailService;
+        private INotificationDataService notificationDataService;
+        private NotificationService notificationService;
 
         [SetUp]
         public void Setup()
@@ -36,7 +36,7 @@
         }
 
         [Test]
-        public void Trying_get_null_unlock_data_should_throw_an_exception()
+        public void Trying_to_send_unlock_request_with_null_unlock_data_should_throw_an_exception()
         {
             // Given
             A.CallTo(() => notificationDataService.GetUnlockData(A<int>._)).Returns(null);
@@ -46,7 +46,7 @@
         }
 
         [Test]
-        public void Trying_to_send_unlock_request_with_null_config_values_should_throw_an_exception()
+        public void Throws_an_exception_when_tracking_system_base_url_is_null()
         {
             // Given
             A.CallTo(() => configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl)).Returns(null);

--- a/DigitalLearningSolutions.Data/Exceptions/EmailAddressNotFoundException.cs
+++ b/DigitalLearningSolutions.Data/Exceptions/EmailAddressNotFoundException.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Data.Exceptions
+{
+    using System;
+
+    public class EmailAddressNotFoundException : Exception
+    {
+        public EmailAddressNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Exceptions/ResetPasswordInsertException.cs
+++ b/DigitalLearningSolutions.Data/Exceptions/ResetPasswordInsertException.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Data.Exceptions
+{
+    using System;
+
+    public class ResetPasswordInsertException : Exception
+    {
+        public ResetPasswordInsertException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Mappers/AdminUserMap.cs
+++ b/DigitalLearningSolutions.Data/Mappers/AdminUserMap.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Mappers
+{
+    using Dapper.FluentMap.Mapping;
+    using DigitalLearningSolutions.Data.Models.User;
+
+    public class AdminUserMap : EntityMap<AdminUser>
+    {
+        public AdminUserMap()
+        {
+            Map(adminUser => adminUser.Id).ToColumn("AdminID");
+            Map(adminUser => adminUser.FirstName).ToColumn("Forename");
+            Map(adminUser => adminUser.Surname).ToColumn("Surname");
+            Map(adminUser => adminUser.EmailAddress).ToColumn("Email");
+            Map(adminUser => adminUser.ResetPasswordId).ToColumn("ResetPasswordID");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Mappers/DelegateUserMap.cs
+++ b/DigitalLearningSolutions.Data/Mappers/DelegateUserMap.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Mappers
+{
+    using Dapper.FluentMap.Mapping;
+    using DigitalLearningSolutions.Data.Models.User;
+
+    public class DelegateUserMap : EntityMap<DelegateUser>
+    {
+        public DelegateUserMap()
+        {
+            Map(delegateUser => delegateUser.Id).ToColumn("CandidateID");
+            Map(delegateUser => delegateUser.FirstName).ToColumn("FirstName");
+            Map(delegateUser => delegateUser.Surname).ToColumn("LastName");
+            Map(delegateUser => delegateUser.EmailAddress).ToColumn("EmailAddress");
+            Map(delegateUser => delegateUser.ResetPasswordId).ToColumn("ResetPasswordID");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Mappers/MapperHelper.cs
+++ b/DigitalLearningSolutions.Data/Mappers/MapperHelper.cs
@@ -11,6 +11,9 @@
                 fluentMapperConfig.AddMap(new CurrentCourseMap());
                 fluentMapperConfig.AddMap(new CompletedCourseMap());
                 fluentMapperConfig.AddMap(new AvailableCourseMap());
+
+                fluentMapperConfig.AddMap(new AdminUserMap());
+                fluentMapperConfig.AddMap(new DelegateUserMap());
             });
         }
     }

--- a/DigitalLearningSolutions.Data/Models/Email/Email.cs
+++ b/DigitalLearningSolutions.Data/Models/Email/Email.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DigitalLearningSolutions.Data.Models.Email
+{
+    using MimeKit;
+
+    public class Email
+    {
+        public string[] To, Cc, Bcc;
+        public string Subject;
+        public BodyBuilder Body;
+
+        public Email()
+        {
+            this.To = new string[0];
+            this.Cc = new string[0];
+            this.Bcc = new string[0];
+            this.Subject = string.Empty;
+            this.Body = new BodyBuilder();
+        }
+
+        public Email(string? to, string? subject, BodyBuilder? body, string? cc = null, string? bcc = null)
+        {
+            this.To = (to is null) ? new string[0] : new string[1] {to};
+            this.Cc = (cc is null) ? new string[0] : new string[1] {cc};
+            this.Bcc = (bcc is null) ? new string[0] : new string[1] {bcc};
+            this.Subject = subject ?? string.Empty;
+            this.Body = body ?? new BodyBuilder();
+        }
+
+        public Email(string[]? to, string? subject, BodyBuilder? body, string[]? cc = null, string[]? bcc = null)
+        {
+            this.To = to ?? new string[0];
+            this.Cc = cc ?? new string[0];
+            this.Bcc = bcc ?? new string[0];
+            this.Subject = subject ?? string.Empty;
+            this.Body = body ?? new BodyBuilder();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/Email/Email.cs
+++ b/DigitalLearningSolutions.Data/Models/Email/Email.cs
@@ -1,42 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DigitalLearningSolutions.Data.Models.Email
+﻿namespace DigitalLearningSolutions.Data.Models.Email
 {
     using MimeKit;
 
     public class Email
     {
-        public string[] To, Cc, Bcc;
-        public string Subject;
         public BodyBuilder Body;
+        public string Subject;
+        public string[] To, Cc, Bcc;
 
-        public Email()
+        public Email(string subject, BodyBuilder body, string to, string? cc = null, string? bcc = null)
         {
-            this.To = new string[0];
-            this.Cc = new string[0];
-            this.Bcc = new string[0];
-            this.Subject = string.Empty;
-            this.Body = new BodyBuilder();
+            Subject = subject;
+            Body = body;
+            To = new string[1] { to };
+            Cc = cc is null ? new string[0] : new string[1] { cc };
+            Bcc = bcc is null ? new string[0] : new string[1] { bcc };
         }
 
-        public Email(string? to, string? subject, BodyBuilder? body, string? cc = null, string? bcc = null)
+        public Email(string subject, BodyBuilder body, string[] to, string[]? cc = null, string[]? bcc = null)
         {
-            this.To = (to is null) ? new string[0] : new string[1] {to};
-            this.Cc = (cc is null) ? new string[0] : new string[1] {cc};
-            this.Bcc = (bcc is null) ? new string[0] : new string[1] {bcc};
-            this.Subject = subject ?? string.Empty;
-            this.Body = body ?? new BodyBuilder();
-        }
-
-        public Email(string[]? to, string? subject, BodyBuilder? body, string[]? cc = null, string[]? bcc = null)
-        {
-            this.To = to ?? new string[0];
-            this.Cc = cc ?? new string[0];
-            this.Bcc = bcc ?? new string[0];
-            this.Subject = subject ?? string.Empty;
-            this.Body = body ?? new BodyBuilder();
+            Subject = subject;
+            Body = body;
+            To = to;
+            Cc = cc ?? new string[0];
+            Bcc = bcc ?? new string[0];
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/User/AdminUser.cs
+++ b/DigitalLearningSolutions.Data/Models/User/AdminUser.cs
@@ -1,0 +1,6 @@
+﻿namespace DigitalLearningSolutions.Data.Models.User
+{
+    public class AdminUser : User
+    {
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
@@ -1,0 +1,6 @@
+﻿namespace DigitalLearningSolutions.Data.Models.User
+{
+    public class DelegateUser : User
+    {
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/User/User.cs
+++ b/DigitalLearningSolutions.Data/Models/User/User.cs
@@ -1,0 +1,15 @@
+﻿namespace DigitalLearningSolutions.Data.Models.User
+{
+    public abstract class User
+    {
+        public int Id { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string Surname { get; set; }
+
+        public string EmailAddress { get; set; }
+
+        public int? ResetPasswordId { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/ConfigService.cs
+++ b/DigitalLearningSolutions.Data/Services/ConfigService.cs
@@ -9,6 +9,7 @@
     {
         string? GetConfigValue(string key);
         bool GetCentreBetaTesting(int centreId);
+        string GetConfigValueMissingExceptionMessage(string missingConfigValue);
     }
 
     public class ConfigService : IConfigService
@@ -21,7 +22,6 @@
         public const string TrackingSystemBaseUrl = "TrackingSystemBaseURL";
         public const string AccessibilityHelpText = "AccessibilityNotice";
         public const string TermsText = "TermsAndConditions";
-        public const string BaseUrl = "BaseURL";
 
         private readonly IDbConnection connection;
 
@@ -33,9 +33,9 @@
         public bool GetCentreBetaTesting(int centreId)
         {
             return connection.Query<bool>(
-               @"SELECT BetaTesting FROM Centres WHERE CentreID = @centreId",
-               new { centreId }
-           ).FirstOrDefault();
+                @"SELECT BetaTesting FROM Centres WHERE CentreID = @centreId",
+                new { centreId }
+            ).FirstOrDefault();
         }
 
         public string? GetConfigValue(string key)
@@ -46,13 +46,15 @@
             ).FirstOrDefault();
         }
 
+        public string GetConfigValueMissingExceptionMessage(string missingConfigValue)
+        {
+            return $"Encountered an error while trying to send an email: The value of {missingConfigValue} is null";
+        }
     }
 
     public class ConfigValueMissingException : Exception
     {
         public ConfigValueMissingException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/ConfigService.cs
+++ b/DigitalLearningSolutions.Data/Services/ConfigService.cs
@@ -21,6 +21,7 @@
         public const string TrackingSystemBaseUrl = "TrackingSystemBaseURL";
         public const string AccessibilityHelpText = "AccessibilityNotice";
         public const string TermsText = "TermsAndConditions";
+        public const string BaseUrl = "BaseURL";
 
         private readonly IDbConnection connection;
 

--- a/DigitalLearningSolutions.Data/Services/EmailService.cs
+++ b/DigitalLearningSolutions.Data/Services/EmailService.cs
@@ -1,0 +1,127 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using System;
+    using DigitalLearningSolutions.Data.Factories;
+    using DigitalLearningSolutions.Data.Models.Email;
+    using MimeKit;
+
+    public interface IEmailService
+    {
+        void SendEmail(Email email);
+        // make class of email details with To, CC, (BCC?) as string lists, and body as BodyBuilder
+
+    }
+
+
+    public class EmailService : IEmailService
+    {
+        private readonly IConfigService configService;
+        private readonly ISmtpClientFactory smtpClientFactory;
+
+        public EmailService (
+            IConfigService configService,
+            ISmtpClientFactory smtpClientFactory
+        )
+        {
+            this.configService = configService;
+            this.smtpClientFactory = smtpClientFactory;
+        }
+
+        public void SendEmail(Email email)
+        {
+            var mailServerUsername = configService.GetConfigValue(ConfigService.MailUsername);
+            var mailServerPassword = configService.GetConfigValue(ConfigService.MailPassword);
+            var mailServerAddress = configService.GetConfigValue(ConfigService.MailServer);
+            var mailServerPortString = configService.GetConfigValue(ConfigService.MailPort);
+            var mailSenderAddress = configService.GetConfigValue(ConfigService.MailFromAddress);
+            if (
+                mailServerUsername == null
+                || mailServerPassword == null
+                || mailServerAddress == null
+                || mailServerPortString == null
+                || mailSenderAddress == null
+            )
+            {
+                var errorMessage = GenerateConfigValueMissingMessage(
+                    mailServerUsername,
+                    mailServerPassword,
+                    mailServerAddress,
+                    mailServerPortString
+                );
+                throw new ConfigValueMissingException(errorMessage);
+            }
+
+            var mailServerPort = int.Parse(mailServerPortString);
+
+            MimeMessage message = CreateMessage(email, mailSenderAddress);
+
+            try
+            {
+                using var client = smtpClientFactory.GetSmtpClient();
+                client.Timeout = 10000;
+                client.Connect(mailServerAddress, mailServerPort);
+
+                client.Authenticate(mailServerUsername, mailServerPassword);
+
+                client.Send(message);
+                client.Disconnect(true);
+            }
+            catch 
+            {
+            }
+        }
+
+        private MimeMessage CreateMessage(Email email, string mailSenderAddress)
+        {
+            var message = new MimeMessage();
+            message.From.Add(MailboxAddress.Parse(mailSenderAddress));
+            foreach (string toAddress in email.To)
+            {
+                message.To.Add(MailboxAddress.Parse(toAddress));
+            }
+            foreach (string ccAddress in email.Cc)
+            {
+                message.Cc.Add(MailboxAddress.Parse(ccAddress));
+            }
+            foreach (string bccAddress in email.Bcc)
+            {
+                message.Bcc.Add(MailboxAddress.Parse(bccAddress));
+            }
+            message.Subject = email.Subject;
+            message.Body = email.Body.ToMessageBody();
+
+            return message;
+        }
+
+        private static string GenerateConfigValueMissingMessage(
+            string? mailServerUsername,
+            string? mailServerPassword,
+            string? mailServerAddress,
+            string? mailServerPortString
+            )
+        {
+            if (mailServerUsername == null)
+            {
+                return "Encountered an error while trying to send an email: The value of mailserverUsername is null";
+            }
+
+            if (mailServerPassword == null)
+            {
+                return "Encountered an error while trying to send an email: The value of mailserverPassword is null";
+            }
+
+            if (mailServerAddress == null)
+            {
+                return "Encountered an error while trying to send an email: The value of mailServerAddress is null";
+            }
+
+            if (mailServerPortString == null)
+            {
+                return "Encountered an error while trying to send an email: The value of mailServerPortString is null";
+            }
+
+            return "Encountered an error while trying to send an email: The value of mailSenderAddress is null";
+            
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/EmailService.cs
+++ b/DigitalLearningSolutions.Data/Services/EmailService.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
-    using System;
     using DigitalLearningSolutions.Data.Factories;
     using DigitalLearningSolutions.Data.Models.Email;
     using MimeKit;
@@ -8,17 +7,14 @@
     public interface IEmailService
     {
         void SendEmail(Email email);
-        // make class of email details with To, CC, (BCC?) as string lists, and body as BodyBuilder
-
     }
-
 
     public class EmailService : IEmailService
     {
         private readonly IConfigService configService;
         private readonly ISmtpClientFactory smtpClientFactory;
 
-        public EmailService (
+        public EmailService(
             IConfigService configService,
             ISmtpClientFactory smtpClientFactory
         )
@@ -29,27 +25,16 @@
 
         public void SendEmail(Email email)
         {
-            var mailServerUsername = configService.GetConfigValue(ConfigService.MailUsername);
-            var mailServerPassword = configService.GetConfigValue(ConfigService.MailPassword);
-            var mailServerAddress = configService.GetConfigValue(ConfigService.MailServer);
-            var mailServerPortString = configService.GetConfigValue(ConfigService.MailPort);
-            var mailSenderAddress = configService.GetConfigValue(ConfigService.MailFromAddress);
-            if (
-                mailServerUsername == null
-                || mailServerPassword == null
-                || mailServerAddress == null
-                || mailServerPortString == null
-                || mailSenderAddress == null
-            )
-            {
-                var errorMessage = GenerateConfigValueMissingMessage(
-                    mailServerUsername,
-                    mailServerPassword,
-                    mailServerAddress,
-                    mailServerPortString
-                );
-                throw new ConfigValueMissingException(errorMessage);
-            }
+            var mailServerUsername = configService.GetConfigValue(ConfigService.MailUsername)
+                                     ?? throw new ConfigValueMissingException(configService.GetConfigValueMissingExceptionMessage("MailServerUsername"));
+            var mailServerPassword = configService.GetConfigValue(ConfigService.MailPassword)
+                                     ?? throw new ConfigValueMissingException(configService.GetConfigValueMissingExceptionMessage("MailServerPassword"));
+            var mailServerAddress = configService.GetConfigValue(ConfigService.MailServer)
+                                    ?? throw new ConfigValueMissingException(configService.GetConfigValueMissingExceptionMessage("MailServerAddress"));
+            var mailServerPortString = configService.GetConfigValue(ConfigService.MailPort)
+                                       ?? throw new ConfigValueMissingException(configService.GetConfigValueMissingExceptionMessage("MailServerPortString"));
+            var mailSenderAddress = configService.GetConfigValue(ConfigService.MailFromAddress)
+                                    ?? throw new ConfigValueMissingException(configService.GetConfigValueMissingExceptionMessage("MailFromAddress"));
 
             var mailServerPort = int.Parse(mailServerPortString);
 
@@ -66,9 +51,7 @@
                 client.Send(message);
                 client.Disconnect(true);
             }
-            catch 
-            {
-            }
+            catch { }
         }
 
         private MimeMessage CreateMessage(Email email, string mailSenderAddress)
@@ -79,49 +62,21 @@
             {
                 message.To.Add(MailboxAddress.Parse(toAddress));
             }
+
             foreach (string ccAddress in email.Cc)
             {
                 message.Cc.Add(MailboxAddress.Parse(ccAddress));
             }
+
             foreach (string bccAddress in email.Bcc)
             {
                 message.Bcc.Add(MailboxAddress.Parse(bccAddress));
             }
+
             message.Subject = email.Subject;
             message.Body = email.Body.ToMessageBody();
 
             return message;
-        }
-
-        private static string GenerateConfigValueMissingMessage(
-            string? mailServerUsername,
-            string? mailServerPassword,
-            string? mailServerAddress,
-            string? mailServerPortString
-            )
-        {
-            if (mailServerUsername == null)
-            {
-                return "Encountered an error while trying to send an email: The value of mailserverUsername is null";
-            }
-
-            if (mailServerPassword == null)
-            {
-                return "Encountered an error while trying to send an email: The value of mailserverPassword is null";
-            }
-
-            if (mailServerAddress == null)
-            {
-                return "Encountered an error while trying to send an email: The value of mailServerAddress is null";
-            }
-
-            if (mailServerPortString == null)
-            {
-                return "Encountered an error while trying to send an email: The value of mailServerPortString is null";
-            }
-
-            return "Encountered an error while trying to send an email: The value of mailSenderAddress is null";
-            
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/NotificationService.cs
+++ b/DigitalLearningSolutions.Data/Services/NotificationService.cs
@@ -1,8 +1,8 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
     using System;
-    using DigitalLearningSolutions.Data.Factories;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.Email;
     using MimeKit;
 
     public interface INotificationService
@@ -15,65 +15,19 @@
     {
         private readonly INotificationDataService notificationDataService;
         private readonly IConfigService configService;
-        private readonly ISmtpClientFactory smtpClientFactory;
+        private readonly IEmailService emailService;
+
         public NotificationService(
             INotificationDataService notificationDataService,
             IConfigService configService,
-            ISmtpClientFactory smtpClientFactory
+            IEmailService emailService
             )
         {
             this.notificationDataService = notificationDataService;
             this.configService = configService;
-            this.smtpClientFactory = smtpClientFactory;
+            this.emailService = emailService;
         }
-        public void SendSMTPMessage(string to, string? cc, string subject, BodyBuilder body)
-        {
-            var mailServerUsername = configService.GetConfigValue(ConfigService.MailUsername);
-            var mailServerPassword = configService.GetConfigValue(ConfigService.MailPassword);
-            var mailServerAddress = configService.GetConfigValue(ConfigService.MailServer);
-            var mailServerPortString = configService.GetConfigValue(ConfigService.MailPort);
-            var mailSenderAddress = configService.GetConfigValue(ConfigService.MailFromAddress);
-            if (
-                mailServerUsername == null
-                || mailServerPassword == null
-                || mailServerAddress == null
-                || mailServerPortString == null
-                || mailSenderAddress == null
-            )
-            {
-                var errorMessage = GenerateConfigValueMissingMessage(
-                    mailServerUsername,
-                    mailServerPassword,
-                    mailServerAddress,
-                    mailServerPortString,
-                    mailSenderAddress
-                );
-                throw new ConfigValueMissingException(errorMessage);
-            }
 
-            var mailServerPort = int.Parse(mailServerPortString);
-            var message = new MimeMessage();
-            message.From.Add(MailboxAddress.Parse(mailSenderAddress));
-            message.To.Add(MailboxAddress.Parse(to));
-            if (cc != null)
-            {
-                message.Cc.Add(MailboxAddress.Parse(cc));
-            }
-            message.Subject = subject;
-            message.Body = body.ToMessageBody();
-            try
-            {
-                using var client = smtpClientFactory.GetSmtpClient();
-                client.Timeout = 10000;
-                client.Connect(mailServerAddress, mailServerPort);
-                client.Authenticate(mailServerUsername, mailServerPassword);
-                client.Send(message);
-                client.Disconnect(true);
-            }
-            catch
-            {
-            }
-        }
         public void SendUnlockRequest(int progressId)
         {
             var unlockData = notificationDataService.GetUnlockData(progressId);
@@ -83,12 +37,12 @@
             }
 
             unlockData.ContactForename = unlockData.ContactForename == "" ? "Colleague" : unlockData.ContactForename;
-
-
-            var trackingSystemBaseUrl = configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl);
+            var trackingSystemBaseUrl = configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl) ??
+                                        throw new ConfigValueMissingException(GenerateConfigValueMissingMessage());
             var unlockUrl = new UriBuilder(trackingSystemBaseUrl);
             unlockUrl.Path += "coursedelegates";
             unlockUrl.Query = $"CustomisationID={unlockData.CustomisationId}";
+            string emailSubjectLine = "Digital Learning Solutions Progress Unlock Request";
             var builder = new BodyBuilder
             {
                 TextBody = $@"Dear {unlockData?.ContactForename}
@@ -101,8 +55,10 @@ To review and unlock their progress, visit the this url: ${unlockUrl}.",
                                     <p>They have reached the maximum number of assessment attempt allowed without passing.</p><p>To review and unlock their progress, <a href='{unlockUrl}'>click here</a>.</p>
                                 </body>"
             };
-            SendSMTPMessage(unlockData.ContactEmail, unlockData.DelegateEmail, "Digital Learning Solutions Progress Unlock Request", builder);
+
+            emailService.SendEmail(new Email(unlockData.ContactEmail, emailSubjectLine, builder, unlockData.DelegateEmail));
         }
+
         public void SendFrameworkCollaboratorInvite(int adminId, int frameworkId, int invitedByAdminId)
         {
             var collaboratorNotification = notificationDataService.GetCollaboratorNotification(adminId, frameworkId, invitedByAdminId);
@@ -111,10 +67,12 @@ To review and unlock their progress, visit the this url: ${unlockUrl}.",
                 throw new NotificationDataException($"No record found when trying to fetch collaboratorNotification Data. adminId: {adminId}, frameworkId: {frameworkId}, invitedByAdminId: {invitedByAdminId})");
             }
             collaboratorNotification.Forename = collaboratorNotification.Forename == "" ? "Colleague" : collaboratorNotification.Forename;
-            var trackingSystemBaseUrl = configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl).Replace("tracking/", "");
+            var trackingSystemBaseUrl = configService.GetConfigValue(ConfigService.TrackingSystemBaseUrl)?.Replace("tracking/", "") ??
+                                        throw new ConfigValueMissingException(GenerateConfigValueMissingMessage());
             if (trackingSystemBaseUrl.Contains("dls.nhs.uk")) { trackingSystemBaseUrl += "v2/"; }
             var frameworkUrl = new UriBuilder(trackingSystemBaseUrl);
             frameworkUrl.Path += $"Framework/Structure/{collaboratorNotification.FrameworkID}";
+            string emailSubjectLine = "DLS Digital Framework Contributor Invitation";
             var builder = new BodyBuilder
             {
                 TextBody = $@"Dear {collaboratorNotification?.Forename},
@@ -125,41 +83,12 @@ To access the framework, visit this url: {frameworkUrl}. You will need to login 
 <p>You have been identified as a {collaboratorNotification?.FrameworkRole} for the digital capability framework, {collaboratorNotification?.FrameworkName} by <a href='mailto:{collaboratorNotification?.InvitedByEmail}'>{collaboratorNotification?.InvitedByName}</a>.</p>
 <p>To access the framework, <a href='{frameworkUrl}'>click here</a>. You will need to login to DLS to view the framework.</p>"
             };
-            SendSMTPMessage(collaboratorNotification?.Email, collaboratorNotification?.InvitedByEmail, "DLS Digital Framework Contributor Invitation", builder);
+
+            emailService.SendEmail(new Email(collaboratorNotification.Email, emailSubjectLine, builder, collaboratorNotification.InvitedByEmail));
         }
-        private static string GenerateConfigValueMissingMessage(
-            string? mailServerUsername,
-            string? mailServerPassword,
-            string? mailServerAddress,
-            string? mailServerPortString,
-            string? mailSenderAddress
-            )
+
+        private static string GenerateConfigValueMissingMessage()
         {
-            if (mailServerUsername == null)
-            {
-                return "Encountered an error while trying to send an unlock request email: The value of mailserverUsername is null";
-            }
-
-            if (mailServerPassword == null)
-            {
-                return "Encountered an error while trying to send an unlock request email: The value of mailserverPassword is null";
-            }
-
-            if (mailServerAddress == null)
-            {
-                return "Encountered an error while trying to send an unlock request email: The value of mailServerAddress is null";
-            }
-
-            if (mailServerPortString == null)
-            {
-                return "Encountered an error while trying to send an unlock request email: The value of mailServerPortString is null";
-            }
-
-            if (mailSenderAddress == null)
-            {
-                return "Encountered an error while trying to send an unlock request email: The value of mailSenderAddress is null";
-            }
-
             return "Encountered an error while trying to send an unlock request email: The value of trackingSystemBaseUrl is null";
         }
     }

--- a/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
+++ b/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
@@ -1,0 +1,121 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using System;
+    using System.Data;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Exceptions;
+    using DigitalLearningSolutions.Data.Models.Email;
+    using DigitalLearningSolutions.Data.Models.User;
+    using Microsoft.Extensions.Logging;
+    using MimeKit;
+
+    public interface IPasswordResetService
+    {
+        void SendResetPasswordEmail(string emailAddress);
+    }
+
+    public class PasswordResetService : IPasswordResetService
+    {
+        private const string AdminTableName = "AdminUsers";
+        private const string DelegatesTableName = "Candidates";
+        private const string AdminIdColumnName = "AdminID";
+        private const string DelegatesIdColumnName = "CandidateID";
+
+        private readonly IUserService userService;
+        private readonly IDbConnection connection;
+        private readonly ILogger<PasswordResetService> logger;
+        private readonly IConfigService configService;
+        private readonly IEmailService emailService;
+
+        public PasswordResetService(
+            IUserService userService,
+            IDbConnection connection,
+            ILogger<PasswordResetService> logger,
+            IConfigService configService,
+            IEmailService emailService)
+        {
+            this.userService = userService;
+            this.connection = connection;
+            this.logger = logger;
+            this.configService = configService;
+            this.emailService = emailService;
+        }
+
+        public void SendResetPasswordEmail(string emailAddress)
+        {
+            User user =
+                this.userService.GetUserByEmailAddress(emailAddress) ??
+                throw new EmailAddressNotFoundException("No user account could be found with the specified email address");
+            string resetPasswordHash = GenerateResetPasswordHash(user);
+            Email resetPasswordEmail = GeneratePasswordResetEmail(emailAddress, resetPasswordHash, user.FirstName);
+            this.emailService.SendEmail(resetPasswordEmail);
+        }
+
+        private string GenerateResetPasswordHash(User user)
+        {
+            string hash = Guid.NewGuid().ToString();
+            string tableName = user.GetType() == typeof(DelegateUser) ? DelegatesTableName : AdminTableName;
+            string idColumnName = user.GetType() == typeof(DelegateUser) ? DelegatesIdColumnName : AdminIdColumnName;
+
+            int numberOfAffectedRows = connection.Execute(
+                $@"BEGIN TRY
+                        DECLARE @ResetPasswordID INT
+                        BEGIN TRANSACTION
+                            INSERT INTO dbo.ResetPassword
+                                ([ResetPasswordHash]
+                                ,[PasswordResetDateTime])
+                            VALUES(@ResetPasswordHash, GETDATE())
+
+                            SET @ResetPasswordID = SCOPE_IDENTITY()
+
+                            UPDATE {tableName}
+                            SET ResetPasswordID = @ResetPasswordID
+                            WHERE {idColumnName} = @UserID
+                        COMMIT TRANSACTION
+                    END TRY
+                    BEGIN CATCH
+                        ROLLBACK TRANSACTION
+                    END CATCH
+                    ", new { ResetPasswordHash = hash, UserID = user.Id });
+            if (numberOfAffectedRows < 2)
+            {
+                string message = $"Not saving reset password hash as db insert/update failed for User ID: {user.Id} from table {tableName}";
+                logger.LogWarning(message);
+                throw new ResetPasswordInsertException(message);
+            }
+
+            return hash;
+        }
+
+        private Email GeneratePasswordResetEmail(string emailAddress, string resetHash, string firstName)
+        {
+            string baseUrl =
+                configService.GetConfigValue(ConfigService.BaseUrl) ??
+                throw new ConfigValueMissingException("Encountered an error while trying to generate a Reset Password email: " +
+                                                      "The value of baseURL is null ");
+            UriBuilder resetPasswordUrl = new UriBuilder(baseUrl);
+            resetPasswordUrl.Path += "ResetPassword";
+            resetPasswordUrl.Query = $"code={resetHash}&email={emailAddress}";
+
+            string emailSubject = "Digital Learning Solutions Tracking System Password Reset";
+
+            BodyBuilder body = new BodyBuilder
+            {
+                TextBody = $@"Dear {firstName},
+                            A request has been made to reset the password for your Digital Learning Solutions account.
+                            To reset your password please follow this link: {resetPasswordUrl}
+                            Note that this link can only be used once and it will expire in two hours.
+                            Please don’t reply to this email as it has been automatically generated.",
+                HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'>
+                                    <p>Dear {firstName},</p>
+                                    <p>A request has been made to reset the password for your Digital Learning Solutions account.</p>
+                                    <p>To reset your password please follow this link: {resetPasswordUrl}</p>
+                                    <p>Note that this link can only be used once and it will expire in two hours.</p>
+                                    <p>Please don’t reply to this email as it has been automatically generated.</p>
+                                </body>"
+            };
+
+            return new Email(emailAddress, emailSubject, body);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -1,0 +1,70 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using System.Data;
+    using System.Linq;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models.User;
+
+    public interface IUserService
+    {
+        public User? GetUserByEmailAddress(string emailAddress);
+        public AdminUser? GetAdminUserByEmailAddress(string emailAddress);
+        public DelegateUser? GetDelegateUserByEmailAddress(string emailAddress);
+
+    }
+
+    public class UserService : IUserService
+    {
+        private readonly IDbConnection connection;
+
+        public UserService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public User? GetUserByEmailAddress(string emailAddress)
+        {
+            // Assume user is a delegate (in Candidates Table)
+            User? user = GetDelegateUserByEmailAddress(emailAddress);
+
+            // If no Candidates entry found, look to AdminUsers
+            user ??= GetAdminUserByEmailAddress(emailAddress);
+
+            return user;
+        }
+
+        public AdminUser? GetAdminUserByEmailAddress(string emailAddress)
+        {
+            AdminUser? user = connection.Query<AdminUser>(
+                @"SELECT TOP (1)
+                        AdminID,
+                        Forename,
+                        Surname,
+                        Email,
+                        ResetPasswordID
+                    FROM AdminUsers
+                    WHERE (Email = @emailAddress)",
+                new { emailAddress }
+            ).FirstOrDefault();
+
+            return user;
+        }
+
+        public DelegateUser? GetDelegateUserByEmailAddress(string emailAddress)
+        {
+            DelegateUser? user = connection.Query<DelegateUser>(
+                @"SELECT TOP (1)
+                        CandidateID,
+                        FirstName,
+                        LastName,
+                        EmailAddress,
+                        ResetPasswordID
+                    FROM Candidates
+                    WHERE (EmailAddress = @emailAddress)",
+                new { emailAddress }
+            ).FirstOrDefault();
+
+            return user;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
+    using System.Collections.Generic;
     using System.Data;
     using System.Linq;
     using Dapper;
@@ -7,10 +8,7 @@
 
     public interface IUserService
     {
-        public User? GetUserByEmailAddress(string emailAddress);
-        public AdminUser? GetAdminUserByEmailAddress(string emailAddress);
-        public DelegateUser? GetDelegateUserByEmailAddress(string emailAddress);
-
+        public (List<AdminUser>, List<DelegateUser>) GetUsersByEmailAddress(string emailAddress);
     }
 
     public class UserService : IUserService
@@ -22,21 +20,18 @@
             this.connection = connection;
         }
 
-        public User? GetUserByEmailAddress(string emailAddress)
+        public (List<AdminUser>, List<DelegateUser>) GetUsersByEmailAddress(string emailAddress)
         {
-            // Assume user is a delegate (in Candidates Table)
-            User? user = GetDelegateUserByEmailAddress(emailAddress);
+            List<AdminUser> adminUsers = GetAdminUsersByEmailAddress(emailAddress);
+            List<DelegateUser> delegateUsers = GetDelegateUsersByEmailAddress(emailAddress);
 
-            // If no Candidates entry found, look to AdminUsers
-            user ??= GetAdminUserByEmailAddress(emailAddress);
-
-            return user;
+            return (adminUsers, delegateUsers);
         }
 
-        public AdminUser? GetAdminUserByEmailAddress(string emailAddress)
+        private List<AdminUser> GetAdminUsersByEmailAddress(string emailAddress)
         {
-            AdminUser? user = connection.Query<AdminUser>(
-                @"SELECT TOP (1)
+            List<AdminUser> user = connection.Query<AdminUser>(
+                @"SELECT
                         AdminID,
                         Forename,
                         Surname,
@@ -45,15 +40,15 @@
                     FROM AdminUsers
                     WHERE (Email = @emailAddress)",
                 new { emailAddress }
-            ).FirstOrDefault();
+            ).ToList();
 
             return user;
         }
 
-        public DelegateUser? GetDelegateUserByEmailAddress(string emailAddress)
+        private List<DelegateUser> GetDelegateUsersByEmailAddress(string emailAddress)
         {
-            DelegateUser? user = connection.Query<DelegateUser>(
-                @"SELECT TOP (1)
+            List<DelegateUser> user = connection.Query<DelegateUser>(
+                @"SELECT
                         CandidateID,
                         FirstName,
                         LastName,
@@ -62,7 +57,7 @@
                     FROM Candidates
                     WHERE (EmailAddress = @emailAddress)",
                 new { emailAddress }
-            ).FirstOrDefault();
+            ).ToList();
 
             return user;
         }

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -30,7 +30,7 @@
 
         private List<AdminUser> GetAdminUsersByEmailAddress(string emailAddress)
         {
-            List<AdminUser> user = connection.Query<AdminUser>(
+            List<AdminUser> users = connection.Query<AdminUser>(
                 @"SELECT
                         AdminID,
                         Forename,
@@ -42,12 +42,12 @@
                 new { emailAddress }
             ).ToList();
 
-            return user;
+            return users;
         }
 
         private List<DelegateUser> GetDelegateUsersByEmailAddress(string emailAddress)
         {
-            List<DelegateUser> user = connection.Query<DelegateUser>(
+            List<DelegateUser> users = connection.Query<DelegateUser>(
                 @"SELECT
                         CandidateID,
                         FirstName,
@@ -59,7 +59,7 @@
                 new { emailAddress }
             ).ToList();
 
-            return user;
+            return users;
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/ForgotPassword/ForgotPasswordControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/ForgotPassword/ForgotPasswordControllerTests.cs
@@ -1,0 +1,75 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.ForgotPassword
+{
+    using DigitalLearningSolutions.Data.Exceptions;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Controllers;
+    using DigitalLearningSolutions.Web.ViewModels.ForgotPassword;
+    using FakeItEasy;
+    using FluentAssertions;
+    using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+
+    class ForgotPasswordControllerTests
+    {
+        private ForgotPasswordController controller;
+        private IPasswordResetService passwordResetService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            passwordResetService = A.Fake<IPasswordResetService>();
+
+            controller = new ForgotPasswordController(passwordResetService);
+        }
+
+        [Test]
+        public void No_model_should_render_basic_form()
+        {
+            // When
+            var result = controller.Index(model: null);
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName();
+        }
+
+        [Test]
+        public void Successful_email_submission_should_render_confirm_page()
+        {
+            // Given
+            A.CallTo(() => passwordResetService.SendResetPasswordEmail(A<string>._)).DoesNothing();
+
+            // When
+            var result = controller.Index("recipient@example.com");
+
+            // Then
+            result.Should().BeRedirectToActionResult().WithActionName("Confirm");
+        }
+
+        [Test]
+        public void Email_submission_should_call_password_reset_service()
+        {
+            // When
+            controller.Index("recipient@example.com");
+
+            // Then
+            A.CallTo(() => passwordResetService.SendResetPasswordEmail(A<string>._)).MustHaveHappened();
+        }
+
+        [Test]
+        public void Bad_email_submission_should_render_basic_form_with_error()
+        {
+            string errorMessage = "No user account could be found with the specified email address";
+
+            // Given
+            A.CallTo(() => passwordResetService.SendResetPasswordEmail(A<string>._)).Throws(new EmailAddressNotFoundException(errorMessage));
+
+            // When
+            var result = controller.Index("recipient@example.com");
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName()
+                .ModelAs<ForgotPasswordViewModel>().ErrorHasOccurred.Should().Be(true);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/ForgotPassword/ForgotPasswordControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/ForgotPassword/ForgotPasswordControllerTests.cs
@@ -7,10 +7,9 @@
     using FakeItEasy;
     using FluentAssertions;
     using FluentAssertions.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
     using NUnit.Framework;
 
-    class ForgotPasswordControllerTests
+    internal class ForgotPasswordControllerTests
     {
         private ForgotPasswordController controller;
         private IPasswordResetService passwordResetService;
@@ -24,7 +23,7 @@
         }
 
         [Test]
-        public void No_model_should_render_basic_form()
+        public void Render_basic_form_when_there_is_no_error_model()
         {
             // When
             var result = controller.Index(model: null);
@@ -37,7 +36,7 @@
         public void Successful_email_submission_should_render_confirm_page()
         {
             // Given
-            A.CallTo(() => passwordResetService.SendResetPasswordEmail(A<string>._)).DoesNothing();
+            A.CallTo(() => passwordResetService.GenerateAndSendPasswordResetLink(A<string>._, A<string>._)).DoesNothing();
 
             // When
             var result = controller.Index("recipient@example.com");
@@ -53,7 +52,7 @@
             controller.Index("recipient@example.com");
 
             // Then
-            A.CallTo(() => passwordResetService.SendResetPasswordEmail(A<string>._)).MustHaveHappened();
+            A.CallTo(() => passwordResetService.GenerateAndSendPasswordResetLink(A<string>._, A<string>._)).MustHaveHappened();
         }
 
         [Test]
@@ -62,14 +61,27 @@
             string errorMessage = "No user account could be found with the specified email address";
 
             // Given
-            A.CallTo(() => passwordResetService.SendResetPasswordEmail(A<string>._)).Throws(new EmailAddressNotFoundException(errorMessage));
+            A.CallTo(() => passwordResetService.GenerateAndSendPasswordResetLink(A<string>._, A<string>._)).Throws(new EmailAddressNotFoundException(errorMessage));
 
             // When
             var result = controller.Index("recipient@example.com");
 
             // Then
             result.Should().BeViewResult().WithDefaultViewName()
-                .ModelAs<ForgotPasswordViewModel>().ErrorHasOccurred.Should().Be(true);
+                .ModelAs<ForgotPasswordViewModel>().EmailErrorMessage.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Test]
+        public void Bad_database_insertion_should_render_unknown_error_page()
+        {
+            // Given
+            A.CallTo(() => passwordResetService.GenerateAndSendPasswordResetLink(A<string>._, A<string>._)).Throws(new ResetPasswordInsertException("DB Insert failed"));
+
+            // When
+            var result = controller.Index("recipient@example.com");
+
+            // Then
+            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions").WithActionName("Error");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/ForgotPasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ForgotPasswordController.cs
@@ -2,12 +2,12 @@
 {
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Services;
-    using Microsoft.AspNetCore.Mvc;
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.ForgotPassword;
+    using Microsoft.AspNetCore.Mvc;
 
     public class ForgotPasswordController : Controller
     {
-
         private readonly IPasswordResetService passwordResetService;
 
         public ForgotPasswordController(IPasswordResetService passwordResetService)
@@ -31,14 +31,24 @@
                 return Index(model);
             }
 
+            string baseUrl = ConfigHelper.GetAppConfig()["AppRootPath"];
+
             try
             {
-                this.passwordResetService.SendResetPasswordEmail(emailAddress);
+                passwordResetService.GenerateAndSendPasswordResetLink
+                (
+                    emailAddress,
+                    baseUrl
+                );
             }
             catch (EmailAddressNotFoundException)
             {
                 ForgotPasswordViewModel model = GetEmailNotFoundErrorModel(emailAddress);
                 return Index(model);
+            }
+            catch (ResetPasswordInsertException)
+            {
+                return RedirectToAction("Error", "LearningSolutions");
             }
 
             return RedirectToAction("Confirm");
@@ -54,7 +64,6 @@
             return new ForgotPasswordViewModel
             (
                 emailAddress,
-                true,
                 "The email address needs to be a valid email address, such as example@domain.com"
             );
         }
@@ -64,7 +73,6 @@
             return new ForgotPasswordViewModel
             (
                 emailAddress,
-                true,
                 "User with this email address does not exist. Please try again"
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/ForgotPasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ForgotPasswordController.cs
@@ -1,21 +1,45 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using DigitalLearningSolutions.Data.Exceptions;
+    using DigitalLearningSolutions.Data.Services;
     using Microsoft.AspNetCore.Mvc;
     using DigitalLearningSolutions.Web.ViewModels.ForgotPassword;
-    using DigitalLearningSolutions.Web.ViewModels.LearningSolutions;
 
     public class ForgotPasswordController : Controller
     {
-        public IActionResult Index()
+
+        private readonly IPasswordResetService passwordResetService;
+
+        public ForgotPasswordController(IPasswordResetService passwordResetService)
         {
-            var model = new ForgotPasswordViewModel();
+            this.passwordResetService = passwordResetService;
+        }
+
+        [HttpGet]
+        public IActionResult Index(ForgotPasswordViewModel? model)
+        {
+            model ??= new ForgotPasswordViewModel();
             return View(model);
         }
 
         [HttpPost]
-        public IActionResult RecoverPassword(string emailAddress)
+        public IActionResult Index(string? emailAddress)
         {
-            // TODO: HEEDLS-354 - form submission logic
+            if (emailAddress?.Contains('@') != true)
+            {
+                ForgotPasswordViewModel model = GetEmailInvalidErrorModel(emailAddress ?? string.Empty);
+                return Index(model);
+            }
+
+            try
+            {
+                this.passwordResetService.SendResetPasswordEmail(emailAddress);
+            }
+            catch (EmailAddressNotFoundException)
+            {
+                ForgotPasswordViewModel model = GetEmailNotFoundErrorModel(emailAddress);
+                return Index(model);
+            }
 
             return RedirectToAction("Confirm");
         }
@@ -23,6 +47,26 @@
         public IActionResult Confirm()
         {
             return View();
+        }
+
+        private ForgotPasswordViewModel GetEmailInvalidErrorModel(string emailAddress)
+        {
+            return new ForgotPasswordViewModel
+            (
+                emailAddress,
+                true,
+                "The email address needs to be a valid email address, such as example@domain.com"
+            );
+        }
+
+        private ForgotPasswordViewModel GetEmailNotFoundErrorModel(string emailAddress)
+        {
+            return new ForgotPasswordViewModel
+            (
+                emailAddress,
+                true,
+                "User with this email address does not exist. Please try again"
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -102,6 +102,9 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IDiagnosticAssessmentService, DiagnosticAssessmentService>();
             services.AddScoped<IPostLearningAssessmentService, PostLearningAssessmentService>();
             services.AddScoped<ICourseCompletionService, CourseCompletionService>();
+            services.AddScoped<IPasswordResetService, PasswordResetService>();
+            services.AddScoped<IEmailService, EmailService>();
+            services.AddScoped<IUserService, UserService>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)

--- a/DigitalLearningSolutions.Web/ViewModels/ForgotPassword/ForgotPasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/ForgotPassword/ForgotPasswordViewModel.cs
@@ -3,18 +3,14 @@
     public class ForgotPasswordViewModel
     {
         public string? EmailAddress;
-
-        public bool ErrorHasOccurred;
-
         public string? EmailErrorMessage;
 
         public ForgotPasswordViewModel() { }
 
-        public ForgotPasswordViewModel(string emailAddress, bool errorHasOccurred, string emailErrorMessage)
+        public ForgotPasswordViewModel(string emailAddress, string emailErrorMessage)
         {
-            this.EmailAddress = emailAddress;
-            this.ErrorHasOccurred = errorHasOccurred;
-            this.EmailErrorMessage = emailErrorMessage;
+            EmailAddress = emailAddress;
+            EmailErrorMessage = emailErrorMessage;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/ForgotPassword/ForgotPasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/ForgotPassword/ForgotPasswordViewModel.cs
@@ -3,5 +3,18 @@
     public class ForgotPasswordViewModel
     {
         public string? EmailAddress;
+
+        public bool ErrorHasOccurred;
+
+        public string? EmailErrorMessage;
+
+        public ForgotPasswordViewModel() { }
+
+        public ForgotPasswordViewModel(string emailAddress, bool errorHasOccurred, string emailErrorMessage)
+        {
+            this.EmailAddress = emailAddress;
+            this.ErrorHasOccurred = errorHasOccurred;
+            this.EmailErrorMessage = emailErrorMessage;
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Confirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Confirm.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-  ViewData["Title"] = "Digital Learning Solutions - Password Reset Email Sent";
+  ViewData["Title"] = "Password Reset Email Sent";
 }
 
 <div class="nhsuk-grid-row">

--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
@@ -1,14 +1,14 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.ForgotPassword
 @model ForgotPasswordViewModel
 @{
-  ViewData["Title"] = "Digital Learning Solutions - Reset Your Password";
-  var inputErrorClass = Model.ErrorHasOccurred == true ? "nhsuk-input--error" : "";
-  var formErrorClass = Model.ErrorHasOccurred == true ? "nhsuk-form-group--error" : "";
+  ViewData["Title"] = "Reset Your Password";
+  var inputErrorClass = !String.IsNullOrWhiteSpace(Model.EmailErrorMessage) ? "nhsuk-input--error" : "";
+  var formErrorClass = !String.IsNullOrWhiteSpace(Model.EmailErrorMessage) ? "nhsuk-form-group--error" : "";
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    @if (Model.ErrorHasOccurred)
+    @if (!String.IsNullOrWhiteSpace(Model.EmailErrorMessage))
     {
       <div class="nhsuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
         <h2 class="nhsuk-error-summary__title" id="error-summary-title">
@@ -31,7 +31,7 @@
         <label class="nhsuk-label nhsuk-u-margin-bottom-4" for="emailAddress">
           Enter your email address and we will send you password reset instructions.
         </label>
-        @if (Model.ErrorHasOccurred)
+        @if (!String.IsNullOrWhiteSpace(Model.EmailErrorMessage))
         {
           <span class="nhsuk-error-message" id="emailAddress-error">
             <span class="nhsuk-u-visually-hidden">Error:</span> @Model.EmailErrorMessage

--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
@@ -2,18 +2,42 @@
 @model ForgotPasswordViewModel
 @{
   ViewData["Title"] = "Digital Learning Solutions - Reset Your Password";
+  var inputErrorClass = Model.ErrorHasOccurred == true ? "nhsuk-input--error" : "";
+  var formErrorClass = Model.ErrorHasOccurred == true ? "nhsuk-form-group--error" : "";
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
+    @if (Model.ErrorHasOccurred)
+    {
+      <div class="nhsuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+        <h2 class="nhsuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+        <div class="nhsuk-error-summary__body">
+          <ul class="nhsuk-list nhsuk-error-summary__list">
+            <li>
+              <a href="#emailAddress">@Model.EmailErrorMessage</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    }
+
     <h1 id="page-heading" class="nhsuk-u-margin-bottom-6">Reset your password</h1>
 
-    <form method="post" asp-action="RecoverPassword" novalidate>
-      <div class="nhsuk-form-group">
+    <form method="post" novalidate>
+      <div class="nhsuk-form-group @formErrorClass">
         <label class="nhsuk-label nhsuk-u-margin-bottom-4" for="emailAddress">
           Enter your email address and we will send you password reset instructions.
         </label>
-        <input class="nhsuk-input nhsuk-u-width-one-half" type="email" id="emailAddress" asp-for="EmailAddress" value="@Model.EmailAddress"/>
+        @if (Model.ErrorHasOccurred)
+        {
+          <span class="nhsuk-error-message" id="emailAddress-error">
+            <span class="nhsuk-u-visually-hidden">Error:</span> @Model.EmailErrorMessage
+          </span>
+        }
+        <input class="nhsuk-input nhsuk-u-width-one-half @inputErrorClass" type="text" id="emailAddress" spellcheck="false" autocomplete="email" aria-describedby="emailAddress-error" asp-for="EmailAddress" value="@Model.EmailAddress"/>
       </div>
 
       <button class="nhsuk-button" type="submit">Reset</button>

--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
@@ -2,13 +2,14 @@
 @model ForgotPasswordViewModel
 @{
   ViewData["Title"] = "Reset Your Password";
-  var inputErrorClass = !String.IsNullOrWhiteSpace(Model.EmailErrorMessage) ? "nhsuk-input--error" : "";
-  var formErrorClass = !String.IsNullOrWhiteSpace(Model.EmailErrorMessage) ? "nhsuk-form-group--error" : "";
+  bool errorHasOccurred = !String.IsNullOrWhiteSpace(Model.EmailErrorMessage);
+  var inputErrorClass = errorHasOccurred ? "nhsuk-input--error" : "";
+  var formErrorClass = errorHasOccurred ? "nhsuk-form-group--error" : "";
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    @if (!String.IsNullOrWhiteSpace(Model.EmailErrorMessage))
+    @if (errorHasOccurred)
     {
       <div class="nhsuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
         <h2 class="nhsuk-error-summary__title" id="error-summary-title">
@@ -31,7 +32,7 @@
         <label class="nhsuk-label nhsuk-u-margin-bottom-4" for="emailAddress">
           Enter your email address and we will send you password reset instructions.
         </label>
-        @if (!String.IsNullOrWhiteSpace(Model.EmailErrorMessage))
+        @if (errorHasOccurred)
         {
           <span class="nhsuk-error-message" id="emailAddress-error">
             <span class="nhsuk-u-visually-hidden">Error:</span> @Model.EmailErrorMessage


### PR DESCRIPTION
ForgotPassword controller has the post functionality implemented with some basic validation. This is hooked up to a new PasswordResetService that does most of the logic. A new basic UserService for getting AdminUsers or Delegates (Candidates) was introduced, as has an EmailService. 

Note that the NotificationService has been modified to now use the EmailService and has been sanity checked, but not properly tested.

Succeeded tests of:
- Manually tested IE11, Edge, Chrome, Firefox*
- Manually tested Chrome mobile view
- Manually tested No JS
- Tested with screen reader
- Ran all unit tests successfully.
*Firefox has a very old bug (see: https://bugzilla.mozilla.org/show_bug.cgi?id=308064 ) that prevents the error summary link from focusing on the input textbox as required by the NHS error summary description - discussion in the Show & Tell on 26th March 2021 confirmed that no workaround should be performed for this.

UI Change (/ForgotPassword page with error messages):
![ForgotPassword with errors](https://user-images.githubusercontent.com/80777689/112627382-7274e980-8e29-11eb-901e-904c5d14358b.PNG)
