### PR TITLE
HEEDLS-362: Integration tests

### DIFF
--- a/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
@@ -16,6 +16,8 @@ namespace DigitalLearningSolutions.Web.IntegrationTests
         [Theory]
         [InlineData("/Home")]
         [InlineData("/ForgotPassword")]
+        [InlineData("/LearningSolutions/AccessibilityHelp")]
+        [InlineData("/LearningSolutions/Terms")]
         public async Task EndpointIsUnauthenticated(string url)
         {
             // Arrange

--- a/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
@@ -1,0 +1,33 @@
+namespace DigitalLearningSolutions.Web.IntegrationTests
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc.Testing;
+    using Xunit;
+
+    public class AuthenticationTests: IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public AuthenticationTests(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Theory]
+        [InlineData("/Home")]
+        [InlineData("/ForgotPassword")]
+        public async Task EndpointIsUnauthenticated(string url)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions {
+                AllowAutoRedirect = false
+            });
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
@@ -4,11 +4,11 @@ namespace DigitalLearningSolutions.Web.IntegrationTests
     using Microsoft.AspNetCore.Mvc.Testing;
     using Xunit;
 
-    public class AuthenticationTests: IClassFixture<WebApplicationFactory<Startup>>
+    public class AuthenticationTests: IClassFixture<CustomWebApplicationFactory<Startup>>
     {
-        private readonly WebApplicationFactory<Startup> _factory;
+        private readonly CustomWebApplicationFactory<Startup> _factory;
 
-        public AuthenticationTests(WebApplicationFactory<Startup> factory)
+        public AuthenticationTests(CustomWebApplicationFactory<Startup> factory)
         {
             _factory = factory;
         }

--- a/DigitalLearningSolutions.Web.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,30 @@
+﻿namespace DigitalLearningSolutions.Web.IntegrationTests
+{
+    using System.Data;
+    using System.Linq;
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Mvc.Testing;
+    using Microsoft.Data.SqlClient;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public class CustomWebApplicationFactory<TStartup>
+        : WebApplicationFactory<TStartup> where TStartup: class
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                var defaultSqlConnection = services.SingleOrDefault(
+                    service => service.ServiceType == typeof(IDbConnection));
+
+                services.Remove(defaultSqlConnection);
+
+                var config = ConfigHelper.GetAppConfig();
+                var connectionString = config.GetConnectionString(ConfigHelper.UnitTestConnectionStringName);
+                services.AddScoped<IDbConnection>(_ => new SqlConnection(connectionString));
+            });
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.IntegrationTests/DigitalLearningSolutions.Web.IntegrationTests.csproj
+++ b/DigitalLearningSolutions.Web.IntegrationTests/DigitalLearningSolutions.Web.IntegrationTests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.13" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DigitalLearningSolutions.Web\DigitalLearningSolutions.Web.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/DigitalLearningSolutions.Web.IntegrationTests/Properties/launchSettings.json
+++ b/DigitalLearningSolutions.Web.IntegrationTests/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:58969/",
+      "sslPort": 44306
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "DigitalLearningSolutions.Web.IntegrationTests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/DigitalLearningSolutions.Web/Controllers/LearningSolutionsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningSolutionsController.cs
@@ -7,7 +7,6 @@
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
 
-    [Authorize(Policy = CustomPolicies.UserOnly)]
     public class LearningSolutionsController : Controller
     {
         private readonly IConfigService configService;

--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -85,6 +85,12 @@
     <TypeScriptCompile Include="Scripts\spec\sortCourses.spec.ts" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="tsconfig.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
     <Exec Command="npm install" />

--- a/DigitalLearningSolutions.sln
+++ b/DigitalLearningSolutions.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DigitalLearningSolutions.Da
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DigitalLearningSolutions.Data.Tests", "DigitalLearningSolutions.Data.Tests\DigitalLearningSolutions.Data.Tests.csproj", "{E3CA47F8-AFEE-4DF4-9D4E-356F02316E17}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DigitalLearningSolutions.Web.IntegrationTests", "DigitalLearningSolutions.Web.IntegrationTests\DigitalLearningSolutions.Web.IntegrationTests.csproj", "{D581EA71-51EE-4BE3-AFE4-07D175EEB039}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{E3CA47F8-AFEE-4DF4-9D4E-356F02316E17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E3CA47F8-AFEE-4DF4-9D4E-356F02316E17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E3CA47F8-AFEE-4DF4-9D4E-356F02316E17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D581EA71-51EE-4BE3-AFE4-07D175EEB039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D581EA71-51EE-4BE3-AFE4-07D175EEB039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D581EA71-51EE-4BE3-AFE4-07D175EEB039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D581EA71-51EE-4BE3-AFE4-07D175EEB039}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Set up basic integration tests:
1. Spin up a test server against which we can run some tests.
2. Use test database when running the tests.
3. Add some basic tests around authentication.
4. Make LearningSolution pages (accessibility help, terms) unauthenticated.

Further work:
Add running these tests to CI/CD pipeline.

Note that the build won't pass atm as some tests are broken due to the clocks change (fixing this is next thing on my list)