### PR TITLE
HEEDLS-523 Changed h3 to h2 to not have out of order headings

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Register/Confirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Confirmation.cshtml
@@ -21,12 +21,12 @@
     </div>
     @if (!Model.Approved) {
       <div class="nhsuk-warning-callout">
-        <h3 class="nhsuk-warning-callout__label">
+        <h2 class="nhsuk-warning-callout__label">
           <span role="text">
             <span class="nhsuk-u-visually-hidden">Important: </span>
             Your registration must be approved
           </span>
-        </h3>
+        </h2>
         <p>
           Your registration must be approved by a centre administrator before you can log in.
           You will receive an email at the address you registered with when your registration


### PR DESCRIPTION
Google Lighthouse was complaining about having an h3 directly beneath an h1, so I've changed it to an h2. Hasn't had any effect on styling since that was all being set by the `nhsuk-warning-callout__label` class anyway.

Appearance before:
![image](https://user-images.githubusercontent.com/30173746/123399948-227aff80-d59d-11eb-9bf9-9669798c24f6.png)

Appearance after:
![image](https://user-images.githubusercontent.com/30173746/123399836-ffe8e680-d59c-11eb-8d08-486aa2673b1d.png)
