### PR TITLE
HEEDLS-525 Refactor my account views to fix inconsistent spacing

### DIFF
--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -12,9 +12,11 @@
 
 @if (User.IsDelegateOnlyAccount()) {
   ViewData["Application"] = "Learning Portal";
-@section NavMenuItems {
-  <partial name="../LearningPortal/Shared/_NavMenuItems" />
-}}
+
+  @section NavMenuItems {
+    <partial name="../LearningPortal/Shared/_NavMenuItems" />
+  }
+}
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -12,26 +12,21 @@
 
 @if (User.IsDelegateOnlyAccount()) {
   ViewData["Application"] = "Learning Portal";
-  @section NavMenuItems {
-  <partial name="../LearningPortal/Shared/_NavMenuItems"/>
-  }
-}
-
-@if (errorHasOccurred) {
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.FirstName), nameof(Model.LastName), nameof(Model.Email), nameof(Model.Password) })"/>
-    </div>
-  </div>
-}
+@section NavMenuItems {
+  <partial name="../LearningPortal/Shared/_NavMenuItems" />
+}}
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.FirstName), nameof(Model.LastName), nameof(Model.Email), nameof(Model.Password) })" />
+    }
+
     <h1 class="nhsuk-heading-xl" id="app-page-heading">Edit details</h1>
   </div>
 </div>
 
-<form class="nhsuk-u-margin-bottom-8" method="post" novalidate asp-action="EditDetails" enctype="multipart/form-data">
+<form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditDetails" enctype="multipart/form-data">
   <div class="hidden-submit">
     <button name="action" class="nhsuk-button" value="save">Save</button>
   </div>
@@ -45,7 +40,7 @@
                      spell-check="false"
                      autocomplete="given-name"
                      hint-text=""
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
 
       <vc:text-input asp-for="LastName"
                      label="Last name"
@@ -54,7 +49,7 @@
                      spell-check="false"
                      autocomplete="family-name"
                      hint-text=""
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
 
       <vc:text-input asp-for="Email"
                      label="Email address"
@@ -63,12 +58,12 @@
                      spell-check="false"
                      autocomplete="email"
                      hint-text=""
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
     </div>
   </div>
 
   @if (Model.IsDelegateUser) {
-    <input type="hidden" asp-for="IsDelegateUser"/>
+    <input type="hidden" asp-for="IsDelegateUser" />
     <div class="nhsuk-grid-row divider">
       <div class="nhsuk-grid-column-full">
         <vc:select-list asp-for="JobGroupId"
@@ -78,7 +73,7 @@
                         deselectable="false"
                         css-class="nhsuk-u-width-one-half"
                         default-option="Select a job group"
-                        select-list-options="@ViewBag.JobGroupOptions"/>
+                        select-list-options="@ViewBag.JobGroupOptions" />
 
         @foreach (EditCustomFieldViewModel customField in ViewBag.CustomFields) {
           @if (customField.Options.Any()) {
@@ -89,7 +84,7 @@
                             deselectable="@(!customField.Mandatory)"
                             css-class="nhsuk-u-width-one-half"
                             default-option="Select a @customField.CustomPrompt.ToLower()"
-                            select-list-options="@customField.Options"/>
+                            select-list-options="@customField.Options" />
           } else {
             <vc:text-input asp-for="@("Answer" + customField.CustomFieldId)"
                            label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
@@ -98,7 +93,7 @@
                            spell-check="false"
                            autocomplete=""
                            hint-text=""
-                           css-class="nhsuk-u-width-one-half"/>
+                           css-class="nhsuk-u-width-one-half" />
           }
         }
       </div>
@@ -110,14 +105,14 @@
       @{ var hintText = @"To change your profile picture, select a new image and click the Preview button to preview it.
                               To remove your profile picture click the remove button.
                               Changes will not be made until the Save button below is clicked."; }
-      <input type="hidden" asp-for="ProfileImage"/>
-      <vc:file-input asp-for="ProfileImageFile" label="Profile picture (optional)" hint-text="@hintText" css-class="nhsuk-u-width-full"/>
+      <input type="hidden" asp-for="ProfileImage" />
+      <vc:file-input asp-for="ProfileImageFile" label="Profile picture (optional)" hint-text="@hintText" css-class="nhsuk-u-width-full" />
     </div>
     <div class="nhsuk-grid-column-one-half">
       @if (Model.ProfileImage != null) {
-        <img class="profile-picture__image" src="data:image;base64,@Convert.ToBase64String(Model.ProfileImage)" alt="Profile Picture"/>
+        <img class="profile-picture__image" src="data:image;base64,@Convert.ToBase64String(Model.ProfileImage)" alt="Profile Picture" />
       } else {
-        <img class="profile-picture__image" src="@Url.Content("~/images/avatar.png")" alt="Default Profile Picture"/>
+        <img class="profile-picture__image" src="@Url.Content("~/images/avatar.png")" alt="Default Profile Picture" />
       }
     </div>
   </div>
@@ -138,7 +133,7 @@
                      spell-check="false"
                      autocomplete=""
                      hint-text=""
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
 
       <button name="action" class="nhsuk-button" value="save">Save</button>
     </div>
@@ -146,6 +141,6 @@
 </form>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Cancel"/>
+    <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Cancel" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/Index.cshtml
@@ -21,18 +21,18 @@
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">Notification preferences</h1>
 
-    @if (Model.AdminNotifications.Notifications.Any())
-    {
-      <partial name="_UserNotificationPreferences" model="Model.AdminNotifications"/>
-    }
+    <div class="nhsuk-u-margin-bottom-7">
+      @if (Model.AdminNotifications.Notifications.Any())
+      {
+        <partial name="_UserNotificationPreferences" model="Model.AdminNotifications" />
+      }
 
-    @if (Model.DelegateNotifications.Notifications.Any())
-    {
-      <partial name="_UserNotificationPreferences" model="Model.DelegateNotifications"/>
-    }
-
-    <div class="top-spaced-goback">
-      <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" />
+      @if (Model.DelegateNotifications.Notifications.Any())
+      {
+        <partial name="_UserNotificationPreferences" model="Model.DelegateNotifications" />
+      }
     </div>
+
+    <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
+++ b/DigitalLearningSolutions.Web/Views/NotificationPreferences/UpdateNotificationPreferences.cshtml
@@ -17,40 +17,41 @@
   }
 }
 
-<form method="post" asp-controller="NotificationPreferences" asp-action="SaveNotificationPreferences" asp-route-userType="@Model.UserType">
-  <div class="nhsuk-form-group">
-    <div class="nhsuk-fieldset" aria-describedby="notification-hint">
-      <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-        <h1 class="nhsuk-fieldset__heading">
-          Update notification preferences
-        </h1>
-      </legend>
-      <div class="nhsuk-hint update-notification-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
-      <div class="nhsuk-checkboxes">
-        @foreach (var (notification, index) in Model.Notifications.Select((item, index) => (item, index)))
-        {
-          <div class="nhsuk-checkboxes__item">
-            <input class="nhsuk-checkboxes__input"
-                   id="notification-@index.ToString()"
-                   name="notificationIds"
-                   type="checkbox"
-                   value="@notification.NotificationId"
-                   aria-describedby="notification-@index.ToString()-item-hint"
-                   @(notification.Accepted ? "checked" : "")>
-            <label class="nhsuk-label nhsuk-checkboxes__label" for="notification-@index.ToString()">
-              @notification.NotificationName
-            </label>
-            <div class="nhsuk-hint nhsuk-checkboxes__hint" id="notification-@index.ToString()-item-hint">
-              @Html.Raw(notification.Description)
-            </div>
-          </div>
-        }
-      </div>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl">Update notification preferences</h1>
 
-      <button class="nhsuk-button" type="submit">Save</button>
-      <div class="top-spaced-goback">
-        <vc:back-link asp-controller="NotificationPreferences" asp-action="Index" link-text="Cancel" />
+    <form class="nhsuk-u-margin-bottom-3" method="post" asp-controller="NotificationPreferences" asp-action="SaveNotificationPreferences" asp-route-userType="@Model.UserType">
+      <div class="nhsuk-form-group">
+        <div class="nhsuk-fieldset" aria-describedby="notification-hint">
+          <div class="nhsuk-hint update-notification-hint" id="notification-hint">Please tick the boxes for all the notifications you would like to receive.</div>
+          <div class="nhsuk-checkboxes">
+            @foreach (var (notification, index) in Model.Notifications.Select((item, index) => (item, index)))
+            {
+              <div class="nhsuk-checkboxes__item">
+                <input class="nhsuk-checkboxes__input"
+                       id="notification-@index.ToString()"
+                       name="notificationIds"
+                       type="checkbox"
+                       value="@notification.NotificationId"
+                       aria-describedby="notification-@index.ToString()-item-hint"
+                       @(notification.Accepted ? "checked" : "")>
+                <label class="nhsuk-label nhsuk-checkboxes__label" for="notification-@index.ToString()">
+                  @notification.NotificationName
+                </label>
+                <div class="nhsuk-hint nhsuk-checkboxes__hint" id="notification-@index.ToString()-item-hint">
+                  @Html.Raw(notification.Description)
+                </div>
+              </div>
+            }
+          </div>
+
+          <button class="nhsuk-button" type="submit">Save</button>
+        </div>
       </div>
-    </div>
+    </form>
+
+    <vc:back-link asp-controller="NotificationPreferences" asp-action="Index" link-text="Cancel" />
   </div>
-</form>
+</div>
+


### PR DESCRIPTION
Refactored the html in the my account edit details screen and the 2 manage notification screens to fix the spacing before the back links. I've changed the html in the update notification preferences relatively significantly as VS was complaining about invalid html (legend inside div). This means that the page does look a bit different to before, but it now looks more like the rest of the pages in the system.

All the automated accessibility tests still pass + checked with chrome lighthouse for 100 rating on accessibility on the update notification page.

![image](https://user-images.githubusercontent.com/59561751/122931935-39cfa800-d365-11eb-97f0-6b1a68cb29cf.png)
![image](https://user-images.githubusercontent.com/59561751/122932210-73a0ae80-d365-11eb-8b1b-925b34cc86ed.png)
![image](https://user-images.githubusercontent.com/59561751/122932268-7f8c7080-d365-11eb-955e-56c74753c8eb.png)

