### PR TITLE
HEEDLS-431 - Changed javascript to copy text before alert and updated…

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/centreCourseSetup.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/centreCourseSetup.ts
@@ -24,20 +24,22 @@ function copyLaunchCourseLinkToClipboard(customisationId: string) {
 }
 
 function copyTextToClipboard(textToCopy: string): void {
-  try {
-    navigator.clipboard.writeText(textToCopy).then(() => {
-      displaySuccessAlert(textToCopy);
-    }, () => {
-      displayFailureAlert(textToCopy);
-    });
-  } catch (e) {
+  if (!navigator.clipboard) {
     const succeeded = copyTextToClipboardFallback(textToCopy);
     if (succeeded) {
       displaySuccessAlert(textToCopy);
     } else {
       displayFailureAlert(textToCopy);
     }
+    return;
   }
+
+  navigator.clipboard.writeText(textToCopy).then(() => {
+    displaySuccessAlert(textToCopy);
+  },
+  () => {
+    displayFailureAlert(textToCopy);
+  });
 }
 
 function copyTextToClipboardFallback(textToCopy: string): boolean {
@@ -61,6 +63,6 @@ function displaySuccessAlert(text: string): void {
   alert(`Copied the text: ${text}`);
 }
 
-function displayFailureAlert(text: string) :void {
+function displayFailureAlert(text: string): void {
   alert(`Copy not supported or blocked. Try manually selecting and copying: ${text}`);
 }

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/centreCourseSetup.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/centreCourseSetup.ts
@@ -20,20 +20,23 @@ function copyLaunchCourseLinkToClipboard(customisationId: string) {
   const launchCourseButtonId = launchCourseButtonIdPrefix + customisationId;
   const launchCourseButton = document.getElementById(launchCourseButtonId) as HTMLAnchorElement;
   const link = launchCourseButton.href;
-  const succeeded = copyTextToClipboard(link);
-  const alertMessage = succeeded
-    ? `Copied the text: ${link}`
-    : `Copy not supported or blocked. Try manually selecting and copying: ${link}`;
-
-  alert(alertMessage);
+  copyTextToClipboard(link);
 }
 
-function copyTextToClipboard(textToCopy: string): boolean {
+function copyTextToClipboard(textToCopy: string): void {
   try {
-    navigator.clipboard.writeText(textToCopy);
-    return true;
+    navigator.clipboard.writeText(textToCopy).then(() => {
+      displaySuccessAlert(textToCopy);
+    }, () => {
+      displayFailureAlert(textToCopy);
+    });
   } catch (e) {
-    return copyTextToClipboardFallback(textToCopy);
+    const succeeded = copyTextToClipboardFallback(textToCopy);
+    if (succeeded) {
+      displaySuccessAlert(textToCopy);
+    } else {
+      displayFailureAlert(textToCopy);
+    }
   }
 }
 
@@ -52,4 +55,12 @@ function copyTextToClipboardFallback(textToCopy: string): boolean {
 
   document.body.removeChild(hiddenInput);
   return succeeded;
+}
+
+function displaySuccessAlert(text: string): void {
+  alert(`Copied the text: ${text}`);
+}
+
+function displayFailureAlert(text: string) :void {
+  alert(`Copy not supported or blocked. Try manually selecting and copying: ${text}`);
 }

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/centreCourseSetup.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/centreCourseSetup.ts
@@ -34,12 +34,9 @@ function copyTextToClipboard(textToCopy: string): void {
     return;
   }
 
-  navigator.clipboard.writeText(textToCopy).then(() => {
-    displaySuccessAlert(textToCopy);
-  },
-  () => {
-    displayFailureAlert(textToCopy);
-  });
+  navigator.clipboard.writeText(textToCopy)
+    .then(() => displaySuccessAlert(textToCopy))
+    .catch(() => displayFailureAlert(textToCopy));
 }
 
 function copyTextToClipboardFallback(textToCopy: string): boolean {

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
@@ -17,10 +17,6 @@
   }
 
   &:focus {
-    background-color: $nhsuk-focus-color;
-    color: $nhsuk-focus-text-color;
-    box-shadow: 0 -2px $nhsuk-focus-color, 0 4px $nhsuk-focus-text-color;
-    outline: 4px solid transparent;
-    text-decoration: none;
+    @include nhsuk-focused-text;
   }
 }

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
@@ -2,17 +2,25 @@
 @import "../shared/cardWithButtons";
 @import "../shared/searchableElements/searchableElements";
 
-.copy-course-button{
-    background: none;
-    border: none;
-    padding: 0;
-    color: $nhsuk-link-color;
-    @extend .nhsuk-u-font-size-19;
-    text-decoration: underline;
+.copy-course-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: $nhsuk-link-color;
+  @extend .nhsuk-u-font-size-19;
+  text-decoration: underline;
 
-    &:hover{
-        color: $nhsuk-link-hover-color;
-        text-decoration: none;
-        cursor: pointer;
-    }
+  &:hover {
+    color: $nhsuk-link-hover-color;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  &:focus {
+    background-color: $nhsuk-focus-color;
+    color: $nhsuk-focus-text-color;
+    box-shadow: 0 -2px $nhsuk-focus-color, 0 4px $nhsuk-focus-text-color;
+    outline: 4px solid transparent;
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
… button styling

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-431

### Description
The previous javascript copying functions only copied the text to clipboard after the alert was dismissed. I've updated it to be copied first. I've also updated the styling of the button to look the same as other links when focussed (which it previously didn't). 

### Screenshots
![image](https://user-images.githubusercontent.com/80777689/126976132-c67f8a63-a089-4782-86e6-8f2edd567b66.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
