### PR TITLE
HEEDLS-471 Make default size of the placeholder image smaller

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/centreConfiguration.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/centreConfiguration.scss
@@ -25,13 +25,8 @@
 
 .centre-detail--placeholder-image__downsize {
   display: block;
-  width: 400px;
-  height: 200px;
-
-  @include govuk-media-query($until: large-desktop) {
-    width: 320px;
-    height: 160px;
-  }
+  width: 300px;
+  height: 150px;
 
   @include govuk-media-query($until: desktop) {
     width: 240px;


### PR DESCRIPTION
Make the largest size that the centre configuration placeholder image can be 300 x 150px

![image](https://user-images.githubusercontent.com/59561751/121536335-dfe0f100-c9fa-11eb-9652-2e897a09d82f.png)
