### PR TITLE
HEEDLS-NONE: Render custom logo only if user is linked to a centre.

### DIFF
--- a/DigitalLearningSolutions.Web/ViewComponents/LogoViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/LogoViewComponent.cs
@@ -17,14 +17,13 @@ namespace DigitalLearningSolutions.Web.ViewComponents
 
         public IViewComponentResult Invoke(int? customisationId)
         {
-            // If the user is not logged in, render nothing for the logo
-            if (User.Identity?.IsAuthenticated != true)
+            var centreId = ((ClaimsPrincipal) User).GetCustomClaimAsInt(CustomClaimTypes.UserCentreId);
+            if (centreId == null)
             {
                 return View(new LogoViewModel(null));
             }
-            var centreId = ((ClaimsPrincipal) User).GetCentreId();
-            var customLogo = logoService.GetLogo(centreId, customisationId);
 
+            var customLogo = logoService.GetLogo(centreId, customisationId);
             var model = new LogoViewModel(customLogo);
             return View(model);
         }


### PR DESCRIPTION
Workaround on test environment to prevent app from crashing. This change is also required for the future, where a user could be authenticated using OpenID, but not be associated with any centres.