### PR TITLE
HEEDLS-336 - Added empty SignIn and Register pages with links from th…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -13,6 +13,18 @@
     {
         public IActionResult Index()
         {
+            if (User.Identity.IsAuthenticated)
+            {
+                return RedirectToAction("Index", "Home");
+            }
+
+            return View();
+        }
+
+        public IActionResult SignIn()
+        {
+            // TODO: HEEDLS-364 - Overwrite this old code for automatic sign in with new code that signs in the user
+
             var claims = new List<Claim>
             {
                 new Claim(ClaimTypes.Email, "kevin.whittaker1@nhs.net"),
@@ -44,7 +56,7 @@
                 IssuedUtc = DateTime.UtcNow
             };
             HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
-            return RedirectToAction("Current", "LearningPortal");
+            return RedirectToAction("Index", "Home");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/Register.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers
+{
+    using Microsoft.AspNetCore.Mvc;
+
+    public class Register : Controller
+    {
+        public IActionResult Index()
+        {
+            if (User.Identity.IsAuthenticated)
+            {
+                return RedirectToAction("Index", "Home");
+            }
+
+            return View();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/Home/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Home/Index.cshtml
@@ -2,4 +2,15 @@
   ViewData["Title"] = "Home";
 }
 
-<h1>Home</h1>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 id="page-heading">Home</h1>
+
+    <a class="nhsuk-button" asp-controller="Login" asp-action="Index">
+      Login
+    </a>
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Register" asp-action="Index">
+      Register
+    </a>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+  ViewData["Title"] = "Login";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 id="page-heading">Login</h1>
+    <a class="nhsuk-button" asp-controller="Login" asp-action="SignIn">
+      Sign in
+    </a>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -1,0 +1,9 @@
+﻿@{
+  ViewData["Title"] = "Register";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 id="page-heading">Register</h1>
+  </div>
+</div>


### PR DESCRIPTION
…e home page.

The new sign in and register pages have been made. The /Home landing page has buttons that take the user to these pages (unless they are already logged in, in which case it just reloads /Home again). The old code that automatically logged in as Kevin has been shifted to the SignIn button on the /Login index page so it can still be used while we don't have a proper log in system.

Manually tested IE11, Edge, Chrome, Firefox
Manually tested Chrome mobile view
Manually tested No JS
Tested with screen reader
Ran all unit tests successfully.

UI screen shots:
![Home](https://user-images.githubusercontent.com/80777689/112815255-063bf500-9078-11eb-8b4e-c083d702ea5b.PNG)
![Login](https://user-images.githubusercontent.com/80777689/112815257-06d48b80-9078-11eb-98ec-50b6d3c78ae2.PNG)
![Register](https://user-images.githubusercontent.com/80777689/112815259-06d48b80-9078-11eb-84db-bf1fa8f0f42a.PNG)
