### PR TITLE
HEEDLS-482 Add style for non clickable card to look like clickable card

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/centreDashboard.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/centreDashboard.scss
@@ -20,3 +20,6 @@
   }
 }
 
+.nhsuk-card--not-clickable {
+  border-bottom-width: nhsuk-spacing(1);
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Dashboard/_DashboardTopCardGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Dashboard/_DashboardTopCardGroup.cshtml
@@ -29,7 +29,7 @@
   </li>
 
   <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item dashboard-4-1-card">
-    <div class="nhsuk-card nhsuk-card--clickable">
+    <div class="nhsuk-card @(User.HasCentreManagerPermissions() ? "nhsuk-card--clickable" : "nhsuk-card--not-clickable")">
       <div class="nhsuk-card__content">
         <p class="nhsuk-heading-xl nhsuk-u-font-size-24 nhsuk-u-margin-bottom-1">
           @Model.NumberOfAdmins <span class="nhsuk-u-visually-hidden">Admins</span>


### PR DESCRIPTION
Added a style nhsuk-card--not-clickable matching the nhsuk-card--clickable except it's hover properties so that the admin card looks the same as the other cards but has no hover/clickable properties

![image](https://user-images.githubusercontent.com/59561751/122408406-46758a00-cf7a-11eb-9a69-a7eb602093e4.png)
