### PR TITLE
HEEDLS-470 - Corrected course statistics count from query

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -22,24 +22,32 @@
     public class CourseDataService : ICourseDataService
     {
         private const string DelegateCountQuery =
-            @"(SELECT COUNT(CandidateID)
+            @"(SELECT COUNT(pr.CandidateID)
                 FROM dbo.Progress AS pr
-                WHERE pr.CustomisationID = cu.CustomisationID) AS DelegateCount";
+                INNER JOIN dbo.Candidates AS can ON can.CandidateID = pr.CandidateID 
+                WHERE pr.CustomisationID = cu.CustomisationID
+                AND can.CentreID = @centreId) AS DelegateCount";
 
         private const string CompletedCountQuery =
-            @"(SELECT COUNT(CandidateID)
+            @"(SELECT COUNT(pr.CandidateID)
                 FROM dbo.Progress AS pr
-                WHERE pr.CustomisationID = cu.CustomisationID AND pr.Completed IS NOT NULL) AS CompletedCount";
+                INNER JOIN dbo.Candidates AS can ON can.CandidateID = pr.CandidateID 
+                WHERE pr.CustomisationID = cu.CustomisationID AND pr.Completed IS NOT NULL
+                AND can.CentreID = @centreId) AS CompletedCount";
 
         private const string AllAttemptsQuery =
-            @"(SELECT COUNT(AssessAttemptID)
+            @"(SELECT COUNT(aa.AssessAttemptID)
                 FROM dbo.AssessAttempts AS aa
-                WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] IS NOT NULL) AS AllAttempts";
+                INNER JOIN dbo.Candidates AS can ON can.CandidateID = aa.CandidateID
+                WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] IS NOT NULL
+                AND can.CentreID = @centreId) AS AllAttempts";
 
         private const string AttemptsPassedQuery =
-            @"(SELECT COUNT(AssessAttemptID)
+            @"(SELECT COUNT(aa.AssessAttemptID)
                 FROM dbo.AssessAttempts AS aa
-                WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] = 1) AS AttemptsPassed";
+                INNER JOIN dbo.Candidates AS can ON can.CandidateID = aa.CandidateID
+                WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] = 1
+                AND can.CentreID = @centreId) AS AttemptsPassed";
 
         private readonly IDbConnection connection;
         private readonly ILogger<CourseDataService> logger;


### PR DESCRIPTION
The different Count values in the course statistics were previously not restricted to candidates the specified centre. Now, the candidates should only count towards the Count values when the record's CentreID matches. This should correct some courses with the "AllCentres" flag from appearing to have more delegates taking the course then are at the centre.