### PR TITLE
HEEDLS-534 - changed centre config image max sizes

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/centreConfiguration.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/centreConfiguration.scss
@@ -2,19 +2,14 @@
 
 .centre-detail-image__downsize {
   display: block;
-  max-width: 500px;
+  max-width: 350px;
   max-height: 350px;
   height: auto;
   width: auto;
 
   @include govuk-media-query($until: large-desktop) {
-    max-width: 400px;
-    max-height: 300px;
-  }
-
-  @include govuk-media-query($until: desktop) {
-    max-width: 300px;
-    max-height: 250px;
+    max-width: 275px;
+    max-height: 275px;
   }
 
   @include govuk-media-query($until: tablet) {


### PR DESCRIPTION
Ran all unit tests

Screen shot of new large-desktop size screen on centre config page for centre 121 (the centre used in the ticket's screen shot)

![Large desktop resized image](https://user-images.githubusercontent.com/80777689/124144150-9c225a00-da83-11eb-8864-50cfa49430e1.PNG)
