### PR TITLE
HEEDLS-481 Handle delegate id from old site claims

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Helpers/CustomClaimHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/CustomClaimHelperTests.cs
@@ -154,7 +154,7 @@
         }
 
         [Test]
-        public void GetCandidateIdHandlesZeroAsNull()
+        public void GetCandidateId_handles_zero_as_null()
         {
             // Given
             var user = new ClaimsPrincipal(new ClaimsIdentity(new[]

--- a/DigitalLearningSolutions.Web.Tests/Helpers/CustomClaimHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/CustomClaimHelperTests.cs
@@ -152,5 +152,21 @@
             // Then
             Assert.Throws<FormatException>(() => user.GetCustomClaimAsRequiredInt(CustomClaimTypes.LearnCandidateId));
         }
+
+        [Test]
+        public void GetCandidateIdHandlesZeroAsNull()
+        {
+            // Given
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(CustomClaimTypes.LearnCandidateId, "0"),
+            }, "mock"));
+
+            // When
+            var result = user.GetCandidateId();
+
+            // Then
+            result.Should().BeNull();
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/NotificationPreferencesController.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Controllers
+namespace DigitalLearningSolutions.Web.Controllers
 {
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Enums;
@@ -34,7 +34,7 @@
             var adminNotifications =
                 notificationPreferencesService.GetNotificationPreferencesForUser(UserType.AdminUser, adminId);
 
-            var delegateId = User.GetCustomClaimAsInt(CustomClaimTypes.LearnCandidateId);
+            var delegateId = User.GetCandidateId();
             var delegateNotifications =
                  notificationPreferencesService.GetNotificationPreferencesForUser(UserType.DelegateUser, delegateId);
 

--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -11,7 +11,8 @@
 
         public static int? GetCandidateId(this ClaimsPrincipal user)
         {
-            return user.GetCustomClaimAsInt(CustomClaimTypes.LearnCandidateId);
+            var id = user.GetCustomClaimAsInt(CustomClaimTypes.LearnCandidateId);
+            return id == 0 ? null : id;
         }
 
         public static int GetCandidateIdKnownNotNull(this ClaimsPrincipal user)

--- a/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
@@ -12,7 +12,7 @@
         public static AuthorizationPolicyBuilder ConfigurePolicyUserOnly(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => context.User.GetCustomClaimAsInt(CustomClaimTypes.LearnCandidateId) != null
+                context => context.User.GetCandidateId() != null
                            && context.User.GetCustomClaimAsBool(CustomClaimTypes.LearnUserAuthenticated) == true
             );
         }


### PR DESCRIPTION
Modify GetCandidateId method to return null if the delegate id claim is 0, as the old site sets delegate id claim to 0 for admin-only users.
Refactor usage of GetClaimAsInt for LearnCandidateId into GetCandidateId.
Add a test. All tests are passing.