### PR TITLE
HEEDLS-421: redirect to former page when logging in

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;
@@ -49,7 +50,7 @@
         public void Index_should_render_basic_form()
         {
             // When
-            var result = controller.Index("");
+            var result = controller.Index(string.Empty);
 
             // Then
             result.Should().BeViewResult().WithDefaultViewName();
@@ -64,7 +65,7 @@
                 .WithMockUser(true);
 
             // When
-            var result = controllerWithAuthenticatedUser.Index("");
+            var result = controllerWithAuthenticatedUser.Index(string.Empty);
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -74,18 +75,10 @@
         [Test]
         public void Successful_sign_in_without_return_url_should_render_home_page()
         {
-            //Given
+            // Given
             var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
             var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
 
             // When
             var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
@@ -98,18 +91,10 @@
         [Test]
         public void Successful_sign_in_with_local_return_url_should_redirect_to_return_url()
         {
-            //Given
+            // Given
             var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
             var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
 
             var returnUrl = "/some/other/page";
             var urlHelper = controller.Url;
@@ -127,18 +112,10 @@
         [Test]
         public void Successful_sign_in_with_nonlocal_return_url_should_render_home_page()
         {
-            //Given
+            // Given
             var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
             var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
 
             var returnUrl = "www.suspicious.com";
             var urlHelper = controller.Url;
@@ -157,18 +134,10 @@
         [Test]
         public void Successful_sign_in_should_call_SignInAsync()
         {
-            //Given
+            // Given
             var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
             var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
 
             // When
             controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
@@ -179,10 +148,23 @@
                 .MustHaveHappened();
         }
 
+        private void GivenSignInIsSuccessful(AdminUser expectedAdmin, List<DelegateUser> expectedDelegates)
+        {
+            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns(
+                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+        }
+
         [Test]
         public void Log_in_request_should_call_login_service()
         {
-            //Given
+            // Given
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
                 .Returns((UserTestHelper.GetDefaultAdminUser(),
                     new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() }));

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -50,7 +50,7 @@
         public void Index_should_render_basic_form()
         {
             // When
-            var result = controller.Index(string.Empty);
+            var result = controller.Index();
 
             // Then
             result.Should().BeViewResult().WithDefaultViewName();
@@ -65,7 +65,7 @@
                 .WithMockUser(true);
 
             // When
-            var result = controllerWithAuthenticatedUser.Index(string.Empty);
+            var result = controllerWithAuthenticatedUser.Index();
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -146,19 +146,6 @@
             A.CallTo(() => authenticationService.SignInAsync(
                     A<HttpContext>._, A<string>._, A<ClaimsPrincipal>._, A<AuthenticationProperties>._))
                 .MustHaveHappened();
-        }
-
-        private void GivenSignInIsSuccessful(AdminUser expectedAdmin, List<DelegateUser> expectedDelegates)
-        {
-            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
-            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
         }
 
         [Test]
@@ -449,6 +436,19 @@
 
             // Then
             result.Should().BeViewResult().WithViewName("CentreInactive");
+        }
+
+        private void GivenSignInIsSuccessful(AdminUser expectedAdmin, List<DelegateUser> expectedDelegates)
+        {
+            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns(
+                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -93,7 +93,7 @@
         }
 
         [Test]
-        public void Successful_sign_in_with_return_url_should_redirect_to_return_url()
+        public void Successful_sign_in_with_local_return_url_should_redirect_to_return_url()
         {
             //Given
             var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
@@ -116,6 +116,33 @@
 
             // Then
             result.Should().BeRedirectResult().WithUrl(returnUrl);
+        }
+
+        [Test]
+        public void Successful_sign_in_with_nonlocal_return_url_should_render_home_page()
+        {
+            //Given
+            var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
+            var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
+            A.CallTo(() => userService.GetUsersByUsername(A<string>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns((expectedAdmin, expectedDelegates));
+            A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
+                .Returns(
+                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+
+            // When
+            var loginViewModel = LoginTestHelper.GetDefaultLoginViewModel();
+            var returnUrl = "www.suspicious.com";
+            loginViewModel.ReturnUrl = returnUrl;
+            var result = controller.Index(loginViewModel);
+
+            // Then
+            result.Should().BeRedirectToActionResult()
+                .WithControllerName("Home").WithActionName("Index");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -76,9 +76,7 @@
         public void Successful_sign_in_without_return_url_should_render_home_page()
         {
             // Given
-            var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
-            var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
+            GivenSignInIsSuccessful();
 
             // When
             var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
@@ -92,9 +90,7 @@
         public void Successful_sign_in_with_local_return_url_should_redirect_to_return_url()
         {
             // Given
-            var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
-            var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
+            GivenSignInIsSuccessful();
 
             var returnUrl = "/some/other/page";
             var urlHelper = controller.Url;
@@ -113,9 +109,7 @@
         public void Successful_sign_in_with_nonlocal_return_url_should_render_home_page()
         {
             // Given
-            var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
-            var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
+            GivenSignInIsSuccessful();
 
             var returnUrl = "www.suspicious.com";
             var urlHelper = controller.Url;
@@ -135,9 +129,7 @@
         public void Successful_sign_in_should_call_SignInAsync()
         {
             // Given
-            var expectedAdmin = UserTestHelper.GetDefaultAdminUser();
-            var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
-            GivenSignInIsSuccessful(expectedAdmin, expectedDelegates);
+            GivenSignInIsSuccessful();
 
             // When
             controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
@@ -438,14 +430,17 @@
             result.Should().BeViewResult().WithViewName("CentreInactive");
         }
 
-        private void GivenSignInIsSuccessful(AdminUser expectedAdmin, List<DelegateUser> expectedDelegates)
+        private void GivenSignInIsSuccessful()
         {
+            var admin = UserTestHelper.GetDefaultAdminUser();
+            var delegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() };
+
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((expectedAdmin, expectedDelegates));
+                .Returns((admin, delegates));
             A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
+                .Returns((admin, delegates));
             A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((expectedAdmin, expectedDelegates));
+                .Returns((admin, delegates));
             A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns(
                     new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -185,6 +185,12 @@
                 IssuedUtc = DateTime.UtcNow
             };
             HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
+
+            return RedirectToReturnUrl(returnUrl) ?? RedirectToAction("Index", "Home");
+        }
+
+        private IActionResult? RedirectToReturnUrl(string? returnUrl)
+        {
             if (!string.IsNullOrEmpty(returnUrl))
             {
                 if (Url.IsLocalUrl(returnUrl))
@@ -193,7 +199,8 @@
                 }
                 logger.LogWarning($"Attempted login redirect to non-local returnUrl {returnUrl}");
             }
-            return RedirectToAction("Index", "Home");
+
+            return null;
         }
 
         private List<Claim> GetClaimsForSignIn

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -13,18 +13,21 @@
     using DigitalLearningSolutions.Web.ViewModels.Login;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
 
     public class LoginController : Controller
     {
         private readonly ILoginService loginService;
         private readonly ISessionService sessionService;
         private readonly IUserService userService;
+        private readonly ILogger<LoginController> logger;
 
-        public LoginController(ILoginService loginService, IUserService userService, ISessionService sessionService)
+        public LoginController(ILoginService loginService, IUserService userService, ISessionService sessionService, ILogger<LoginController> logger)
         {
             this.loginService = loginService;
             this.userService = userService;
             this.sessionService = sessionService;
+            this.logger = logger;
         }
 
         public IActionResult Index(string? returnUrl)
@@ -184,7 +187,11 @@
             HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
             if (!string.IsNullOrEmpty(returnUrl))
             {
-                return Redirect(returnUrl);
+                if (Url.IsLocalUrl(returnUrl))
+                {
+                    return Redirect(returnUrl);
+                }
+                logger.LogWarning($"Attempted login redirect to non-local returnUrl {returnUrl}");
             }
             return RedirectToAction("Index", "Home");
         }

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -30,7 +30,7 @@
             this.logger = logger;
         }
 
-        public IActionResult Index(string? returnUrl)
+        public IActionResult Index(string? returnUrl = null)
         {
             if (User.Identity.IsAuthenticated)
             {

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -4,6 +4,7 @@ namespace DigitalLearningSolutions.Web
     using System.Data;
     using System.IO;
     using System.Threading.Tasks;
+    using System.Web;
     using DigitalLearningSolutions.Data.DataServices;
     using System.Web;
     using DigitalLearningSolutions.Data.Factories;
@@ -157,7 +158,8 @@ namespace DigitalLearningSolutions.Web
 
         private Task RedirectToLogin(RedirectContext<CookieAuthenticationOptions> context)
         {
-            context.HttpContext.Response.Redirect( "/Login");
+            var url = HttpUtility.UrlEncode(config["AppRootPath"] + context.Request.Path);
+            context.HttpContext.Response.Redirect($"/Login?returnUrl={url}");
             return Task.CompletedTask;
         }
 

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -158,7 +158,7 @@ namespace DigitalLearningSolutions.Web
 
         private Task RedirectToLogin(RedirectContext<CookieAuthenticationOptions> context)
         {
-            var url = HttpUtility.UrlEncode(config["AppRootPath"] + context.Request.Path);
+            var url = HttpUtility.UrlEncode(context.Request.Path);
             context.HttpContext.Response.Redirect($"/Login?returnUrl={url}");
             return Task.CompletedTask;
         }

--- a/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
@@ -9,6 +9,14 @@
             Username = string.Empty;
             Password = string.Empty;
             RememberMe = false;
+            ReturnUrl = string.Empty;
+        }
+        public LoginViewModel(string? returnUrl)
+        {
+            Username = string.Empty;
+            Password = string.Empty;
+            RememberMe = false;
+            ReturnUrl = returnUrl;
         }
 
         [Required(ErrorMessage = "Please enter a username to log in.")]
@@ -19,5 +27,7 @@
         public string? Password { get; set; }
 
         public bool RememberMe { get; set; }
+
+        public string? ReturnUrl { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Login/LoginViewModel.cs
@@ -9,8 +9,8 @@
             Username = string.Empty;
             Password = string.Empty;
             RememberMe = false;
-            ReturnUrl = string.Empty;
         }
+
         public LoginViewModel(string? returnUrl)
         {
             Username = string.Empty;

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -18,6 +18,9 @@
       @if (errorHasOccurred) {
         <partial name="_ErrorSummary"/>
       }
+
+      <input type="hidden" value="@Model.ReturnUrl" asp-for="ReturnUrl"/>
+
       <div class="nhsuk-u-margin-bottom-8">
         <h1 id="page-heading" class="nhsuk-heading-xl">Log in</h1>
         <p class="nhsuk-body-l">Enter your details to log into your account.</p>


### PR DESCRIPTION
This uses the returnUrl implementation from https://github.com/TechnologyEnhancedLearning/DLSV2/commit/78d49feed4ec0ce443ec9b51c3ef811be1a16de7
and passes it through the login process, including login failures and choosing a centre.