### PR TITLE
HEEDLS-352 Add the role button to links styled as buttons

### DIFF
--- a/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ForgotPassword/Index.cshtml
@@ -36,10 +36,10 @@
     <p class="nhsuk-u-font-size-24">
       Alternatively, sign in or register for an account:
     </p>
-    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index">
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index" role="button">
       Sign in
     </a>
-    <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="Register" asp-action="Index">
+    <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="Register" asp-action="Index" role="button">
       Register
     </a>
 

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -65,13 +65,13 @@
       </div>
 
       <button class="nhsuk-button" type="submit">Log in</button>
-      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="ForgotPassword" asp-action="Index">
+      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-2" asp-controller="ForgotPassword" asp-action="Index" role="button">
         Forgot password
       </a>
     </form>
 
     <p class="nhsuk-u-font-size-24">Alternatively, if you are a new user, register:</p>
-    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Register" asp-action="Index">
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Register" asp-action="Index" role="button">
       Register
     </a>
 

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -9,7 +9,7 @@
     <p class="nhsuk-u-font-size-24">
       Alternatively, if you already have an account, sign in:
     </p>
-    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index">
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index" role="button">
       Sign in
     </a>
   </div>


### PR DESCRIPTION
Added the button role to the links styled as buttons added between the Login, Register and Forgot Password screens. This makes screen readers read them out as buttons rather than links, matching their styling. Checked that they were read out as expected.