### PR TITLE
HEEDLS-367 Changed centre id of RegistrationDataService test

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
@@ -20,14 +20,13 @@
             service = new RegistrationDataService(connection);
         }
 
-        [Ignore("Clashes with existing test data")]
         [Test]
         public async Task Sets_all_fields_correctly_on_registration()
         {
             using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
             // Given
-            var delegateRegistrationModel = UserTestHelper.GetDefaultDelegateRegistrationModel();
+            var delegateRegistrationModel = UserTestHelper.GetDefaultDelegateRegistrationModel(centre: 3);
 
             // When
             var candidateNumber = service.RegisterDelegate(delegateRegistrationModel);


### PR DESCRIPTION
I had originally misdiagnosed the reason the test was failing: it wasn't because it couldn't delete the test user it was making; it was because a user with the same email and centre ID already existed! For some reason this made it throw an exception before the stored procedure returned - which would have given this away since it always returns -4 when a user already exists.
I've changed the centre ID used in the test and everything's dandy now.