### PR TITLE
HEEDLS-382 Clear temp data on cancel

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CentreConfiguration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CentreConfiguration/RegistrationPromptsController.cs
@@ -178,6 +178,14 @@
             return RedirectToAction("Error", "LearningSolutions");
         }
 
+        [HttpGet]
+        [Route("Add/Cancel")]
+        public IActionResult AddRegistrationPromptCancel()
+        {
+            TempData.Clear();
+            return RedirectToAction("Index");
+        }
+
         private IActionResult EditRegistrationPromptPostSave(EditRegistrationPromptViewModel model)
         {
             IgnoreAddNewAnswerValidation();

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptSelectPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptSelectPrompt.cshtml
@@ -60,6 +60,6 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <vc:back-link asp-controller="RegistrationPrompts" asp-action="Index" link-text="Cancel"/>
+    <vc:back-link asp-controller="RegistrationPrompts" asp-action="AddRegistrationPromptCancel" link-text="Cancel"/>
   </div>
 </div>


### PR DESCRIPTION
Clear the temp data when the cancel link on the first page of the add prompt journey is clicked.