### PR TITLE
HEEDLS-NONE - Set editor config default values to shift parameters on…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,12 +8,16 @@ trim_trailing_whitespace = true
 
 # ReSharper properties
 resharper_csharp_wrap_after_declaration_lpar = true
+resharper_csharp_wrap_after_invocation_lpar = true
+resharper_csharp_wrap_arguments_style = chop_if_long
 resharper_csharp_wrap_before_declaration_lpar = true
+resharper_csharp_wrap_before_invocation_lpar = true
 resharper_csharp_wrap_lines = true
 resharper_csharp_wrap_parameters_style = chop_if_long
 resharper_keep_existing_declaration_parens_arrangement = true
 resharper_place_constructor_initializer_on_same_line = true
 resharper_wrap_before_declaration_rpar = true
+resharper_wrap_before_invocation_rpar = true
 
 [*.{cs}]
 indent_size = 4


### PR DESCRIPTION
…to new lines if too long in method invocation.

Previous change only set method signatures, not invocations. This fixes that.