### PR TITLE
Heedls 380 manage registration prompts

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/CustomPromptsTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CustomPromptsTestHelper.cs
@@ -7,43 +7,11 @@
     {
         public static CentreCustomPrompts GetDefaultCentreCustomPrompts
         (
-            int centreId = 29,
-            CustomPrompt? customPrompt1 = null,
-            CustomPrompt? customPrompt2 = null,
-            CustomPrompt? customPrompt3 = null,
-            CustomPrompt? customPrompt4 = null,
-            CustomPrompt? customPrompt5 = null,
-            CustomPrompt? customPrompt6 = null
+            List<CustomPrompt> customPrompts,
+            int centreId = 29
         )
         {
-            var centreCustomPrompts = new CentreCustomPrompts(centreId, new List<CustomPrompt>());
-
-            if (customPrompt1 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt1);
-            }
-            if (customPrompt2 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt2);
-            }
-            if (customPrompt3 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt3);
-            }
-            if (customPrompt4 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt4);
-            }
-            if (customPrompt5 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt5);
-            }
-            if (customPrompt6 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt6);
-            }
-
-            return centreCustomPrompts;
+            return new CentreCustomPrompts(centreId, customPrompts);
         }
 
         public static CustomPrompt GetDefaultCustomPrompt
@@ -59,43 +27,11 @@
 
         public static CentreCustomPromptsWithAnswers GetDefaultCentreCustomPromptsWithAnswers
         (
-            int centreId = 29,
-            CustomPromptWithAnswer? customPrompt1 = null,
-            CustomPromptWithAnswer? customPrompt2 = null,
-            CustomPromptWithAnswer? customPrompt3 = null,
-            CustomPromptWithAnswer? customPrompt4 = null,
-            CustomPromptWithAnswer? customPrompt5 = null,
-            CustomPromptWithAnswer? customPrompt6 = null
+            List<CustomPromptWithAnswer> customPrompts,
+            int centreId = 29
         )
         {
-            var centreCustomPrompts = new CentreCustomPromptsWithAnswers(centreId, new List<CustomPromptWithAnswer>());
-
-            if (customPrompt1 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt1);
-            }
-            if (customPrompt2 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt2);
-            }
-            if (customPrompt3 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt3);
-            }
-            if (customPrompt4 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt4);
-            }
-            if (customPrompt5 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt5);
-            }
-            if (customPrompt6 != null)
-            {
-                centreCustomPrompts.CustomPrompts.Add(customPrompt6);
-            }
-
-            return centreCustomPrompts;
+            return new CentreCustomPromptsWithAnswers(centreId, customPrompts);
         }
 
         public static CustomPromptWithAnswer GetDefaultCustomPromptWithAnswer

--- a/DigitalLearningSolutions.Data.Tests/Helpers/CustomPromptsTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/CustomPromptsTestHelper.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Helpers
 {
+    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public static class CustomPromptsTestHelper
@@ -15,26 +16,98 @@
             CustomPrompt? customPrompt6 = null
         )
         {
-            return new CentreCustomPrompts
+            var centreCustomPrompts = new CentreCustomPrompts(centreId, new List<CustomPrompt>());
+
+            if (customPrompt1 != null)
             {
-                CentreId = centreId,
-                CustomField1 = customPrompt1,
-                CustomField2 = customPrompt2,
-                CustomField3 = customPrompt3,
-                CustomField4 = customPrompt4,
-                CustomField5 = customPrompt5,
-                CustomField6 = customPrompt6
-            };
+                centreCustomPrompts.CustomPrompts.Add(customPrompt1);
+            }
+            if (customPrompt2 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt2);
+            }
+            if (customPrompt3 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt3);
+            }
+            if (customPrompt4 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt4);
+            }
+            if (customPrompt5 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt5);
+            }
+            if (customPrompt6 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt6);
+            }
+
+            return centreCustomPrompts;
         }
 
         public static CustomPrompt GetDefaultCustomPrompt
         (
-            string? text = "Custom Prompt",
+            int promptNumber,
+            string text = "Custom Prompt",
             string? options = "",
             bool mandatory = false
         )
         {
-            return new CustomPrompt(text, options, mandatory);
+            return new CustomPrompt(promptNumber, text, options, mandatory);
+        }
+
+        public static CentreCustomPromptsWithAnswers GetDefaultCentreCustomPromptsWithAnswers
+        (
+            int centreId = 29,
+            CustomPromptWithAnswer? customPrompt1 = null,
+            CustomPromptWithAnswer? customPrompt2 = null,
+            CustomPromptWithAnswer? customPrompt3 = null,
+            CustomPromptWithAnswer? customPrompt4 = null,
+            CustomPromptWithAnswer? customPrompt5 = null,
+            CustomPromptWithAnswer? customPrompt6 = null
+        )
+        {
+            var centreCustomPrompts = new CentreCustomPromptsWithAnswers(centreId, new List<CustomPromptWithAnswer>());
+
+            if (customPrompt1 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt1);
+            }
+            if (customPrompt2 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt2);
+            }
+            if (customPrompt3 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt3);
+            }
+            if (customPrompt4 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt4);
+            }
+            if (customPrompt5 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt5);
+            }
+            if (customPrompt6 != null)
+            {
+                centreCustomPrompts.CustomPrompts.Add(customPrompt6);
+            }
+
+            return centreCustomPrompts;
+        }
+
+        public static CustomPromptWithAnswer GetDefaultCustomPromptWithAnswer
+        (
+            int promptNumber,
+            string text = "Custom Prompt",
+            string? options = "",
+            bool mandatory = false,
+            string? answer = null
+        )
+        {
+            return new CustomPromptWithAnswer(promptNumber, text, options, mandatory, answer);
         }
 
         public static CentreCustomPromptsResult GetDefaultCentreCustomPromptsResult

--- a/DigitalLearningSolutions.Data.Tests/Models/CustomPromptTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Models/CustomPromptTests.cs
@@ -11,7 +11,7 @@
         public void CustomPrompt_constructor_populates_options_with_null()
         {
             // When
-            var result = new CustomPrompt("Test", null, false);
+            var result = new CustomPrompt(1,"Test", null, false);
 
             // Then
             using (new AssertionScope())
@@ -25,7 +25,7 @@
         public void CustomPrompt_constructor_populates_options_with_single_entry()
         {
             // When
-            var result = new CustomPrompt("Test", "Option", false);
+            var result = new CustomPrompt(1,"Test", "Option", false);
 
             // Then
             using (new AssertionScope())
@@ -42,7 +42,7 @@
             var options = "Option1\r\nOption2\r\nOption3\r\nOption4";
 
             // When
-            var result = new CustomPrompt("Test", options, false);
+            var result = new CustomPrompt(1,"Test", options, false);
 
             // Then
             using (new AssertionScope())
@@ -59,7 +59,7 @@
             var options = "Option1\r\nOption2\r\n\r\nOption3\r\n\r\n\r\n\r\nOption4";
 
             // When
-            var result = new CustomPrompt("Test", options, false);
+            var result = new CustomPrompt(1,"Test", options, false);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Data.Tests/Services/CustomPromptsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CustomPromptsServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
     using DigitalLearningSolutions.Data.DataServices;
-    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using FakeItEasy;
@@ -25,8 +24,8 @@
         public void GetCustomPromptsForCentreByCentreId_Returns_Populated_CentreCustomPrompts()
         {
             // Given
-            var expectedPrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(options: null, mandatory: true);
-            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(text: "Department / team", options: null, mandatory: true);
+            var expectedPrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1,options: null, mandatory: true);
+            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(2,text: "Department / team", options: null, mandatory: true);
             var expectedCustomerPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPrompt1: expectedPrompt1, customPrompt2: expectedPrompt2);
             A.CallTo(() => customPromptsDataService.GetCentreCustomPromptsByCentreId(29))
                 .Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPromptsResult(customField1Prompt: "Custom Prompt", customField1Options: null));
@@ -38,9 +37,34 @@
             using (new AssertionScope())
             {
                 result.Should().BeEquivalentTo(expectedCustomerPrompts);
-                result.CustomField1.Should().BeEquivalentTo(expectedPrompt1);
-                result.CustomField2.Should().BeEquivalentTo(expectedPrompt2);
-                result.CustomField3.Should().BeNull();
+                result.CustomPrompts.Count.Should().Be(2);
+                result.CustomPrompts[0].Should().BeEquivalentTo(expectedPrompt1);
+                result.CustomPrompts[1].Should().BeEquivalentTo(expectedPrompt2);
+            }
+        }
+
+        [Test]
+        public void GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser_Returns_Populated_CentreCustomPrompts()
+        {
+            // Given#
+            var answer1 = "Answer 1";
+            var delegateUser = UserTestHelper.GetDefaultDelegateUser(answer1: answer1);
+            var expectedPrompt1 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1, options: null, mandatory: true, answer: answer1);
+            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2, text: "Department / team", options: null, mandatory: true);
+            var expectedCustomerPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: expectedPrompt1, customPrompt2: expectedPrompt2);
+            A.CallTo(() => customPromptsDataService.GetCentreCustomPromptsByCentreId(29))
+                .Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPromptsResult(customField1Prompt: "Custom Prompt", customField1Options: null));
+
+            // When
+            var result = customPromptsService.GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(29, delegateUser);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(expectedCustomerPrompts);
+                result.CustomPrompts.Count.Should().Be(2);
+                result.CustomPrompts[0].Should().BeEquivalentTo(expectedPrompt1);
+                result.CustomPrompts[1].Should().BeEquivalentTo(expectedPrompt2);
             }
         }
 
@@ -57,10 +81,10 @@
             // Then
             using (new AssertionScope())
             {
-                result.CustomField1.Should().NotBeNull();
-                result.CustomField1.Options.Count.Should().Be(2);
-                result.CustomField1.Options[0].Should().BeEquivalentTo("Clinical");
-                result.CustomField1.Options[1].Should().BeEquivalentTo("Non-Clinical");
+                result.CustomPrompts.Should().NotBeNull();
+                result.CustomPrompts[0].Options.Count.Should().Be(2);
+                result.CustomPrompts[0].Options[0].Should().BeEquivalentTo("Clinical");
+                result.CustomPrompts[0].Options[1].Should().BeEquivalentTo("Non-Clinical");
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/CustomPromptsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CustomPromptsServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.Services
 {
+    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using FakeItEasy;
@@ -24,9 +26,10 @@
         public void GetCustomPromptsForCentreByCentreId_Returns_Populated_CentreCustomPrompts()
         {
             // Given
-            var expectedPrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1,options: null, mandatory: true);
-            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(2,text: "Department / team", options: null, mandatory: true);
-            var expectedCustomerPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPrompt1: expectedPrompt1, customPrompt2: expectedPrompt2);
+            var expectedPrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1, options: null, mandatory: true);
+            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(2, "Department / team", null, true);
+            var customPromts = new List<CustomPrompt> { expectedPrompt1, expectedPrompt2 };
+            var expectedCustomerPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPromts);
             A.CallTo(() => customPromptsDataService.GetCentreCustomPromptsByCentreId(29))
                 .Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPromptsResult(customField1Prompt: "Custom Prompt", customField1Options: null));
 
@@ -50,8 +53,9 @@
             var answer1 = "Answer 1";
             var delegateUser = UserTestHelper.GetDefaultDelegateUser(answer1: answer1);
             var expectedPrompt1 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1, options: null, mandatory: true, answer: answer1);
-            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2, text: "Department / team", options: null, mandatory: true);
-            var expectedCustomerPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: expectedPrompt1, customPrompt2: expectedPrompt2);
+            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2, "Department / team", null, true);
+            var customPrompts = new List<CustomPromptWithAnswer> { expectedPrompt1, expectedPrompt2 };
+            var expectedCustomerPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompts);
             A.CallTo(() => customPromptsDataService.GetCentreCustomPromptsByCentreId(29))
                 .Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPromptsResult(customField1Prompt: "Custom Prompt", customField1Options: null));
 

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CentreCustomPromptsWithAnswers.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CentreCustomPromptsWithAnswers.cs
@@ -2,9 +2,9 @@
 {
     using System.Collections.Generic;
 
-    public class CentreCustomPrompts
+    public class CentreCustomPromptsWithAnswers
     {
-        public CentreCustomPrompts(int centreId, List<CustomPrompt> customPrompts)
+        public CentreCustomPromptsWithAnswers(int centreId, List<CustomPromptWithAnswer> customPrompts)
         {
             CentreId = centreId;
             CustomPrompts = customPrompts;
@@ -12,6 +12,6 @@
 
         public int CentreId { get; set; }
 
-        public List<CustomPrompt> CustomPrompts { get; set; }
+        public List<CustomPromptWithAnswer> CustomPrompts { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
@@ -4,8 +4,9 @@
 
     public class CustomPrompt
     {
-        public CustomPrompt(string? text, string? options, bool mandatory)
+        public CustomPrompt(int customPromptNumber, string text, string? options, bool mandatory)
         {
+            CustomPromptNumber = customPromptNumber;
             CustomPromptText = text;
             Options = SplitOptionsString(options);
             Mandatory = mandatory;
@@ -23,7 +24,8 @@
             return optionsList;
         }
 
-        public string? CustomPromptText { get; set; }
+        public int CustomPromptNumber { get; set; } 
+        public string CustomPromptText { get; set; }
         public List<string> Options { get; set; }
         public bool Mandatory { get; set; }
     }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPromptWithAnswer.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPromptWithAnswer.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
+{
+    public class CustomPromptWithAnswer : CustomPrompt
+    {
+        public CustomPromptWithAnswer(int customPromptNumber, string text, string? options, bool mandatory, string? answer)
+            : base(customPromptNumber, text, options, mandatory)
+        {
+            Answer = answer;
+        }
+
+        public string? Answer { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
@@ -1,11 +1,16 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
+    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using DigitalLearningSolutions.Data.Models.User;
 
     public interface ICustomPromptsService
     {
         public CentreCustomPrompts? GetCustomPromptsForCentreByCentreId(int? centreId);
+
+        public CentreCustomPromptsWithAnswers? GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(int? centreId,
+            DelegateUser? delegateUser);
     }
 
     public class CustomPromptsService : ICustomPromptsService
@@ -26,21 +31,138 @@
 
             var result = customPromptsDataService.GetCentreCustomPromptsByCentreId(centreId.Value);
 
-            return new CentreCustomPrompts
-            {
-                CentreId = result.CentreId,
-                CustomField1 = PopulateCustomPrompt(result.CustomField1Prompt, result.CustomField1Options, result.CustomField1Mandatory),
-                CustomField2 = PopulateCustomPrompt(result.CustomField2Prompt, result.CustomField2Options, result.CustomField2Mandatory),
-                CustomField3 = PopulateCustomPrompt(result.CustomField3Prompt, result.CustomField3Options, result.CustomField3Mandatory),
-                CustomField4 = PopulateCustomPrompt(result.CustomField4Prompt, result.CustomField4Options, result.CustomField4Mandatory),
-                CustomField5 = PopulateCustomPrompt(result.CustomField5Prompt, result.CustomField5Options, result.CustomField5Mandatory),
-                CustomField6 = PopulateCustomPrompt(result.CustomField6Prompt, result.CustomField6Options, result.CustomField6Mandatory)
-            };
+            return new CentreCustomPrompts(result.CentreId, PopulateCustomPromptListFromCentreCustomPromptsResult(result));
         }
 
-        private CustomPrompt? PopulateCustomPrompt(string? prompt, string? options, bool mandatory)
+        public CentreCustomPromptsWithAnswers? GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(int? centreId,
+            DelegateUser? delegateUser)
         {
-            return prompt != null ? new CustomPrompt(prompt, options, mandatory) : null;
+            if (centreId == null || delegateUser == null)
+            {
+                return null;
+            }
+
+            var result = customPromptsDataService.GetCentreCustomPromptsByCentreId(centreId.Value);
+
+            return new CentreCustomPromptsWithAnswers(result.CentreId, PopulateCustomPromptWithAnswerListFromCentreCustomPromptsResult(result, delegateUser));
+        }
+
+        private List<CustomPrompt> PopulateCustomPromptListFromCentreCustomPromptsResult(CentreCustomPromptsResult? result)
+        {
+            var list = new List<CustomPrompt>();
+
+            if (result == null)
+            {
+                return list;
+            }
+
+            var prompt1 = PopulateCustomPrompt(1, result.CustomField1Prompt, result.CustomField1Options,
+                result.CustomField1Mandatory);
+            if (prompt1 != null)
+            {
+                list.Add(prompt1);
+            }
+
+            var prompt2 = PopulateCustomPrompt(2, result.CustomField2Prompt, result.CustomField2Options,
+                result.CustomField2Mandatory);
+            if (prompt2 != null)
+            {
+                list.Add(prompt2);
+            }
+
+            var prompt3 = PopulateCustomPrompt(3, result.CustomField3Prompt, result.CustomField3Options,
+                result.CustomField3Mandatory);
+            if (prompt3 != null)
+            {
+                list.Add(prompt3);
+            }
+
+            var prompt4 = PopulateCustomPrompt(4, result.CustomField4Prompt, result.CustomField4Options,
+                result.CustomField4Mandatory);
+            if (prompt4 != null)
+            {
+                list.Add(prompt4);
+            }
+
+            var prompt5 = PopulateCustomPrompt(5, result.CustomField5Prompt, result.CustomField5Options,
+                result.CustomField5Mandatory);
+            if (prompt5 != null)
+            {
+                list.Add(prompt5);
+            }
+
+            var prompt6 = PopulateCustomPrompt(6, result.CustomField6Prompt, result.CustomField6Options,
+                result.CustomField6Mandatory);
+            if (prompt6 != null)
+            {
+                list.Add(prompt6);
+            }
+
+            return list;
+        }
+
+        private List<CustomPromptWithAnswer> PopulateCustomPromptWithAnswerListFromCentreCustomPromptsResult(CentreCustomPromptsResult? result, DelegateUser delegateUser)
+        {
+            var list = new List<CustomPromptWithAnswer>();
+
+            if (result == null)
+            {
+                return list;
+            }
+
+            var prompt1 = PopulateCustomPromptWithAnswer(1, result.CustomField1Prompt, result.CustomField1Options,
+                result.CustomField1Mandatory, delegateUser.Answer1);
+            if (prompt1 != null)
+            {
+                list.Add(prompt1);
+            }
+
+            var prompt2 = PopulateCustomPromptWithAnswer(2, result.CustomField2Prompt, result.CustomField2Options,
+                result.CustomField2Mandatory, delegateUser.Answer2);
+            if (prompt2 != null)
+            {
+                list.Add(prompt2);
+            }
+
+            var prompt3 = PopulateCustomPromptWithAnswer(3, result.CustomField3Prompt, result.CustomField3Options,
+                result.CustomField3Mandatory, delegateUser.Answer3);
+            if (prompt3 != null)
+            {
+                list.Add(prompt3);
+            }
+
+            var prompt4 = PopulateCustomPromptWithAnswer(4, result.CustomField4Prompt, result.CustomField4Options,
+                result.CustomField4Mandatory, delegateUser.Answer4);
+            if (prompt4 != null)
+            {
+                list.Add(prompt4);
+            }
+
+            var prompt5 = PopulateCustomPromptWithAnswer(5, result.CustomField5Prompt, result.CustomField5Options,
+                result.CustomField5Mandatory, delegateUser.Answer5);
+            if (prompt5 != null)
+            {
+                list.Add(prompt5);
+            }
+
+            var prompt6 = PopulateCustomPromptWithAnswer(6, result.CustomField6Prompt, result.CustomField6Options,
+                result.CustomField6Mandatory, delegateUser.Answer6);
+            if (prompt6 != null)
+            {
+                list.Add(prompt6);
+            }
+
+            return list;
+        }
+
+        private CustomPrompt? PopulateCustomPrompt(int promptNumber, string? prompt, string? options, bool mandatory)
+        {
+            return prompt != null ? new CustomPrompt(promptNumber, prompt, options, mandatory) : null;
+        }
+
+        private CustomPromptWithAnswer? PopulateCustomPromptWithAnswer(int promptNumber, string? prompt, string? options, bool mandatory, string? answer)
+        {
+            return prompt != null ? new CustomPromptWithAnswer(promptNumber, prompt, options, mandatory, answer) : null;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
@@ -42,7 +42,7 @@
             return new CentreCustomPromptsWithAnswers(result.CentreId, PopulateCustomPromptWithAnswerListFromCentreCustomPromptsResult(result, delegateUser));
         }
 
-        private List<CustomPrompt> PopulateCustomPromptListFromCentreCustomPromptsResult(CentreCustomPromptsResult? result)
+        private static List<CustomPrompt> PopulateCustomPromptListFromCentreCustomPromptsResult(CentreCustomPromptsResult? result)
         {
             var list = new List<CustomPrompt>();
 
@@ -96,7 +96,7 @@
             return list;
         }
 
-        private List<CustomPromptWithAnswer> PopulateCustomPromptWithAnswerListFromCentreCustomPromptsResult(CentreCustomPromptsResult? result, DelegateUser delegateUser)
+        private static List<CustomPromptWithAnswer> PopulateCustomPromptWithAnswerListFromCentreCustomPromptsResult(CentreCustomPromptsResult? result, DelegateUser delegateUser)
         {
             var list = new List<CustomPromptWithAnswer>();
 

--- a/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CustomPromptsService.cs
@@ -7,9 +7,9 @@
 
     public interface ICustomPromptsService
     {
-        public CentreCustomPrompts? GetCustomPromptsForCentreByCentreId(int? centreId);
+        public CentreCustomPrompts GetCustomPromptsForCentreByCentreId(int centreId);
 
-        public CentreCustomPromptsWithAnswers? GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(int? centreId,
+        public CentreCustomPromptsWithAnswers? GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(int centreId,
             DelegateUser? delegateUser);
     }
 
@@ -22,27 +22,22 @@
             this.customPromptsDataService = customPromptsDataService;
         }
 
-        public CentreCustomPrompts? GetCustomPromptsForCentreByCentreId(int? centreId)
+        public CentreCustomPrompts GetCustomPromptsForCentreByCentreId(int centreId)
         {
-            if (centreId == null)
-            {
-                return null;
-            }
-
-            var result = customPromptsDataService.GetCentreCustomPromptsByCentreId(centreId.Value);
+            var result = customPromptsDataService.GetCentreCustomPromptsByCentreId(centreId);
 
             return new CentreCustomPrompts(result.CentreId, PopulateCustomPromptListFromCentreCustomPromptsResult(result));
         }
 
-        public CentreCustomPromptsWithAnswers? GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(int? centreId,
+        public CentreCustomPromptsWithAnswers? GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(int centreId,
             DelegateUser? delegateUser)
         {
-            if (centreId == null || delegateUser == null)
+            if (delegateUser == null)
             {
                 return null;
             }
 
-            var result = customPromptsDataService.GetCentreCustomPromptsByCentreId(centreId.Value);
+            var result = customPromptsDataService.GetCentreCustomPromptsByCentreId(centreId);
 
             return new CentreCustomPromptsWithAnswers(result.CentreId, PopulateCustomPromptWithAnswerListFromCentreCustomPromptsResult(result, delegateUser));
         }
@@ -155,12 +150,12 @@
             return list;
         }
 
-        private CustomPrompt? PopulateCustomPrompt(int promptNumber, string? prompt, string? options, bool mandatory)
+        private static CustomPrompt? PopulateCustomPrompt(int promptNumber, string? prompt, string? options, bool mandatory)
         {
             return prompt != null ? new CustomPrompt(promptNumber, prompt, options, mandatory) : null;
         }
 
-        private CustomPromptWithAnswer? PopulateCustomPromptWithAnswer(int promptNumber, string? prompt, string? options, bool mandatory, string? answer)
+        private static CustomPromptWithAnswer? PopulateCustomPromptWithAnswer(int promptNumber, string? prompt, string? options, bool mandatory, string? answer)
         {
             return prompt != null ? new CustomPromptWithAnswer(promptNumber, prompt, options, mandatory, answer) : null;
         }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
@@ -14,7 +14,7 @@
             // Given
             var adminUser = UserTestHelper.GetDefaultAdminUser();
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPrompt());
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1));
             
             // When
             var returnedModel = new MyAccountViewModel(adminUser, delegateUser, customPrompts);
@@ -61,7 +61,7 @@
         {
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPrompt());
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1));
 
             // When
             var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts);
@@ -86,7 +86,7 @@
         {
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPrompt(), customPrompt2: CustomPromptsTestHelper.GetDefaultCustomPrompt());
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1), customPrompt2: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2));
 
             // When
             var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts);
@@ -96,12 +96,12 @@
             {
                 returnedModel.CustomFields.Should().NotBeNullOrEmpty();
                 returnedModel.CustomFields[0].CustomFieldId.Should().Be(1);
-                returnedModel.CustomFields[0].CustomPrompt.Should().BeEquivalentTo(customPrompts.CustomField1?.CustomPromptText);
+                returnedModel.CustomFields[0].CustomPrompt.Should().BeEquivalentTo(customPrompts.CustomPrompts[0].CustomPromptText);
                 returnedModel.CustomFields[0].Answer.Should().BeEquivalentTo(delegateUser.Answer1);
                 returnedModel.CustomFields[0].Mandatory.Should().BeFalse();
 
                 returnedModel.CustomFields[1].CustomFieldId.Should().Be(2);
-                returnedModel.CustomFields[1].CustomPrompt.Should().BeEquivalentTo(customPrompts.CustomField1?.CustomPromptText);
+                returnedModel.CustomFields[1].CustomPrompt.Should().BeEquivalentTo(customPrompts.CustomPrompts[1].CustomPromptText);
                 returnedModel.CustomFields[1].Answer.Should().BeEquivalentTo(delegateUser.Answer1);
                 returnedModel.CustomFields[1].Mandatory.Should().BeFalse();
             }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.MyAccount
 {
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Tests.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.MyAccount;
     using FluentAssertions;
@@ -14,8 +16,12 @@
             // Given
             var adminUser = UserTestHelper.GetDefaultAdminUser();
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1));
-            
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
+                new List<CustomPromptWithAnswer>
+                {
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1)
+                });
+
             // When
             var returnedModel = new MyAccountViewModel(adminUser, delegateUser, customPrompts);
 
@@ -61,7 +67,11 @@
         {
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1));
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
+                new List<CustomPromptWithAnswer>
+                {
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1)
+                });
 
             // When
             var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts);
@@ -77,7 +87,6 @@
                 returnedModel.User.Should().BeEquivalentTo(delegateUser.EmailAddress);
                 returnedModel.JobGroup.Should().BeEquivalentTo(delegateUser.JobGroupName);
                 returnedModel.CustomFields.Should().NotBeNullOrEmpty();
-                
             }
         }
 
@@ -86,7 +95,12 @@
         {
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(customPrompt1: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1), customPrompt2: CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2));
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
+                new List<CustomPromptWithAnswer>
+                {
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2)
+                });
 
             // When
             var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts);
@@ -96,12 +110,14 @@
             {
                 returnedModel.CustomFields.Should().NotBeNullOrEmpty();
                 returnedModel.CustomFields[0].CustomFieldId.Should().Be(1);
-                returnedModel.CustomFields[0].CustomPrompt.Should().BeEquivalentTo(customPrompts.CustomPrompts[0].CustomPromptText);
+                returnedModel.CustomFields[0].CustomPrompt.Should()
+                    .BeEquivalentTo(customPrompts.CustomPrompts[0].CustomPromptText);
                 returnedModel.CustomFields[0].Answer.Should().BeEquivalentTo(delegateUser.Answer1);
                 returnedModel.CustomFields[0].Mandatory.Should().BeFalse();
 
                 returnedModel.CustomFields[1].CustomFieldId.Should().Be(2);
-                returnedModel.CustomFields[1].CustomPrompt.Should().BeEquivalentTo(customPrompts.CustomPrompts[1].CustomPromptText);
+                returnedModel.CustomFields[1].CustomPrompt.Should()
+                    .BeEquivalentTo(customPrompts.CustomPrompts[1].CustomPromptText);
                 returnedModel.CustomFields[1].Answer.Should().BeEquivalentTo(delegateUser.Answer1);
                 returnedModel.CustomFields[1].Mandatory.Should().BeFalse();
             }

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -31,7 +31,7 @@
             var userDelegateId = User.GetNullableCandidateId();
             var (adminUser, delegateUser) = userService.GetUsersById(userAdminId, userDelegateId);
 
-            var customPrompts = customPromptsService.GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(delegateUser?.CentreId, delegateUser);
+            var customPrompts = customPromptsService.GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(User.GetCentreId(), delegateUser);
 
             var model = new MyAccountViewModel(adminUser, delegateUser, customPrompts);
 

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -31,7 +31,7 @@
             var userDelegateId = User.GetNullableCandidateId();
             var (adminUser, delegateUser) = userService.GetUsersById(userAdminId, userDelegateId);
 
-            var customPrompts = customPromptsService.GetCustomPromptsForCentreByCentreId(delegateUser?.CentreId);
+            var customPrompts = customPromptsService.GetCentreCustomPromptsWithAnswersByCentreIdAndDelegateUser(delegateUser?.CentreId, delegateUser);
 
             var model = new MyAccountViewModel(adminUser, delegateUser, customPrompts);
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CentreConfigurationController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CentreConfigurationController.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem
 {
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem;
     using Microsoft.AspNetCore.Authorization;
@@ -11,10 +12,12 @@
     public class CentreConfigurationController : Controller
     {
         private readonly ICentresDataService centresDataService;
+        private readonly ICustomPromptsService customPromptsService;
 
-        public CentreConfigurationController(ICentresDataService centresDataService)
+        public CentreConfigurationController(ICentresDataService centresDataService, ICustomPromptsService customPromptsService)
         {
             this.centresDataService = centresDataService;
+            this.customPromptsService = customPromptsService;
         }
 
         public IActionResult Index()
@@ -26,6 +29,18 @@
             var model = new CentreConfigurationViewModel(centreDetails);
 
             return View("Index", model);
+        }
+
+        [Route("RegistrationPrompts")]
+        public IActionResult RegistrationPrompts()
+        {
+            var centreId = User.GetCentreId();
+
+            var customPrompts = customPromptsService.GetCustomPromptsForCentreByCentreId(centreId);
+
+            var model = new DisplayRegistrationPromptsViewModel(customPrompts);
+
+            return View(model);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -133,7 +133,7 @@ h1#page-heading {
 .right-align-tag-column {
   padding: 0;
 
-  @include govuk-media-query($from: desktop) {
+  @include govuk-media-query($from: tablet) {
     text-align: right;
     padding-left: nhsuk-spacing(3);
   }
@@ -143,9 +143,15 @@ h1#page-heading {
   width: 100%;
   max-width: 10em;
   text-align: center;
-  margin-bottom: nhsuk-spacing(4);
+  margin-bottom: 0;
 
-  @include govuk-media-query($from: desktop) {
+  @include govuk-media-query($until: desktop){
+      margin-top: nhsuk-spacing(2);
+  }
+}
+
+.left-button-mobile-margin-bottom {
+  @include govuk-media-query($until: tablet) {
     margin-bottom: 0;
   }
 }

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -130,6 +130,26 @@ h1#page-heading {
   }
 }
 
+.right-align-tag-column {
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    text-align: right;
+    padding-left: nhsuk-spacing(3);
+  }
+}
+
+.right-align-tag {
+  width: 100%;
+  max-width: 10em;
+  text-align: center;
+  margin-bottom: nhsuk-spacing(4);
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 0;
+  }
+}
+
 ul.no-bullets {
   list-style-type: none;
   padding: 0;

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -70,3 +70,9 @@ hr.thick {
 .not-passed-text {
   @extend .nhsuk-u-secondary-text-color;
 }
+
+.left-button-mobile-margin-bottom {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: 0;
+  }
+}

--- a/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningMenu/index.scss
@@ -70,9 +70,3 @@ hr.thick {
 .not-passed-text {
   @extend .nhsuk-u-secondary-text-color;
 }
-
-.left-button-mobile-margin-bottom {
-  @include govuk-media-query($until: tablet) {
-    margin-bottom: 0;
-  }
-}

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
 {
     using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Models.User;
 
@@ -9,7 +10,7 @@
         public MyAccountViewModel(
             AdminUser? adminUser,
             DelegateUser? delegateUser,
-            CentreCustomPrompts? customPrompts)
+            CentreCustomPromptsWithAnswers? customPrompts)
         {
             FirstName = adminUser?.FirstName ?? delegateUser?.FirstName;
             Surname = adminUser?.LastName ?? delegateUser?.LastName;
@@ -20,20 +21,11 @@
             JobGroup = delegateUser?.JobGroupName;
 
             CustomFields = new List<CustomFieldViewModel>();
-
-            TryAddCustomFieldViewModelToList(1, customPrompts?.CustomField1, delegateUser?.Answer1);
-            TryAddCustomFieldViewModelToList(2, customPrompts?.CustomField2, delegateUser?.Answer2);
-            TryAddCustomFieldViewModelToList(3, customPrompts?.CustomField3, delegateUser?.Answer3);
-            TryAddCustomFieldViewModelToList(4, customPrompts?.CustomField4, delegateUser?.Answer4);
-            TryAddCustomFieldViewModelToList(5, customPrompts?.CustomField5, delegateUser?.Answer5);
-            TryAddCustomFieldViewModelToList(6, customPrompts?.CustomField6, delegateUser?.Answer6);
-        }
-
-        private void TryAddCustomFieldViewModelToList(int fieldNumber, CustomPrompt? customPrompt, string? answer)
-        {
-            if (customPrompt != null)
+            if (customPrompts != null)
             {
-                CustomFields.Add(new CustomFieldViewModel(fieldNumber, customPrompt.CustomPromptText, customPrompt.Mandatory, answer));
+                CustomFields = customPrompts.CustomPrompts.Select(cp =>
+                        new CustomFieldViewModel(cp.CustomPromptNumber, cp.CustomPromptText, cp.Mandatory, cp.Answer))
+                    .ToList();
             }
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CustomPromptManagementViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CustomPromptManagementViewModel.cs
@@ -1,0 +1,23 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem
+{
+    using System.Collections.Generic;
+
+    public class CustomPromptManagementViewModel
+    {
+        public CustomPromptManagementViewModel(int fieldId, string? prompt, bool mandatory, List<string> options)
+        {
+            CustomFieldId = fieldId;
+            CustomPrompt = prompt;
+            Mandatory = mandatory;
+            Options = options;
+        }
+
+        public int CustomFieldId { get; set; }
+
+        public string? CustomPrompt { get; set; }
+
+        public bool Mandatory { get; set; }
+
+        public List<string> Options { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CustomPromptManagementViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CustomPromptManagementViewModel.cs
@@ -4,17 +4,17 @@
 
     public class CustomPromptManagementViewModel
     {
-        public CustomPromptManagementViewModel(int fieldId, string? prompt, bool mandatory, List<string> options)
+        public CustomPromptManagementViewModel(int fieldId, string promptName, bool mandatory, List<string> options)
         {
             CustomFieldId = fieldId;
-            CustomPrompt = prompt;
+            CustomPromptName = promptName;
             Mandatory = mandatory;
             Options = options;
         }
 
         public int CustomFieldId { get; set; }
 
-        public string? CustomPrompt { get; set; }
+        public string CustomPromptName { get; set; }
 
         public bool Mandatory { get; set; }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/DisplayRegistrationPromptsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/DisplayRegistrationPromptsViewModel.cs
@@ -1,0 +1,30 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+
+    public class DisplayRegistrationPromptsViewModel
+    {
+        public DisplayRegistrationPromptsViewModel(CentreCustomPrompts? customPrompts)
+        {
+            CustomFields = new List<CustomPromptManagementViewModel>();
+
+            TryAddCustomPromptManagementViewModelToList(1, customPrompts?.CustomField1);
+            TryAddCustomPromptManagementViewModelToList(2, customPrompts?.CustomField2);
+            TryAddCustomPromptManagementViewModelToList(3, customPrompts?.CustomField3);
+            TryAddCustomPromptManagementViewModelToList(4, customPrompts?.CustomField4);
+            TryAddCustomPromptManagementViewModelToList(5, customPrompts?.CustomField5);
+            TryAddCustomPromptManagementViewModelToList(6, customPrompts?.CustomField6);
+        }
+
+        private void TryAddCustomPromptManagementViewModelToList(int fieldNumber, CustomPrompt? customPrompt)
+        {
+            if (customPrompt != null)
+            {
+                CustomFields.Add(new CustomPromptManagementViewModel(fieldNumber, customPrompt.CustomPromptText, customPrompt.Mandatory, customPrompt.Options));
+            }
+        }
+
+        public List<CustomPromptManagementViewModel> CustomFields { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/DisplayRegistrationPromptsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/DisplayRegistrationPromptsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem
 {
     using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public class DisplayRegistrationPromptsViewModel
@@ -9,19 +10,11 @@
         {
             CustomFields = new List<CustomPromptManagementViewModel>();
 
-            TryAddCustomPromptManagementViewModelToList(1, customPrompts?.CustomField1);
-            TryAddCustomPromptManagementViewModelToList(2, customPrompts?.CustomField2);
-            TryAddCustomPromptManagementViewModelToList(3, customPrompts?.CustomField3);
-            TryAddCustomPromptManagementViewModelToList(4, customPrompts?.CustomField4);
-            TryAddCustomPromptManagementViewModelToList(5, customPrompts?.CustomField5);
-            TryAddCustomPromptManagementViewModelToList(6, customPrompts?.CustomField6);
-        }
-
-        private void TryAddCustomPromptManagementViewModelToList(int fieldNumber, CustomPrompt? customPrompt)
-        {
-            if (customPrompt != null)
+            if (customPrompts != null)
             {
-                CustomFields.Add(new CustomPromptManagementViewModel(fieldNumber, customPrompt.CustomPromptText, customPrompt.Mandatory, customPrompt.Options));
+                CustomFields = customPrompts.CustomPrompts.Select(cp =>
+                        new CustomPromptManagementViewModel(cp.CustomPromptNumber, cp.CustomPromptText, cp.Mandatory,cp.Options))
+                    .ToList();
             }
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/DisplayRegistrationPromptsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/DisplayRegistrationPromptsViewModel.cs
@@ -6,16 +6,11 @@
 
     public class DisplayRegistrationPromptsViewModel
     {
-        public DisplayRegistrationPromptsViewModel(CentreCustomPrompts? customPrompts)
+        public DisplayRegistrationPromptsViewModel(CentreCustomPrompts customPrompts)
         {
-            CustomFields = new List<CustomPromptManagementViewModel>();
-
-            if (customPrompts != null)
-            {
-                CustomFields = customPrompts.CustomPrompts.Select(cp =>
+            CustomFields = customPrompts.CustomPrompts.Select(cp =>
                         new CustomPromptManagementViewModel(cp.CustomPromptNumber, cp.CustomPromptText, cp.Mandatory,cp.Options))
                     .ToList();
-            }
         }
 
         public List<CustomPromptManagementViewModel> CustomFields { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/Index.cshtml
@@ -218,3 +218,9 @@
     </details>
   </div>
 </div>
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <a class="nhsuk-button" asp-controller="CentreConfiguration" asp-action="RegistrationPrompts">Manage registration prompts</a>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
@@ -32,7 +32,7 @@
             <div class="nhsuk-grid-column-full">
               @if (customField.Options.Count != 0) {
                 <p class="nhsuk-u-font-weight-bold">Answers delegate can choose from:</p>
-                <ul class="">
+                <ul>
                   @foreach (var answer in customField.Options)
                   {
                     <li>@answer</li>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
@@ -1,18 +1,15 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem
 @model DisplayRegistrationPromptsViewModel
 
-@{
-  ViewData["Title"] = "Manage delegate registration prompts";
-}
+@{ ViewData["Title"] = "Manage delegate registration prompts"; }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 class="nhsuk-heading-xl" id="page-heading">Manage delegate registration prompts</h1>
+    <h1 class="nhsuk-heading-xl">Manage delegate registration prompt</h1>
   </div>
 </div>
 
-@foreach (var customField in Model.CustomFields)
-{
+@foreach (var customField in Model.CustomFields) {
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
       <details class="nhsuk-details nhsuk-expander">
@@ -20,7 +17,7 @@
           <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-three-quarters nhsuk-u-three-quarters-tablet">
               <span class="nhsuk-details__summary-text">
-                @customField.CustomPrompt
+                @customField.CustomPromptName
               </span>
             </div>
             <div class="nhsuk-grid-column-one-quarter nhsuk-u-one-quarter-tablet right-align-tag-column">
@@ -33,16 +30,15 @@
         <div class="nhsuk-details__text">
           <div class="nhsuk-grid-row nhsuk-u-margin-bottom-3">
             <div class="nhsuk-grid-column-full">
-              @if (customField.Options.Count != 0)
-              {
+              @if (customField.Options.Count != 0) {
                 <p class="nhsuk-u-font-weight-bold">Answers delegate can choose from:</p>
-                @foreach (var answer in customField.Options)
-                {
-                  <p class="nhsuk-u-margin-0">@answer</p>
-                }
-              }
-              else
-              {
+                <ul class="">
+                  @foreach (var answer in customField.Options)
+                  {
+                    <li>@answer</li>
+                  }
+                </ul>
+              } else {
                 <p>This is a free text field. Delegates can input any text.</p>
               }
             </div>
@@ -59,6 +55,16 @@
           </div>
         </div>
       </details>
+    </div>
+  </div>
+}
+
+@if (Model.CustomFields.Count == 0) {
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <p class="nhsuk-body-l">
+        Your centre does not have any delegate registration prompts.
+      </p>
     </div>
   </div>
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
@@ -18,12 +18,12 @@
       <details class="nhsuk-details nhsuk-expander">
         <summary class="nhsuk-details__summary">
           <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-three-quarters">
+            <div class="nhsuk-grid-column-three-quarters nhsuk-u-three-quarters-tablet">
               <span class="nhsuk-details__summary-text">
                 @customField.CustomPrompt
               </span>
             </div>
-            <div class="nhsuk-grid-column-one-quarter right-align-tag-column">
+            <div class="nhsuk-grid-column-one-quarter nhsuk-u-one-quarter-tablet right-align-tag-column">
               <strong class="nhsuk-u-font-size-19 right-align-tag nhsuk-tag @(customField.Mandatory ? "" : "nhsuk-tag--grey")">
                 @(customField.Mandatory ? "Mandatory" : "Optional")
               </strong>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts.cshtml
@@ -1,0 +1,78 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem
+@model DisplayRegistrationPromptsViewModel
+
+@{
+  ViewData["Title"] = "Manage delegate registration prompts";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl" id="page-heading">Manage delegate registration prompts</h1>
+  </div>
+</div>
+
+@foreach (var customField in Model.CustomFields)
+{
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <details class="nhsuk-details nhsuk-expander">
+        <summary class="nhsuk-details__summary">
+          <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-three-quarters">
+              <span class="nhsuk-details__summary-text">
+                @customField.CustomPrompt
+              </span>
+            </div>
+            <div class="nhsuk-grid-column-one-quarter right-align-tag-column">
+              <strong class="nhsuk-u-font-size-19 right-align-tag nhsuk-tag @(customField.Mandatory ? "" : "nhsuk-tag--grey")">
+                @(customField.Mandatory ? "Mandatory" : "Optional")
+              </strong>
+            </div>
+          </div>
+        </summary>
+        <div class="nhsuk-details__text">
+          <div class="nhsuk-grid-row nhsuk-u-margin-bottom-3">
+            <div class="nhsuk-grid-column-full">
+              @if (customField.Options.Count != 0)
+              {
+                <p class="nhsuk-u-font-weight-bold">Answers delegate can choose from:</p>
+                @foreach (var answer in customField.Options)
+                {
+                  <p class="nhsuk-u-margin-0">@answer</p>
+                }
+              }
+              else
+              {
+                <p>This is a free text field. Delegates can input any text.</p>
+              }
+            </div>
+          </div>
+          <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-full">
+              <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1" role="button">
+                Edit
+              </a>
+              <a class="nhsuk-button delete-button nhsuk-button--secondary nhsuk-u-margin-bottom-1" role="button">
+                Remove
+              </a>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+  </div>
+}
+
+@if (Model.CustomFields.Count < 6) {
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <a class="nhsuk-button">Add a new prompt</a>
+    </div>
+  </div>
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <vc:back-link asp-controller="CentreConfiguration" asp-action="Index"/>
+  </div>
+</div>


### PR DESCRIPTION
Added a screen to display the currently set custom registration prompts and a new button link on the CentreConfiguration

Checked the layout works down to mobile. 

I've put a message in slack to confirm the text for the free text prompts, so will potentially have to update that.

![image](https://user-images.githubusercontent.com/59561751/117955573-19491280-b310-11eb-8199-01ab3e29e23f.png)

![image](https://user-images.githubusercontent.com/59561751/117957361-e9027380-b311-11eb-9209-889a08fdcadc.png)

![image](https://user-images.githubusercontent.com/59561751/117957689-3a126780-b312-11eb-8a41-482c6e4ec49c.png)
