### PR TITLE
HEEDLS-NONE Add comment suppressions to ReSharper errors

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/RedirectEmptySessionData.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/RedirectEmptySessionData.cs
@@ -17,6 +17,7 @@
                 var userSessionData = controller.TempData.Peek<T>();
                 if (userSessionData == null)
                 {
+                    // ReSharper disable once Mvc.ActionNotResolved
                     context.Result = controller.RedirectToAction("Index");
                 }
             }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_NavMenuItems.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_NavMenuItems.cshtml
@@ -1,5 +1,6 @@
 ﻿@using DigitalLearningSolutions.Web.Extensions
 <li class="nhsuk-header__navigation-item @Html.IsSelected("FrameworksDashboard")">
+  @* ReSharper disable once Mvc.ActionNotResolved *@
   <a class="nhsuk-header__navigation-link" asp-action="MyFrameworks">
     My Frameworks
     <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
@@ -8,6 +9,7 @@
   </a>
 </li>
 <li class="nhsuk-header__navigation-item @Html.IsSelected("FrameworksViewAll")">
+  @* ReSharper disable once Mvc.ActionNotResolved *@
   <a class="nhsuk-header__navigation-link" asp-action="AllFrameworks">
     All Frameworks
     <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_NavMenuItems.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_NavMenuItems.cshtml
@@ -1,7 +1,6 @@
 ﻿@using DigitalLearningSolutions.Web.Extensions
 <li class="nhsuk-header__navigation-item @Html.IsSelected("FrameworksDashboard")">
-  @* ReSharper disable once Mvc.ActionNotResolved *@
-  <a class="nhsuk-header__navigation-link" asp-action="MyFrameworks">
+  <a class="nhsuk-header__navigation-link" asp-controller="Frameworks" asp-action="FrameworksDashboard">
     My Frameworks
     <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -9,8 +8,7 @@
   </a>
 </li>
 <li class="nhsuk-header__navigation-item @Html.IsSelected("FrameworksViewAll")">
-  @* ReSharper disable once Mvc.ActionNotResolved *@
-  <a class="nhsuk-header__navigation-link" asp-action="AllFrameworks">
+  <a class="nhsuk-header__navigation-link" asp-controller="Frameworks" asp-action="FrameworksViewAll">
     All Frameworks
     <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>


### PR DESCRIPTION
There are a couple of places in code where we rely on actions with certain names existing on controllers in generic code (extensions, service filters etc.). ReSharper doesn't like us doing this because if those actions don't exist on a controller we might get a runtime error.
I've added comments suppressing those errors where they already exist in code because I got sick of seeing the squiggly lines in my IDE.

Tested by doing ordinary development with these changes for over a week, I'm just pushing it in case it's useful to anyone else.