### PR TITLE
HEEDLS-400 Added optional centreid parameter to Find Your Centre page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/FindYourCentre/FindYourCentreViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/FindYourCentre/FindYourCentreViewModelTests.cs
@@ -1,0 +1,35 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.FindYourCentre
+{
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ViewModels.FindYourCentre;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class FindYourCentreViewModelTests
+    {
+        private string defaultUrl = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
+
+        [Test]
+        public void FindYourCentreViewModel_without_centreid_should_have_default_Url()
+        {
+            // When
+            var model = new FindYourCentreViewModel();
+
+            // Then
+            model.Url.Should().BeEquivalentTo(defaultUrl);
+        }
+
+        [Test]
+        public void FindYourCentreViewModel_with_centreid_should_have_centreid_added_to_Url()
+        {
+            // Given
+            var centreId = "5";
+
+            // When
+            var model = new FindYourCentreViewModel(centreId);
+
+            // Then
+            model.Url.Should().BeEquivalentTo(defaultUrl + "&centreid=" + centreId);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
@@ -1,12 +1,14 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using DigitalLearningSolutions.Web.ViewModels.FindYourCentre;
     using Microsoft.AspNetCore.Mvc;
 
     public class FindYourCentreController : Controller
     {
-        public IActionResult Index()
+        public IActionResult Index(string centreId)
         {
-            return View();
+            var model = new FindYourCentreViewModel(centreId);
+            return View(model);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
@@ -5,9 +5,9 @@
 
     public class FindYourCentreController : Controller
     {
-        public IActionResult Index(string centreId)
+        public IActionResult Index(string? centreId)
         {
-            var model = new FindYourCentreViewModel(centreId);
+            var model = centreId == null ? new FindYourCentreViewModel() : new FindYourCentreViewModel(centreId);
             return View(model);
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/FindYourCentre/FindYourCentreViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/FindYourCentre/FindYourCentreViewModel.cs
@@ -1,14 +1,19 @@
 namespace DigitalLearningSolutions.Web.ViewModels.FindYourCentre
 {
+    using DigitalLearningSolutions.Web.Helpers;
+
     public class FindYourCentreViewModel
     {
-        public string CentreId { get; set; }
+        public string Url { get; set; }
 
-        public FindYourCentreViewModel() { }
+        public FindYourCentreViewModel()
+        {
+            Url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
+        }
 
         public FindYourCentreViewModel(string centreId)
         {
-            CentreId = centreId;
+            Url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true&centreid=" + centreId;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/FindYourCentre/FindYourCentreViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/FindYourCentre/FindYourCentreViewModel.cs
@@ -1,0 +1,14 @@
+namespace DigitalLearningSolutions.Web.ViewModels.FindYourCentre
+{
+    public class FindYourCentreViewModel
+    {
+        public string CentreId { get; set; }
+
+        public FindYourCentreViewModel() { }
+
+        public FindYourCentreViewModel(string centreId)
+        {
+            CentreId = centreId;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
@@ -3,7 +3,7 @@
 @model FindYourCentreViewModel
 @{
   ViewData["Title"] = "Find Your Centre";
-  var url = "https://www.dls.nhs.uk/dev-prev" + "/findyourcentre?nonav=true";
+  var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
   url += String.IsNullOrEmpty(Model.CentreId) ? "" : "&centreid=" + Model.CentreId;
 }
 

--- a/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
@@ -1,7 +1,10 @@
 ﻿@using DigitalLearningSolutions.Web.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.FindYourCentre
+@model FindYourCentreViewModel
 @{
   ViewData["Title"] = "Find Your Centre";
-  var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
+  var url = "https://www.dls.nhs.uk/dev-prev" + "/findyourcentre?nonav=true";
+  url += String.IsNullOrEmpty(Model.CentreId) ? "" : "&centreid=" + Model.CentreId;
 }
 
 <div class="nhsuk-grid-row responsive-iframe-wrapper">

--- a/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/FindYourCentre/Index.cshtml
@@ -3,10 +3,8 @@
 @model FindYourCentreViewModel
 @{
   ViewData["Title"] = "Find Your Centre";
-  var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/findyourcentre?nonav=true";
-  url += String.IsNullOrEmpty(Model.CentreId) ? "" : "&centreid=" + Model.CentreId;
 }
 
 <div class="nhsuk-grid-row responsive-iframe-wrapper">
-  <iframe class="responsive-iframe" title="Find Your Centre" src="@url"></iframe>
+  <iframe class="responsive-iframe" title="Find Your Centre" src="@Model.Url"></iframe>
 </div>


### PR DESCRIPTION
Passes through a centreid parameter on the Find Your Centre page to the iframe, so we can load it already focussed on a particular centre if necessary. This isn't the whole ticket but other tickets rely on this working, so I'm putting it up and getting it merged early.

Tested in Firefox, Chrome, Edge and IE