### PR TITLE
HEEDLS-352 Add Sign In/Register links between login pages

### DIFF
--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
@@ -11,7 +11,7 @@
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred)
     {
-      <partial name="_ErrorSummary"/>
+      <partial name="_ErrorSummary" />
     }
 
     <h1 id="page-heading" class="nhsuk-u-margin-bottom-6">Reset your password</h1>
@@ -27,11 +27,21 @@
             <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState["EmailAddress"].Errors[0].ErrorMessage
           </span>
         }
-        <input class="nhsuk-input nhsuk-u-width-one-half @inputErrorClass" type="text" id="EmailAddress" spellcheck="false" autocomplete="email" aria-describedby="EmailAddress-error" asp-for="EmailAddress"/>
+        <input class="nhsuk-input nhsuk-u-width-one-half @inputErrorClass" type="text" id="EmailAddress" spellcheck="false" autocomplete="email" aria-describedby="EmailAddress-error" asp-for="EmailAddress" />
       </div>
 
       <button class="nhsuk-button" type="submit">Reset</button>
     </form>
+
+    <p class="nhsuk-u-font-size-24">
+      Alternatively, sign in or register for an account:
+    </p>
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index">
+      Sign in
+    </a>
+    <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="Register" asp-action="Index">
+      Register
+    </a>
 
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -6,4 +6,11 @@
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">Register</h1>
   </div>
+
+  <p class="nhsuk-u-font-size-24">
+    Alternatively, if you already have an account, sign in:
+  </p>
+  <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index">
+    Sign in
+  </a>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -5,12 +5,12 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">Register</h1>
-  </div>
 
-  <p class="nhsuk-u-font-size-24">
-    Alternatively, if you already have an account, sign in:
-  </p>
-  <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index">
-    Sign in
-  </a>
+    <p class="nhsuk-u-font-size-24">
+      Alternatively, if you already have an account, sign in:
+    </p>
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index">
+      Sign in
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
Added the Sign In and Register links between the Register and ForgotPassword pages and checked the existing ones on the Login page.

Checked that they display and work OK in Chrome/Firefox/IE and on Edge with no JS, and that there is no layout strangeness at mobile sizes.

ForgotPassword:
![image](https://user-images.githubusercontent.com/59561751/114198131-e2679180-994a-11eb-99fb-cfff82ae9b7f.png)

Register:
![image](https://user-images.githubusercontent.com/59561751/114198164-edbabd00-994a-11eb-8a8e-63a581f0fb78.png)
