### PR TITLE
HEEDLS-529 Fix back link spacing for Register journey pages

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
@@ -1,5 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.MyAccount
-@using DigitalLearningSolutions.Web.ViewModels.Register
+﻿@using DigitalLearningSolutions.Web.ViewModels.Register
 @model LearnerInformationViewModel
 
 @{
@@ -9,24 +8,22 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <form method="post" asp-action="LearnerInformation">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@(new[] {
+                                                   nameof(Model.JobGroup),
+                                                   nameof(Model.Answer1),
+                                                   nameof(Model.Answer2),
+                                                   nameof(Model.Answer3),
+                                                   nameof(Model.Answer4),
+                                                   nameof(Model.Answer5),
+                                                   nameof(Model.Answer6)
+                                                 })"/>
+    }
+      
+    <h1 class="nhsuk-heading-xl">Learner information</h1>
 
-      @if (errorHasOccurred) {
-        <vc:error-summary order-of-property-names="@(new[] {
-           nameof(Model.JobGroup),
-           nameof(Model.Answer1),
-           nameof(Model.Answer2),
-           nameof(Model.Answer3),
-           nameof(Model.Answer4),
-           nameof(Model.Answer5),
-           nameof(Model.Answer6)
-        })"/>
-      }
-
-      <div class="nhsuk-u-margin-bottom-8">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Learner information</h1>
-      </div>
-
+    <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="LearnerInformation">
+      
       <vc:select-list
         asp-for="JobGroup"
         label="Job Group"

--- a/DigitalLearningSolutions.Web/Views/Register/Password.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Password.cshtml
@@ -8,15 +8,13 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <form method="post" asp-action="Password">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Password), nameof(Model.ConfirmPassword) })"/>
+    }
 
-      @if (errorHasOccurred) {
-        <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Password), nameof(Model.ConfirmPassword) })"/>
-      }
-
-      <div class="nhsuk-u-margin-bottom-8">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Create password</h1>
-      </div>
+    <h1 class="nhsuk-heading-xl">Create password</h1>
+    
+    <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="Password">
 
       <vc:text-input
         asp-for="Password"
@@ -26,7 +24,7 @@
         spell-check="false"
         autocomplete="new-password"
         hint-text="Your new password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
-        css-class="nhsuk-u-width-one-half"/>
+        css-class="nhsuk-u-width-one-half" />
 
       <vc:text-input
         asp-for="ConfirmPassword"
@@ -36,7 +34,7 @@
         spell-check="false"
         autocomplete="new-password"
         hint-text=""
-        css-class="nhsuk-u-width-one-half"/>
+        css-class="nhsuk-u-width-one-half" />
 
       <button class="nhsuk-button" type="submit">Next</button>
     </form>

--- a/DigitalLearningSolutions.Web/Views/Register/PersonalInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/PersonalInformation.cshtml
@@ -14,7 +14,7 @@
       }
 
       <div class="nhsuk-u-margin-bottom-8">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Register</h1>
+        <h1 class="nhsuk-heading-xl">Register</h1>
         <input type="hidden" asp-for="IsCentreSpecificRegistration" value="@Model.IsCentreSpecificRegistration" />
 
         @if (Model.IsCentreSpecificRegistration) {


### PR DESCRIPTION
Refactored the Registration journey pages to make spacing consistent:
Personal information - increased spacing after h1
![image](https://user-images.githubusercontent.com/59561751/123113337-6273a280-d436-11eb-87b8-8667d42b0e0e.png)

Learner info - fixed spacing before back link
![image](https://user-images.githubusercontent.com/59561751/123113397-70c1be80-d436-11eb-8af1-80499e5162ec.png)

Password - fixed spacing before back link
![image](https://user-images.githubusercontent.com/59561751/123113457-7ae3bd00-d436-11eb-8ab3-4f517fe51f27.png)
