### PR TITLE
HEEDLS-376 - Centre manager details added to centre config page

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CentresDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CentresDataServiceTests.cs
@@ -106,7 +106,11 @@
                 NotifyEmail = "notify@test.com",
                 BannerText = "xxxxxxxxxxxxxxxxxxxx",
                 SignatureImage = null,
-                CentreLogo = Convert.FromBase64String(CentreLogoTestHelper.DefaultCentreLogoAsBase64String)
+                CentreLogo = Convert.FromBase64String(CentreLogoTestHelper.DefaultCentreLogoAsBase64String),
+                ContactForename = "xxxxx",
+                ContactSurname = "xxxx",
+                ContactEmail = "nybwhudkra@ic.vs",
+                ContactTelephone = "xxxxxxxxxxxx"
             };
 
             // When

--- a/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
@@ -75,10 +75,10 @@
                             c.BannerText,
                             c.SignatureImage,
                             c.CentreLogo,
-	                        c.ContactForename,
-	                        c.ContactSurname,
+                            c.ContactForename,
+                            c.ContactSurname,
                             c.ContactEmail,
-	                        c.ContactTelephone
+                            c.ContactTelephone
                         FROM Centres AS c
                         INNER JOIN Regions AS r ON r.RegionID = c.RegionID
                         WHERE CentreID = @centreId",

--- a/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
@@ -74,7 +74,11 @@
                             c.NotifyEmail,
                             c.BannerText,
                             c.SignatureImage,
-                            c.CentreLogo
+                            c.CentreLogo,
+	                        c.ContactForename,
+	                        c.ContactSurname,
+                            c.ContactEmail,
+	                        c.ContactTelephone
                         FROM Centres AS c
                         INNER JOIN Regions AS r ON r.RegionID = c.RegionID
                         WHERE CentreID = @centreId",

--- a/DigitalLearningSolutions.Data/Models/Centre.cs
+++ b/DigitalLearningSolutions.Data/Models/Centre.cs
@@ -10,5 +10,9 @@
         public string BannerText { get; set; }
         public byte[]? SignatureImage { get; set; }
         public byte[]? CentreLogo { get; set; }
+        public string? ContactForename { get; set; }
+        public string? ContactSurname { get; set; }
+        public string? ContactEmail { get; set; }
+        public string? ContactTelephone { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfigurationViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfigurationViewModel.cs
@@ -12,6 +12,10 @@
             BannerText = centre.BannerText;
             SignatureImage = centre.SignatureImage;
             CentreLogo = centre.CentreLogo;
+            ContactForename = centre.ContactForename;
+            ContactSurname = centre.ContactSurname;
+            ContactEmail = centre.ContactEmail;
+            ContactTelephone = centre.ContactTelephone;
         }
 
         public string CentreName { get; set; }
@@ -20,5 +24,9 @@
         public string BannerText { get; set; }
         public byte[]? SignatureImage { get; set; }
         public byte[]? CentreLogo { get; set; }
+        public string? ContactForename { get; set; }
+        public string? ContactSurname { get; set; }
+        public string? ContactEmail { get; set; }
+        public string? ContactTelephone { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/Index.cshtml
@@ -75,5 +75,52 @@
         </dl>
       </div>
     </details>
+
+    <details class="nhsuk-details nhsuk-expander bottom-margin-nhsuk-card">
+      <summary class="nhsuk-details__summary">
+        <span class="nhsuk-details__summary-text">
+          Centre manager details
+        </span>
+      </summary>
+      <div class="nhsuk-details__text">
+        <dl class="nhsuk-summary-list">
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+              First name:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.ContactForename
+            </dd>
+          </div>
+
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+              Last name:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.ContactSurname
+            </dd>
+          </div>
+
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+              Email:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.ContactEmail
+            </dd>
+          </div>
+
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+              Telephone:
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+              @Model.ContactTelephone
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </details>
   </div>
 </div>


### PR DESCRIPTION
Tested:
- Ran all unit tests
- Checked in Chrome, IE11, Firefox, Edge,
- Checked Mobile view/zoom/screenreader/no js

Screenshots of new expander on centre config page:

![Centre Manager Details](https://user-images.githubusercontent.com/80777689/117956948-75606680-b311-11eb-9367-ec1a2660697d.PNG)

![Centre Manager Details Mobile view](https://user-images.githubusercontent.com/80777689/117956944-74c7d000-b311-11eb-808d-9812d82a81e6.PNG)

