### PR TITLE
Heedls 349 edit notification preferences

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
@@ -41,9 +41,7 @@
         [Route("/NotificationPreferences/Edit/{userType}")]
         public IActionResult UpdateNotificationPreferences(string userType)
         {
-            var claimType = userType == UserTypes.Admin ? CustomClaimTypes.UserAdminId : CustomClaimTypes.LearnCandidateId;
-
-            var userId = User.GetCustomClaimAsInt(claimType);
+            var userId = userType == UserTypes.Admin ? User.GetAdminId() : User.GetCandidateId();
             var notifications = GetNotificationPreferencesForUser(userType, userId);
 
             var model = new UpdateNotificationPreferencesViewModel(notifications, userType);
@@ -51,7 +49,7 @@
             return View(model);
         }
 
-        // TODO AIR-349 this should be moved into the repository once the user type enum is merged
+        // TODO HEEDLS-349 this should be moved into the service once the user type enum is merged
         private IEnumerable<NotificationPreference> GetNotificationPreferencesForUser(string userType, int? userId)
         {
             if (userType == UserTypes.Admin)
@@ -69,7 +67,8 @@
         [Route("/NotificationPreferences/Edit/{userType}")]
         public IActionResult SaveNotificationPreferences(IEnumerable<int> notifications)
         {
-            throw new NotImplementedException();
+            // TODO HEEDLS-349 wire this up to an actual service method
+            return RedirectToAction("Index", "NotificationPreferences");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using System;
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Services;
@@ -34,6 +35,7 @@
             return View(model);
         }
 
+        [HttpGet]
         [Route("/NotificationPreferences/Edit/{userType}")]
         public IActionResult UpdateNotificationPreferences(string userType)
         {
@@ -62,6 +64,13 @@
             var model = new UpdateNotificationPreferencesViewModel(notifications, userType);
 
             return View(model);
+        }
+
+        [HttpPost]
+        [Route("/NotificationPreferences/Edit/{userType}")]
+        public IActionResult SaveNotificationPreferences(IEnumerable<int> notifications)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
     using System.Collections.Generic;
-    using System.Linq;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
@@ -31,6 +30,36 @@
             var delegateNotifications = notificationPreferencesDataService.GetNotificationPreferencesForDelegate(delegateId);
 
             var model = new NotificationPreferencesViewModel(adminNotifications, delegateNotifications);
+
+            return View(model);
+        }
+
+        [Route("/NotificationPreferences/Edit/{userType}")]
+        public IActionResult UpdateNotificationPreferences(string userType)
+        {
+            if (!User.Identity.IsAuthenticated)
+            {
+                return RedirectToAction("Index", "Login");
+            }
+
+            IEnumerable<NotificationPreference> notifications;
+
+            if (userType == UserTypes.Admin)
+            {
+                var adminId = User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId);
+                notifications = notificationPreferencesDataService.GetNotificationPreferencesForAdmin(adminId);
+            }
+            else if (userType == UserTypes.Delegate)
+            {
+                var delegateId = User.GetCustomClaimAsInt(CustomClaimTypes.LearnCandidateId);
+                notifications = notificationPreferencesDataService.GetNotificationPreferencesForDelegate(delegateId);
+            }
+            else
+            {
+                return RedirectToAction("Index", "Login"); //TODO AIR-349 is this correct?
+            }
+
+            var model = new UpdateNotificationPreferencesViewModel(notifications, userType);
 
             return View(model);
         }

--- a/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
@@ -56,7 +56,7 @@
             }
             else
             {
-                return RedirectToAction("Index", "Login"); //TODO AIR-349 is this correct?
+                return RedirectToAction("Index", "Home");
             }
 
             var model = new UpdateNotificationPreferencesViewModel(notifications, userType);

--- a/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.MyAccount;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
     public class NotificationPreferencesController : Controller
@@ -35,15 +36,11 @@
             return View(model);
         }
 
+        [Authorize]
         [HttpGet]
         [Route("/NotificationPreferences/Edit/{userType}")]
         public IActionResult UpdateNotificationPreferences(string userType)
         {
-            if (!User.Identity.IsAuthenticated)
-            {
-                return RedirectToAction("Index", "Login");
-            }
-
             IEnumerable<NotificationPreference> notifications;
 
             if (userType == UserTypes.Admin)

--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -4,6 +4,11 @@
 
     public static class CustomClaimHelper
     {
+        public static int GetAdminId(this ClaimsPrincipal user)
+        {
+            return user.GetCustomClaimAsRequiredInt(CustomClaimTypes.UserAdminId);
+        }
+
         public static int GetCandidateId(this ClaimsPrincipal user)
         {
             return user.GetCustomClaimAsRequiredInt(CustomClaimTypes.LearnCandidateId);

--- a/DigitalLearningSolutions.Web/Helpers/UserTypes.cs
+++ b/DigitalLearningSolutions.Web/Helpers/UserTypes.cs
@@ -1,0 +1,8 @@
+﻿namespace DigitalLearningSolutions.Web.Helpers
+{
+    public static class UserTypes
+    {
+        public const string Admin = "Administrator";
+        public const string Delegate = "Delegate";
+    }
+}

--- a/DigitalLearningSolutions.Web/Styles/myAccount/updateNotificationPreferences.scss
+++ b/DigitalLearningSolutions.Web/Styles/myAccount/updateNotificationPreferences.scss
@@ -1,0 +1,9 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+.update-notification-hint {
+  margin-bottom: 24px;
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 32px;
+  }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/NotificationPreferencesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/NotificationPreferencesViewModel.cs
@@ -10,18 +10,18 @@
             IEnumerable<NotificationPreference> adminNotifications,
             IEnumerable<NotificationPreference> delegateNotifications)
         {
-            AdminNotifications = new NotificationPreferenceListViewModel(adminNotifications, UserTypes.Admin);
-            DelegateNotifications = new NotificationPreferenceListViewModel(delegateNotifications, UserTypes.Delegate);
+            AdminNotifications = new NotificationPreferenceExpanderViewModel(adminNotifications, UserTypes.Admin);
+            DelegateNotifications = new NotificationPreferenceExpanderViewModel(delegateNotifications, UserTypes.Delegate);
         }
 
-        public NotificationPreferenceListViewModel AdminNotifications { get; set; }
+        public NotificationPreferenceExpanderViewModel AdminNotifications { get; set; }
 
-        public NotificationPreferenceListViewModel DelegateNotifications { get; set; }
+        public NotificationPreferenceExpanderViewModel DelegateNotifications { get; set; }
     }
 
-    public class NotificationPreferenceListViewModel
+    public class NotificationPreferenceExpanderViewModel
     {
-        public NotificationPreferenceListViewModel(IEnumerable<NotificationPreference> notifications, string userType)
+        public NotificationPreferenceExpanderViewModel(IEnumerable<NotificationPreference> notifications, string userType)
         {
             Notifications = notifications;
             UserType = userType;

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/NotificationPreferencesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/NotificationPreferencesViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Web.Helpers;
 
     public class NotificationPreferencesViewModel
     {
@@ -9,8 +10,8 @@
             IEnumerable<NotificationPreference> adminNotifications,
             IEnumerable<NotificationPreference> delegateNotifications)
         {
-            AdminNotifications = new NotificationPreferenceListViewModel(adminNotifications);
-            DelegateNotifications = new NotificationPreferenceListViewModel(delegateNotifications);
+            AdminNotifications = new NotificationPreferenceListViewModel(adminNotifications, UserTypes.Admin);
+            DelegateNotifications = new NotificationPreferenceListViewModel(delegateNotifications, UserTypes.Delegate);
         }
 
         public NotificationPreferenceListViewModel AdminNotifications { get; set; }
@@ -20,10 +21,13 @@
 
     public class NotificationPreferenceListViewModel
     {
-        public NotificationPreferenceListViewModel(IEnumerable<NotificationPreference> notifications)
+        public NotificationPreferenceListViewModel(IEnumerable<NotificationPreference> notifications, string userType)
         {
             Notifications = notifications;
+            UserType = userType;
         }
+
+        public string UserType { get; set; }
 
         public IEnumerable<NotificationPreference> Notifications { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/UpdateNotificationPreferencesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/UpdateNotificationPreferencesViewModel.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models;
+
+    public class UpdateNotificationPreferencesViewModel // TODO 
+    {
+        public UpdateNotificationPreferencesViewModel(
+            IEnumerable<NotificationPreference> notifications, string userType)
+        {
+            Notifications = notifications;
+            UserType = userType;
+        }
+
+        public string UserType { get; set; }
+        public IEnumerable<NotificationPreference> Notifications { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/UpdateNotificationPreferencesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/UpdateNotificationPreferencesViewModel.cs
@@ -3,7 +3,7 @@
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models;
 
-    public class UpdateNotificationPreferencesViewModel // TODO 
+    public class UpdateNotificationPreferencesViewModel
     {
         public UpdateNotificationPreferencesViewModel(
             IEnumerable<NotificationPreference> notifications, string userType)

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/UpdateNotificationPreferencesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/UpdateNotificationPreferencesViewModel.cs
@@ -6,7 +6,8 @@
     public class UpdateNotificationPreferencesViewModel
     {
         public UpdateNotificationPreferencesViewModel(
-            IEnumerable<NotificationPreference> notifications, string userType)
+            IEnumerable<NotificationPreference> notifications,
+            string userType)
         {
             Notifications = notifications;
             UserType = userType;

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
@@ -10,7 +10,7 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 class="nhsuk-heading-xl">Notification Preferences</h1>
+    <h1 class="nhsuk-heading-xl">Notification preferences</h1>
 
     @if (Model.AdminNotifications.Notifications.Any())
     {

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
@@ -14,12 +14,12 @@
 
     @if (Model.AdminNotifications.Notifications.Any())
     {
-      <partial name="_NotificationPreferenceList" model="Model.AdminNotifications" />
+      <partial name="_NotificationPreferenceExpander" model="Model.AdminNotifications" />
     }
 
     @if (Model.DelegateNotifications.Notifications.Any())
     {
-      <partial name="_NotificationPreferenceList" model="Model.DelegateNotifications" />
+      <partial name="_NotificationPreferenceExpander" model="Model.DelegateNotifications" />
     }
 
     <div class="top-spaced-goback">

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
@@ -14,30 +14,12 @@
 
     @if (Model.AdminNotifications.Notifications.Any())
     {
-      <details class="nhsuk-details nhsuk-expander">
-        <summary class="nhsuk-details__summary">
-          <span class="nhsuk-details__summary-text">
-            My admin account notifications
-          </span>
-        </summary>
-        <div class="nhsuk-details__text">
-          <partial name="_NotificationPreferenceList" model="Model.AdminNotifications" />
-        </div>
-      </details>
+      <partial name="_NotificationPreferenceList" model="Model.AdminNotifications" />
     }
 
     @if (Model.DelegateNotifications.Notifications.Any())
     {
-      <details class="nhsuk-details nhsuk-expander">
-        <summary class="nhsuk-details__summary">
-          <span class="nhsuk-details__summary-text">
-            My delegate account notifications
-          </span>
-        </summary>
-        <div class="nhsuk-details__text">
-          <partial name="_NotificationPreferenceList" model="Model.DelegateNotifications" />
-        </div>
-      </details>
+      <partial name="_NotificationPreferenceList" model="Model.DelegateNotifications" />
     }
 
     <div class="top-spaced-goback">

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -12,14 +12,14 @@
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">Update Notification Preferences</h1>
     <div class="nhsuk-hint">Please tick the boxes for all the notifications you would like to receive.</div>
-    @foreach (var notification in Model.Notifications) {
-      <div class="nhsuk-grid-row">
-        <input class="nhsuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="email">
-        <label class="nhsuk-label nhsuk-checkboxes__label" for="example-1">
-          @notification.Description
-        </label>
-      </div>
-    }
+@*     @foreach (var notification in Model.Notifications) { *@
+@*       <div class="nhsuk-grid-row"> *@
+@*         <input class="nhsuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="email"> *@
+@*         <label class="nhsuk-label nhsuk-checkboxes__label" for="example-1"> *@
+@*           @notification.Description *@
+@*         </label> *@
+@*       </div> *@
+@*     } *@
 
     @*save button here*@
     <div class="top-spaced-goback">

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -12,16 +12,6 @@
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">Update Notification Preferences</h1>
     <div class="nhsuk-hint">Please tick the boxes for all the notifications you would like to receive.</div>
-@*     @foreach (var notification in Model.Notifications) { *@
-@*       <div class="nhsuk-grid-row"> *@
-@*         <input class="nhsuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="email"> *@
-@*         <label class="nhsuk-label nhsuk-checkboxes__label" for="example-1"> *@
-@*           @notification.Description *@
-@*         </label> *@
-@*       </div> *@
-@*     } *@
-
-    @*save button here*@
     <div class="top-spaced-goback">
       <vc:back-link asp-controller="MyAccount" asp-action="Index"></vc:back-link>
     </div>

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -2,7 +2,7 @@
 
 @model UpdateNotificationPreferencesViewModel
 
-<link rel="stylesheet" href="@Url.Content("~/css/myAccount/notificationPreferences.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/myAccount/updateNotificationPreferences.css")" asp-append-version="true">
 
 @{
   ViewData["Title"] = "Update Notification Preferences";
@@ -16,7 +16,7 @@
           Update notification preferences
         </h1>
       </legend>
-      <div class="nhsuk-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
+      <div class="nhsuk-hint update-notification-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
       <div class="nhsuk-checkboxes">
         @foreach (var (notification, index) in Model.Notifications.Select((item, index) => (item, index)))
         {

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -1,0 +1,29 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.MyAccount
+
+@model UpdateNotificationPreferencesViewModel
+
+<link rel="stylesheet" href="@Url.Content("~/css/myAccount/notificationPreferences.css")" asp-append-version="true">
+
+@{
+  ViewData["Title"] = "Update Notification Preferences";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl">Update Notification Preferences</h1>
+    <div class="nhsuk-hint">Please tick the boxes for all the notifications you would like to receive.</div>
+    @foreach (var notification in Model.Notifications) {
+      <div class="nhsuk-grid-row">
+        <input class="nhsuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="email">
+        <label class="nhsuk-label nhsuk-checkboxes__label" for="example-1">
+          @notification.Description
+        </label>
+      </div>
+    }
+
+    @*save button here*@
+    <div class="top-spaced-goback">
+      <vc:back-link asp-controller="MyAccount" asp-action="Index"></vc:back-link>
+    </div>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -8,12 +8,38 @@
   ViewData["Title"] = "Update Notification Preferences";
 }
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <h1 class="nhsuk-heading-xl">Update Notification Preferences</h1>
-    <div class="nhsuk-hint">Please tick the boxes for all the notifications you would like to receive.</div>
+<div class="nhsuk-form-group">
+  <div class="nhsuk-fieldset" aria-describedby="notification-hint">
+    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+      <h1 class="nhsuk-fieldset__heading">
+        Update notification preferences
+      </h1>
+    </legend>
+    <div class="nhsuk-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
+      <div class="nhsuk-checkboxes">
+        @foreach (var (notification, index) in Model.Notifications.Select((item, index) => (item, index))) {
+          <div class="nhsuk-checkboxes__item">
+            <input
+              class="nhsuk-checkboxes__input"
+              id="notification-@index.ToString())"
+              name="notification"
+              type="checkbox"
+              value="@notification.NotificationId"
+              aria-describedby="notification-@index.ToString()-item-hint"
+              @(notification.Accepted ? "checked" : "")>
+            <label class="nhsuk-label nhsuk-checkboxes__label" for="notification-@index.ToString()">
+              @notification.NotificationName
+            </label>
+            <div class="nhsuk-hint nhsuk-checkboxes__hint" id="notification-@index.ToString()-item-hint">
+              @Html.Raw(notification.Description)
+            </div>
+          </div>
+        }
+      </div>
+
+    @*save button here*@
     <div class="top-spaced-goback">
-      <vc:back-link asp-controller="MyAccount" asp-action="Index"></vc:back-link>
+      <vc:back-link asp-controller="NotificationPreferences" asp-action="Index"></vc:back-link>
     </div>
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -8,25 +8,26 @@
   ViewData["Title"] = "Update Notification Preferences";
 }
 
-<div class="nhsuk-form-group">
-  <div class="nhsuk-fieldset" aria-describedby="notification-hint">
-    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-      <h1 class="nhsuk-fieldset__heading">
-        Update notification preferences
-      </h1>
-    </legend>
-    <div class="nhsuk-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
+<form method="post" asp-controller="NotificationPreferences" asp-action="SaveNotificationPreferences" asp-route-userType="@Model.UserType">
+  <div class="nhsuk-form-group">
+    <div class="nhsuk-fieldset" aria-describedby="notification-hint">
+      <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+        <h1 class="nhsuk-fieldset__heading">
+          Update notification preferences
+        </h1>
+      </legend>
+      <div class="nhsuk-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
       <div class="nhsuk-checkboxes">
-        @foreach (var (notification, index) in Model.Notifications.Select((item, index) => (item, index))) {
+        @foreach (var (notification, index) in Model.Notifications.Select((item, index) => (item, index)))
+        {
           <div class="nhsuk-checkboxes__item">
-            <input
-              class="nhsuk-checkboxes__input"
-              id="notification-@index.ToString())"
-              name="notification"
-              type="checkbox"
-              value="@notification.NotificationId"
-              aria-describedby="notification-@index.ToString()-item-hint"
-              @(notification.Accepted ? "checked" : "")>
+            <input class="nhsuk-checkboxes__input"
+                   id="notification-@index.ToString()"
+                   name="notifications"
+                   type="checkbox"
+                   value="@notification.NotificationId"
+                   aria-describedby="notification-@index.ToString()-item-hint"
+                   @(notification.Accepted ? "checked" : "")>
             <label class="nhsuk-label nhsuk-checkboxes__label" for="notification-@index.ToString()">
               @notification.NotificationName
             </label>
@@ -37,9 +38,10 @@
         }
       </div>
 
-    @*save button here*@
-    <div class="top-spaced-goback">
-      <vc:back-link asp-controller="NotificationPreferences" asp-action="Index"></vc:back-link>
+      <button class="nhsuk-button" type="submit">Save</button>
+      <div class="top-spaced-goback">
+        <vc:back-link asp-controller="NotificationPreferences" asp-action="Index"></vc:back-link>
+      </div>
     </div>
   </div>
-</div>
+</form>

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceExpander.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceExpander.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.MyAccount
 
-@model NotificationPreferenceListViewModel
+@model NotificationPreferenceExpanderViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/myAccount/notificationPreferences.css")" asp-append-version="true">
 

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceList.cshtml
@@ -1,24 +1,40 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.MyAccount
+﻿@using DigitalLearningSolutions.Web.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.MyAccount
 
 @model NotificationPreferenceListViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/myAccount/notificationPreferences.css")" asp-append-version="true">
 
-<dl class="nhsuk-grid-column-full nhsuk-summary-list preference-list">
-  @foreach (var notification in Model.Notifications) {
-    <div class="nhsuk-grid-row preference-row">
-      <div class="nhsuk-grid-column-three-quarters preference-text-column">
-        <div class="nhsuk-heading-xs">@notification.NotificationName</div>
-        <p class="nhsuk-body-m">@Html.Raw(notification.Description)</p>
-      </div>
-      <div class="nhsuk-grid-column-one-quarter preference-tag-column">
-        <strong class="nhsuk-u-font-size-19 preference-tag nhsuk-tag @(notification.Accepted ? "" : "nhsuk-tag--grey")">
-          @(notification.Accepted ? "Subscribed" : "Unsubscribed")
-        </strong>
-      </div>
-    </div>
-  }
-</dl>
-<a class="nhsuk-button" role="button">
-  Update preferences
-</a>
+<details class="nhsuk-details nhsuk-expander">
+  <summary class="nhsuk-details__summary">
+    <span class="nhsuk-details__summary-text">
+      My @(Model.UserType == UserTypes.Admin ? "admin" : "delegate") account notifications
+    </span>
+  </summary>
+  <div class="nhsuk-details__text">
+    <dl class="nhsuk-grid-column-full nhsuk-summary-list preference-list">
+      @foreach (var notification in Model.Notifications) {
+        <div class="nhsuk-grid-row preference-row">
+          <div class="nhsuk-grid-column-three-quarters preference-text-column">
+            <div class="nhsuk-heading-xs">@notification.NotificationName</div>
+            <p class="nhsuk-body-m">@Html.Raw(notification.Description)</p>
+          </div>
+          <div class="nhsuk-grid-column-one-quarter preference-tag-column">
+            <strong class="nhsuk-u-font-size-19 preference-tag nhsuk-tag @(notification.Accepted ? "" : "nhsuk-tag--grey")">
+              @(notification.Accepted ? "Subscribed" : "Unsubscribed")
+            </strong>
+          </div>
+        </div>
+      }
+    </dl>
+    <a
+      class="nhsuk-button"
+      asp-controller="NotificationPreferences"
+      asp-action="UpdateNotificationPreferences"
+      asp-route-userType="@Model.UserType"
+      role="button"
+    >
+      Update preferences
+    </a>
+  </div>
+</details>


### PR DESCRIPTION
This partial review covers making the update notification preferences page accessible by user type. Currently no notification information is displayed, though it is fetched from the database.

Update 29/04/21: this is being expanded to a complete review for the frontend of this ticket

![image](https://user-images.githubusercontent.com/34240850/116584283-17924e80-a90f-11eb-98e0-3d863319f001.png)

![image](https://user-images.githubusercontent.com/34240850/116584184-021d2480-a90f-11eb-832b-1655b5db7484.png)

![image](https://user-images.githubusercontent.com/34240850/116587793-b3718980-a912-11eb-8d5f-65e7a8cefafc.png)

![image](https://user-images.githubusercontent.com/34240850/116587742-a5bc0400-a912-11eb-9afe-d0f4c0e32f30.png)
