### PR TITLE
HEEDLS-426 Split the custom prompts option strings

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CustomPromptsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CustomPromptsDataServiceTests.cs
@@ -1,6 +1,6 @@
-﻿namespace DigitalLearningSolutions.Data.Tests.Services
+﻿namespace DigitalLearningSolutions.Data.Tests.DataServices
 {
-    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using FluentAssertions;
     using NUnit.Framework;

--- a/DigitalLearningSolutions.Data.Tests/Models/CustomPromptTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Models/CustomPromptTests.cs
@@ -1,0 +1,72 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Models
+{
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using NUnit.Framework;
+
+    public class CustomPromptTests
+    {
+        [Test]
+        public void CustomPrompt_constructor_populates_options_with_null()
+        {
+            // When
+            var result = new CustomPrompt("Test", null, false);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Options.Should().NotBeNull();
+                result.Options.Count.Should().Be(0);
+            }
+        }
+
+        [Test]
+        public void CustomPrompt_constructor_populates_options_with_single_entry()
+        {
+            // When
+            var result = new CustomPrompt("Test", "Option", false);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Options.Should().NotBeNull();
+                result.Options.Count.Should().Be(1);
+            }
+        }
+
+        [Test]
+        public void CustomPrompt_constructor_populates_options_with_several_newline_separated_entries()
+        {
+            // Given
+            var options = "Option1\r\nOption2\r\nOption3\r\nOption4";
+
+            // When
+            var result = new CustomPrompt("Test", options, false);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Options.Should().NotBeNull();
+                result.Options.Count.Should().Be(4);
+            }
+        }
+
+        [Test]
+        public void CustomPrompt_constructor_populates_options_with_extra_newline_separated_entries()
+        {
+            // Given
+            var options = "Option1\r\nOption2\r\n\r\nOption3\r\n\r\n\r\n\r\nOption4";
+
+            // When
+            var result = new CustomPrompt("Test", options, false);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Options.Should().NotBeNull();
+                result.Options.Count.Should().Be(4);
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/CustomPromptsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CustomPromptsServiceTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using FakeItEasy;
@@ -39,6 +41,26 @@
                 result.CustomField1.Should().BeEquivalentTo(expectedPrompt1);
                 result.CustomField2.Should().BeEquivalentTo(expectedPrompt2);
                 result.CustomField3.Should().BeNull();
+            }
+        }
+
+        [Test]
+        public void GetCustomPrompts_with_options_splits_correctly()
+        {
+            // Given
+            A.CallTo(() => customPromptsDataService.GetCentreCustomPromptsByCentreId(29))
+                .Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPromptsResult());
+
+            // When
+            var result = customPromptsService.GetCustomPromptsForCentreByCentreId(29);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.CustomField1.Should().NotBeNull();
+                result.CustomField1.Options.Count.Should().Be(2);
+                result.CustomField1.Options[0].Should().BeEquivalentTo("Clinical");
+                result.CustomField1.Options[1].Should().BeEquivalentTo("Non-Clinical");
             }
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/CustomPromptsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CustomPromptsDataService.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Services
+﻿namespace DigitalLearningSolutions.Data.DataServices
 {
     using System.Data;
     using System.Linq;

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
@@ -1,16 +1,30 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
 {
+    using System.Collections.Generic;
+
     public class CustomPrompt
     {
         public CustomPrompt(string? text, string? options, bool mandatory)
         {
             CustomPromptText = text;
-            Options = options;
+            Options = SplitOptionsString(options);
             Mandatory = mandatory;
         }
-        
+
+        private List<string> SplitOptionsString(string? options)
+        {
+            var optionsList = new List<string>();
+            if (options != null)
+            {
+                optionsList.AddRange(options.Split(new char[] { '\r', '\n' },
+                    System.StringSplitOptions.RemoveEmptyEntries));
+            }
+
+            return optionsList;
+        }
+
         public string? CustomPromptText { get; set; }
-        public string? Options { get; set; }
+        public List<string> Options { get; set; }
         public bool Mandatory { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
@@ -16,7 +16,7 @@
             var optionsList = new List<string>();
             if (options != null)
             {
-                optionsList.AddRange(options.Split(new char[] { '\r', '\n' },
+                optionsList.AddRange(options.Split(new [] { '\r', '\n' },
                     System.StringSplitOptions.RemoveEmptyEntries));
             }
 

--- a/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
+    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public interface ICustomPromptsService


### PR DESCRIPTION
Changed the options returned from the CustomPromptsService from a nullable string to a List<string> and moved the DataService to the DataServices folder.

I've tried this against all centres in the database, and the only one that wasn't either successfully split or null (empty list) was centre ID 435 which has an F1Options with a single option in it. i.e. we shouldn't have any issues with unexpected characters not splitting