### PR TITLE
HEEDLS-367 Add option to select list view component to make default optional selectable

### DIFF
--- a/DigitalLearningSolutions.Web/ViewComponents/SelectListViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/SelectListViewComponent.cs
@@ -14,7 +14,8 @@
             string? defaultOption,
             IEnumerable<SelectListItem> selectListOptions,
             string? hintText,
-            string? cssClass
+            string? cssClass,
+            bool? deselectable
         )
         {
             var model = ViewData.Model;
@@ -34,7 +35,8 @@
                 string.IsNullOrEmpty(cssClass) ? null : cssClass,
                 string.IsNullOrEmpty(hintText) ? null : hintText,
                 errorMessage,
-                hasError);
+                hasError,
+                deselectable ?? false);
             return View(textBoxViewModel);
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SelectListViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SelectListViewModel.cs
@@ -16,7 +16,8 @@
             string? cssClass = null,
             string? hintText = null,
             string? errorMessage = null,
-            bool hasError = false
+            bool hasError = false,
+            bool deselectable = false
         )
         {
             Id = id;
@@ -29,6 +30,7 @@
             HintText = hintText;
             ErrorMessage = errorMessage;
             HasError = hasError;
+            Deselectable = deselectable;
         }
 
         public string Id { get; set; }
@@ -41,5 +43,6 @@
         public string? HintText { get; set; }
         public string? ErrorMessage { get; set; }
         public bool HasError { get; set; }
+        public bool Deselectable { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -74,6 +74,7 @@
                         label="Job group"
                         value="@Model.JobGroupId.ToString()"
                         hint-text=""
+                        deselectable="false"
                         css-class="nhsuk-u-width-one-half"
                         default-option="Select a job group"
                         select-list-options="@ViewBag.JobGroupOptions"/>
@@ -84,6 +85,7 @@
                             label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
                             value="@customField.Answer"
                             hint-text=""
+                            deselectable="@(!customField.Mandatory)"
                             css-class="nhsuk-u-width-one-half"
                             default-option="Select a @customField.CustomPrompt.ToLower()"
                             select-list-options="@customField.Options"/>

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -26,11 +26,12 @@
           label="Centre"
           value="@Model.Centre?.ToString()"
           hint-text=""
+          deselectable="false"
           css-class="nhsuk-u-width-full"
           default-option="Select a centre"
           select-list-options="@ViewBag.CentreOptions"/>
       </div>
-      
+
       <p class="nhsuk-body-l">
         Now enter your personal details.
       </p>

--- a/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
@@ -32,6 +32,7 @@
         label="Job Group"
         value="@Model.JobGroup?.ToString()"
         hint-text=""
+        deselectable="false"
         css-class="nhsuk-u-width-one-half"
         default-option="Select a job group"
         select-list-options="@ViewBag.JobGroupOptions" />
@@ -43,6 +44,7 @@
             label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
             value="@customField.Answer"
             hint-text=""
+            deselectable="@(!customField.Mandatory)"
             css-class="nhsuk-u-width-one-half"
             default-option="Select a @customField.CustomPrompt.ToLower()"
             select-list-options="@customField.Options" />

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/SelectList/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/SelectList/Default.cshtml
@@ -1,4 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Common
+@using DigitalLearningSolutions.Web.ViewModels.Common
 @model SelectListViewModel
 
 <div class="nhsuk-form-group @(Model.HasError ? "nhsuk-form-group--error" : "")">
@@ -23,6 +23,6 @@
           name="@Model.Name"
           value="@Model.Value"
           asp-items="Model.SelectListOptions">
-    <option value="" disabled selected=@(Model.Value != null ? "" : "selected") >@Model.DefaultOption</option>
+    <option value="" disabled="@(!Model.Deselectable)" selected=@(Model.Value != null ? "" : "selected") >@Model.DefaultOption</option>
   </select>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptSelectPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptSelectPrompt.cshtml
@@ -36,6 +36,7 @@
                       label="Prompt name"
                       value="@Model.CustomPromptId?.ToString()"
                       hint-text=""
+                      deselectable="false"
                       css-class="nhsuk-u-width-one-half"
                       default-option="Select a prompt name"
                       select-list-options="@ViewBag.CustomPromptNameOptions"/>


### PR DESCRIPTION
Fixes the bug reported by Jonathan on the ticket: "When registering, if you have an optional field with a specified list of options, once you've selected one you can't then unselect it and blank the field without going back a page and starting over."

Tested by going through the registration journey with a centre that has some mandatory and some optional select custom prompts, all were displayed and only the optional prompts could be deselected.