### PR TITLE
HEEDLS-383 Change spacing around buttons and add table caption

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -190,3 +190,7 @@ ul.no-bullets {
 .word-break {
   word-break: break-word;
 }
+
+.vertical-align-centre {
+    vertical-align: middle
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/AddRegistrationPromptConfigureAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/AddRegistrationPromptConfigureAnswersViewModel.cs
@@ -8,10 +8,11 @@
     {
         public RegistrationPromptAnswersViewModel() { }
 
-        public RegistrationPromptAnswersViewModel(string optionsString, string? answer = null)
+        public RegistrationPromptAnswersViewModel(string optionsString, string? answer = null, bool isEditScreen = false)
         {
             OptionsString = optionsString;
             Answer = answer;
+            IsEditScreen = isEditScreen;
         }
 
         public string? OptionsString { get; set; }
@@ -21,5 +22,7 @@
         [Required(ErrorMessage = "Enter an answer.")]
         [MaxLength(100, ErrorMessage = "Answer must be at most 100 characters")]
         public string? Answer { get; set; }
+
+        public bool IsEditScreen { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/AddRegistrationPromptConfigureAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/AddRegistrationPromptConfigureAnswersViewModel.cs
@@ -8,11 +8,11 @@
     {
         public RegistrationPromptAnswersViewModel() { }
 
-        public RegistrationPromptAnswersViewModel(string optionsString, string? answer = null, bool isEditScreen = false)
+        public RegistrationPromptAnswersViewModel(string optionsString, string? answer = null, bool includeAnswersTableCaption = false)
         {
             OptionsString = optionsString;
             Answer = answer;
-            IsEditScreen = isEditScreen;
+            IncludeAnswersTableCaption = includeAnswersTableCaption;
         }
 
         public string? OptionsString { get; set; }
@@ -23,6 +23,6 @@
         [MaxLength(100, ErrorMessage = "Answer must be at most 100 characters")]
         public string? Answer { get; set; }
 
-        public bool IsEditScreen { get; set; }
+        public bool IncludeAnswersTableCaption { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/EditRegistrationPromptViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/EditRegistrationPromptViewModel.cs
@@ -5,11 +5,14 @@
 
     public class EditRegistrationPromptViewModel : RegistrationPromptAnswersViewModel
     {
-        public EditRegistrationPromptViewModel() { }
+        public EditRegistrationPromptViewModel()
+        {
+            IsEditScreen = true;
+        }
 
         public EditRegistrationPromptViewModel
             (int promptNumber, string prompt, bool mandatory, string optionsString, string? answer = null)
-            : base(optionsString, answer)
+            : base(optionsString, answer, true)
         {
             PromptNumber = promptNumber;
             Prompt = prompt;
@@ -22,6 +25,7 @@
             Prompt = customPrompt.CustomPromptText;
             Mandatory = customPrompt.Mandatory;
             OptionsString = NewlineSeparatedStringListHelper.JoinNewlineSeparatedList(customPrompt.Options);
+            IsEditScreen = true;
         }
 
         public int PromptNumber { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/EditRegistrationPromptViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CentreConfiguration/EditRegistrationPromptViewModel.cs
@@ -7,7 +7,7 @@
     {
         public EditRegistrationPromptViewModel()
         {
-            IsEditScreen = true;
+            IncludeAnswersTableCaption = true;
         }
 
         public EditRegistrationPromptViewModel
@@ -25,7 +25,7 @@
             Prompt = customPrompt.CustomPromptText;
             Mandatory = customPrompt.Mandatory;
             OptionsString = NewlineSeparatedStringListHelper.JoinNewlineSeparatedList(customPrompt.Options);
-            IsEditScreen = true;
+            IncludeAnswersTableCaption = true;
         }
 
         public int PromptNumber { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -42,7 +42,7 @@
       @if (string.IsNullOrEmpty(Model.OptionsString)) {
         <partial name="_NoConfiguredAnswers"/>
       } else {
-        <partial name="_RegistrationPromptAnswerTable" model="(Model.Options, false)"/>
+        <partial name="_RegistrationPromptAnswerTable" model="Model"/>
       }
     </div>
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -42,7 +42,7 @@
       @if (string.IsNullOrEmpty(Model.OptionsString)) {
         <partial name="_NoConfiguredAnswers"/>
       } else {
-        <partial name="_RegistrationPromptAnswerTable" model="Model.Options"/>
+        <partial name="_RegistrationPromptAnswerTable" model="(Model.Options, false)"/>
       }
     </div>
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -68,7 +68,7 @@
       @if (string.IsNullOrEmpty(Model.OptionsString)) {
         <partial name="_NoConfiguredAnswers"/>
       } else {
-        <partial name="_RegistrationPromptAnswerTable" model="(Model.Options, true)"/>
+        <partial name="_RegistrationPromptAnswerTable" model="Model"/>
       }
     </div>
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -68,7 +68,7 @@
       @if (string.IsNullOrEmpty(Model.OptionsString)) {
         <partial name="_NoConfiguredAnswers"/>
       } else {
-        <partial name="_RegistrationPromptAnswerTable" model="Model.Options"/>
+        <partial name="_RegistrationPromptAnswerTable" model="(Model.Options, true)"/>
       }
     </div>
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
@@ -1,8 +1,9 @@
 ﻿@using DigitalLearningSolutions.Web.Controllers.TrackingSystem.CentreConfiguration
-@model (List<string>, bool)
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CentreConfiguration
+@model RegistrationPromptAnswersViewModel
 
 <table class="nhsuk-table">
-  @if (Model.Item2) {
+  @if (Model.IsEditScreen) {
     <caption class="nhsuk-table__caption">Configured Answers:</caption>
   }
   <thead role="rowgroup" class="nhsuk-table__head">
@@ -16,13 +17,13 @@
   </tr>
   </thead>
   <tbody class="nhsuk-table__body">
-  @foreach (var answer in Model.Item1!) {
+  @foreach (var answer in Model.Options!) {
     <tr role="row" class="nhsuk-table__row">
       <td class="nhsuk-table__cell word-break">@answer</td>
       <td class="nhsuk-table__cell vertical-align-centre">
         <button name="action"
                 class="nhsuk-button nhsuk-button--secondary nhsuk-u-padding-bottom-1 nhsuk-u-padding-top-1 nhsuk-u-margin-bottom-1 nhsuk-u-margin-top-0"
-                value="@(RegistrationPromptsController.DeleteAction + Model.Item1.IndexOf(answer))">
+                value="@(RegistrationPromptsController.DeleteAction + Model.Options.IndexOf(answer))">
           Remove
         </button>
       </td>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
@@ -3,7 +3,7 @@
 @model RegistrationPromptAnswersViewModel
 
 <table class="nhsuk-table">
-  @if (Model.IsEditScreen) {
+  @if (Model.IncludeAnswersTableCaption) {
     <caption class="nhsuk-table__caption">Configured Answers:</caption>
   }
   <thead role="rowgroup" class="nhsuk-table__head">
@@ -17,7 +17,7 @@
   </tr>
   </thead>
   <tbody class="nhsuk-table__body">
-  @foreach (var answer in Model.Options!) {
+  @foreach (var answer in Model.Options) {
     <tr role="row" class="nhsuk-table__row">
       <td class="nhsuk-table__cell word-break">@answer</td>
       <td class="nhsuk-table__cell vertical-align-centre">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
@@ -1,7 +1,10 @@
 ﻿@using DigitalLearningSolutions.Web.Controllers.TrackingSystem.CentreConfiguration
-@model List<string>
+@model (List<string>, bool)
 
 <table class="nhsuk-table">
+  @if (Model.Item2) {
+    <caption class="nhsuk-table__caption">Configured Answers:</caption>
+  }
   <thead role="rowgroup" class="nhsuk-table__head">
   <tr role="row">
     <th role="columnheader" class="" scope="col">
@@ -13,14 +16,13 @@
   </tr>
   </thead>
   <tbody class="nhsuk-table__body">
-  @foreach (var answer in Model!)
-  {
+  @foreach (var answer in Model.Item1!) {
     <tr role="row" class="nhsuk-table__row">
       <td class="nhsuk-table__cell word-break">@answer</td>
-      <td class="nhsuk-table__cell ">
+      <td class="nhsuk-table__cell vertical-align-centre">
         <button name="action"
-                class="nhsuk-button nhsuk-button--secondary nhsuk-u-padding-bottom-1 nhsuk-u-padding-top-1 nhsuk-u-margin-bottom-0"
-                value="@(RegistrationPromptsController.DeleteAction + Model.IndexOf(answer))">
+                class="nhsuk-button nhsuk-button--secondary nhsuk-u-padding-bottom-1 nhsuk-u-padding-top-1 nhsuk-u-margin-bottom-1 nhsuk-u-margin-top-0"
+                value="@(RegistrationPromptsController.DeleteAction + Model.Item1.IndexOf(answer))">
           Remove
         </button>
       </td>


### PR DESCRIPTION
Bug fixes for 383. Remove buttons in the answer table are now vertically aligned, and I've added the 'Configured answers:' caption to the table for the Edit screen.

![image](https://user-images.githubusercontent.com/59561751/120638294-ddfdb780-c467-11eb-8fdd-353609979f68.png)
