### PR TITLE
HEEDLS-363 - Basic login form with error display created

### DIFF
--- a/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/AuthenticationTests.cs
@@ -15,6 +15,7 @@ namespace DigitalLearningSolutions.Web.IntegrationTests
 
         [Theory]
         [InlineData("/Home")]
+        [InlineData("/Login")]
         [InlineData("/ForgotPassword")]
         [InlineData("/LearningSolutions/AccessibilityHelp")]
         [InlineData("/LearningSolutions/Terms")]

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Security.Claims;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Login;
@@ -23,8 +24,7 @@
         }
 
         [HttpPost]
-        [Route("/Login")]
-        public IActionResult Login(LoginViewModel model)
+        public IActionResult Index(LoginViewModel model)
         {
             // TODO: HEEDLS-364 - Overwrite this old code for automatic sign in with new code that signs in the user after validation
             if (model.Username?.ToLower() == "testusernameerror")

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Security.Claims;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ViewModels.Login;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.FeatureManagement.Mvc;
@@ -21,9 +22,25 @@
             return View();
         }
 
-        public IActionResult SignIn()
+        [HttpPost]
+        [Route("/Login")]
+        public IActionResult Login(LoginViewModel model)
         {
-            // TODO: HEEDLS-364 - Overwrite this old code for automatic sign in with new code that signs in the user
+            // TODO: HEEDLS-364 - Overwrite this old code for automatic sign in with new code that signs in the user after validation
+            if (model.Username?.ToLower() == "testusernameerror")
+            {
+                ModelState.AddModelError("username", "There is a username error.");
+            }
+
+            if (model.Username?.ToLower() == "testpassworderror")
+            {
+                ModelState.AddModelError("password", "There is a password error.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View("Index", model);
+            }
 
             var claims = new List<Claim>
             {

--- a/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
@@ -1,0 +1,23 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Login
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class LoginViewModel
+    {
+        public LoginViewModel()
+        {
+            Username = string.Empty;
+            Password = string.Empty;
+            RememberMe = false;
+        }
+
+        [Required]
+        public string Username { get; set; }
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; }
+
+        public bool RememberMe { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
@@ -11,16 +11,13 @@
             RememberMe = false;
         }
 
-        [Display(Order = -1)]
         [Required(ErrorMessage = "Please enter a username to log in.")]
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
-        [Display(Order = 2)]
         [Required (ErrorMessage = "Please enter a password to log in.")]
         [DataType(DataType.Password)]
-        public string Password { get; set; }
+        public string? Password { get; set; }
 
-        [Display(Order = 3)]
         public bool RememberMe { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
@@ -11,13 +11,16 @@
             RememberMe = false;
         }
 
-        [Required]
+        [Display(Order = -1)]
+        [Required(ErrorMessage = "Please enter a username to log in.")]
         public string Username { get; set; }
 
-        [Required]
+        [Display(Order = 2)]
+        [Required (ErrorMessage = "Please enter a password to log in.")]
         [DataType(DataType.Password)]
         public string Password { get; set; }
 
+        [Display(Order = 3)]
         public bool RememberMe { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -1,12 +1,82 @@
-﻿@{
+﻿@using DigitalLearningSolutions.Web.ViewModels.Login
+@model LoginViewModel 
+@{
   ViewData["Title"] = "Login";
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+  var usernameError = ViewData.ModelState["Username"]?.Errors?.Count > 0;
+  var passwordError = ViewData.ModelState["Password"]?.Errors?.Count > 0;
+  var passwordInputErrorClass = passwordError ? "nhsuk-input--error" : "";
+  var passwordFormErrorClass = passwordError ? "nhsuk-form-group--error" : "";
+  var usernameInputErrorClass = usernameError ? "nhsuk-input--error" : "";
+  var usernameFormGroupError = usernameError ? "nhsuk-form-group--error" : "";
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">Login</h1>
-    <a class="nhsuk-button" asp-controller="Login" asp-action="SignIn">
-      Sign in
+    <form method="post" novalidate asp-action="Login">
+
+      @if (errorHasOccurred) {
+        <partial name="_ErrorSummary"/>
+      }
+
+      <h1 id="page-heading">Login</h1>
+      <p>Enter your details to log into your account.</p>
+
+      <div class="nhsuk-form-group @usernameFormGroupError">
+        <label class="nhsuk-label" for="Username">
+          Email or user ID
+        </label>
+        @if (usernameError) {
+          <span class="nhsuk-error-message" id="username-error">
+            @foreach (var error in ViewData.ModelState["Username"].Errors) {
+              <span class="nhsuk-u-visually-hidden">Error:</span> @error.ErrorMessage
+            }
+          </span>
+        }
+        <input class="nhsuk-input nhsuk-u-width-one-half nhsuk-u-margin-bottom-4 @usernameInputErrorClass" type="text" id="Username" spellcheck="false" autocomplete="email" aria-describedby="username-error" asp-for="Username" />
+      </div>
+
+      <div class="nhsuk-form-group @passwordFormErrorClass">
+        <label class="nhsuk-label" for="Password">
+          Password
+        </label>
+        @if (passwordError) {
+          <span class="nhsuk-error-message" id="password-error">
+            @foreach (var error in ViewData.ModelState["Password"].Errors) {
+              <span class="nhsuk-u-visually-hidden">Error:</span> @error.ErrorMessage
+            }
+          </span>
+        }
+        <input class="nhsuk-input nhsuk-u-width-one-half nhsuk-u-margin-bottom-4 @passwordInputErrorClass" type="password" id="Password" spellcheck="false" aria-describedby="password-error" asp-for="Password" />
+      </div>
+
+      <div class="nhsuk-checkboxes__item">
+        @Html.CheckBoxFor(model => model.RememberMe, new { @class = "nhsuk-checkboxes__input", id = "RememberMe" })
+        <label class="nhsuk-label nhsuk-checkboxes__label" for="RememberMe">
+          Remember Me
+        </label>
+      </div>
+
+      <div class="nhsuk-inset-text">
+        <span class="nhsuk-u-visually-hidden">Information: </span>
+        <p>
+          By logging in, I consent to my details being stored and processed in line with your
+          <a class="" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy</a>
+          and agree to use the system according to
+          <a class="" asp-controller="LearningSolutions" asp-action="Terms">Terms of Use</a>
+        </p>
+      </div>
+
+      <button class="nhsuk-button" type="submit">Login</button>
+      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-5" asp-controller="ForgotPassword" asp-action="Index">
+        Forgot Password
+      </a>
+    </form>
+
+    <p>Alternatively, if you are a new user, register:</p>
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Register" asp-action="Index">
+      Register
     </a>
+
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -1,14 +1,14 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Login
 @model LoginViewModel 
 @{
-    var errorHasOccurred = !ViewData.ModelState.IsValid;
-    ViewData["Title"] = errorHasOccurred ? "Error: Log in" : "Log in";
-    var usernameError = ViewData.ModelState["Username"]?.Errors?.Count > 0;
-    var passwordError = ViewData.ModelState["Password"]?.Errors?.Count > 0;
-    var passwordInputErrorClass = passwordError ? "nhsuk-input--error" : "";
-    var passwordFormErrorClass = passwordError ? "nhsuk-form-group--error" : "";
-    var usernameInputErrorClass = usernameError ? "nhsuk-input--error" : "";
-    var usernameFormGroupError = usernameError ? "nhsuk-form-group--error" : "";
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+  ViewData["Title"] = errorHasOccurred ? "Error: Log in" : "Log in";
+  var usernameError = ViewData.ModelState["Username"]?.Errors?.Count > 0;
+  var passwordError = ViewData.ModelState["Password"]?.Errors?.Count > 0;
+  var passwordInputErrorClass = passwordError ? "nhsuk-input--error" : "";
+  var passwordFormErrorClass = passwordError ? "nhsuk-form-group--error" : "";
+  var usernameInputErrorClass = usernameError ? "nhsuk-input--error" : "";
+  var usernameFormGroupError = usernameError ? "nhsuk-form-group--error" : "";
 }
 
 <div class="nhsuk-grid-row">
@@ -32,7 +32,7 @@
             <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState["Username"].Errors[0].ErrorMessage
           </span>
         }
-        <input class="nhsuk-input nhsuk-u-width-one-half @usernameInputErrorClass" type="text" id="Username" spellcheck="false" autocomplete="email" aria-describedby="username-error" asp-for="Username" />
+        <input class="nhsuk-input nhsuk-u-width-one-half @usernameInputErrorClass" type="text" id="Username" spellcheck="false" autocomplete="email" aria-describedby="username-error" asp-for="Username"/>
       </div>
 
       <div class="nhsuk-form-group @passwordFormErrorClass">
@@ -40,15 +40,15 @@
           Password
         </label>
         @if (passwordError) {
-      <span class="nhsuk-error-message" id="password-error">
-        <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState["Password"].Errors[0].ErrorMessage
-      </span>
+          <span class="nhsuk-error-message" id="password-error">
+            <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState["Password"].Errors[0].ErrorMessage
+          </span>
         }
-        <input class="nhsuk-input nhsuk-u-width-one-half @passwordInputErrorClass" type="password" id="Password" spellcheck="false" aria-describedby="password-error" asp-for="Password" />
+        <input class="nhsuk-input nhsuk-u-width-one-half @passwordInputErrorClass" type="password" id="Password" spellcheck="false" aria-describedby="password-error" asp-for="Password"/>
       </div>
 
       <div class="nhsuk-checkboxes__item">
-        <input class="nhsuk-checkboxes__input" type="checkbox" id="RememberMe" spellcheck="false" asp-for="RememberMe" />
+        <input class="nhsuk-checkboxes__input" type="checkbox" id="RememberMe" spellcheck="false" asp-for="RememberMe"/>
         <label class="nhsuk-label nhsuk-checkboxes__label" for="RememberMe">
           Remember Me
         </label>

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -1,7 +1,8 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Login
 @model LoginViewModel 
 @{
-  ViewData["Title"] = "Login";
+  ViewData["Title"] = "Log in";
+  //ViewBag["ErrorSummaryOrder"] = new [] { "Username", "Password", "RememberMe" };
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   var usernameError = ViewData.ModelState["Username"]?.Errors?.Count > 0;
   var passwordError = ViewData.ModelState["Password"]?.Errors?.Count > 0;
@@ -13,14 +14,15 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <form method="post" novalidate asp-action="Login">
+    <form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="Index">
 
       @if (errorHasOccurred) {
         <partial name="_ErrorSummary"/>
       }
-
-      <h1 id="page-heading">Login</h1>
-      <p>Enter your details to log into your account.</p>
+      <div class="nhsuk-u-margin-bottom-8">
+        <h1 id="page-heading">Log in</h1>
+        <p class="nhsuk-body-l">Enter your details to log into your account.</p>
+      </div>
 
       <div class="nhsuk-form-group @usernameFormGroupError">
         <label class="nhsuk-label" for="Username">
@@ -28,12 +30,10 @@
         </label>
         @if (usernameError) {
           <span class="nhsuk-error-message" id="username-error">
-            @foreach (var error in ViewData.ModelState["Username"].Errors) {
-              <span class="nhsuk-u-visually-hidden">Error:</span> @error.ErrorMessage
-            }
+            <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState["Username"].Errors[0].ErrorMessage
           </span>
         }
-        <input class="nhsuk-input nhsuk-u-width-one-half nhsuk-u-margin-bottom-4 @usernameInputErrorClass" type="text" id="Username" spellcheck="false" autocomplete="email" aria-describedby="username-error" asp-for="Username" />
+        <input class="nhsuk-input nhsuk-u-width-one-half @usernameInputErrorClass" type="text" id="Username" spellcheck="false" autocomplete="email" aria-describedby="username-error" asp-for="Username" />
       </div>
 
       <div class="nhsuk-form-group @passwordFormErrorClass">
@@ -41,39 +41,37 @@
           Password
         </label>
         @if (passwordError) {
-          <span class="nhsuk-error-message" id="password-error">
-            @foreach (var error in ViewData.ModelState["Password"].Errors) {
-              <span class="nhsuk-u-visually-hidden">Error:</span> @error.ErrorMessage
-            }
-          </span>
+      <span class="nhsuk-error-message" id="password-error">
+        <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState["Password"].Errors[0].ErrorMessage
+      </span>
         }
-        <input class="nhsuk-input nhsuk-u-width-one-half nhsuk-u-margin-bottom-4 @passwordInputErrorClass" type="password" id="Password" spellcheck="false" aria-describedby="password-error" asp-for="Password" />
+        <input class="nhsuk-input nhsuk-u-width-one-half @passwordInputErrorClass" type="password" id="Password" spellcheck="false" aria-describedby="password-error" asp-for="Password" />
       </div>
 
       <div class="nhsuk-checkboxes__item">
-        @Html.CheckBoxFor(model => model.RememberMe, new { @class = "nhsuk-checkboxes__input", id = "RememberMe" })
+        <input class="nhsuk-checkboxes__input" type="checkbox" id="RememberMe" spellcheck="false" asp-for="RememberMe" />
         <label class="nhsuk-label nhsuk-checkboxes__label" for="RememberMe">
           Remember Me
         </label>
       </div>
 
-      <div class="nhsuk-inset-text">
+      <div class="nhsuk-inset-text nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4">
         <span class="nhsuk-u-visually-hidden">Information: </span>
         <p>
           By logging in, I consent to my details being stored and processed in line with your
-          <a class="" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy</a>
+          <a href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy</a>
           and agree to use the system according to
-          <a class="" asp-controller="LearningSolutions" asp-action="Terms">Terms of Use</a>
+          <a asp-controller="LearningSolutions" asp-action="Terms">Terms of Use</a>
         </p>
       </div>
 
-      <button class="nhsuk-button" type="submit">Login</button>
-      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-5" asp-controller="ForgotPassword" asp-action="Index">
-        Forgot Password
+      <button class="nhsuk-button" type="submit">Log in</button>
+      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="ForgotPassword" asp-action="Index">
+        Forgot password
       </a>
     </form>
 
-    <p>Alternatively, if you are a new user, register:</p>
+    <p class="nhsuk-u-font-size-24">Alternatively, if you are a new user, register:</p>
     <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Register" asp-action="Index">
       Register
     </a>

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -1,15 +1,14 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Login
 @model LoginViewModel 
 @{
-  ViewData["Title"] = "Log in";
-  //ViewBag["ErrorSummaryOrder"] = new [] { "Username", "Password", "RememberMe" };
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  var usernameError = ViewData.ModelState["Username"]?.Errors?.Count > 0;
-  var passwordError = ViewData.ModelState["Password"]?.Errors?.Count > 0;
-  var passwordInputErrorClass = passwordError ? "nhsuk-input--error" : "";
-  var passwordFormErrorClass = passwordError ? "nhsuk-form-group--error" : "";
-  var usernameInputErrorClass = usernameError ? "nhsuk-input--error" : "";
-  var usernameFormGroupError = usernameError ? "nhsuk-form-group--error" : "";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Log in" : "Log in";
+    var usernameError = ViewData.ModelState["Username"]?.Errors?.Count > 0;
+    var passwordError = ViewData.ModelState["Password"]?.Errors?.Count > 0;
+    var passwordInputErrorClass = passwordError ? "nhsuk-input--error" : "";
+    var passwordFormErrorClass = passwordError ? "nhsuk-form-group--error" : "";
+    var usernameInputErrorClass = usernameError ? "nhsuk-input--error" : "";
+    var usernameFormGroupError = usernameError ? "nhsuk-form-group--error" : "";
 }
 
 <div class="nhsuk-grid-row">


### PR DESCRIPTION
The page at /Login now has a basic form for entering details, however the actual logging in functionality does not exist. The error display also has been implemented. Entering the username as "TestUsernameError" or "TestPasswordError" will prevent the automatic log in and allows the UI to display the appropriate errors. The "Remember Me" checkbox is also present, but is non-functional as that will also be dealt with in a different ticket.

Tested with:
- IE11, Edge, Chrome, Firefox
- Chrome mobile view
- No javascript
- With Screen Reader
- Ran all unit tests

There are a couple of things worth noting: 
- Keyboard Focus is not set to the Error Summary when it is first displayed.
- When using NV Access screen reader in Browse Mode, the visual/keyboard focus can differ from normal when encountering errors.

UI screen shots below, one as the basic Login page, one with sample errors displayed (page is partially cropped to focus on the errors).

![Login](https://user-images.githubusercontent.com/80777689/113151874-717af800-922d-11eb-88ab-535e873a572c.PNG)

![Login With errors](https://user-images.githubusercontent.com/80777689/113151871-70e26180-922d-11eb-87ec-eaad14c24c92.PNG)