### PR TITLE
Heedls 359 application selector portal redirect

### DIFF
--- a/DigitalLearningSolutions.Web/Attributes/AdminOnlyAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/AdminOnlyAttribute.cs
@@ -1,0 +1,21 @@
+﻿namespace DigitalLearningSolutions.Web.Attributes
+{
+    using System;
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class AdminOnlyAttribute : Attribute, IAuthorizationFilter
+    {
+        public void OnAuthorization(AuthorizationFilterContext context)
+        {
+            var user = context.HttpContext.User;
+
+            if (!user.GetAdminId().HasValue)
+            {
+                context.Result = new RedirectToActionResult("Current", "LearningPortal", new {});
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Attributes/DelegateOnlyInaccessibleAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/DelegateOnlyInaccessibleAttribute.cs
@@ -6,13 +6,13 @@
     using Microsoft.AspNetCore.Mvc.Filters;
 
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-    public class AdminOnlyAttribute : Attribute, IAuthorizationFilter
+    public class DelegateOnlyInaccessibleAttribute : Attribute, IAuthorizationFilter
     {
         public void OnAuthorization(AuthorizationFilterContext context)
         {
             var user = context.HttpContext.User;
 
-            if (!user.GetAdminId().HasValue)
+            if (user.Identity.IsAuthenticated && !user.GetAdminId().HasValue)
             {
                 context.Result = new RedirectToActionResult("Current", "LearningPortal", new {});
             }

--- a/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.ApplicationSelector;
     using Microsoft.AspNetCore.Authorization;
@@ -8,6 +9,7 @@
     public class ApplicationSelectorController : Controller
     {
         [Authorize]
+        [DelegateOnlyInaccessible]
         public IActionResult Index()
         {
             var learningPortalAccess = User.GetCustomClaimAsBool(CustomClaimTypes.LearnUserAuthenticated) ?? false;

--- a/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
@@ -1,9 +1,11 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using DigitalLearningSolutions.Web.Attributes;
     using Microsoft.AspNetCore.Mvc;
 
     public class FindYourCentreController : Controller
     {
+        [DelegateOnlyInaccessible]
         public IActionResult Index()
         {
             return View();

--- a/DigitalLearningSolutions.Web/Controllers/HomeController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/HomeController.cs
@@ -3,11 +3,13 @@
 namespace DigitalLearningSolutions.Web.Controllers
 {
     using System.Collections.Generic;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common.MiniHub;
     using DigitalLearningSolutions.Web.ViewModels.Home;
     using Microsoft.Extensions.Configuration;
 
+    [DelegateOnlyInaccessible]
     public class HomeController : Controller
     {
         private const string LandingPageMiniHubName = "Digital Learning Solutions";

--- a/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
@@ -1,8 +1,10 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.ViewModels.LearningContent;
     using Microsoft.AspNetCore.Mvc;
 
+    [DelegateOnlyInaccessible]
     public class LearningContentController : Controller
     {
         private const string ItSkillsPathwayBrand = "ITSkillsPathway";

--- a/DigitalLearningSolutions.Web/Controllers/PricingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/PricingController.cs
@@ -1,9 +1,11 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using DigitalLearningSolutions.Web.Attributes;
     using Microsoft.AspNetCore.Mvc;
     
     public class PricingController : Controller
     {
+        [DelegateOnlyInaccessible]
         public IActionResult Index()
         {
             return View();


### PR DESCRIPTION
This is a partial review for HEEDLS-359 that covers the redirection of delegate-only accounts to the Learning Portal, but not changes to the navigation bar.