### PR TITLE
HEEDLS-474 - Added side nav menu to delegate approval page

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/sideNavMenus.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/sideNavMenus.scss
@@ -1,0 +1,49 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+.side-nav-menu {
+  @include govuk-media-query($until: desktop) {
+      display: none;
+  }
+}
+
+.side-nav__heading {
+  font-weight: 600;
+  color: #4c6272;
+  margin-bottom: 12px;
+  padding-top: 4px;
+  font-size: 1.1875rem;
+  line-height: 1.25;
+}
+
+.side-nav__link {
+  text-decoration: none;
+  color: #005eb8;
+
+  &:visited {
+    color: #005eb8;
+  }
+
+  &:hover {
+    color: #7C2855;
+    text-decoration: underline;
+  }
+}
+
+.side-nav__list {
+  font-weight: 400;
+  margin-bottom: 0;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.side-nav__item {
+  padding-bottom: 4px;
+  padding-top: 4px;
+}
+
+.side-nav__item--selected {
+  border-left: 4px solid #005eb8;
+  margin-left: -12px;
+  padding-left: 8px;
+  font-weight: bold;
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateApprovals/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateApprovals/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@inject IConfiguration Configuration
-
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates
 @using Microsoft.Extensions.Configuration
 @model DelegateApprovalsViewModel
@@ -19,12 +18,13 @@
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
+  <div class="nhsuk-grid-column-one-quarter">
+    <partial name="~/Views/TrackingSystem/Shared/_DelegatesSideNavMenu.cshtml" />
+  </div>
+  <div class="nhsuk-grid-column-three-quarters">
     <h1 class="nhsuk-heading-xl">Approve delegate registrations</h1>
-    @if (Model.Delegates.Any())
-    {
-      @foreach (var delegateApproval in Model.Delegates)
-      {
+    @if (Model.Delegates.Any()) {
+      @foreach (var delegateApproval in Model.Delegates) {
         <partial name="_unapprovedDelegateExpandable" model="delegateApproval" />
       }
       <div class="nhsuk-grid-row nhsuk-u-margin-top-7">
@@ -36,9 +36,7 @@
           </form>
         </div>
       </div>
-    }
-    else
-    {
+    } else {
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
           <p>No accounts need approval.</p>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Shared/_DelegatesSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Shared/_DelegatesSideNavMenu.cshtml
@@ -1,0 +1,32 @@
+﻿@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
+@{
+  var title = ViewData["Title"].ToString();
+  var selectedClass = "side-nav__item--selected";
+
+  var allDelegatesItemClass = title == "All delegates" ? selectedClass : string.Empty;
+  var delegateGroupsItemClass = title == "Delegate groups" ? selectedClass : string.Empty;
+  var courseDelegateItemClass = title == "Course delegates" ? selectedClass : string.Empty;
+  var approvedRegistrationItemClass = title == "Approve delegate registrations" ? selectedClass : string.Empty;
+}
+
+<link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/sideNavMenus.css")" asp-append-version="true">
+
+<nav class="side-nav-menu">
+  <h2 class="side-nav__heading">Delegates</h2>
+  <ul class="nhsuk-list side-nav__list">
+    <li class="side-nav__item @allDelegatesItemClass">
+      <a class="side-nav__link" href="@Configuration["CurrentSystemBaseUrl"]/tracking/delegates">All delegates</a>
+    </li>
+    <li class="side-nav__item @delegateGroupsItemClass">
+      <a class="side-nav__link" href="@Configuration["CurrentSystemBaseUrl"]/tracking/delegategroups">Delegate groups</a>
+    </li>
+    <li class="side-nav__item @courseDelegateItemClass">
+      <a class="side-nav__link" href="@Configuration["CurrentSystemBaseUrl"]/tracking/coursedelegates">Course delegates</a>
+    </li>
+    <li class="side-nav__item @approvedRegistrationItemClass">
+      <a class="side-nav__link" asp-action="Index" asp-controller="DelegateApprovals">Approve registrations</a>
+    </li>
+  </ul>
+</nav>


### PR DESCRIPTION
The partial's logic to decide which link is "selected" will likely need to be changed when the new pages are introduced. 

Ran all unit tests
Tested in Chrome, IE, Edge, Firefox
Checked with screen reader, mobile view, no JS.

Screen shot of mobile view (note that the screen looks as it would if no new nav bar was present, as this mimics the behaviour found on the NHS site):

![Delegates side menu mobile view](https://user-images.githubusercontent.com/80777689/120667566-8a9a6200-c485-11eb-8306-02215e49d5b4.PNG)

Screen shot of desktop view:
![Delegates side menu](https://user-images.githubusercontent.com/80777689/120667577-8d955280-c485-11eb-98d7-43aa11e85d56.PNG)


