### PR TITLE
HEEDLS-346: move whitespace trimming from database to memory

### DIFF
--- a/DigitalLearningSolutions.Data/Services/NotificationPreferencesDataService.cs
+++ b/DigitalLearningSolutions.Data/Services/NotificationPreferencesDataService.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models;
 
@@ -27,17 +28,14 @@
                 return new List<NotificationPreference>();
             }
 
-            return connection.Query<NotificationPreference>(
+            var preferences = connection.Query<NotificationPreference>(
                 @"DECLARE @CentreAdmin BIT, @IsCentreManager BIT, @ContentManager BIT, @ContentCreator BIT, @Supervisor BIT, @Trainer BIT
 
                     SELECT @CentreAdmin = CentreAdmin, @IsCentreManager = IsCentreManager, @ContentManager = ContentManager, @ContentCreator = ContentCreator, @Supervisor = Supervisor, @Trainer = Trainer
 	                    FROM AdminUsers
 	                    WHERE AdminID = @adminId
 
-                    DECLARE @Whitespace VARCHAR(3)
-                    SET @Whitespace = CHAR(10)+CHAR(13)+CHAR(32)
-
-                    SELECT DISTINCT n.NotificationID, TRIM(@Whitespace FROM n.NotificationName) AS NotificationName, n.Description, CASE WHEN nu.NotificationUserID IS NOT NULL THEN 1 ELSE 0 END AS accepted
+                    SELECT DISTINCT n.NotificationID, n.NotificationName, n.Description, CASE WHEN nu.NotificationUserID IS NOT NULL THEN 1 ELSE 0 END AS accepted
 	                    FROM Notifications AS n
 	                    JOIN NotificationRoles AS nr ON nr.NotificationID = n.NotificationID
 	                    LEFT JOIN NotificationUsers AS nu ON nu.NotificationID = n.NotificationID AND nu.AdminUserID = @adminId
@@ -49,7 +47,15 @@
 	                    OR (nr.RoleID = 7 AND @Trainer = 1)
                         ORDER BY n.NotificationID",
                 new { adminId }
-            );
+            ).ToList();
+
+            foreach (var notificationPreference in preferences)
+            {
+                // the notification names in the DB have trailing whitespace
+                notificationPreference.NotificationName = notificationPreference.NotificationName.Trim();
+            }
+
+            return preferences;
         }
 
         public IEnumerable<NotificationPreference> GetNotificationPreferencesForDelegate(int? delegateId)
@@ -59,18 +65,23 @@
                 return new List<NotificationPreference>();
             }
 
-            return connection.Query<NotificationPreference>(
-                @"DECLARE @Whitespace VARCHAR(3)
-                    SET @Whitespace = CHAR(10)+CHAR(13)+CHAR(32)
-
-                    SELECT DISTINCT n.NotificationID, TRIM(@Whitespace FROM n.NotificationName) AS NotificationName, n.Description, CASE WHEN nu.NotificationUserID IS NOT NULL THEN 1 ELSE 0 END AS accepted
+            var preferences = connection.Query<NotificationPreference>(
+                @"SELECT DISTINCT n.NotificationID, n.NotificationName, n.Description, CASE WHEN nu.NotificationUserID IS NOT NULL THEN 1 ELSE 0 END AS accepted
 	                    FROM Notifications AS n
 	                    JOIN NotificationRoles AS nr ON nr.NotificationID = n.NotificationID
 	                    LEFT JOIN NotificationUsers AS nu ON nu.NotificationID = n.NotificationID AND nu.CandidateID = @delegateId
 	                    WHERE nr.RoleID = 5
                         ORDER BY n.NotificationID",
                 new { delegateId }
-            );
+            ).ToList();
+
+            foreach (var notificationPreference in preferences)
+            {
+                // the notification names in the DB have trailing whitespace
+                notificationPreference.NotificationName = notificationPreference.NotificationName.Trim();
+            }
+
+            return preferences;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/NotificationPreferencesDataService.cs
+++ b/DigitalLearningSolutions.Data/Services/NotificationPreferencesDataService.cs
@@ -49,11 +49,7 @@
                 new { adminId }
             ).ToList();
 
-            foreach (var notificationPreference in preferences)
-            {
-                // the notification names in the DB have trailing whitespace
-                notificationPreference.NotificationName = notificationPreference.NotificationName.Trim();
-            }
+            RemoveTrailingNameWhitespace(preferences);
 
             return preferences;
         }
@@ -75,13 +71,18 @@
                 new { delegateId }
             ).ToList();
 
-            foreach (var notificationPreference in preferences)
+            RemoveTrailingNameWhitespace(preferences);
+
+            return preferences;
+        }
+
+        private void RemoveTrailingNameWhitespace(IEnumerable<NotificationPreference> notificationPreferences)
+        {
+            foreach (var notificationPreference in notificationPreferences)
             {
                 // the notification names in the DB have trailing whitespace
                 notificationPreference.NotificationName = notificationPreference.NotificationName.Trim();
             }
-
-            return preferences;
         }
     }
 }


### PR DESCRIPTION
The 'TRIM()' function used here isn't present in the version of SQL Server used for the UAT DB, and its predecessors can only trim spaces not arbitrary characters.