### PR TITLE
HEEDLS-524 Refactor prompt management pages for consistent spacing

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -13,70 +13,50 @@
 }
 
 @section NavMenuItems {
-  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml"/>
-}
-
-@if (errorHasOccurred) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <vc:error-summary order-of-property-names="@new []{ nameof(EditRegistrationPromptViewModel.OptionsString), nameof(EditRegistrationPromptViewModel.Answer)}"/>
-    </div>
-  </div>
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@new []{ nameof(EditRegistrationPromptViewModel.OptionsString), nameof(EditRegistrationPromptViewModel.Answer)}" />
+    }
+
     <h1 class="nhsuk-heading-xl">Configure answers</h1>
-  </div>
-</div>
 
-<form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
-  <div class="hidden-submit">
-    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
-  </div>
+    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
+      <div class="hidden-submit">
+        <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
+      </div>
 
-  <input type="hidden" asp-for="OptionsString"/>
+      <input type="hidden" asp-for="OptionsString" />
 
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
       @if (string.IsNullOrEmpty(Model.OptionsString)) {
-        <partial name="_NoConfiguredAnswers"/>
+        <partial name="_NoConfiguredAnswers" />
       } else {
-        <partial name="_RegistrationPromptAnswerTable" model="Model"/>
+        <partial name="_RegistrationPromptAnswerTable" model="Model" />
       }
-    </div>
-  </div>
 
-  <div class="nhsuk-grid-row divider">
-    <div class="nhsuk-grid-column-one-half">
-      <vc:text-input asp-for="Answer"
-                     label="Add a new answer?"
-                     populate-with-current-value="true"
-                     type="text"
-                     spell-check="true"
-                     autocomplete=""
-                     hint-text=""
-                     css-class="nhsuk-u-width-full nhsuk-u-font-weight-bold"/>
-      <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@RegistrationPromptsController.AddPromptAction">Add</button>
-    </div>
-  </div>
+      <div class="divider">
+        <vc:text-input asp-for="Answer"
+                       label="Add a new answer?"
+                       populate-with-current-value="true"
+                       type="text"
+                       spell-check="true"
+                       autocomplete=""
+                       hint-text=""
+                       css-class="nhsuk-u-width-one-half nhsuk-u-font-weight-bold" />
+        <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@RegistrationPromptsController.AddPromptAction">Add</button>
+      </div>
 
-  <div class="nhsuk-grid-row divider">
-    <div class="nhsuk-grid-column-one-half">
-      <p class="nhsuk-label">Want to add answers in bulk?</p>
-      <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@RegistrationPromptsController.BulkAction">Bulk add</button>
-    </div>
-  </div>
+      <div class="divider">
+        <p class="nhsuk-label">Want to add answers in bulk?</p>
+        <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@RegistrationPromptsController.BulkAction">Bulk add</button>
+      </div>
 
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
       <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.NextAction">Next</button>
-    </div>
-  </div>
-</form>
+    </form>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <vc:back-link asp-controller="RegistrationPrompts" asp-action="AddRegistrationPromptSelectPrompt" link-text="Go back"/>
+    <vc:back-link asp-controller="RegistrationPrompts" asp-action="AddRegistrationPromptSelectPrompt" link-text="Go back" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptSelectPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/AddRegistrationPromptSelectPrompt.cshtml
@@ -12,26 +12,18 @@
 }
 
 @section NavMenuItems {
-  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml"/>
-}
-
-@if (errorHasOccurred) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <vc:error-summary order-of-property-names="@new []{ nameof(AddRegistrationPromptSelectPromptViewModel.CustomPromptId)}"/>
-    </div>
-  </div>
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
 }
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <h1 class="nhsuk-heading-xl">Add delegate registration prompt</h1>
-  </div>
-</div>
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@new []{ nameof(AddRegistrationPromptSelectPromptViewModel.CustomPromptId)}" />
+    }
 
-<form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="AddRegistrationPromptSelectPrompt">
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl">Add delegate registration prompt</h1>
+
+    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddRegistrationPromptSelectPrompt">
       <vc:select-list asp-for="CustomPromptId"
                       label="Prompt name"
                       value="@Model.CustomPromptId?.ToString()"
@@ -39,7 +31,7 @@
                       deselectable="false"
                       css-class="nhsuk-u-width-one-half"
                       default-option="Select a prompt name"
-                      select-list-options="@ViewBag.CustomPromptNameOptions"/>
+                      select-list-options="@ViewBag.CustomPromptNameOptions" />
 
       <p class="nhsuk-body-m">
         Tick the box below if all users that register with your centre are required to fill in this field.
@@ -55,12 +47,8 @@
       </div>
 
       <button class="nhsuk-button">Next</button>
-    </div>
-  </div>
-</form>
+    </form>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <vc:back-link asp-controller="RegistrationPrompts" asp-action="Index" link-text="Cancel"/>
+    <vc:back-link asp-controller="RegistrationPrompts" asp-action="Index" link-text="Cancel" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/BulkRegistrationPromptAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/BulkRegistrationPromptAnswers.cshtml
@@ -23,7 +23,7 @@
 
     <h1 class="nhsuk-heading-xl">Configure answers in bulk</h1>
 
-    <form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="@(Model.IsAddPromptJourney ? "AddRegistrationPromptBulkPost" : "EditRegistrationPromptBulkPost")">
+    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="@(Model.IsAddPromptJourney ? "AddRegistrationPromptBulkPost" : "EditRegistrationPromptBulkPost")">
 
       <input type="hidden" asp-for="IsAddPromptJourney" />
       <input type="hidden" asp-for="PromptNumber" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -16,21 +16,17 @@
   <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
 }
 
-@if (errorHasOccurred) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <vc:error-summary order-of-property-names="@new []{ nameof(EditRegistrationPromptViewModel.OptionsString), nameof(EditRegistrationPromptViewModel.Answer)}" />
-    </div>
-  </div>
-}
-
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@new []{ nameof(EditRegistrationPromptViewModel.OptionsString), nameof(EditRegistrationPromptViewModel.Answer)}" />
+    }
+
     <h1 class="nhsuk-heading-xl">Edit delegate registration prompt</h1>
   </div>
 </div>
 
-<form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="EditRegistrationPrompt">
+<form method="post" novalidate asp-action="EditRegistrationPrompt">
   <div class="hidden-submit">
     <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
   </div>
@@ -93,7 +89,7 @@
     </div>
   </div>
 
-  <div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-row nhsuk-u-margin-bottom-3">
     <div class="nhsuk-grid-column-full">
       <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.SaveAction">Save</button>
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
@@ -8,7 +8,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var canAddNewPrompt = Model.CustomFields.Count == 6;
+  var canAddNewPrompt = Model.CustomFields.Count <= 6;
 }
 
 @section NavMenuItems {
@@ -34,7 +34,7 @@
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">Manage delegate registration prompts</h1>
 
-    <div class="@(canAddNewPrompt ? "nhsuk-u-margin-bottom-7" : "nhsuk-u-margin-bottom-3")">
+    <div class="@(canAddNewPrompt ? "nhsuk-u-margin-bottom-3" : "nhsuk-u-margin-bottom-7")">
       @foreach (var customField in Model.CustomFields) {
         <partial name="_CustomPromptExpander" model="customField" />
       }
@@ -45,7 +45,7 @@
         </p>
       }
 
-      @if (!canAddNewPrompt) {
+      @if (canAddNewPrompt) {
         <a class="nhsuk-button" asp-action="AddRegistrationPromptNew">Add a new prompt</a>
       }
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
@@ -8,7 +8,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var canAddNewPrompt = Model.CustomFields.Count <= 6;
+  var canAddNewPrompt = Model.CustomFields.Count < 6;
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
@@ -8,7 +8,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var hasSixPrompts = Model.CustomFields.Count == 6;
+  var canAddNewPrompt = Model.CustomFields.Count == 6;
 }
 
 @section NavMenuItems {
@@ -34,7 +34,7 @@
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">Manage delegate registration prompts</h1>
 
-    <div class="@(hasSixPrompts ? "nhsuk-u-margin-bottom-7" : "nhsuk-u-margin-bottom-3")">
+    <div class="@(canAddNewPrompt ? "nhsuk-u-margin-bottom-7" : "nhsuk-u-margin-bottom-3")">
       @foreach (var customField in Model.CustomFields) {
         <partial name="_CustomPromptExpander" model="customField" />
       }
@@ -45,7 +45,7 @@
         </p>
       }
 
-      @if (!hasSixPrompts) {
+      @if (!canAddNewPrompt) {
         <a class="nhsuk-button" asp-action="AddRegistrationPromptNew">Add a new prompt</a>
       }
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/Index.cshtml
@@ -8,19 +8,24 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
+  var hasSixPrompts = Model.CustomFields.Count == 6;
 }
 
 @section NavMenuItems {
-  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml"/>
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
 }
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-controller="CentreConfiguration" asp-action="Index">Centre configuration</a></li>
+        <li class="nhsuk-breadcrumb__item">
+          <a class="nhsuk-breadcrumb__link" asp-controller="CentreConfiguration" asp-action="Index">Centre configuration</a>
+        </li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-controller="CentreConfiguration" asp-action="Index">Back to centre configuration</a></p>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="CentreConfiguration" asp-action="Index">Back to centre configuration</a>
+      </p>
     </div>
   </nav>
 }
@@ -28,80 +33,23 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">Manage delegate registration prompts</h1>
-  </div>
-</div>
 
-@foreach (var customField in Model.CustomFields) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <details class="nhsuk-details nhsuk-expander">
-        <summary class="nhsuk-details__summary">
-          <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-three-quarters nhsuk-u-three-quarters-tablet">
-              <span class="nhsuk-details__summary-text">
-                @customField.CustomPromptName
-              </span>
-            </div>
-            <div class="nhsuk-grid-column-one-quarter nhsuk-u-one-quarter-tablet right-align-tag-column">
-              <span class="nhsuk-u-visually-hidden">This prompt is:</span>
-              <strong class="nhsuk-u-font-size-19 right-align-tag nhsuk-tag @(customField.Mandatory ? "" : "nhsuk-tag--grey")">
-                @(customField.Mandatory ? "Mandatory" : "Optional")
-              </strong>
-            </div>
-          </div>
-        </summary>
-        <div class="nhsuk-details__text">
-          <div class="nhsuk-grid-row nhsuk-u-margin-bottom-3">
-            <div class="nhsuk-grid-column-full">
-              @if (customField.Options.Count != 0) {
-                <p class="nhsuk-u-font-weight-bold">Answers delegate can choose from:</p>
-                <ul>
-                  @foreach (var answer in customField.Options)
-                  {
-                    <li class="word-break">@answer</li>
-                  }
-                </ul>
-              } else {
-                <p>This is a free text field. Delegates can input any text.</p>
-              }
-            </div>
-          </div>
-          <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-full">
-              <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1" role="button" asp-controller="RegistrationPrompts" asp-action="EditRegistrationPromptStart" asp-route-promptNumber="@customField.CustomFieldId">
-                Edit
-              </a>
-              <a class="nhsuk-button delete-button nhsuk-button--secondary nhsuk-u-margin-bottom-1" role="button" asp-controller="RegistrationPrompts" asp-action="RemoveRegistrationPrompt" asp-route-promptNumber="@customField.CustomFieldId">
-                Remove
-              </a>
-            </div>
-          </div>
-        </div>
-      </details>
+    <div class="@(hasSixPrompts ? "nhsuk-u-margin-bottom-7" : "nhsuk-u-margin-bottom-3")">
+      @foreach (var customField in Model.CustomFields) {
+        <partial name="_CustomPromptExpander" model="customField" />
+      }
+
+      @if (Model.CustomFields.Count == 0) {
+        <p class="nhsuk-body-l">
+          Your centre does not have any delegate registration prompts.
+        </p>
+      }
+
+      @if (!hasSixPrompts) {
+        <a class="nhsuk-button" asp-action="AddRegistrationPromptNew">Add a new prompt</a>
+      }
     </div>
-  </div>
-}
 
-@if (Model.CustomFields.Count == 0) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <p class="nhsuk-body-l">
-        Your centre does not have any delegate registration prompts.
-      </p>
-    </div>
-  </div>
-}
-
-@if (Model.CustomFields.Count < 6) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <a class="nhsuk-button" asp-action="AddRegistrationPromptNew">Add a new prompt</a>
-    </div>
-  </div>
-}
-
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <vc:back-link asp-controller="CentreConfiguration" asp-action="Index" link-text="Go back"/>
+    <vc:back-link asp-controller="CentreConfiguration" asp-action="Index" link-text="Go back" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/RemoveRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/RemoveRegistrationPrompt.cshtml
@@ -17,16 +17,12 @@
   <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
 }
 
-@if (errorHasOccurred) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <vc:error-summary order-of-property-names="@new []{ nameof(RemoveRegistrationPromptViewModel.Confirm) }" />
-    </div>
-  </div>
-}
-
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@new []{ nameof(RemoveRegistrationPromptViewModel.Confirm) }" />
+    }
+
     <h1 class="nhsuk-heading-xl">Remove delegate registration prompt</h1>
   </div>
 </div>
@@ -44,18 +40,14 @@
 </div>
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full nhsuk-body-m">
+  <div class="nhsuk-grid-column-full">
     @if (Model.DelegateCount == 1) {
-      <p>@Model.DelegateCount user has responded to this prompt. Deleting the prompt will permanently delete their response.</p>
+      <p class="nhsuk-body-m">@Model.DelegateCount user has responded to this prompt. Deleting the prompt will permanently delete their response.</p>
     } else {
-      <p>@Model.DelegateCount users have responded to this prompt. Deleting the prompt will permanently delete all of their responses.</p>
+      <p class="nhsuk-body-m">@Model.DelegateCount users have responded to this prompt. Deleting the prompt will permanently delete all of their responses.</p>
     }
-  </div>
-</div>
-
-<form class="nhsuk-u-margin-bottom-8" method="post" asp-action="RemoveRegistrationPrompt">
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
+    
+    <form class="nhsuk-u-margin-bottom-5" method="post" asp-action="RemoveRegistrationPrompt">
       <div class="nhsuk-form-group @confirmFormErrorClass">
         <fieldset class="nhsuk-fieldset" aria-describedby="confirm-error">
           @if (confirmError) {
@@ -79,12 +71,8 @@
       </div>
       <input type="hidden" asp-for="DelegateCount" />
       <button class="nhsuk-button delete-button nhsuk-button--secondary" type="submit">Delete prompt</button>
-    </div>
-  </div>
-</form>
+    </form>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
     <vc:back-link asp-controller="RegistrationPrompts" asp-action="Index" link-text="Cancel" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_CustomPromptExpander.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/_CustomPromptExpander.cshtml
@@ -1,0 +1,52 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CentreConfiguration
+@model CustomPromptManagementViewModel
+
+<details class="nhsuk-details nhsuk-expander">
+  <summary class="nhsuk-details__summary">
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-three-quarters nhsuk-u-three-quarters-tablet">
+        <span class="nhsuk-details__summary-text">
+          @Model.CustomPromptName
+        </span>
+      </div>
+      <div class="nhsuk-grid-column-one-quarter nhsuk-u-one-quarter-tablet right-align-tag-column">
+        <span class="nhsuk-u-visually-hidden">This prompt is:</span>
+        <strong class="nhsuk-u-font-size-19 right-align-tag nhsuk-tag @(Model.Mandatory ? "" : "nhsuk-tag--grey")">
+          @(Model.Mandatory ? "Mandatory" : "Optional")
+        </strong>
+      </div>
+    </div>
+  </summary>
+  <div class="nhsuk-details__text">
+    <div class="nhsuk-grid-row nhsuk-u-margin-bottom-3">
+      <div class="nhsuk-grid-column-full">
+        @if (Model.Options.Count != 0) {
+          <p class="nhsuk-u-font-weight-bold">Answers delegate can choose from:</p>
+          <ul>
+            @foreach (var answer in Model.Options) {
+              <li class="word-break">@answer</li>
+            }
+          </ul>
+        } else {
+          <p>This is a free text field. Delegates can input any text.</p>
+        }
+      </div>
+    </div>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-full">
+        <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1" role="button"
+           asp-controller="RegistrationPrompts"
+           asp-action="EditRegistrationPromptStart"
+           asp-route-promptNumber="@Model.CustomFieldId">
+          Edit
+        </a>
+        <a class="nhsuk-button delete-button nhsuk-button--secondary nhsuk-u-margin-bottom-1" role="button"
+           asp-controller="RegistrationPrompts"
+           asp-action="RemoveRegistrationPrompt"
+           asp-route-promptNumber="@Model.CustomFieldId">
+          Remove
+        </a>
+      </div>
+    </div>
+  </div>
+</details>


### PR DESCRIPTION
Changed all the pages in the manage registration prompt area to have approximately equal spacing between the h1 elements and the page content and the bottom of the content and the back link view component.

![image](https://user-images.githubusercontent.com/59561751/122929418-d6447b00-d362-11eb-83b4-d271b121ec43.png)

![image](https://user-images.githubusercontent.com/59561751/122929512-f2e0b300-d362-11eb-842d-70314616e41a.png)

![image](https://user-images.githubusercontent.com/59561751/122929559-fffda200-d362-11eb-9f2d-045d26f99677.png)

![image](https://user-images.githubusercontent.com/59561751/122929582-0724b000-d363-11eb-8ad2-859994ccf6a8.png)

![image](https://user-images.githubusercontent.com/59561751/122929603-0e4bbe00-d363-11eb-8469-52412468474a.png)

![image](https://user-images.githubusercontent.com/59561751/122929637-1572cc00-d363-11eb-9d87-eef7911c3238.png)
