### PR TITLE
HEEDLS-NONE Fix socket clashes when running UI tests for multiple builds simultaneously

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/SeleniumServerFactory.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/SeleniumServerFactory.cs
@@ -39,6 +39,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests
             return WebHost.CreateDefaultBuilder(Array.Empty<string>())
                 .UseStartup<TStartup>()
                 .UseSerilog()
+                .UseUrls("http://127.0.0.1:0")
                 .ConfigureAppConfiguration(configBuilder =>
                 {
                     var jsonConfigSources = configBuilder.Sources


### PR DESCRIPTION
The issue we are experiencing is unexpected failures when running Automated UI tests, specifically when multiple pipelines are running at the same time. The exception raised is a failure to bind to the address `http://127.0.0.1:5000/` when starting the web host in `SeleniumServerFactory`.

We have four executors on a single Windows machine. When running the Automated UI tests, the address `http://127.0.0.1:5000/` is in use. When a second build comes onto that stage at the same time, it is unable to bind to the address and thus the second pipeline fails at that stage. This is the cause of the failure.

The proposed fix is to specify a url to use when creating the `WebHostBuilder`. The IP address chosen is `127.0.0.1` to be consistent with the previous configuration, but the port is set to `0`, which results in a random port being chosen each time. This will prevent the clashes.

This fix does appear to solve the issue, by reasoning and by some manual testing. However, there are other seemingly unrelated errors cropping up on various stages of the pipeline. They were not easily reproducible with the limited testing I've done. I believer they may be caused by other factors. To be investigated.