### PR TITLE
HEEDLS-383 Make default action on enter Add prompt

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -32,7 +32,7 @@
 
 <form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
   <div class="hidden-submit">
-    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.NextAction">Next</button>
+    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
   </div>
 
   <input type="hidden" asp-for="OptionsString"/>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -33,7 +33,7 @@
 
 <form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="EditRegistrationPrompt">
   <div class="hidden-submit">
-    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.SaveAction">Save</button>
+    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
   </div>
 
   <input type="hidden" asp-for="OptionsString"/>


### PR DESCRIPTION
Made the default action on enter on both the Edit Prompt and Add prompt configure answers screen Add prompt. This only gets triggered when an input is selected and enter is pressed. This is fine on the Add prompt screen as the Add Answer is only input.

For the Edit Prompt screen, this may cause some unexpected form posts if you hit enter when you have the Mandatory checkbox selected, but I think that is probably relatively unlikely compared to the fairly common behaviour to enter something in a textbox and hit enter to submit it.