### PR TITLE
Heedls 557 email length consistency

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
@@ -8,7 +8,7 @@
         public override void Up()
         {
             Delete.Index("IX_AdminUsers_Email").OnTable("AdminUsers");
-            Alter.Column("Email").OnTable("AdminUsers").AsString(255);
+            Alter.Column("Email").OnTable("AdminUsers").AsString(255).Nullable();
             Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
                 .Unique().WithOptions().NonClustered();
         }
@@ -16,7 +16,7 @@
         public override void Down()
         {
             Delete.Index("IX_AdminUsers_Email").OnTable("AdminUsers");
-            Alter.Column("Email").OnTable("AdminUsers").AsString(250);
+            Alter.Column("Email").OnTable("AdminUsers").AsString(250).Nullable();
             Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
                 .Unique().WithOptions().NonClustered();
         }

--- a/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
@@ -19,7 +19,6 @@
             Alter.Column("Email").OnTable("AdminUsers").AsString(250);
             Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
                 .Unique().WithOptions().NonClustered();
-            ;
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
@@ -7,7 +7,7 @@
     {
         public override void Up()
         {
-            Delete.Index("IX_AdminUsers_Email");
+            Delete.Index("IX_AdminUsers_Email").OnTable("AdminUsers");
             Alter.Column("Email").OnTable("AdminUsers").AsString(255);
             Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
                 .Unique().WithOptions().NonClustered();
@@ -15,7 +15,7 @@
 
         public override void Down()
         {
-            Delete.Index("IX_AdminUsers_Email");
+            Delete.Index("IX_AdminUsers_Email").OnTable("AdminUsers");
             Alter.Column("Email").OnTable("AdminUsers").AsString(250);
             Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
                 .Unique().WithOptions().NonClustered();

--- a/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
@@ -1,16 +1,25 @@
 ﻿namespace DigitalLearningSolutions.Data.Migrations
 {
     using FluentMigrator;
+
     [Migration(202107221605)]
     public class ChangeEmailMaxLengthOnAdminUsers : Migration
     {
         public override void Up()
         {
-            Alter.Column("Email").OnTable("AdminUsers").AsString(255).NotNullable();
+            Delete.Index("IX_AdminUsers_Email");
+            Alter.Column("Email").OnTable("AdminUsers").AsString(255);
+            Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
+                .Unique().WithOptions().NonClustered();
         }
+
         public override void Down()
         {
-            Alter.Column("Email").OnTable("AdminUsers").AsString(250).NotNullable();
+            Delete.Index("IX_AdminUsers_Email");
+            Alter.Column("Email").OnTable("AdminUsers").AsString(250);
+            Create.Index("IX_AdminUsers_Email").OnTable("AdminUsers").OnColumn("Email").Ascending().WithOptions()
+                .Unique().WithOptions().NonClustered();
+            ;
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202107221605_ChangeEmailMaxLengthOnAdminUsers.cs
@@ -1,0 +1,16 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202107221605)]
+    public class ChangeEmailMaxLengthOnAdminUsers : Migration
+    {
+        public override void Up()
+        {
+            Alter.Column("Email").OnTable("AdminUsers").AsString(255).NotNullable();
+        }
+        public override void Down()
+        {
+            Alter.Column("Email").OnTable("AdminUsers").AsString(250).NotNullable();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202107221606_ChangeEmailMaxLengthOnAdminUsers.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202107221606_ChangeEmailMaxLengthOnAdminUsers.cs
@@ -2,7 +2,7 @@
 {
     using FluentMigrator;
 
-    [Migration(202107221605)]
+    [Migration(202107221606)]
     public class ChangeEmailMaxLengthOnAdminUsers : Migration
     {
         public override void Up()

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/EditDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/EditDetailsViewModel.cs
@@ -43,7 +43,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
         public string? LastName { get; set; }
 
         [Required(ErrorMessage = "Enter your email address")]
-        [MaxLength(250, ErrorMessage = "Email address must be 250 characters or fewer")]
+        [MaxLength(255, ErrorMessage = "Email address must be 255 characters or fewer")]
         [EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
         [NoWhitespace("Email address must not contain any whitespace characters")]
         public string? Email { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/Register/PersonalInformationViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/PersonalInformationViewModel.cs
@@ -36,7 +36,7 @@
         public string? LastName { get; set; }
 
         [Required(ErrorMessage = "Enter an email address")]
-        [MaxLength(250, ErrorMessage = "Email address must be 250 characters or fewer")]
+        [MaxLength(255, ErrorMessage = "Email address must be 255 characters or fewer")]
         [EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
         [NoWhitespace("Email address must not contain any whitespace characters")]
         public string? Email { get; set; }


### PR DESCRIPTION
### JIRA link
[HEEDLS-557](https://softwiretech.atlassian.net/browse/HEEDLS-557)

### Description
I created a migration that changed the maximum length of the Email column on AdminUsers table from 250 to 255 characters, so it is consistent with the Candidates table. The migration also deletes and recreates the AdminUsers_Email index accordingly as it depends the Email column.

I also modified two view models so the form input for Email will have the same max length.

I will document these changes in the release notes after merge!
