### PR TITLE
HEEDLS-487 await SignInAsync in login POST

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -18,7 +18,7 @@
             DateTime? dateRegistered = null,
             string firstName = "Firstname",
             string lastName = "Test",
-            string emailAddress = "email@test.com",
+            string? emailAddress = "email@test.com",
             string password = "password",
             int? resetPasswordId = null,
             bool approved = true,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -3,9 +3,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;
+    using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
-    using DigitalLearningSolutions.Data.Tests.Helpers;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.Controllers;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -20,12 +20,12 @@
 
     internal class LoginControllerTests
     {
-        private IAuthenticationService authenticationService;
-        private LoginController controller;
-        private ILoginService loginService;
-        private ISessionService sessionService;
-        private IUserService userService;
-        private ILogger<LoginController> logger;
+        private IAuthenticationService authenticationService = null!;
+        private LoginController controller = null!;
+        private ILogger<LoginController> logger = null!;
+        private ILoginService loginService = null!;
+        private ISessionService sessionService = null!;
+        private IUserService userService = null!;
 
         [SetUp]
         public void SetUp()
@@ -43,7 +43,8 @@
 
             authenticationService =
                 (IAuthenticationService)controller.HttpContext.RequestServices.GetService(
-                    typeof(IAuthenticationService));
+                    typeof(IAuthenticationService)
+                );
         }
 
         [Test]
@@ -73,13 +74,13 @@
         }
 
         [Test]
-        public void Successful_sign_in_without_return_url_should_render_home_page()
+        public async Task Successful_sign_in_without_return_url_should_render_home_pageAsync()
         {
             // Given
             GivenSignInIsSuccessful();
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -87,7 +88,7 @@
         }
 
         [Test]
-        public void Successful_sign_in_with_local_return_url_should_redirect_to_return_url()
+        public async Task Successful_sign_in_with_local_return_url_should_redirect_to_return_url()
         {
             // Given
             GivenSignInIsSuccessful();
@@ -99,14 +100,14 @@
             // When
             var loginViewModel = LoginTestHelper.GetDefaultLoginViewModel();
             loginViewModel.ReturnUrl = returnUrl;
-            var result = controller.Index(loginViewModel);
+            var result = await controller.Index(loginViewModel);
 
             // Then
             result.Should().BeRedirectResult().WithUrl(returnUrl);
         }
 
         [Test]
-        public void Successful_sign_in_with_nonlocal_return_url_should_render_home_page()
+        public async Task Successful_sign_in_with_nonlocal_return_url_should_render_home_page()
         {
             // Given
             GivenSignInIsSuccessful();
@@ -118,7 +119,7 @@
             // When
             var loginViewModel = LoginTestHelper.GetDefaultLoginViewModel();
             loginViewModel.ReturnUrl = returnUrl;
-            var result = controller.Index(loginViewModel);
+            var result = await controller.Index(loginViewModel);
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -126,33 +127,43 @@
         }
 
         [Test]
-        public void Successful_sign_in_should_call_SignInAsync()
+        public async Task Successful_sign_in_should_call_SignInAsync()
         {
             // Given
             GivenSignInIsSuccessful();
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
-            A.CallTo(() => authenticationService.SignInAsync(
-                    A<HttpContext>._, A<string>._, A<ClaimsPrincipal>._, A<AuthenticationProperties>._))
+            A.CallTo(
+                    () => authenticationService.SignInAsync(
+                        A<HttpContext>._,
+                        A<string>._,
+                        A<ClaimsPrincipal>._,
+                        A<AuthenticationProperties>._
+                    )
+                )
                 .MustHaveHappened();
         }
 
         [Test]
-        public void Log_in_request_should_call_login_service()
+        public async Task Log_in_request_should_call_login_service()
         {
             // Given
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((UserTestHelper.GetDefaultAdminUser(),
-                    new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() }));
+                .Returns(
+                    (UserTestHelper.GetDefaultAdminUser(),
+                        new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() })
+                );
             A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns((UserTestHelper.GetDefaultAdminUser(),
-                    new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() }));
+                .Returns(
+                    (UserTestHelper.GetDefaultAdminUser(),
+                        new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() })
+                );
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
@@ -162,14 +173,14 @@
         }
 
         [Test]
-        public void No_user_account_found_should_render_basic_form_with_error()
+        public async Task No_user_account_found_should_render_basic_form_with_error()
         {
             // Given
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
                 .Returns((null, new List<DelegateUser>()));
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeViewResult().WithViewName("Index").ModelAs<LoginViewModel>();
@@ -177,7 +188,7 @@
         }
 
         [Test]
-        public void Bad_password_should_render_basic_form_with_error()
+        public async Task Bad_password_should_render_basic_form_with_error()
         {
             // Given
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
@@ -186,7 +197,7 @@
                 .Returns((null, new List<DelegateUser>()));
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeViewResult().WithViewName("Index").ModelAs<LoginViewModel>();
@@ -194,24 +205,26 @@
         }
 
         [Test]
-        public void Unapproved_delegate_account_redirects_to_not_approved_page()
+        public async Task Unapproved_delegate_account_redirects_to_not_approved_page()
         {
             // Given
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
-                .Returns((UserTestHelper.GetDefaultAdminUser(),
-                    new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() }));
+                .Returns(
+                    (UserTestHelper.GetDefaultAdminUser(),
+                        new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser() })
+                );
             A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns((null, new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser(approved: false) }));
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeViewResult().WithViewName("AccountNotApproved");
         }
 
         [Test]
-        public void Log_in_with_approved_delegate_id_fetches_associated_admin_user()
+        public async Task Log_in_with_approved_delegate_id_fetches_associated_admin_user()
         {
             // Given
             var testDelegate = UserTestHelper.GetDefaultDelegateUser(emailAddress: "TestAccountAssociation@email.com");
@@ -221,7 +234,7 @@
                 .Returns((null, new List<DelegateUser> { testDelegate }));
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             A.CallTo(() => loginService.GetVerifiedAdminUserAssociatedWithDelegateUser(testDelegate, A<string>._))
@@ -229,7 +242,7 @@
         }
 
         [Test]
-        public void Multiple_available_centres_should_redirect_to_ChooseACentre_page()
+        public async Task Multiple_available_centres_should_redirect_to_ChooseACentre_page()
         {
             // Given
             var expectedAdminUser = UserTestHelper.GetDefaultAdminUser(centreId: 1, centreName: "Centre 1");
@@ -240,22 +253,23 @@
             A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns((expectedAdminUser, expectedDelegateUsers));
             A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(new List<CentreUserDetails>
-                {
-                    new CentreUserDetails(1, "Centre 1", true),
-                    new CentreUserDetails(2, "Centre 2", false, true)
-                });
+                .Returns(
+                    new List<CentreUserDetails>
+                    {
+                        new CentreUserDetails(1, "Centre 1", true),
+                        new CentreUserDetails(2, "Centre 2", false, true)
+                    }
+                );
 
             // When
-            var result =
-                controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeRedirectToActionResult().WithActionName("ChooseACentre");
         }
 
         [Test]
-        public void
+        public async Task
             When_user_has_multiple_accounts_with_different_passwords_only_use_ones_matching_input_password_to_check_for_centres()
         {
             // Given
@@ -270,15 +284,18 @@
                 .Returns((expectedAdminUser, new List<DelegateUser>()));
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
-            A.CallTo(() => userService.GetUserCentres(
-                    A<AdminUser>.That.IsEqualTo(expectedAdminUser),
-                    A<List<DelegateUser>>.That.IsEmpty()))
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            A.CallTo(
+                    () => userService.GetUserCentres(
+                        A<AdminUser>.That.IsEqualTo(expectedAdminUser),
+                        A<List<DelegateUser>>.That.IsEmpty()
+                    )
+                )
                 .MustHaveHappened();
         }
 
         [Test]
-        public void Log_in_as_admin_records_admin_session()
+        public async Task Log_in_as_admin_records_admin_session()
         {
             // Given
             var expectedAdmin = UserTestHelper.GetDefaultAdminUser(10);
@@ -289,11 +306,13 @@
             A.CallTo(() => userService.GetUsersWithActiveCentres(A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns((expectedAdmin, new List<DelegateUser>()));
             A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(new List<CentreUserDetails>
-                    { new CentreUserDetails(expectedAdmin.CentreId, expectedAdmin.CentreName, true) });
+                .Returns(
+                    new List<CentreUserDetails>
+                        { new CentreUserDetails(expectedAdmin.CentreId, expectedAdmin.CentreName, true) }
+                );
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             A.CallTo(() => sessionService.StartAdminSession(expectedAdmin.Id))
@@ -301,7 +320,7 @@
         }
 
         [Test]
-        public void Log_in_as_delegate_does_not_record_admin_session()
+        public async Task Log_in_as_delegate_does_not_record_admin_session()
         {
             // Given
             var expectedDelegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser(approved: true) };
@@ -313,7 +332,7 @@
                 .Returns(null);
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             A.CallTo(() => sessionService.StartAdminSession(A<int>._))
@@ -321,7 +340,7 @@
         }
 
         [Test]
-        public void
+        public async Task
             When_user_has_accounts_with_different_approved_statuses_only_check_for_centres_on_approved_accounts()
         {
             // Given
@@ -340,17 +359,20 @@
                 .Returns((expectedAdminUser, expectedApprovedDelegateUsers));
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
-            A.CallTo(() => userService.GetUserCentres(
-                    A<AdminUser>.That.IsEqualTo(expectedAdminUser),
-                    A<List<DelegateUser>>.That.IsSameSequenceAs(expectedApprovedDelegateUsers)))
+            A.CallTo(
+                    () => userService.GetUserCentres(
+                        A<AdminUser>.That.IsEqualTo(expectedAdminUser),
+                        A<List<DelegateUser>>.That.IsSameSequenceAs(expectedApprovedDelegateUsers)
+                    )
+                )
                 .MustHaveHappened();
         }
 
         [Test]
-        public void Multiple_approved_accounts_at_same_centre_should_log_in()
+        public async Task Multiple_approved_accounts_at_same_centre_should_log_in()
         {
             // Given
             var expectedAdminUser = UserTestHelper.GetDefaultAdminUser(centreId: 1, centreName: "Centre 1");
@@ -364,10 +386,11 @@
                 .Returns((expectedAdminUser, expectedDelegateUsers));
             A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) }
+                );
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -375,7 +398,7 @@
         }
 
         [Test]
-        public void
+        public async Task
             When_user_has_accounts_with_inactive_centres_only_use_active_centre_details_for_login()
         {
             // Given
@@ -396,17 +419,20 @@
                 .Returns((null, new List<DelegateUser> { delegateUserAtActiveCentre }));
 
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
-            A.CallTo(() => userService.GetUserCentres(
-                    null,
-                    A<List<DelegateUser>>.That.IsSameSequenceAs(delegateUserAtActiveCentre)))
+            A.CallTo(
+                    () => userService.GetUserCentres(
+                        null,
+                        A<List<DelegateUser>>.That.IsSameSequenceAs(delegateUserAtActiveCentre)
+                    )
+                )
                 .MustHaveHappened();
         }
 
         [Test]
-        public void
+        public async Task
             When_user_has_verified_accounts_only_at_inactive_centres_then_redirect_to_centre_inactive_page()
         {
             // Given
@@ -424,14 +450,14 @@
                 .Returns(new List<CentreUserDetails>());
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeViewResult().WithViewName("CentreInactive");
         }
 
         [Test]
-        public void User_without_email_address_can_still_login()
+        public async Task User_without_email_address_can_still_login()
         {
             // Given
             var delegates = new List<DelegateUser> { UserTestHelper.GetDefaultDelegateUser(emailAddress: null) };
@@ -443,10 +469,11 @@
                 .Returns((null, delegates));
             A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", false, true) });
+                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", false, true) }
+                );
 
             // When
-            var result = controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -454,10 +481,10 @@
         }
 
         [Test]
-        public void Leading_trailing_whitespaces_in_username_are_ignored()
+        public async Task Leading_trailing_whitespaces_in_username_are_ignored()
         {
             // When
-            controller.Index(LoginTestHelper.GetDefaultLoginViewModel("\ttest@example.com "));
+            await controller.Index(LoginTestHelper.GetDefaultLoginViewModel("\ttest@example.com "));
 
             // Then
             A.CallTo(() => userService.GetUsersByUsername("test@example.com")).MustHaveHappened(1, Times.Exactly);
@@ -476,7 +503,8 @@
                 .Returns((admin, delegates));
             A.CallTo(() => userService.GetUserCentres(A<AdminUser>._, A<List<DelegateUser>>._))
                 .Returns(
-                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) });
+                    new List<CentreUserDetails> { new CentreUserDetails(1, "Centre 1", true, true) }
+                );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;
+    using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Extensions;
@@ -42,7 +43,7 @@
         }
 
         [HttpPost]
-        public IActionResult Index(LoginViewModel model)
+        public async Task<IActionResult> Index(LoginViewModel model)
         {
             if (!ModelState.IsValid)
             {
@@ -91,7 +92,7 @@
             {
                 sessionService.StartAdminSession(adminLoginDetails?.Id);
 
-                return LogIn(adminLoginDetails, delegateLoginDetails.FirstOrDefault(), model.RememberMe, model.ReturnUrl);
+                return await LogIn(adminLoginDetails, delegateLoginDetails.FirstOrDefault(), model.RememberMe, model.ReturnUrl);
             }
 
             var chooseACentreViewModel = new ChooseACentreViewModel(availableCentres);
@@ -124,7 +125,7 @@
 
         [ServiceFilter(typeof(RedirectEmptySessionData<List<DelegateLoginDetails>>))]
         [HttpGet]
-        public IActionResult ChooseCentre(int centreId)
+        public async Task<IActionResult> ChooseCentre(int centreId)
         {
             var rememberMe = (bool)TempData["RememberMe"];
             var adminLoginDetails = TempData.Peek<AdminLoginDetails>();
@@ -137,7 +138,7 @@
                 delegateLoginDetails?.FirstOrDefault(du => du.CentreId == centreId);
 
             sessionService.StartAdminSession(adminAccountForChosenCentre?.Id);
-            return LogIn(adminAccountForChosenCentre, delegateAccountForChosenCentre, rememberMe, returnUrl);
+            return await LogIn(adminAccountForChosenCentre, delegateAccountForChosenCentre, rememberMe, returnUrl);
         }
 
         private (AdminLoginDetails?, List<DelegateLoginDetails>) GetLoginDetails
@@ -168,7 +169,7 @@
             TempData["ReturnUrl"] = returnUrl;
         }
 
-        private IActionResult LogIn
+        private async Task<IActionResult> LogIn
         (
             AdminLoginDetails? adminLoginDetails,
             DelegateLoginDetails? delegateLoginDetails,
@@ -184,7 +185,7 @@
                 IsPersistent = rememberMe,
                 IssuedUtc = DateTime.UtcNow
             };
-            HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
+            await HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
 
             return RedirectToReturnUrl(returnUrl) ?? RedirectToAction("Index", "Home");
         }


### PR DESCRIPTION
Changed the login method that was calling HttpContext.SignInAsync to await that and propagated up the async/awaits in the login controller and unit tests of it.

Ran all unit tests and did a quick sanity check that login still works.