### PR TITLE
HEEDLS-530 Fix spacing before back link on change password page

### DIFF
--- a/DigitalLearningSolutions.Web/Views/ChangePassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ChangePassword/Index.cshtml
@@ -10,19 +10,16 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <form method="post" asp-action="Index">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.CurrentPassword), nameof(Model.Password), nameof(Model.ConfirmPassword) })" />
+    }
 
-      @if (errorHasOccurred) {
-        <vc:error-summary order-of-property-names="@(new[] { nameof(Model.CurrentPassword), nameof(Model.Password), nameof(Model.ConfirmPassword) })"/>
-      }
+    <h1 class="nhsuk-heading-xl">Change password</h1>
+    <p class="nhsuk-body-l">
+      Use the form below to change the password for delegate and admin accounts associated with your email address.
+    </p>
 
-      <div class="nhsuk-u-margin-bottom-8">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Change password</h1>
-        <p class="nhsuk-body-l">
-          Use the form below to change the password for delegate and admin accounts associated with your email address.
-        </p>
-      </div>
-
+    <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="Index">
       <vc:text-input asp-for="@nameof(Model.CurrentPassword)"
                      label="Current password"
                      populate-with-current-value="false"
@@ -30,7 +27,7 @@
                      spell-check="false"
                      hint-text=""
                      autocomplete="current-password"
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
 
       <vc:text-input asp-for="@nameof(Model.Password)"
                      label="New password"
@@ -39,7 +36,7 @@
                      spell-check="false"
                      hint-text="Your new password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
                      autocomplete="new-password"
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
 
       <vc:text-input asp-for="@nameof(Model.ConfirmPassword)"
                      label="Re-type new password"
@@ -48,11 +45,11 @@
                      spell-check="false"
                      hint-text=""
                      autocomplete="new-password"
-                     css-class="nhsuk-u-width-one-half"/>
+                     css-class="nhsuk-u-width-one-half" />
 
       <button class="nhsuk-button" type="submit">Change password</button>
-
-      <vc:back-link asp-controller="MyAccount" asp-action="Index" asp-all-route-data="@null" link-text="Cancel"/>
     </form>
+
+    <vc:back-link asp-controller="MyAccount" asp-action="Index" asp-all-route-data="@null" link-text="Cancel" />
   </div>
 </div>


### PR DESCRIPTION
Changed the spacing after the h1 and before the back link to make it consistent with other pages.
![image](https://user-images.githubusercontent.com/59561751/123114957-a0bd9180-d437-11eb-8278-6c25ba00c7bf.png)
