### PR TITLE
HEEDLS-558 Show tracking system to UserAdmin

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
@@ -13,7 +13,7 @@
         public IActionResult Index()
         {
             var learningPortalAccess = User.GetCustomClaimAsBool(CustomClaimTypes.LearnUserAuthenticated) ?? false;
-            var trackingSystemAccess = User.GetCustomClaimAsBool(CustomClaimTypes.UserCentreAdmin) ?? false;
+            var trackingSystemAccess = User.GetCustomClaimAsBool(CustomClaimTypes.UserUserAdmin) | User.GetCustomClaimAsBool(CustomClaimTypes.UserCentreManager) | User.GetCustomClaimAsBool(CustomClaimTypes.UserCentreAdmin) ?? false;
             var contentManagementSystemAccess =
                 User.GetCustomClaimAsBool(CustomClaimTypes.UserAuthenticatedCm) ?? false;
             var superviseAccess = User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) ?? false;

--- a/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
@@ -13,7 +13,7 @@
         public IActionResult Index()
         {
             var learningPortalAccess = User.GetCustomClaimAsBool(CustomClaimTypes.LearnUserAuthenticated) ?? false;
-            var trackingSystemAccess = User.GetCustomClaimAsBool(CustomClaimTypes.UserUserAdmin) | User.GetCustomClaimAsBool(CustomClaimTypes.UserCentreManager) | User.GetCustomClaimAsBool(CustomClaimTypes.UserCentreAdmin) ?? false;
+            var trackingSystemAccess = User.HasCentreAdminPermissions();
             var contentManagementSystemAccess =
                 User.GetCustomClaimAsBool(CustomClaimTypes.UserAuthenticatedCm) ?? false;
             var superviseAccess = User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) ?? false;


### PR DESCRIPTION
A small bug fix - I changed the tracking system access to accept users who are User Admins, Centre Managers, or Centre Admins, rather than assuming that if a user is a Centre Admin they have those other permissions. 