### PR TITLE
HEEDLS-NONE: Fix broken tests - use UTC time.

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/SessionTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/SessionTestHelper.cs
@@ -43,7 +43,7 @@
             bool active = true
         )
         {
-            loginTime ??= DateTime.Now;
+            loginTime ??= DateTime.UtcNow;
             return new Session(sessionId, candidateId, customisationId, loginTime.Value, duration, active);
         }
 

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseContentServiceTests.cs
@@ -885,7 +885,7 @@
 
                 // Then
                 const int twoMinutesInMilliseconds = 120000;
-                result.Should().BeCloseTo(DateTime.Now, twoMinutesInMilliseconds);
+                result.Should().BeCloseTo(DateTime.UtcNow, twoMinutesInMilliseconds);
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/SessionDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SessionDataServiceTests.cs
@@ -124,7 +124,7 @@
 
                 var activeSession = updatedSessions.First(session => session.SessionId == sessionId);
                 activeSession.LoginTime.AddMinutes(activeSession.Duration)
-                    .Should().BeCloseTo(DateTime.Now, twoMinutesInMilliseconds);
+                    .Should().BeCloseTo(DateTime.UtcNow, twoMinutesInMilliseconds);
             }
         }
 


### PR DESCRIPTION
Previously, default session was created not using UTC time. Hence, the clock changes made the tests failed because the expected time was +1 hour from UTC (British Summer Time). 