### PR TITLE
Heedls 406 fix forgot password email url

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkNotificationService.cs
@@ -63,8 +63,8 @@ using System.Collections.Generic;
                         TextBody = $@"Dear {recipient.FirstName},
 A comment has been submitted  against the framework, {baseFramework.FrameworkName} by {sender.FirstName} {sender.LastName} ({sender.Email}){(parentComment != null ? " in response to the thread " + parentComment : "")}.
 The comment reads: {comment}
-To view or reply to the comment in the framework system, visit this url: {commentUrl}. You will need to login to DLS to view the framework.",
-                        HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'><p>Dear {recipient.FirstName},</p><p>A comment has been submitted  against the framework, <strong>{baseFramework.FrameworkName}</strong>, by <a href='mailto:{sender.Email}'>{sender.FirstName} {sender.LastName}</a>{(parentComment != null ? " in response to the thread <strong>" + parentComment + "</strong>" : ".")}</p><p>The comment reads: <strong>{comment}</strong></p><p><a href='{commentUrl}'>Click here</a> to view or reply to the comment in the framework system. You will need to login to DLS to view the framework.</p>"
+To view or reply to the comment in the framework system, visit this url: {commentUrl.Uri}. You will need to login to DLS to view the framework.",
+                        HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'><p>Dear {recipient.FirstName},</p><p>A comment has been submitted  against the framework, <strong>{baseFramework.FrameworkName}</strong>, by <a href='mailto:{sender.Email}'>{sender.FirstName} {sender.LastName}</a>{(parentComment != null ? " in response to the thread <strong>" + parentComment + "</strong>" : ".")}</p><p>The comment reads: <strong>{comment}</strong></p><p><a href='{commentUrl.Uri}'>Click here</a> to view or reply to the comment in the framework system. You will need to login to DLS to view the framework.</p>"
                     };
                     emailService.SendEmail(new Email(emailSubject, builder, recipient.Email));
                 }
@@ -97,8 +97,8 @@ To view or reply to the comment in the framework system, visit this url: {commen
             {
                 TextBody = $@"Dear {collaboratorNotification?.Forename},
 You have been identified as a {collaboratorNotification?.FrameworkRole} for the framework, {collaboratorNotification?.FrameworkName} by {collaboratorNotification?.InvitedByName} ({collaboratorNotification?.InvitedByEmail}).
-To access the framework, visit this url: {frameworkUrl}. You will need to login to DLS to view the framework.",
-                HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'><p>Dear {collaboratorNotification?.Forename},</p><p>You have been identified as a {collaboratorNotification?.FrameworkRole} for the  framework, {collaboratorNotification?.FrameworkName} by <a href='mailto:{collaboratorNotification?.InvitedByEmail}'>{collaboratorNotification?.InvitedByName}</a>.</p><p><a href='{frameworkUrl}'>Click here</a> to access the framework. You will need to login to DLS to view the framework.</p>"
+To access the framework, visit this url: {frameworkUrl.Uri}. You will need to login to DLS to view the framework.",
+                HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'><p>Dear {collaboratorNotification?.Forename},</p><p>You have been identified as a {collaboratorNotification?.FrameworkRole} for the  framework, {collaboratorNotification?.FrameworkName} by <a href='mailto:{collaboratorNotification?.InvitedByEmail}'>{collaboratorNotification?.InvitedByName}</a>.</p><p><a href='{frameworkUrl.Uri}'>Click here</a> to access the framework. You will need to login to DLS to view the framework.</p>"
             };
 
             emailService.SendEmail(new Email(emailSubjectLine, builder, collaboratorNotification.Email, collaboratorNotification.InvitedByEmail));

--- a/DigitalLearningSolutions.Data/Services/NotificationService.cs
+++ b/DigitalLearningSolutions.Data/Services/NotificationService.cs
@@ -47,11 +47,11 @@
                 TextBody = $@"Dear {unlockData?.ContactForename}
 Digital Learning Solutions Delegate, {unlockData?.DelegateName}, has requested that you unlock their progress for the course {unlockData?.CourseName}.
 They have reached the maximum number of assessment attempt allowed without passing.
-To review and unlock their progress, visit the this url: ${unlockUrl}.",
+To review and unlock their progress, visit the this url: ${unlockUrl.Uri}.",
                 HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'>
                                     <p>Dear {unlockData?.ContactForename}</p>
                                     <p>Digital Learning Solutions Delegate, {unlockData?.DelegateName}, has requested that you unlock their progress for the course {unlockData?.CourseName}</p>
-                                    <p>They have reached the maximum number of assessment attempt allowed without passing.</p><p>To review and unlock their progress, <a href='{unlockUrl}'>click here</a>.</p>
+                                    <p>They have reached the maximum number of assessment attempt allowed without passing.</p><p>To review and unlock their progress, <a href='{unlockUrl.Uri}'>click here</a>.</p>
                                 </body>"
             };
 

--- a/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
+++ b/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
@@ -95,20 +95,20 @@
             }
             resetPasswordUrl.Path += "ResetPassword";
             resetPasswordUrl.Query = $"code={resetHash}&email={emailAddress}";
-
+            
             string emailSubject = "Digital Learning Solutions Tracking System Password Reset";
 
             BodyBuilder body = new BodyBuilder
             {
                 TextBody = $@"Dear {firstName},
                             A request has been made to reset the password for your Digital Learning Solutions account.
-                            To reset your password please follow this link: {resetPasswordUrl}
+                            To reset your password please follow this link: {resetPasswordUrl.Uri}
                             Note that this link can only be used once and it will expire in two hours.
                             Please don’t reply to this email as it has been automatically generated.",
                 HtmlBody = $@"<body style= 'font - family: Calibri; font - size: small;'>
                                     <p>Dear {firstName},</p>
                                     <p>A request has been made to reset the password for your Digital Learning Solutions account.</p>
-                                    <p>To reset your password please follow this link: <a href=""{resetPasswordUrl}"">{resetPasswordUrl}</a></p>
+                                    <p>To reset your password please follow this link: <a href=""{resetPasswordUrl.Uri}"">{resetPasswordUrl.Uri}</a></p>
                                     <p>Note that this link can only be used once and it will expire in two hours.</p>
                                     <p>Please don’t reply to this email as it has been automatically generated.</p>
                                 </body>"

--- a/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
+++ b/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
@@ -89,6 +89,10 @@
         private Email GeneratePasswordResetEmail(string emailAddress, string resetHash, string firstName, string baseUrl)
         {
             UriBuilder resetPasswordUrl = new UriBuilder(baseUrl);
+            if (!resetPasswordUrl.Path.EndsWith('/'))
+            {
+                resetPasswordUrl.Path += '/';
+            }
             resetPasswordUrl.Path += "ResetPassword";
             resetPasswordUrl.Query = $"code={resetHash}&email={emailAddress}";
 


### PR DESCRIPTION
Added an extra slash in the forgot password url if it isn't already there before appending the ResetPassword part of the path.

The port it being added because we are just using string interpolation on the UriBuilders rather than on UriBuilder.Uri. I've removed it from the password url by changing the string interpolation values.

I've checked elsewhere in the solution and there are also similar instances of this being done in the same way (UriBuilder in string interpolation) in the NotificationService and FrameworkNotificationService. I've not seen emails generated from those, but we may want to also update those to be using .Uri as well.

Checked that the url was correct in debug locally, i.e. this doesn't remove the port from localhost.
Ran all unit tests.