### PR TITLE
HEEDLS-381 Move hidden input for prompt name inside form

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/RemoveRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CentreConfiguration/RegistrationPrompts/RemoveRegistrationPrompt.cshtml
@@ -38,7 +38,6 @@
     </div>
   </div>
   <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
-    <input type="hidden" asp-for="PromptName" />
     @Model.PromptName
   </div>
 </div>
@@ -77,6 +76,7 @@
           </div>
         </fieldset>
       </div>
+      <input type="hidden" asp-for="PromptName" />
       <input type="hidden" asp-for="DelegateCount" />
       <button class="nhsuk-button delete-button nhsuk-button--secondary" type="submit">Delete prompt</button>
     </div>


### PR DESCRIPTION
Moved the hidden input used to preserve the prompt name on failed validation of the checkbox inside the form tag.