### PR TITLE
HEEDLS-394 - Removed the nav bar from Accessibility and Terms of Use …

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -100,6 +100,10 @@ nav, .nhsuk-header__navigation, #header-navigation {
   @include mq($from: large-desktop) {
     display: none;
   }
+
+  &.visual-separator-no-nav-bar {
+    display: block;
+  }
 }
 .loading-spinner {
   margin: 0;

--- a/DigitalLearningSolutions.Web/Styles/learningSolutions/accessibilityAndTermsOfUse.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningSolutions/accessibilityAndTermsOfUse.scss
@@ -1,0 +1,5 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+.visual-separator {
+  display: block;
+}

--- a/DigitalLearningSolutions.Web/Styles/learningSolutions/accessibilityAndTermsOfUse.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningSolutions/accessibilityAndTermsOfUse.scss
@@ -1,5 +1,0 @@
-﻿@import "~nhsuk-frontend/packages/core/all";
-
-.visual-separator {
-  display: block;
-}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -84,10 +84,10 @@
           <h2 class="nhsuk-u-visually-hidden">Support links</h2>
           <ul class="nhsuk-footer__list">
             <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" asp-controller="LearningSolutions" asp-action="Terms">Terms of use</a>
+              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use</a>
             </li>
             <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility</a>
+              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility</a>
             </li>
             <li class="nhsuk-footer__list-item">
               <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy</a>

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/AccessibilityHelp.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/AccessibilityHelp.cshtml
@@ -4,7 +4,6 @@
   ViewData["Title"] = "Digital Learning Solutions - Accessibility";
   ViewData["DoNotDisplayNavBar"] = true;
 }
-<link rel="stylesheet" href="@Url.Content("~/css/learningSolutions/accessibilityAndTermsOfUse.css")" asp-append-version="true">
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/AccessibilityHelp.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/AccessibilityHelp.cshtml
@@ -2,7 +2,9 @@
 @model AccessibilityHelpViewModel
 @{
   ViewData["Title"] = "Digital Learning Solutions - Accessibility";
+  ViewData["DoNotDisplayNavBar"] = true;
 }
+<link rel="stylesheet" href="@Url.Content("~/css/learningSolutions/accessibilityAndTermsOfUse.css")" asp-append-version="true">
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Terms.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Terms.cshtml
@@ -4,7 +4,6 @@
   ViewData["Title"] = "Digital Learning Solutions - Terms of Use";
   ViewData["DoNotDisplayNavBar"] = true;
 }
-<link rel="stylesheet" href="@Url.Content("~/css/learningSolutions/accessibilityAndTermsOfUse.css")" asp-append-version="true">
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Terms.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Terms.cshtml
@@ -2,7 +2,9 @@
 @model TermsViewModel
 @{
   ViewData["Title"] = "Digital Learning Solutions - Terms of Use";
+  ViewData["DoNotDisplayNavBar"] = true;
 }
+<link rel="stylesheet" href="@Url.Content("~/css/learningSolutions/accessibilityAndTermsOfUse.css")" asp-append-version="true">
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
           </a>
         </div>
 
-        @if (ViewData["DoNotDisplayNavBar"] == null) {
+        @if ((bool?)ViewData["DoNotDisplayNavBar"] != true) {
           <div class="nhsuk-header__content" id="content-header">
             <div class="nhsuk-header__menu">
               <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
@@ -67,7 +67,7 @@
         <vc:logo customisation-id="@((int?) ViewData["CustomisationId"])" />
       </div>
 
-      @if (ViewData["DoNotDisplayNavBar"] == null) {
+      @if ((bool?)ViewData["DoNotDisplayNavBar"] != true) {
         <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
           <div class="nhsuk-width-container">
             <p class="nhsuk-header__navigation-title">
@@ -173,7 +173,9 @@
           </div>
         </nav>
       }
-      <div class="visual-separator"></div>
+
+      @{ var visualSeparatorStyle = (bool?)ViewData["DoNotDisplayNavBar"] == true ? "display : block;" : string.Empty; }
+      <div class="visual-separator" style="@visualSeparatorStyle"></div>
     </header>
 
     @RenderSection("NavBreadcrumbs", required: false)

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -174,8 +174,8 @@
         </nav>
       }
 
-      @{ var visualSeparatorStyle = (bool?)ViewData["DoNotDisplayNavBar"] == true ? "display : block;" : string.Empty; }
-      <div class="visual-separator" style="@visualSeparatorStyle"></div>
+      @{ var visualSeparatorNoNavBar = (bool?)ViewData["DoNotDisplayNavBar"] == true ? "visual-separator-no-nav-bar" : string.Empty; }
+      <div class="visual-separator @visualSeparatorNoNavBar"></div>
     </header>
 
     @RenderSection("NavBreadcrumbs", required: false)

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -57,118 +57,122 @@
           </a>
         </div>
 
-        <div class="nhsuk-header__content" id="content-header">
-          <div class="nhsuk-header__menu">
-            <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+        @if (ViewData["DoNotDisplayNavBar"] == null) {
+          <div class="nhsuk-header__content" id="content-header">
+            <div class="nhsuk-header__menu">
+              <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+            </div>
           </div>
-        </div>
+        }
         <vc:logo customisation-id="@((int?) ViewData["CustomisationId"])" />
       </div>
 
-      <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
-        <div class="nhsuk-width-container">
-          <p class="nhsuk-header__navigation-title">
-            <span id="label-navigation">Menu</span>
-            <button class="nhsuk-header__navigation-close" id="close-menu">
-              <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-              </svg>
-              <span class="nhsuk-u-visually-hidden">Close menu</span>
-            </button>
-          </p>
-          <ul class="nhsuk-header__navigation-list">
-            @RenderSection("NavMenuItems", required: false)
-            @if (!IsSectionDefined("NavMenuItems")) {
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" asp-controller="Home" asp-action="Index">
-                  Welcome
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" asp-controller="FindYourCentre" asp-action="Index">
-                  Find your centre
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" asp-controller="Pricing" asp-action="Index">
-                  Pricing
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-            }
-            @{
-              string helpPage;
-              if (User.HasClaim(c => c.Type == CustomClaimTypes.UserAdminId)) {
-                helpPage = "/help/Introduction.html";
-              } else if (User.Identity.IsAuthenticated) {
-                helpPage = "/learningportal/help/LearningPortal.html";
-              } else {
-                helpPage = "/help/Introduction.html";
-              }
-            }
-            <li class="nhsuk-header__navigation-item">
-              <a class="nhsuk-header__navigation-link" href="@(Configuration["CurrentSystemBaseUrl"] + helpPage)" target="_blank">
-                Help
-                <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+      @if (ViewData["DoNotDisplayNavBar"] == null) {
+        <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
+          <div class="nhsuk-width-container">
+            <p class="nhsuk-header__navigation-title">
+              <span id="label-navigation">Menu</span>
+              <button class="nhsuk-header__navigation-close" id="close-menu">
+                <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
                 </svg>
-              </a>
-            </li>
-            @if (!User.Identity.IsAuthenticated) {
+                <span class="nhsuk-u-visually-hidden">Close menu</span>
+              </button>
+            </p>
+            <ul class="nhsuk-header__navigation-list">
+              @RenderSection("NavMenuItems", required: false)
+              @if (!IsSectionDefined("NavMenuItems")) {
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" asp-controller="Home" asp-action="Index">
+                    Welcome
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" asp-controller="FindYourCentre" asp-action="Index">
+                    Find your centre
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" asp-controller="Pricing" asp-action="Index">
+                    Pricing
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+              }
+              @{
+                string helpPage;
+                if (User.HasClaim(c => c.Type == CustomClaimTypes.UserAdminId)) {
+                  helpPage = "/help/Introduction.html";
+                } else if (User.Identity.IsAuthenticated) {
+                  helpPage = "/learningportal/help/LearningPortal.html";
+                } else {
+                  helpPage = "/help/Introduction.html";
+                }
+              }
               <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" asp-controller="Login" asp-action="Index">
-                  Log in
+                <a class="nhsuk-header__navigation-link" href="@(Configuration["CurrentSystemBaseUrl"] + helpPage)" target="_blank">
+                  Help
                   <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
                   </svg>
                 </a>
               </li>
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" asp-controller="Register" asp-action="Index">
-                  Register
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-            }
-            @if (User.Identity.IsAuthenticated) {
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["AppRootPath"]/MyAccount">
-                  My account
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["CurrentSystemBaseUrl"]/Home?action=appselect">
-                  Switch application
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@Configuration["CurrentSystemBaseUrl"]/logout">
-                  Log out
-                  <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                  </svg>
-                </a>
-              </li>
-            }
-          </ul>
-        </div>
-      </nav>
+              @if (!User.Identity.IsAuthenticated) {
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" asp-controller="Login" asp-action="Index">
+                    Log in
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" asp-controller="Register" asp-action="Index">
+                    Register
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+              }
+              @if (User.Identity.IsAuthenticated) {
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" href="@Configuration["AppRootPath"]/MyAccount">
+                    My account
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" href="@Configuration["CurrentSystemBaseUrl"]/Home?action=appselect">
+                    Switch application
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+                <li class="nhsuk-header__navigation-item">
+                  <a class="nhsuk-header__navigation-link" href="@Configuration["CurrentSystemBaseUrl"]/logout">
+                    Log out
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                    </svg>
+                  </a>
+                </li>
+              }
+            </ul>
+          </div>
+        </nav>
+      }
       <div class="visual-separator"></div>
     </header>
 
@@ -187,10 +191,10 @@
           <h2 class="nhsuk-u-visually-hidden">Support links</h2>
           <ul class="nhsuk-footer__list">
             <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" asp-controller="LearningSolutions" asp-action="Terms">Terms of use</a>
+              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use</a>
             </li>
             <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility</a>
+              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility</a>
             </li>
             <li class="nhsuk-footer__list-item">
               <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy</a>


### PR DESCRIPTION
…pages and made sure they open in new tabs. Also made sure the "Menu" button that appears when the nav bar is collapsed no longer appears on these pages, and the visual separator is always present on these pages.

Test manually in chrome and ran all unit tests.

Screen shot of Terms of use page and Accessibility page:
![Accessibility Page](https://user-images.githubusercontent.com/80777689/116271032-889efe00-a777-11eb-81b9-a42364385de6.PNG)
![Terms of Use page](https://user-images.githubusercontent.com/80777689/116271036-89379480-a777-11eb-8632-0fd13c7472de.PNG)


