### PR TITLE
Heedls 391 add basic myaccount details

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using System.Security.Claims;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.MyAccount;
@@ -21,12 +22,14 @@
                 return RedirectToAction("Index", "Login");
             }
 
-            var userEmail = User.GetEmail();
+            var userEmail = User.GetCustomClaim(ClaimTypes.Email);
             var delegateId = User.GetCustomClaim(CustomClaimTypes.LearnCandidateNumber);
             var centreId = User.GetCentreId();
+            var firstName = User.GetCustomClaim(CustomClaimTypes.UserForename);
+            var surname = User.GetCustomClaim(CustomClaimTypes.UserSurname);
             var centreName = centresService.GetCentreName(centreId);
 
-            var model = new MyAccountViewModel(centreName, userEmail, delegateId);
+            var model = new MyAccountViewModel(centreName, userEmail, delegateId, firstName, surname);
             return View(model);
         }
     }

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -84,3 +84,7 @@ h1#page-heading {
   height: 100%;
 }
 
+.bottom-margin-nhsuk-card {
+  @include nhsuk-responsive-margin(7, 'bottom');
+}
+

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -2,11 +2,18 @@
 {
     public class MyAccountViewModel
     {
-        public MyAccountViewModel(string? centreName, string? userEmail, string? delegateId)
+        public MyAccountViewModel(
+            string? centreName,
+            string? userEmail,
+            string? delegateId,
+            string? firstName,
+            string? surname)
         {
             Centre = centreName;
             User = userEmail;
             DelegateId = delegateId;
+            FirstName = firstName;
+            Surname = surname;
         }
 
         public string? Centre { get; set; }
@@ -14,5 +21,9 @@
         public string? User { get; set; }
 
         public string? DelegateId { get; set; }
+
+        public string? FirstName { get; set; }
+
+        public string? Surname { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -56,7 +56,7 @@
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <details class="nhsuk-details nhsuk-expander">
+    <details class="nhsuk-details nhsuk-expander bottom-margin-nhsuk-card">
       <summary class="nhsuk-details__summary">
         <span class="nhsuk-details__summary-text">
           My Details
@@ -82,18 +82,14 @@
             </dd>
           </div>
 
-          @if (Model.User?.Length > 0)
-          {
-            <div class="nhsuk-summary-list__row account-summarylist_row">
-              <dt class="nhsuk-summary-list__key">
-                Email address:
-              </dt>
-              <dd class="nhsuk-summary-list__value">
-                @Model.User
-              </dd>
-            </div>
-          }
-
+          <div class="nhsuk-summary-list__row account-summarylist_row">
+            <dt class="nhsuk-summary-list__key">
+              Email address:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.User
+            </dd>
+          </div>
         </dl>
 
         <a class="nhsuk-button" role="button">

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -12,7 +12,7 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 id="app-page-heading">My account</h1>
+    <h1 class="nhsuk-heading-xl" id="app-page-heading">My account</h1>
 
     <div class="nhsuk-card">
       <div class="nhsuk-card__content account-card-content">

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -56,14 +56,67 @@
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <a class="nhsuk-button">
+    <details class="nhsuk-details nhsuk-expander">
+      <summary class="nhsuk-details__summary">
+        <span class="nhsuk-details__summary-text">
+          My Details
+        </span>
+      </summary>
+      <div class="nhsuk-details__text">
+        <dl class="nhsuk-summary-list">
+          <div class="nhsuk-summary-list__row account-summarylist_row">
+            <dt class="nhsuk-summary-list__key">
+              First name:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.FirstName
+            </dd>
+          </div>
+
+          <div class="nhsuk-summary-list__row account-summarylist_row">
+            <dt class="nhsuk-summary-list__key">
+              Last name:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.Surname
+            </dd>
+          </div>
+
+          @if (Model.User?.Length > 0)
+          {
+            <div class="nhsuk-summary-list__row account-summarylist_row">
+              <dt class="nhsuk-summary-list__key">
+                Email address:
+              </dt>
+              <dd class="nhsuk-summary-list__value">
+                @Model.User
+              </dd>
+            </div>
+          }
+
+        </dl>
+
+        <a class="nhsuk-button" role="button">
+          Edit details
+        </a>
+        <a class="nhsuk-button nhsuk-button--secondary  nhsuk-u-margin-left-2" role="button">
+          Change password
+        </a>
+
+      </div>
+    </details>
+  </div>
+</div>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <a class="nhsuk-button" role="button">
       Manage notifications
     </a>
   </div>
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <a class="nhsuk-button nhsuk-button--secondary" href="@Configuration["CurrentSystemBaseUrl"]/logout">
+    <a class="nhsuk-button nhsuk-button--secondary" href="@Configuration["CurrentSystemBaseUrl"]/logout" role="button">
       Log out
     </a>
   </div>


### PR DESCRIPTION
Added an expandable container with basic account details in it populating them the same way as the existing fields from the basic version.

Checked that the contents of the page display/resize correctly in Chrome and with Chrome devices, and checked that it worked fine with Edge no javascript. Also checked that the screen reader was able to read out the contents of the expander.

Changed the way the email was being retrieved as the existing version didn't seem to work.

![image](https://user-images.githubusercontent.com/59561751/114713842-6f369480-9d29-11eb-8146-d574e3a294e2.png)

![image](https://user-images.githubusercontent.com/59561751/114713886-78bffc80-9d29-11eb-8630-a6ffd90417d3.png)
