### PR TITLE
Heedls 341 old content in iframes

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers
+{
+    using Microsoft.AspNetCore.Mvc;
+
+    [Route("FindYourCentre")]
+    public class FindYourCentreController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
@@ -2,7 +2,6 @@
 {
     using Microsoft.AspNetCore.Mvc;
 
-    [Route("FindYourCentre")]
     public class FindYourCentreController : Controller
     {
         public IActionResult Index()

--- a/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
@@ -1,0 +1,34 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers
+{
+    using DigitalLearningSolutions.Web.ViewModels.LearningContent;
+    using Microsoft.AspNetCore.Mvc;
+
+    [Route("LearningContent")]
+    public class LearningContentController : Controller
+    {
+        private const string ItSkillsPathwayBrand = "ITSkillsPathway";
+        private const string ReasonableAdjustmentFlagBrand = "ReasonableAdjustmentFlag";
+        public const string TerminologyAndClassificationsDeliveryServiceBrand = "TerminologyandClassificationsDeliveryService";
+
+        [Route("ITSkillsPathway")]
+        public IActionResult ItSkillsPathway()
+        {
+            var model = new LearningContentViewModel(ItSkillsPathwayBrand);
+            return View("Index", model);
+        }
+
+        [Route("ReasonableAdjustmentFlag")]
+        public IActionResult ReasonableAdjustmentFlag()
+        {
+            var model = new LearningContentViewModel(ReasonableAdjustmentFlagBrand);
+            return View("Index", model);
+        }
+
+        [Route("TerminologyandClassificationsDeliveryService")]
+        public IActionResult TerminologyAndClassificationsDeliveryService()
+        {
+            var model = new LearningContentViewModel(TerminologyAndClassificationsDeliveryServiceBrand);
+            return View("Index", model);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
@@ -3,28 +3,24 @@
     using DigitalLearningSolutions.Web.ViewModels.LearningContent;
     using Microsoft.AspNetCore.Mvc;
 
-    [Route("LearningContent")]
     public class LearningContentController : Controller
     {
         private const string ItSkillsPathwayBrand = "ITSkillsPathway";
         private const string ReasonableAdjustmentFlagBrand = "ReasonableAdjustmentFlag";
         public const string TerminologyAndClassificationsDeliveryServiceBrand = "TerminologyandClassificationsDeliveryService";
-
-        [Route("ITSkillsPathway")]
+        
         public IActionResult ItSkillsPathway()
         {
             var model = new LearningContentViewModel(ItSkillsPathwayBrand);
             return View("Index", model);
         }
-
-        [Route("ReasonableAdjustmentFlag")]
+        
         public IActionResult ReasonableAdjustmentFlag()
         {
             var model = new LearningContentViewModel(ReasonableAdjustmentFlagBrand);
             return View("Index", model);
         }
-
-        [Route("TerminologyandClassificationsDeliveryService")]
+        
         public IActionResult TerminologyAndClassificationsDeliveryService()
         {
             var model = new LearningContentViewModel(TerminologyAndClassificationsDeliveryServiceBrand);

--- a/DigitalLearningSolutions.Web/Controllers/PricingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/PricingController.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers
+{
+    using Microsoft.AspNetCore.Mvc;
+
+    [Route("Pricing")]
+    public class PricingController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/PricingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/PricingController.cs
@@ -1,8 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
     using Microsoft.AspNetCore.Mvc;
-
-    [Route("Pricing")]
+    
     public class PricingController : Controller
     {
         public IActionResult Index()

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -61,8 +61,26 @@ h1#page-heading {
   margin-bottom: 16px;
 }
 
+#maincontentwrapper {
+  display: flex;
+}
+
+.nhsuk-main-wrapper {
+  flex: 1;
+}
+
+.responsive-iframe-wrapper {
+  height: 100%;
+  flex: 1 1 auto;
+  display: flex;
+}
+
+.responsive-iframe-wrapper-padding {
+  padding-bottom: nhsuk-spacing(7);
+}
+
 .responsive-iframe {
   width: 100%;
-  min-height: 500px;
+  height: 100%;
 }
 

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -61,3 +61,8 @@ h1#page-heading {
   margin-bottom: 16px;
 }
 
+.responsive-iframe {
+  width: 100%;
+  min-height: 500px;
+}
+

--- a/DigitalLearningSolutions.Web/ViewComponents/BackLinkViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/BackLinkViewComponent.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using DigitalLearningSolutions.Web.ViewModels.Common;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class BackLinkViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(string aspController, string aspAction)
+        {
+            return View(new BackLinkViewModel(aspController, aspAction));
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/BackLinkViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/BackLinkViewModel.cs
@@ -1,0 +1,15 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common
+{
+    public class BackLinkViewModel
+    {
+        public readonly string AspAction;
+
+        public readonly string AspController;
+
+        public BackLinkViewModel(string aspController, string aspAction)
+        {
+            AspAction = aspAction;
+            AspController = aspController;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningContent/LearningContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningContent/LearningContentViewModel.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningContent
+{
+    public class LearningContentViewModel
+    {
+        public readonly string Brand;
+
+        public LearningContentViewModel(string brand)
+        {
+            Brand = brand;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
@@ -1,0 +1,9 @@
+﻿@using DigitalLearningSolutions.Web.Helpers
+@{
+  ViewData["Title"] = "Find Your Centre";
+  var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
+}
+
+<div class="nhsuk-grid-row">
+  <iframe class="responsive-iframe" src="@url"></iframe>
+</div>

--- a/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
@@ -4,6 +4,6 @@
   var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
 }
 
-<div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row responsive-iframe-wrapper">
   <iframe class="responsive-iframe" src="@url"></iframe>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
@@ -12,6 +12,6 @@
 <div class="nhsuk-grid-row">
   <vc:back-link asp-controller="Home" asp-action="Index"></vc:back-link>
 </div>
-<div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row responsive-iframe-wrapper responsive-iframe-wrapper-padding">
   <iframe class="responsive-iframe" src="@url"></iframe>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
@@ -1,0 +1,17 @@
+﻿@using DigitalLearningSolutions.Web.Helpers
+@using Microsoft.Extensions.Configuration
+
+@inject IConfiguration Configuration
+
+@model DigitalLearningSolutions.Web.ViewModels.LearningContent.LearningContentViewModel
+@{
+  ViewData["Title"] = "Learning Content";
+  var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/Learning?brand=" + Model.Brand + "&nonav=true";
+}
+
+<div class="nhsuk-grid-row">
+  <vc:back-link asp-controller="Home" asp-action="Index"></vc:back-link>
+</div>
+<div class="nhsuk-grid-row">
+  <iframe class="responsive-iframe" src="@url"></iframe>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Pricing/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Pricing/Index.cshtml
@@ -4,6 +4,6 @@
   var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/pricing?nonav=true";
 }
 
-<div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row responsive-iframe-wrapper">
   <iframe class="responsive-iframe" src="@url"></iframe>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Pricing/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Pricing/Index.cshtml
@@ -1,0 +1,9 @@
+﻿@using DigitalLearningSolutions.Web.Helpers
+@{
+  ViewData["Title"] = "Pricing";
+  var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/pricing?nonav=true";
+}
+
+<div class="nhsuk-grid-row">
+  <iframe class="responsive-iframe" src="@url"></iframe>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/BackLink/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/BackLink/Default.cshtml
@@ -1,0 +1,11 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common
+@model BackLinkViewModel
+
+<div class="nhsuk-back-link">
+  <a class="nhsuk-back-link__link" asp-controller="@Model.AspController" asp-action="@Model.AspAction">
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+    </svg>
+    Go back
+  </a>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -80,7 +80,7 @@
             @RenderSection("NavMenuItems", required: false)
             @if (!IsSectionDefined("NavMenuItems")) {
               <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["AppRootPath"]/Home">
+                <a class="nhsuk-header__navigation-link" asp-controller="Home" asp-action="Index">
                   Welcome
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -88,7 +88,7 @@
                 </a>
               </li>
               <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["CurrentSystemBaseUrl"]/findyourcentre">
+                <a class="nhsuk-header__navigation-link" asp-controller="FindYourCentre" asp-action="Index">
                   Find your centre
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -96,7 +96,7 @@
                 </a>
               </li>
               <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["CurrentSystemBaseUrl"]/pricing">
+                <a class="nhsuk-header__navigation-link" asp-controller="Pricing" asp-action="Index">
                   Pricing
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -124,7 +124,7 @@
             </li>
             @if (!User.Identity.IsAuthenticated) {
               <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["AppRootPath"]/Login">
+                <a class="nhsuk-header__navigation-link" asp-controller="Login" asp-action="Index">
                   Log in
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -132,7 +132,7 @@
                 </a>
               </li>
               <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["AppRootPath"]/Register">
+                <a class="nhsuk-header__navigation-link" asp-controller="Register" asp-action="Index">
                   Register
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>


### PR DESCRIPTION
Added several new controllers to display content from the old site in iframes. Added a view component for the nhsuk back link.

I've tested the responsive sizing of the iframe across a few browsers and with the chrome devtools devices. There is currently an issue that the size of the main nhsuk-width-container is 960px, the exact breakpoint for the old site, so we get the tablet(?) layouts in the iframe which have some slightly odd layout behaviour as you resize the window. We also currently have double margins (the main layout plus the margins in the iframe) which would ease some of this layout behaviour.

The FindYourCentre iframe content doesn't fully work with javascript off (tested in Edge), the GoogleMaps map doesn't load.

The screen reader gets into the iframe correctly, but we are then limited by the accessibility of the content we are displaying within that area. It is also possible that it will start reading from the top, when it is already scrolled to the bottom of the content. I was able to trigger this behaviour by tabbing through to the Skip to Main Content link, which came after all the content in the iframe, and so the iframe was scrolled to the last tab item it contained.

![image](https://user-images.githubusercontent.com/59561751/114539247-35dc2700-9c4c-11eb-8646-00c5c8f96b16.png)
