### PR TITLE
HEEDLS-344: Add 'My Account' page without details expandable

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/CentresServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CentresServiceTests.cs
@@ -45,5 +45,25 @@
             // Then
             result.Should().BeNull();
         }
+
+        [Test]
+        public void Get_centre_name_should_return_the_correct_value()
+        {
+            // When
+            var result = centresService.GetCentreName(2);
+
+            // Then
+            result.Should().Be("North West Boroughs Healthcare NHS Foundation Trust");
+        }
+
+        [Test]
+        public void Get_centre_name_should_return_null_when_the_centre_does_not_exist()
+        {
+            // When
+            var result = centresService.GetCentreName(1);
+
+            // Then
+            result.Should().BeNull();
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CentresServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CentresServiceTests.cs
@@ -2,7 +2,9 @@
 {
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
+    using FakeItEasy;
     using FluentAssertions;
+    using Microsoft.Extensions.Logging;
     using NUnit.Framework;
 
     public class CentresServiceTests
@@ -13,7 +15,8 @@
         public void Setup()
         {
             var connection = ServiceTestHelper.GetDatabaseConnection();
-            centresService = new CentresService(connection);
+            var logger = A.Fake<ILogger<CentresService>>();
+            centresService = new CentresService(connection, logger);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Data/Services/CentresService.cs
@@ -1,7 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
-    using System.Data;
     using Dapper;
+    using System.Data;
 
     public interface ICentresService
     {

--- a/DigitalLearningSolutions.Data/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Data/Services/CentresService.cs
@@ -6,6 +6,7 @@
     public interface ICentresService
     {
         string? GetBannerText(int centreId);
+        string? GetCentreName(int centreId);
     }
 
     public class CentresService : ICentresService
@@ -21,6 +22,16 @@
         {
             return connection.QueryFirstOrDefault<string?>(
                 @"SELECT BannerText
+                        FROM Centres
+                        WHERE CentreID = @centreId",
+                new { centreId }
+            );
+        }
+
+        public string? GetCentreName(int centreId)
+        {
+            return connection.QueryFirstOrDefault<string?>(
+                @"SELECT CentreName
                         FROM Centres
                         WHERE CentreID = @centreId",
                 new { centreId }

--- a/DigitalLearningSolutions.Data/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Data/Services/CentresService.cs
@@ -45,6 +45,8 @@
                     $"No centre found for centre id {centreId}"
                 );
             }
+
+            return name;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Data/Services/CentresService.cs
@@ -13,9 +13,9 @@
     public class CentresService : ICentresService
     {
         private readonly IDbConnection connection;
-        private readonly ILogger<CourseService> logger;
+        private readonly ILogger<CentresService> logger;
 
-        public CentresService(IDbConnection connection, ILogger<CourseService> logger)
+        public CentresService(IDbConnection connection, ILogger<CentresService> logger)
         {
             this.connection = connection;
             this.logger = logger;

--- a/DigitalLearningSolutions.Data/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Data/Services/CentresService.cs
@@ -2,6 +2,7 @@
 {
     using Dapper;
     using System.Data;
+    using Microsoft.Extensions.Logging;
 
     public interface ICentresService
     {
@@ -12,10 +13,12 @@
     public class CentresService : ICentresService
     {
         private readonly IDbConnection connection;
+        private readonly ILogger<CourseService> logger;
 
-        public CentresService(IDbConnection connection)
+        public CentresService(IDbConnection connection, ILogger<CourseService> logger)
         {
             this.connection = connection;
+            this.logger = logger;
         }
 
         public string? GetBannerText(int centreId)
@@ -30,12 +33,18 @@
 
         public string? GetCentreName(int centreId)
         {
-            return connection.QueryFirstOrDefault<string?>(
+            var name = connection.QueryFirstOrDefault<string?>(
                 @"SELECT CentreName
                         FROM Centres
                         WHERE CentreID = @centreId",
                 new { centreId }
             );
+            if (name == null)
+            {
+                logger.LogWarning(
+                    $"No centre found for centre id {centreId}"
+                );
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -8,6 +8,7 @@
     public class MyAccountController : Controller
     {
         private readonly ICentresService centresService;
+
         public MyAccountController(ICentresService centresService)
         {
             this.centresService = centresService;

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace DigitalLearningSolutions.Web.Controllers
+﻿namespace DigitalLearningSolutions.Web.Controllers
 {
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DigitalLearningSolutions.Web.Controllers
+{
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ViewModels.MyAccount;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class MyAccountController : Controller
+    {
+        private readonly ICentresService centresService;
+        public MyAccountController(ICentresService centresService)
+        {
+            this.centresService = centresService;
+        }
+
+        public IActionResult Index()
+        {
+            if (!User.Identity.IsAuthenticated)
+            {
+                return RedirectToAction("Index", "Login");
+            }
+
+            var userEmail = User.GetEmail();
+            var delegateId = User.GetCustomClaim(CustomClaimTypes.LearnCandidateNumber);
+            var centreId = User.GetCentreId();
+            var centreName = centresService.GetCentreName(centreId);
+
+            var model = new MyAccountViewModel(centreName, userEmail, delegateId);
+            return View(model);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Styles/myAccount/myAccount.scss
+++ b/DigitalLearningSolutions.Web/Styles/myAccount/myAccount.scss
@@ -1,7 +1,5 @@
 ﻿@import "~nhsuk-frontend/packages/core/all";
 
-$nhs-dark-grey: #425563;
-
 .account-card-content {
   padding: 16px 32px;
 }

--- a/DigitalLearningSolutions.Web/Styles/myAccount/myAccount.scss
+++ b/DigitalLearningSolutions.Web/Styles/myAccount/myAccount.scss
@@ -3,22 +3,19 @@
 $nhs-dark-grey: #425563;
 
 .account-card-content {
-  padding-top: 16px;
-  padding-bottom: 16px;
-  padding-left: 32px;
-  padding-right: 32px;
+  padding: 16px 32px;
 }
 
 .account-summarylist_row:last-child {
-  border: 0;
-  margin-bottom: 0px;
+  border: none;
+  margin-bottom: 0;
 }
 
 .account-summarylist_row:last-child .nhsuk-summary-list__key {
-  border: 0;
+  border: none;
 }
 
 .account-summarylist_row:last-child .nhsuk-summary-list__value {
-  border: 0;
+  border: none;
   margin-bottom: 0px;
 }

--- a/DigitalLearningSolutions.Web/Styles/myAccount/myAccount.scss
+++ b/DigitalLearningSolutions.Web/Styles/myAccount/myAccount.scss
@@ -1,0 +1,24 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+$nhs-dark-grey: #425563;
+
+.account-card-content {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-left: 32px;
+  padding-right: 32px;
+}
+
+.account-summarylist_row:last-child {
+  border: 0;
+  margin-bottom: 0px;
+}
+
+.account-summarylist_row:last-child .nhsuk-summary-list__key {
+  border: 0;
+}
+
+.account-summarylist_row:last-child .nhsuk-summary-list__value {
+  border: 0;
+  margin-bottom: 0px;
+}

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
+{
+    public class MyAccountViewModel
+    {
+        public MyAccountViewModel(string? centreName, string? userEmail, string? delegateId)
+        {
+            Centre = centreName;
+            User = userEmail;
+            DelegateId = delegateId;
+        }
+
+        public string? Centre { get; set; }
+
+        public string? User { get; set; }
+
+        public string? DelegateId { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
+﻿namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
 {
     public class MyAccountViewModel
     {

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -1,0 +1,67 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.MyAccount
+@using Microsoft.Extensions.Configuration
+@model MyAccountViewModel
+
+@inject IConfiguration Configuration
+
+@{
+  ViewData["Title"] = "My Account";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 id="page-heading">My account</h1>
+
+    <div class="nhsuk-card">
+      <div class="nhsuk-card__content">
+        <dl class="nhsuk-summary-list">
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+              Centre:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.Centre
+            </dd>
+          </div>
+
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+              User:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.User
+            </dd>
+
+          </div>
+
+          @if (Model.DelegateId?.Length > 0)
+          {
+            <div class="nhsuk-summary-list__row">
+              <dt class="nhsuk-summary-list__key">
+                Delegate id:
+              </dt>
+              <dd class="nhsuk-summary-list__value">
+                @Model.DelegateId
+              </dd>
+            </div>
+          }
+
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <a class="nhsuk-button">
+      Manage notifications
+    </a>
+  </div>
+</div>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <a class="nhsuk-button nhsuk-button--secondary" href="@Configuration["CurrentSystemBaseUrl"]/logout">
+      Sign out
+    </a>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -4,18 +4,20 @@
 
 @inject IConfiguration Configuration
 
+<link rel="stylesheet" href="@Url.Content("~/css/myAccount/myAccount.css")" asp-append-version="true">
+
 @{
   ViewData["Title"] = "My Account";
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">My account</h1>
+    <h1 id="app-page-heading">My account</h1>
 
     <div class="nhsuk-card">
-      <div class="nhsuk-card__content">
+      <div class="nhsuk-card__content account-card-content">
         <dl class="nhsuk-summary-list">
-          <div class="nhsuk-summary-list__row">
+          <div class="nhsuk-summary-list__row account-summarylist_row">
             <dt class="nhsuk-summary-list__key">
               Centre:
             </dt>
@@ -24,19 +26,21 @@
             </dd>
           </div>
 
-          <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-              User:
-            </dt>
-            <dd class="nhsuk-summary-list__value">
-              @Model.User
-            </dd>
-
-          </div>
+          @if (Model.User?.Length > 0)
+          {
+            <div class="nhsuk-summary-list__row account-summarylist_row">
+              <dt class="nhsuk-summary-list__key">
+                User:
+              </dt>
+              <dd class="nhsuk-summary-list__value">
+                @Model.User
+              </dd>
+            </div>
+          }
 
           @if (Model.DelegateId?.Length > 0)
           {
-            <div class="nhsuk-summary-list__row">
+            <div class="nhsuk-summary-list__row account-summarylist_row">
               <dt class="nhsuk-summary-list__key">
                 Delegate id:
               </dt>
@@ -45,7 +49,6 @@
               </dd>
             </div>
           }
-
         </dl>
       </div>
     </div>


### PR DESCRIPTION
This creates the MyAccount page as specified on HEEDLS-344. It doesn't create any way to get to that page except by entering the URL directly, as one wasn't specified on the ticket and I assumed it was to be added later.