### PR TITLE
HEEDLS-339 - Fixed log in links and admin user id login.

### DIFF
--- a/DigitalLearningSolutions.Data/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Data/Services/LoginService.cs
@@ -9,7 +9,7 @@
         public (AdminUser?, List<DelegateUser>) VerifyUsers(
             string password, AdminUser? unverifiedAdminUser, List<DelegateUser> unverifiedDelegateUsers);
 
-        public AdminUser? GetVerifiedAdminUserAssociatedWithDelegateUser(DelegateUser approvedDelegateUser,
+        public AdminUser? GetVerifiedAdminUserAssociatedWithDelegateUser(DelegateUser delegateUser,
             string password);
 
         public List<DelegateUser> GetVerifiedDelegateUsersAssociatedWithAdminUser(AdminUser adminUser, string password);

--- a/DigitalLearningSolutions.Data/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Data/Services/LoginService.cs
@@ -11,8 +11,6 @@
 
         public AdminUser? GetVerifiedAdminUserAssociatedWithDelegateUser(DelegateUser delegateUser,
             string password);
-
-        public List<DelegateUser> GetVerifiedDelegateUsersAssociatedWithAdminUser(AdminUser adminUser, string password);
     }
 
     public class LoginService : ILoginService
@@ -52,21 +50,6 @@
             return cryptoService.VerifyHashedPassword(adminUserAssociatedWithDelegate?.Password, password)
                 ? adminUserAssociatedWithDelegate
                 : null;
-        }
-
-        public List<DelegateUser> GetVerifiedDelegateUsersAssociatedWithAdminUser(AdminUser adminUser, string password)
-        {
-            var delegateUsersAssociatedWithAdmin = new List<DelegateUser>();
-
-            if (string.IsNullOrWhiteSpace(adminUser.EmailAddress))
-            {
-                return delegateUsersAssociatedWithAdmin;
-            }
-
-            delegateUsersAssociatedWithAdmin = userService.GetDelegateUsersByUsername(adminUser.EmailAddress);
-
-            return delegateUsersAssociatedWithAdmin
-                .Where(du => cryptoService.VerifyHashedPassword(du.Password, password)).ToList();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Data/Services/LoginService.cs
@@ -11,6 +11,8 @@
 
         public AdminUser? GetVerifiedAdminUserAssociatedWithDelegateUser(DelegateUser approvedDelegateUser,
             string password);
+
+        public List<DelegateUser> GetVerifiedDelegateUsersAssociatedWithAdminUser(AdminUser adminUser, string password);
     }
 
     public class LoginService : ILoginService
@@ -38,19 +40,33 @@
             return (verifiedAdminUser, verifiedDelegateUsers);
         }
 
-        public AdminUser? GetVerifiedAdminUserAssociatedWithDelegateUser(DelegateUser approvedDelegateUser,
-            string password)
+        public AdminUser? GetVerifiedAdminUserAssociatedWithDelegateUser(DelegateUser delegateUser, string password)
         {
-            if (string.IsNullOrWhiteSpace(approvedDelegateUser.EmailAddress))
+            if (string.IsNullOrWhiteSpace(delegateUser.EmailAddress))
             {
                 return null;
             }
 
             var adminUserAssociatedWithDelegate =
-                userService.GetAdminUserByUsername(approvedDelegateUser.EmailAddress);
+                userService.GetAdminUserByUsername(delegateUser.EmailAddress);
             return cryptoService.VerifyHashedPassword(adminUserAssociatedWithDelegate?.Password, password)
                 ? adminUserAssociatedWithDelegate
                 : null;
+        }
+
+        public List<DelegateUser> GetVerifiedDelegateUsersAssociatedWithAdminUser(AdminUser adminUser, string password)
+        {
+            var delegateUsersAssociatedWithAdmin = new List<DelegateUser>();
+
+            if (string.IsNullOrWhiteSpace(adminUser.EmailAddress))
+            {
+                return delegateUsersAssociatedWithAdmin;
+            }
+
+            delegateUsersAssociatedWithAdmin = userService.GetDelegateUsersByUsername(adminUser.EmailAddress);
+
+            return delegateUsersAssociatedWithAdmin
+                .Where(du => cryptoService.VerifyHashedPassword(du.Password, password)).ToList();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -52,7 +52,8 @@
                         au.CategoryID,
                         au.Supervisor AS IsSupervisor,
                         au.Trainer AS IsTrainer,
-                        au.IsFrameworkDeveloper
+                        au.IsFrameworkDeveloper,
+                        au.Login
                     FROM AdminUsers AS au
                     INNER JOIN Centres AS ct ON ct.CentreID = au.CentreID
                     WHERE au.Active = 1 AND au.Approved = 1 AND (au.Login = @username OR au.Email = @username)",

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -26,7 +26,9 @@
         public (AdminUser?, List<DelegateUser>) GetUsersByUsername(string username)
         {
             var adminUser = GetAdminUserByUsername(username);
-            List<DelegateUser> delegateUsers = GetDelegateUsersByUsername(username);
+            string delegateUsername =
+                string.IsNullOrWhiteSpace(adminUser?.EmailAddress) ? username : adminUser.EmailAddress;
+            List<DelegateUser> delegateUsers = GetDelegateUsersByUsername(delegateUsername);
 
             return (adminUser, delegateUsers);
         }

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -26,7 +26,7 @@
         public (AdminUser?, List<DelegateUser>) GetUsersByUsername(string username)
         {
             var adminUser = GetAdminUserByUsername(username);
-            string delegateUsername =
+            var delegateUsername =
                 string.IsNullOrWhiteSpace(adminUser?.EmailAddress) ? username : adminUser.EmailAddress;
             List<DelegateUser> delegateUsers = GetDelegateUsersByUsername(delegateUsername);
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -146,27 +146,7 @@
         }
 
         [Test]
-        public void Log_in_with_admin_id_recovers_associated_delegate_users()
-        {
-            // Given
-            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((UserTestHelper.GetDefaultAdminUser(emailAddress: "TestAccountAssociation@email.com"),
-                    new List<DelegateUser>()));
-            A.CallTo(() => userService.GetDelegateUsersByUsername(A<string>._))
-                .Returns(new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() });
-            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((null, new List<DelegateUser>()));
-
-            // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
-
-            // Then
-            A.CallTo(() => userService.GetDelegateUsersByUsername("TestAccountAssociation@email.com"))
-                .MustHaveHappened();
-        }
-
-        [Test]
-        public void Log_in_with_approved_delegate_id_recovers_associated_admin_user()
+        public void Log_in_with_approved_delegate_id_fetches_associated_admin_user()
         {
             // Given
             controller = LoginTestHelper.GetLoginControllerWithSignInFunctionality(loginService, userService);

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -136,6 +136,8 @@
                     new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() }));
             A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns((null, new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser(approved: false) }));
+            A.CallTo(() => loginService.GetVerifiedAdminUserAssociatedWithDelegateUser(A<DelegateUser>._, A<string>._))
+                .Returns(null);
 
             // When
             var result =

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -57,6 +57,17 @@
                 return View("Index", model);
             }
 
+            if (verifiedAdminUser != null && verifiedDelegateUsers.Count == 0)
+            {
+                verifiedDelegateUsers =
+                    loginService.GetVerifiedDelegateUsersAssociatedWithAdminUser(verifiedAdminUser, model.Password);
+            }
+            else if (verifiedAdminUser == null && verifiedDelegateUsers.Count > 0)
+            {
+                verifiedAdminUser ??=
+                    loginService.GetVerifiedAdminUserAssociatedWithDelegateUser(verifiedDelegateUsers.First(), model.Password);
+            }
+
             var approvedDelegateUser = verifiedDelegateUsers.FirstOrDefault(du => du.Approved);
 
             if (verifiedAdminUser == null && approvedDelegateUser == null)
@@ -64,14 +75,12 @@
                 return View("AccountNotApproved");
             }
 
-            LogIn(verifiedAdminUser, approvedDelegateUser, model.Password, model.RememberMe);
+            LogIn(verifiedAdminUser, approvedDelegateUser, model.RememberMe);
             return RedirectToAction("Index", "Home");
         }
 
-        private void LogIn(AdminUser? adminUser, DelegateUser? delegateUser, string password, bool rememberMe)
+        private void LogIn(AdminUser? adminUser, DelegateUser? delegateUser, bool rememberMe)
         {
-            adminUser ??= loginService.GetVerifiedAdminUserAssociatedWithDelegateUser(delegateUser, password);
-
             var claims = GetClaimsForSignIn(adminUser, delegateUser);
             var claimsIdentity = new ClaimsIdentity(claims, "Identity.Application");
             var authProperties = new AuthenticationProperties

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -48,11 +48,6 @@
                 return View("Index", model);
             }
 
-            if (unverifiedAdminUser != null && unverifiedDelegateUsers.Count == 0)
-            {
-                unverifiedDelegateUsers = userService.GetDelegateUsersByUsername(unverifiedAdminUser.EmailAddress);
-            }
-
             var (verifiedAdminUser, verifiedDelegateUsers) =
                 loginService.VerifyUsers(model.Password, unverifiedAdminUser, unverifiedDelegateUsers);
 
@@ -69,14 +64,8 @@
                 return View("AccountNotApproved");
             }
 
-            if (verifiedAdminUser == null && verifiedDelegateUsers.Count > 0)
-            {
-                verifiedAdminUser ??= loginService.GetVerifiedAdminUserAssociatedWithDelegateUser
-                (
-                    verifiedDelegateUsers.First(), model.Password
-                );
-            }
-
+            verifiedAdminUser ??= loginService.GetVerifiedAdminUserAssociatedWithDelegateUser(verifiedDelegateUsers.First(), model.Password);
+            
             LogIn(verifiedAdminUser, approvedDelegateUser, model.RememberMe);
             return RedirectToAction("Index", "Home");
         }

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -48,6 +48,11 @@
                 return View("Index", model);
             }
 
+            if (unverifiedAdminUser != null && unverifiedDelegateUsers.Count == 0)
+            {
+                unverifiedDelegateUsers = userService.GetDelegateUsersByUsername(unverifiedAdminUser.EmailAddress);
+            }
+
             var (verifiedAdminUser, verifiedDelegateUsers) =
                 loginService.VerifyUsers(model.Password, unverifiedAdminUser, unverifiedDelegateUsers);
 
@@ -57,22 +62,19 @@
                 return View("Index", model);
             }
 
-            if (verifiedAdminUser != null && verifiedDelegateUsers.Count == 0)
-            {
-                verifiedDelegateUsers =
-                    loginService.GetVerifiedDelegateUsersAssociatedWithAdminUser(verifiedAdminUser, model.Password);
-            }
-            else if (verifiedAdminUser == null && verifiedDelegateUsers.Count > 0)
-            {
-                verifiedAdminUser ??=
-                    loginService.GetVerifiedAdminUserAssociatedWithDelegateUser(verifiedDelegateUsers.First(), model.Password);
-            }
-
             var approvedDelegateUser = verifiedDelegateUsers.FirstOrDefault(du => du.Approved);
 
             if (verifiedAdminUser == null && approvedDelegateUser == null)
             {
                 return View("AccountNotApproved");
+            }
+
+            if (verifiedAdminUser == null && verifiedDelegateUsers.Count > 0)
+            {
+                verifiedAdminUser ??= loginService.GetVerifiedAdminUserAssociatedWithDelegateUser
+                (
+                    verifiedDelegateUsers.First(), model.Password
+                );
             }
 
             LogIn(verifiedAdminUser, approvedDelegateUser, model.RememberMe);

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -58,9 +58,9 @@
         <span class="nhsuk-u-visually-hidden">Information: </span>
         <p>
           By logging in, I consent to my details being stored and processed in line with your
-          <a target="_blank" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy (opens in new window)</a>
+          <a target="_blank" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy</a>
           and agree to use the system according to
-          <a target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of Use (opens in new window)</a>
+          <a target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of Use</a>
         </p>
       </div>
 

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -58,9 +58,9 @@
         <span class="nhsuk-u-visually-hidden">Information: </span>
         <p>
           By logging in, I consent to my details being stored and processed in line with your
-          <a href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy</a>
+          <a target="_blank" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy Policy (opens in new window)</a>
           and agree to use the system according to
-          <a asp-controller="LearningSolutions" asp-action="Terms">Terms of Use</a>
+          <a target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of Use (opens in new window)</a>
         </p>
       </div>
 


### PR DESCRIPTION
Made changes to the Log in Index page so that the links to Privacy and Terms of Use now open in new tabs.
Also modified the log in controller to grab delegate accounts associated with an admin account if only the admin account specific log in was used. Similar logic was already set up for grabbing admin accounts from delegate specific login.

Tested:
- Ran all unit tests
- Manually tested different log ins
- Tested log in and link opening in chrome.