### PR TITLE
HEEDLS-455 Change dl element with no dt children to a div

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests.cs
@@ -49,6 +49,9 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests
         [InlineData("/TrackingSystem/CentreConfiguration/EditCentreManagerDetails")]
         [InlineData("/TrackingSystem/CentreConfiguration/EditCentreWebsiteDetails")]
         [InlineData("/TrackingSystem/Delegates/Approve")]
+        [InlineData("/NotificationPreferences")]
+        [InlineData("/NotificationPreferences/Edit/AdminUser")]
+        [InlineData("/NotificationPreferences/Edit/DelegateUser")]
         public void Authenticated_page_has_no_accessibility_errors(string url)
         {
             // when

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceList.cshtml
@@ -3,21 +3,21 @@
 
 <link rel="stylesheet" href="@Url.Content("~/css/myAccount/notificationPreferences.css")" asp-append-version="true">
 
-<div class="nhsuk-grid-column-full nhsuk-summary-list preference-list">
+<dl class="nhsuk-grid-column-full nhsuk-summary-list preference-list">
   @foreach (var notification in Model.Notifications) {
     <div class="nhsuk-grid-row preference-row">
-      <div class="nhsuk-grid-column-three-quarters preference-text-column">
-        <div class="nhsuk-heading-xs">@notification.NotificationName</div>
-        <p class="nhsuk-body-m">@Html.Raw(notification.Description)</p>
-      </div>
-      <div class="nhsuk-grid-column-one-quarter preference-tag-column">
+      <dt class="nhsuk-grid-column-three-quarters preference-text-column">
+        <span class="nhsuk-heading-xs">@notification.NotificationName</span>
+        <span class="nhsuk-body-m">@Html.Raw(notification.Description)</span>
+      </dt>
+      <dd class="nhsuk-grid-column-one-quarter nhsuk-u-margin-left-0 preference-tag-column">
         <strong class="nhsuk-u-font-size-19 preference-tag nhsuk-tag @(notification.Accepted ? "" : "nhsuk-tag--grey")">
           @(notification.Accepted ? "Subscribed" : "Unsubscribed")
         </strong>
-      </div>
+      </dd>
     </div>
   }
-</div>
+</dl>
 <a
   class="nhsuk-button"
   asp-controller="NotificationPreferences"

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/_NotificationPreferenceList.cshtml
@@ -3,7 +3,7 @@
 
 <link rel="stylesheet" href="@Url.Content("~/css/myAccount/notificationPreferences.css")" asp-append-version="true">
 
-<dl class="nhsuk-grid-column-full nhsuk-summary-list preference-list">
+<div class="nhsuk-grid-column-full nhsuk-summary-list preference-list">
   @foreach (var notification in Model.Notifications) {
     <div class="nhsuk-grid-row preference-row">
       <div class="nhsuk-grid-column-three-quarters preference-text-column">
@@ -17,7 +17,7 @@
       </div>
     </div>
   }
-</dl>
+</div>
 <a
   class="nhsuk-button"
   asp-controller="NotificationPreferences"


### PR DESCRIPTION
Changed the dl element in the notification list that had no child dt/dd elements to a div. Style should still be the same as I've not changed the css classes.
Added Notification preferences pages to accessibility tests now they pass.

Checked the layout wasn't broken by this change and the expanders etc. still work.