### PR TITLE
HEEDLS-361 - reverted SetTempDataForChooseACentre to use ChooseACentr…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -80,12 +80,14 @@
                 return LogIn(adminLoginDetails, delegateLoginDetails.FirstOrDefault(), model.RememberMe);
             }
 
+            var chooseACentreViewModel = new ChooseACentreViewModel(availableCentres);
+
             SetTempDataForChooseACentre
             (
                 model.RememberMe,
                 adminLoginDetails,
                 delegateLoginDetails,
-                availableCentres
+                chooseACentreViewModel
             );
 
             return RedirectToAction("ChooseACentre", "Login");
@@ -101,8 +103,7 @@
                 return RedirectToAction("Index", "Home");
             }
 
-            var availableCentres = TempData.Peek<List<CentreUserDetails>>();
-            ChooseACentreViewModel model = new ChooseACentreViewModel(availableCentres);
+            ChooseACentreViewModel model = TempData.Peek<ChooseACentreViewModel>();
             return View("ChooseACentre", model);
         }
 
@@ -140,14 +141,14 @@
             bool rememberMe,
             AdminLoginDetails? adminLoginDetails,
             List<DelegateLoginDetails> delegateLoginDetails,
-            List<CentreUserDetails> availableCentres
+            ChooseACentreViewModel chooseACentreViewModel
         )
         {
             TempData.Clear();
             TempData["RememberMe"] = rememberMe;
             TempData.Set(adminLoginDetails);
             TempData.Set(delegateLoginDetails);
-            TempData.Set(availableCentres);
+            TempData.Set(chooseACentreViewModel);
         }
 
         private IActionResult LogIn


### PR DESCRIPTION
…eViewModel rather than a list.

TempData can handle lists, but the TempData.Set we have for ease of use does not look at what the list is a list of - so when I changed things around to put the availableCentres (List<CentreUserDetails>) in the TempData, it overwrites the list of DelegateLoginDetails. Then when TempData.Get is used, it just recovers the same List so it doesn't crash immediately, but when getting the user claims instead. This bug fix reverts that change so it works again and the details aren't overwritten.

Ran all unit tests and tested manually.