### PR TITLE
HEEDLS-350 Validate password if not null before ModelState validation

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Models/User/UserAccountSetTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Models/User/UserAccountSetTests.cs
@@ -13,12 +13,8 @@
         [Test]
         public void Any_returns_false_if_adminUser_null_and_delegateUsers_empty()
         {
-            // Given
-            AdminUser? adminUser = null;
-            var delegates = new List<DelegateUser>();
-
             // When
-            var result = new UserAccountSet(adminUser, delegates).Any();
+            var result = new UserAccountSet().Any();
 
             // Then
             result.Should().BeFalse();

--- a/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
@@ -317,7 +317,7 @@
             A.CallTo(() => userDataService.GetDelegateUsersByEmailAddress(signedInEmail))
                 .Returns(new List<DelegateUser>());
             A.CallTo(() => loginService.VerifyUsers(password, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(new UserAccountSet(null, new List<DelegateUser>()));
+                .Returns(new UserAccountSet());
 
             // When
             userService.UpdateUserAccountDetails(accountDetailsData, centreAnswersData);

--- a/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
@@ -212,10 +212,9 @@
                 .DoesNothing();
 
             // When
-            var result = userService.TryUpdateUserAccountDetails(accountDetailsData);
+            userService.UpdateUserAccountDetails(accountDetailsData);
 
             // Then
-            result.Should().BeTrue();
             A.CallTo(() => userDataService.UpdateAdminUser(A<string>._, A<string>._, A<string>._, null, A<int>._))
                 .MustHaveHappened();
             A.CallTo(() => userDataService.UpdateDelegateUsers(A<string>._, A<string>._, A<string>._, null, A<int[]>._))
@@ -246,11 +245,9 @@
                 .DoesNothing();
 
             // When
-            var result =
-                userService.TryUpdateUserAccountDetails(accountDetailsData, centreAnswersData);
+            userService.UpdateUserAccountDetails(accountDetailsData, centreAnswersData);
 
             // Then
-            result.Should().BeTrue();
             A.CallTo(() => userDataService.UpdateDelegateUsers(A<string>._, A<string>._, A<string>._, null, A<int[]>._))
                 .MustHaveHappened();
             A.CallTo(() => userDataService.UpdateAdminUser(A<string>._, A<string>._, A<string>._, null, A<int>._))
@@ -288,10 +285,9 @@
                 .DoesNothing();
 
             // When
-            var result = userService.TryUpdateUserAccountDetails(accountDetailsData, centreAnswersData);
+            userService.UpdateUserAccountDetails(accountDetailsData, centreAnswersData);
 
             // Then
-            result.Should().BeTrue();
             A.CallTo(() => userDataService.UpdateDelegateUsers(A<string>._, A<string>._, A<string>._, null, A<int[]>._))
                 .MustHaveHappened();
             A.CallTo(() => userDataService.UpdateAdminUser(A<string>._, A<string>._, A<string>._, null, A<int>._))
@@ -324,10 +320,9 @@
                 .Returns(new UserAccountSet(null, new List<DelegateUser>()));
 
             // When
-            var result = userService.TryUpdateUserAccountDetails(accountDetailsData, centreAnswersData);
+            userService.UpdateUserAccountDetails(accountDetailsData, centreAnswersData);
 
             // Then
-            result.Should().BeFalse();
             A.CallTo(() => userDataService.UpdateDelegateUsers(A<string>._, A<string>._, A<string>._, null, A<int[]>._))
                 .MustNotHaveHappened();
             A.CallTo(() => userDataService.UpdateAdminUser(A<string>._, A<string>._, A<string>._, null, A<int>._))

--- a/DigitalLearningSolutions.Data/Models/User/UserAccountSet.cs
+++ b/DigitalLearningSolutions.Data/Models/User/UserAccountSet.cs
@@ -8,6 +8,8 @@
         public readonly AdminUser? AdminAccount;
         public readonly List<DelegateUser> DelegateAccounts;
 
+        public UserAccountSet() : this(null, null) { }
+
         public UserAccountSet(AdminUser? adminAccount, IEnumerable<DelegateUser?>? delegateAccounts)
         {
             AdminAccount = adminAccount;

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -18,7 +18,7 @@ namespace DigitalLearningSolutions.Data.Services
 
         public List<CentreUserDetails> GetUserCentres(AdminUser? adminUser, List<DelegateUser> delegateUsers);
 
-        public bool TryUpdateUserAccountDetails(
+        public void UpdateUserAccountDetails(
             AccountDetailsData accountDetailsData,
             CentreAnswersData? centreAnswersData = null
         );
@@ -26,6 +26,8 @@ namespace DigitalLearningSolutions.Data.Services
         public bool NewEmailAddressIsValid(string emailAddress, int? adminUserId, int? delegateUserId, int centreId);
 
         UserAccountSet GetVerifiedLinkedUsersAccounts(int? adminId, int? delegateId, string password);
+
+        public bool IsPasswordValid(int? adminId, int? delegateId, string password);
     }
 
     public class UserService : IUserService
@@ -103,7 +105,7 @@ namespace DigitalLearningSolutions.Data.Services
             return availableCentres.OrderByDescending(ac => ac.IsAdmin).ThenBy(ac => ac.CentreName).ToList();
         }
 
-        public bool TryUpdateUserAccountDetails(
+        public void UpdateUserAccountDetails(
             AccountDetailsData accountDetailsData,
             CentreAnswersData? centreAnswersData = null
         )
@@ -114,11 +116,6 @@ namespace DigitalLearningSolutions.Data.Services
                     accountDetailsData.DelegateId,
                     accountDetailsData.Password
                 );
-
-            if (verifiedAdminUser == null && verifiedDelegateUsers.Count == 0)
-            {
-                return false;
-            }
 
             if (verifiedAdminUser != null)
             {
@@ -156,8 +153,6 @@ namespace DigitalLearningSolutions.Data.Services
                     );
                 }
             }
-
-            return true;
         }
 
         public bool NewEmailAddressIsValid(string emailAddress, int? adminUserId, int? delegateUserId, int centreId)
@@ -200,6 +195,13 @@ namespace DigitalLearningSolutions.Data.Services
             var (adminUser, delegateUsers) = GetUsersByEmailAddress(signedInEmailIfAny);
 
             return loginService.VerifyUsers(password, adminUser, delegateUsers);
+        }
+
+        public bool IsPasswordValid(int? adminId, int? delegateId, string password)
+        {
+            var verifiedLinkedUsersAccounts = GetVerifiedLinkedUsersAccounts(adminId, delegateId, password);
+
+            return verifiedLinkedUsersAccounts.Any();
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/ChangePasswordControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/ChangePasswordControllerTests.cs
@@ -76,7 +76,7 @@
         {
             // Given
             var user = Builder<AdminUser>.CreateNew().Build();
-            GivenPasswordVerificationReturnsUsers(new UserAccountSet(user, new DelegateUser[] { }), "current-password");
+            GivenPasswordVerificationReturnsUsers(new UserAccountSet(), "current-password");
 
             // When
             var result = await authenticatedController.Index(
@@ -158,7 +158,7 @@
         private void GivenPasswordVerificationFails()
         {
             A.CallTo(() => userService.GetVerifiedLinkedUsersAccounts(A<int>._, A<int>._, A<string>._))
-                .Returns(new UserAccountSet(null, new List<DelegateUser>()));
+                .Returns(new UserAccountSet());
         }
 
         private void ThenMustHaveChangedPasswordForUsersOnce(string newPassword, IEnumerable<User> expectedUsers)

--- a/DigitalLearningSolutions.Web.Tests/Controllers/ChangePasswordControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/ChangePasswordControllerTests.cs
@@ -76,7 +76,7 @@
         {
             // Given
             var user = Builder<AdminUser>.CreateNew().Build();
-            GivenPasswordVerificationReturnsUsers(new UserAccountSet(), "current-password");
+            GivenPasswordVerificationReturnsUsers(new UserAccountSet(user, null), "current-password");
 
             // When
             var result = await authenticatedController.Index(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -196,7 +196,7 @@
             A.CallTo(() => userService.GetUsersByUsername(A<string>._))
                 .Returns((UserTestHelper.GetDefaultAdminUser(), new List<DelegateUser>()));
             A.CallTo(() => loginService.VerifyUsers(A<string>._, A<AdminUser>._, A<List<DelegateUser>>._))
-                .Returns(new UserAccountSet(null, new List<DelegateUser>()));
+                .Returns(new UserAccountSet());
 
             // When
             var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());

--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -5,7 +5,6 @@
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
-    using DigitalLearningSolutions.Data.Tests.Helpers;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.Controllers;
     using DigitalLearningSolutions.Web.Helpers;
@@ -21,13 +20,12 @@
 
     public class MyAccountControllerTests
     {
+        private const string Email = "test@user.com";
         private CustomPromptHelper customPromptHelper = null!;
         private ICustomPromptsService customPromptsService = null!;
         private IImageResizeService imageResizeService = null!;
         private IJobGroupsDataService jobGroupsDataService = null!;
         private IUserService userService = null!;
-
-        private const string Email = "test@user.com";
 
         [SetUp]
         public void Setup()
@@ -43,8 +41,13 @@
         public void EditDetailsPostSave_with_invalid_model_doesnt_call_services()
         {
             // Given
-            var myAccountController = new MyAccountController
-                (customPromptsService, userService, imageResizeService, jobGroupsDataService, customPromptHelper).WithDefaultContext().WithMockUser(true);
+            var myAccountController = new MyAccountController(
+                customPromptsService,
+                userService,
+                imageResizeService,
+                jobGroupsDataService,
+                customPromptHelper
+            ).WithDefaultContext().WithMockUser(true);
             var model = new EditDetailsViewModel();
             myAccountController.ModelState.AddModelError(nameof(EditDetailsViewModel.Email), "Required");
 
@@ -52,7 +55,8 @@
             var result = myAccountController.EditDetails(model, "save");
 
             // Then
-            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._))
+                .MustNotHaveHappened();
             result.As<ViewResult>().Model.Should().BeEquivalentTo(model);
         }
 
@@ -60,18 +64,27 @@
         public void EditDetailsPostSave_with_missing_delegate_answers_fails_validation()
         {
             // Given
-            var myAccountController = new MyAccountController
-                (customPromptsService, userService, imageResizeService, jobGroupsDataService, customPromptHelper).WithDefaultContext().WithMockUser(true, adminId: null);
-            var customPromptLists = new List<CustomPrompt> { CustomPromptsTestHelper.GetDefaultCustomPrompt(1, mandatory: true) };
+            var myAccountController = new MyAccountController(
+                customPromptsService,
+                userService,
+                imageResizeService,
+                jobGroupsDataService,
+                customPromptHelper
+            ).WithDefaultContext().WithMockUser(true, adminId: null);
+            var customPromptLists = new List<CustomPrompt>
+                { CustomPromptsTestHelper.GetDefaultCustomPrompt(1, mandatory: true) };
             A.CallTo
-                (() => customPromptsService.GetCustomPromptsForCentreByCentreId(2)).Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPromptLists, 2));
+                (() => customPromptsService.GetCustomPromptsForCentreByCentreId(2)).Returns(
+                CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPromptLists, 2)
+            );
             var model = new EditDetailsViewModel();
 
             // When
             var result = myAccountController.EditDetails(model, "save");
 
             // Then
-            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._))
+                .MustNotHaveHappened();
             result.As<ViewResult>().Model.Should().BeEquivalentTo(model);
             myAccountController.ModelState[nameof(EditDetailsViewModel.JobGroupId)].ValidationState.Should().Be
                 (ModelValidationState.Invalid);
@@ -83,8 +96,13 @@
         public void EditDetailsPostSave_for_admin_user_with_missing_delegate_answers_doesnt_fail_validation()
         {
             // Given
-            var myAccountController = new MyAccountController
-                (customPromptsService, userService, imageResizeService, jobGroupsDataService, customPromptHelper).WithDefaultContext().WithMockUser(true, delegateId: null);
+            var myAccountController = new MyAccountController(
+                customPromptsService,
+                userService,
+                imageResizeService,
+                jobGroupsDataService,
+                customPromptHelper
+            ).WithDefaultContext().WithMockUser(true, delegateId: null);
             A.CallTo(() => userService.IsPasswordValid(7, null, "password")).Returns(true);
             A.CallTo(() => userService.NewEmailAddressIsValid(Email, 7, null, 2)).Returns(true);
             A.CallTo(() => userService.UpdateUserAccountDetails(A<AccountDetailsData>._, null)).DoesNothing();
@@ -109,11 +127,19 @@
         public void EditDetailsPostSave_with_profile_image_fails_validation()
         {
             // Given
-            var myAccountController = new MyAccountController
-                (customPromptsService, userService, imageResizeService, jobGroupsDataService, customPromptHelper).WithDefaultContext().WithMockUser(true, adminId: null);
-            var customPromptLists = new List<CustomPrompt> { CustomPromptsTestHelper.GetDefaultCustomPrompt(1, mandatory: true) };
+            var myAccountController = new MyAccountController(
+                customPromptsService,
+                userService,
+                imageResizeService,
+                jobGroupsDataService,
+                customPromptHelper
+            ).WithDefaultContext().WithMockUser(true, adminId: null);
+            var customPromptLists = new List<CustomPrompt>
+                { CustomPromptsTestHelper.GetDefaultCustomPrompt(1, mandatory: true) };
             A.CallTo
-                (() => customPromptsService.GetCustomPromptsForCentreByCentreId(2)).Returns(CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPromptLists, 2));
+                (() => customPromptsService.GetCustomPromptsForCentreByCentreId(2)).Returns(
+                CustomPromptsTestHelper.GetDefaultCentreCustomPrompts(customPromptLists, 2)
+            );
             var model = new EditDetailsViewModel
             {
                 ProfileImageFile = A.Fake<FormFile>()
@@ -123,9 +149,44 @@
             var result = myAccountController.EditDetails(model, "save");
 
             // Then
-            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._))
+                .MustNotHaveHappened();
             result.As<ViewResult>().Model.Should().BeEquivalentTo(model);
             myAccountController.ModelState[nameof(EditDetailsViewModel.ProfileImageFile)].ValidationState.Should().Be
+                (ModelValidationState.Invalid);
+        }
+
+        [Test]
+        public void EditDetailsPostSave_with_invalid_password_fails_validation()
+        {
+            // Given
+            var myAccountController = new MyAccountController(
+                customPromptsService,
+                userService,
+                imageResizeService,
+                jobGroupsDataService,
+                customPromptHelper
+            ).WithDefaultContext().WithMockUser(true, delegateId: null);
+            A.CallTo(() => userService.IsPasswordValid(7, null, "password")).Returns(false);
+            A.CallTo(() => userService.NewEmailAddressIsValid(Email, 7, null, 2)).Returns(true);
+            A.CallTo(() => userService.UpdateUserAccountDetails(A<AccountDetailsData>._, null)).DoesNothing();
+
+            var model = new EditDetailsViewModel
+            {
+                FirstName = "Test",
+                LastName = "User",
+                Email = Email,
+                Password = "password"
+            };
+
+            // When
+            var result = myAccountController.EditDetails(model, "save");
+
+            // Then
+            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int?>._, A<int?>._, A<int>._))
+                .MustNotHaveHappened();
+            result.As<ViewResult>().Model.Should().BeEquivalentTo(model);
+            myAccountController.ModelState[nameof(EditDetailsViewModel.Password)].ValidationState.Should().Be
                 (ModelValidationState.Invalid);
         }
 
@@ -133,8 +194,13 @@
         public void PostEditRegistrationPrompt_returns_error_with_unexpected_action()
         {
             // Given
-            var myAccountController = new MyAccountController
-                (customPromptsService, userService, imageResizeService, jobGroupsDataService, customPromptHelper).WithDefaultContext().WithMockUser(true, adminId: null);
+            var myAccountController = new MyAccountController(
+                customPromptsService,
+                userService,
+                imageResizeService,
+                jobGroupsDataService,
+                customPromptHelper
+            ).WithDefaultContext().WithMockUser(true, adminId: null);
             const string action = "unexpectedString";
             var model = new EditDetailsViewModel();
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -85,8 +85,9 @@
             // Given
             var myAccountController = new MyAccountController
                 (customPromptsService, userService, imageResizeService, jobGroupsDataService, customPromptHelper).WithDefaultContext().WithMockUser(true, delegateId: null);
+            A.CallTo(() => userService.IsPasswordValid(7, null, "password")).Returns(true);
             A.CallTo(() => userService.NewEmailAddressIsValid(Email, 7, null, 2)).Returns(true);
-            A.CallTo(() => userService.TryUpdateUserAccountDetails(A<AccountDetailsData>._, null)).Returns(true);
+            A.CallTo(() => userService.UpdateUserAccountDetails(A<AccountDetailsData>._, null)).DoesNothing();
             var model = new EditDetailsViewModel
             {
                 FirstName = "Test",
@@ -100,7 +101,7 @@
 
             // Then
             A.CallTo(() => userService.NewEmailAddressIsValid(Email, 7, null, 2)).MustHaveHappened();
-            A.CallTo(() => userService.TryUpdateUserAccountDetails(A<AccountDetailsData>._, null)).MustHaveHappened();
+            A.CallTo(() => userService.UpdateUserAccountDetails(A<AccountDetailsData>._, null)).MustHaveHappened();
             result.Should().BeRedirectToActionResult().WithActionName("Index");
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -33,7 +33,7 @@
             var delegateId = User.GetCandidateId();
 
             var verifiedLinkedUsersAccounts = string.IsNullOrEmpty(model.CurrentPassword)
-                ? new UserAccountSet(null, null)
+                ? new UserAccountSet()
                 : userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, model.CurrentPassword!);
 
             if (!verifiedLinkedUsersAccounts.Any())

--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
     using System.Threading.Tasks;
+    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.MyAccount;
@@ -30,7 +31,12 @@
         {
             var adminId = User.GetAdminId();
             var delegateId = User.GetCandidateId();
-            if (model.CurrentPassword != null && !userService.IsPasswordValid(adminId, delegateId, model.CurrentPassword))
+
+            var verifiedLinkedUsersAccounts = string.IsNullOrEmpty(model.CurrentPassword)
+                ? new UserAccountSet(null, null)
+                : userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, model.CurrentPassword!);
+
+            if (!verifiedLinkedUsersAccounts.Any())
             {
                 ModelState.AddModelError(
                     nameof(ChangePasswordViewModel.CurrentPassword),
@@ -42,9 +48,6 @@
             {
                 return View(model);
             }
-
-            var verifiedLinkedUsersAccounts =
-                userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, model.CurrentPassword!);
 
             var newPassword = model.Password!;
 

--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -28,29 +28,23 @@
         [HttpPost]
         public async Task<IActionResult> Index(ChangePasswordViewModel model)
         {
+            var adminId = User.GetAdminId();
+            var delegateId = User.GetCandidateId();
+            if (model.CurrentPassword != null && !userService.IsPasswordValid(adminId, delegateId, model.CurrentPassword))
+            {
+                ModelState.AddModelError(
+                    nameof(ChangePasswordViewModel.CurrentPassword),
+                    CommonValidationErrorMessages.IncorrectPassword
+                );
+            }
+
             if (!ModelState.IsValid)
             {
                 return View(model);
             }
 
-            var currentPassword = model.CurrentPassword!;
-
-            var adminId = User.GetAdminId();
-            var delegateId = User.GetCandidateId();
-
             var verifiedLinkedUsersAccounts =
-                userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, currentPassword);
-
-            var passwordIsInvalid = !verifiedLinkedUsersAccounts.Any();
-
-            if (passwordIsInvalid)
-            {
-                ModelState.AddModelError(
-                    nameof(model.CurrentPassword),
-                    CommonValidationErrorMessages.IncorrectPassword
-                );
-                return View(model);
-            }
+                userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, model.CurrentPassword!);
 
             var newPassword = model.Password!;
 

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -104,6 +104,11 @@
                     "Preview your new profile picture before saving");
             }
 
+            if (model.Password != null && !userService.IsPasswordValid(userAdminId, userDelegateId, model.Password))
+            {
+                ModelState.AddModelError(nameof(EditDetailsViewModel.Password), CommonValidationErrorMessages.IncorrectPassword);
+            }
+
             if (!ModelState.IsValid)
             {
                 return View(model);
@@ -118,11 +123,7 @@
 
             var (accountDetailsData, centreAnswersData) = MapToUpdateAccountData(model, userAdminId, userDelegateId);
 
-            if (!userService.TryUpdateUserAccountDetails(accountDetailsData, centreAnswersData))
-            {
-                ModelState.AddModelError(nameof(EditDetailsViewModel.Password), CommonValidationErrorMessages.IncorrectPassword);
-                return View(model);
-            }
+            userService.UpdateUserAccountDetails(accountDetailsData, centreAnswersData);
 
             return RedirectToAction("Index");
         }


### PR DESCRIPTION
Moved the validation of the password if it isn't null before the ModelState.IsValid check for both the ChangePassword and MyAccount EditDetails so that the user is shown the invalid current password error even if they also have other validation errors.