### PR TITLE
Heedls 522 fix pagination invalid html

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
@@ -229,6 +229,11 @@ div#search {
   text-align: center;
 }
 
+#page-indicator {
+  @include nhsuk-typography-responsive(24);
+  padding-top: 1px;
+}
+
 button.nhsuk-pagination__link {
   border: none;
   background-color: transparent;
@@ -246,6 +251,10 @@ button.nhsuk-pagination__link {
     @include mq($until: tablet) {
       flex-direction: column-reverse;
     }
+  }
+
+  &.nhsuk-pagination__link--next {
+    float: right;
   }
 
   &:hover {
@@ -271,6 +280,10 @@ button.nhsuk-pagination__link {
   .nhsuk-pagination-item--next & {
     text-align: left;
   }
+}
+
+.nhsuk-pagination {
+  padding: 0;
 }
 
 @include mq($from: 768px, $until: 1024px) {

--- a/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
@@ -1,5 +1,9 @@
 ﻿@import "~nhsuk-frontend/packages/core/all";
 
+// Some of the NHS styles break down with the 3/4 column layout below this
+// size. Since the NHS large-desktop is 990px, defined this xl-desktop size.
+$xl-desktop: 1024px;
+
 $nhs-dark-grey: #425563;
 
 .searchable-element {
@@ -286,13 +290,13 @@ button.nhsuk-pagination__link {
   padding: 0;
 }
 
-@include mq($from: 768px, $until: 1024px) {
+@include mq($from: 768px, $until: $xl-desktop) {
   .asset-card-header {
     min-height: 222px;
   }
 }
 
-@include mq($from: 1024px) {
+@include mq($from: $xl-desktop) {
   .asset-card-header {
     min-height: 163px;
   }

--- a/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
@@ -220,7 +220,7 @@ div#search {
   }
 }
 
-.pagination-item {
+.pagination-button-container {
   width: 38%;
 }
 

--- a/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/searchableElements.scss
@@ -234,6 +234,7 @@ button.nhsuk-pagination__link {
   background-color: transparent;
   color: $nhsuk-link-color;
   display: flex;
+  width: auto;
   // Since IE is bad at drawing boxes the correct size
   overflow: visible;
 

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/centreAdministrators.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/centreAdministrators.scss
@@ -1,0 +1,31 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+button.nhsuk-pagination__link {
+  @include mq($until: 1024px) {
+    flex-direction: column;
+  }
+
+  &.nhsuk-pagination__link--prev {
+    @include mq($until: 1024px) {
+      flex-direction: column-reverse;
+    }
+  }
+
+  &.nhsuk-pagination__link--next {
+    @include mq($until: 1024px) {
+      float: right;
+    }
+  }
+}
+
+.nhsuk-pagination-item--next .nhsuk-pagination__title {
+  @include mq($until: 1024px) {
+    padding-right: 0;
+  }
+}
+
+.nhsuk-pagination-item--previous .nhsuk-pagination__title {
+  @include mq($until: 1024px) {
+    padding-left: 0;
+  }
+}

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/centreAdministrators.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/centreAdministrators.scss
@@ -1,31 +1,28 @@
 ﻿@import "~nhsuk-frontend/packages/core/all";
+@import "../shared/searchableElements";
 
 button.nhsuk-pagination__link {
-  @include mq($until: 1024px) {
-    flex-direction: column;
-  }
-
-  &.nhsuk-pagination__link--prev {
-    @include mq($until: 1024px) {
-      flex-direction: column-reverse;
+  &.nhsuk-pagination__link--next {
+    @include mq($until: $xl-desktop) {
+      flex-direction: column;
     }
   }
 
-  &.nhsuk-pagination__link--next {
-    @include mq($until: 1024px) {
-      float: right;
+  &.nhsuk-pagination__link--prev {
+    @include mq($until: $xl-desktop) {
+      flex-direction: column-reverse;
     }
   }
 }
 
 .nhsuk-pagination-item--next .nhsuk-pagination__title {
-  @include mq($until: 1024px) {
+  @include mq($until: $xl-desktop) {
     padding-right: 0;
   }
 }
 
 .nhsuk-pagination-item--previous .nhsuk-pagination__title {
-  @include mq($until: 1024px) {
+  @include mq($until: $xl-desktop) {
     padding-left: 0;
   }
 }

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_Pagination.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_Pagination.cshtml
@@ -2,16 +2,16 @@
 @model BaseSearchablePageViewModel
 
 <nav class="nhsuk-pagination" role="navigation" aria-label="Pagination">
-  <ul class="nhsuk-list nhsuk-pagination__list">
+  <div class="nhsuk-list nhsuk-pagination__list">
     <div class="pagination-button-container">
-      <li class="nhsuk-pagination-item--previous" @(Model.Page == 1 ? "hidden" : "")>
+      <div class="nhsuk-pagination-item--previous" @(Model.Page == 1 ? "hidden" : "")>
         <button class="nhsuk-pagination__link nhsuk-pagination__link--prev" type="submit" asp-action="@ViewContext.RouteData.Values["action"].ToString()" asp-route-page="@(Model.Page - 1)">
           <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
           </svg>
           <span class="nhsuk-pagination__title">Previous</span>
         </button>
-      </li>
+      </div>
     </div>
     <div class="page-indicator-container">
       <span aria-live="polite" aria-atomic="true">
@@ -20,14 +20,14 @@
       </span>
     </div>
     <div class="pagination-button-container">
-      <li class="nhsuk-pagination-item--next" @(Model.Page < Model.TotalPages ? "" : "hidden")>
+      <div class="nhsuk-pagination-item--next" @(Model.Page < Model.TotalPages ? "" : "hidden")>
         <button class="nhsuk-pagination__link nhsuk-pagination__link--next" type="submit" asp-action="@ViewContext.RouteData.Values["action"].ToString()" asp-route-page="@(Model.Page + 1)">
           <span class="nhsuk-pagination__title">Next</span>
           <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
           </svg>
         </button>
-      </li>
+      </div>
     </div>
-  </ul>
+  </div>
 </nav>

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_Pagination.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_Pagination.cshtml
@@ -2,7 +2,7 @@
 @model BaseSearchablePageViewModel
 
 <nav class="nhsuk-pagination" role="navigation" aria-label="Pagination">
-  <div class="nhsuk-list nhsuk-pagination__list">
+  <div class="nhsuk-pagination__list">
     <div class="pagination-button-container">
       <div class="nhsuk-pagination-item--previous" @(Model.Page == 1 ? "hidden" : "")>
         <button class="nhsuk-pagination__link nhsuk-pagination__link--prev" type="submit" asp-action="@ViewContext.RouteData.Values["action"].ToString()" asp-route-page="@(Model.Page - 1)">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/Index.cshtml
@@ -4,7 +4,6 @@
 @using Microsoft.Extensions.Configuration
 @model CentreAdministratorsViewModel
 
-<link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/centreAdministrators.css")" asp-append-version="true">
 
 @{

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/Index.cshtml
@@ -5,6 +5,7 @@
 @model CentreAdministratorsViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/centreAdministrators.css")" asp-append-version="true">
 
 @{
   ViewData["Title"] = "Centre Administrators";


### PR DESCRIPTION
Changed the pagination to use divs instead of ul/li since the custom layout/styling needed container divs which weren't allowed in the ul element.
Fixed the highlighting on the previous page button
Improved the layout of the buttons on mobile - particularly on the admins page where the 3/4 column layout was making the problem worse. For the admin page I've increased the point at which the buttons collapse the arrows to below the text. Wasn't able to get the arrow on the Next button to push right properly, but it's probably close enough.

Desktop admins
![image](https://user-images.githubusercontent.com/59561751/124129541-c836de80-da75-11eb-94ab-330741b3be69.png)

Large tablet/small desktop admins (1024px)
![image](https://user-images.githubusercontent.com/59561751/124129656-e6044380-da75-11eb-9614-f916f1a39491.png)

Mobile admins
![image](https://user-images.githubusercontent.com/59561751/124129579-d422a080-da75-11eb-8cea-81f7cbb218e1.png)

Large tablet/small desktop courses (1024px)
![image](https://user-images.githubusercontent.com/59561751/124129880-1fd54a00-da76-11eb-892c-32914762f973.png)
