### PR TITLE
HEEDLS-398 Add extra containing div to Pricing title

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Pricing/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Pricing/Index.cshtml
@@ -5,7 +5,9 @@
 }
 
 <div class="nhsuk-grid-row">
-  <h1 class="nhsuk-heading-xl heading-margin-2" id="page-heading">Pricing</h1>
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl heading-margin-2" id="page-heading">Pricing</h1>
+  </div>
 </div>
 <div class="nhsuk-grid-row responsive-iframe-wrapper responsive-iframe-wrapper-padding">
   <iframe class="responsive-iframe" title="Pricing" src="@url"></iframe>


### PR DESCRIPTION
Added a nhsuk-grid-column-full around the Pricing h1 so that there are the correct margins on mobile

![image](https://user-images.githubusercontent.com/59561751/116264448-34454f80-a772-11eb-91b4-2f5bc903d75b.png)
