### PR TITLE
HEEDLS-468 Increase spacing on admin table and add screen reader

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/Index.cshtml
@@ -35,7 +35,7 @@
     }
 
     @if (Model.CentreHasNoActivity) {
-      <p class="current-centre nhsuk-body-l nhsuk-u-padding-left-2">Your centre overall rank: no activity</p>
+      <p class="current-centre nhsuk-body-l nhsuk-u-padding-left-2" aria-current="true">Your centre overall rank: no activity</p>
     }
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/Index.cshtml
@@ -35,7 +35,8 @@
     }
 
     @if (Model.CentreHasNoActivity) {
-      <p class="current-centre nhsuk-body-l nhsuk-u-padding-left-2" aria-current="true">Your centre overall rank: no activity</p>
+      <p class="current-centre nhsuk-body-l nhsuk-u-padding-left-2 nhsuk-u-padding-top-3 nhsuk-u-padding-bottom-3"
+         aria-current="true">Your centre overall rank: no activity</p>
     }
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/_RankingStandardUserTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/_RankingStandardUserTable.cshtml
@@ -14,7 +14,7 @@
   </thead>
   <tbody class="nhsuk-table__body">
   @foreach (var centre in Model.Centres) {
-    <tr role="row" class="nhsuk-table__row @(centre.IsHighlighted ? "current-centre" : string.Empty)">
+    <tr role="row" class="nhsuk-table__row @(centre.IsHighlighted ? "current-centre" : string.Empty)" @(centre.IsHighlighted ? "aria-current=\"true\"" : "")>
       <td class="nhsuk-table__cell nhsuk-u-padding-left-2">@centre.Rank</td>
       <td class="nhsuk-table__cell ">@centre.CentreName</td>
     </tr>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/_RankingSuperAdminTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Ranking/_RankingSuperAdminTable.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Ranking
 @model CentreRankingViewModel
 
-<table role="table" class="nhsuk-table-responsive">
+<table role="table" class="nhsuk-table-responsive nhsuk-u-margin-bottom-7">
   <thead role="rowgroup" class="nhsuk-table__head">
   <tr role="row">
     <th role="columnheader" class="nhsuk-u-padding-left-2" scope="col">
@@ -17,7 +17,7 @@
   </thead>
   <tbody class="nhsuk-table__body">
   @foreach (var centre in Model.Centres) {
-    <tr role="row" class="nhsuk-table__row @(centre.IsHighlighted ? "current-centre" : string.Empty)">
+    <tr role="row" class="nhsuk-table__row @(centre.IsHighlighted ? "current-centre" : string.Empty)" @(centre.IsHighlighted ? "aria-current=\"true\"" : "")>
       <td role="cell" class="nhsuk-table__cell nhsuk-u-padding-left-2 cell-right-padding">
         <span class="nhsuk-table-responsive__heading">Rank </span>@centre.Rank
       </td>


### PR DESCRIPTION
Increased the spacing between the table and the no activity text on the admin table. Also added aria-current to the highlighted row (which I think is the right attribute?)

![image](https://user-images.githubusercontent.com/59561751/124246286-b1959380-db18-11eb-9333-e54fe22779f0.png)
