### PR TITLE
HEEDLS-387: Use consistent wording for logging in and out across site.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
@@ -34,10 +34,10 @@
     </form>
 
     <p class="nhsuk-u-font-size-24">
-      Alternatively, sign in or register for an account:
+      Alternatively, log in or register for an account:
     </p>
     <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index" role="button">
-      Sign in
+      Log in
     </a>
     <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="Register" asp-action="Index" role="button">
       Register

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -64,7 +64,7 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <a class="nhsuk-button nhsuk-button--secondary" href="@Configuration["CurrentSystemBaseUrl"]/logout">
-      Sign out
+      Log out
     </a>
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -7,10 +7,10 @@
     <h1 id="page-heading">Register</h1>
 
     <p class="nhsuk-u-font-size-24">
-      Alternatively, if you already have an account, sign in:
+      Alternatively, if you already have an account, log in:
     </p>
     <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index" role="button">
-      Sign in
+      Log in
     </a>
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -125,7 +125,7 @@
             @if (!User.Identity.IsAuthenticated) {
               <li class="nhsuk-header__navigation-item">
                 <a class="nhsuk-header__navigation-link" href="@Configuration["AppRootPath"]/Login">
-                  Sign in
+                  Log in
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
                   </svg>


### PR DESCRIPTION
Replace "Sign in" with "Log in" and "Sign out" with "Log out" across the site.
I did not change the "Login" into "Log in" on the landing page, because this will be handled as part of HEEDLS-338.