### PR TITLE
Heedls 458 Chartist IE issues

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -33,25 +33,32 @@ const options = {
 };
 
 request.onload = () => {
-  let response = request.response;
-  // IE11 does not support automatic parsing to JSON with XMLHttpRequest.responseType, so we need to manually parse the JSON string
+  let { response } = request;
+  // IE does not support automatic parsing to JSON with XMLHttpRequest.responseType
+  // so we need to manually parse the JSON string if not already parsed
   if (typeof request.response === 'string') {
     response = JSON.parse(response);
   }
   const data = constructChartistData(response);
-  // eslint-disable-next-line no-new
   const chart = new Chartist.Line('.ct-chart', data, options);
 
   chart.on('draw',
-    (foo: any) => {
-      const element = foo.element;
-      if (element.classes().indexOf('ct-horizontal') >= 0 && element.classes().indexOf('ct-label') >= 0) {
-        const xOrigin = Number(element.getNode().getAttribute("x"));
-        const yOrigin = element.getNode().getAttribute("y");
-        const width = Number(element.getNode().getAttribute("width"));
-        const rotation = document.documentElement.clientWidth > 640 ? -45 : -60;
+    // The type here is Chartist.ChartDrawData, but the type specification is missing getNode()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (drawnElement: any) => {
+      const { element } = drawnElement;
+      // IE renders text in SVGs with 'text' tags that do not work with most CSS properties
+      // so we set the relevant attributes manually
+      if (element.getNode().tagName === 'text'
+        && element.classes().indexOf('ct-horizontal') >= 0
+        && element.classes().indexOf('ct-label') >= 0) {
+        const xOrigin = Number(element.getNode().getAttribute('x'));
+        const yOrigin = element.getNode().getAttribute('y');
+        const width = Number(element.getNode().getAttribute('width'));
+        const mediaQuery = window.matchMedia('(min-width: 641px)');
+        const rotation = mediaQuery.matches ? -45 : -60;
         element.attr({
-          transform: `translate(-${width}) rotate(${rotation} ${xOrigin + width} ${yOrigin})`
+          transform: `translate(-${width}) rotate(${rotation} ${xOrigin + width} ${yOrigin})`,
         });
       }
     });

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -40,7 +40,21 @@ request.onload = () => {
   }
   const data = constructChartistData(response);
   // eslint-disable-next-line no-new
-  new Chartist.Line('.ct-chart', data, options);
+  const chart = new Chartist.Line('.ct-chart', data, options);
+
+  chart.on('draw',
+    (foo: any) => {
+      const element = foo.element;
+      if (element.classes().indexOf('ct-horizontal') >= 0 && element.classes().indexOf('ct-label') >= 0) {
+        const xOrigin = element.getNode().getAttribute("x");
+        const yOrigin = element.getNode().getAttribute("y");
+        const width = element.getNode().getAttribute("width");
+        const height = element.getNode().getAttribute("height");
+          element.attr({
+          transform: `translate(-${width/2} ${height}) rotate(-45 ${xOrigin} ${yOrigin})`
+        });
+      }
+    });
 };
 
 request.open('GET', path, true);

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -33,7 +33,12 @@ const options = {
 };
 
 request.onload = () => {
-  const data = constructChartistData(request.response);
+  let response = request.response;
+  // IE11 does not support automatic parsing to JSON with XMLHttpRequest.responseType, so we need to manually parse the JSON string
+  if (typeof request.response === 'string') {
+    response = JSON.parse(response);
+  }
+  const data = constructChartistData(response);
   // eslint-disable-next-line no-new
   new Chartist.Line('.ct-chart', data, options);
 };

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -55,6 +55,7 @@ request.onload = () => {
         const xOrigin = Number(element.getNode().getAttribute('x'));
         const yOrigin = element.getNode().getAttribute('y');
         const width = Number(element.getNode().getAttribute('width'));
+        // this should match the NHS tablet breakpoint
         const mediaQuery = window.matchMedia('(min-width: 641px)');
         const rotation = mediaQuery.matches ? -45 : -60;
         element.attr({

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -46,12 +46,12 @@ request.onload = () => {
     (foo: any) => {
       const element = foo.element;
       if (element.classes().indexOf('ct-horizontal') >= 0 && element.classes().indexOf('ct-label') >= 0) {
-        const xOrigin = element.getNode().getAttribute("x");
+        const xOrigin = Number(element.getNode().getAttribute("x"));
         const yOrigin = element.getNode().getAttribute("y");
-        const width = element.getNode().getAttribute("width");
+        const width = Number(element.getNode().getAttribute("width"));
         const height = element.getNode().getAttribute("height");
           element.attr({
-          transform: `translate(-${width/2} ${height}) rotate(-45 ${xOrigin} ${yOrigin})`
+          transform: `translate(-${width}) rotate(-45 ${xOrigin + width} ${yOrigin})`
         });
       }
     });

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -49,9 +49,9 @@ request.onload = () => {
         const xOrigin = Number(element.getNode().getAttribute("x"));
         const yOrigin = element.getNode().getAttribute("y");
         const width = Number(element.getNode().getAttribute("width"));
-        const height = element.getNode().getAttribute("height");
-          element.attr({
-          transform: `translate(-${width}) rotate(-45 ${xOrigin + width} ${yOrigin})`
+        const rotation = document.documentElement.clientWidth > 640 ? -45 : -60;
+        element.attr({
+          transform: `translate(-${width}) rotate(${rotation} ${xOrigin + width} ${yOrigin})`
         });
       }
     });

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/reports.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/reports.scss
@@ -79,6 +79,7 @@ $light-blue: #8EBAFF;
 
 .ct-label {
   color: $nhsuk-secondary-text-color;
+  fill: $nhsuk-secondary-text-color;
 }
 
 .ct-label.ct-label.ct-horizontal {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-458

### Description
The chartist chart was not displaying in IE. This turned out to be due to a problem parsing the data. However, once this problem was fixed it revealed that the label styling does not work in IE due to how it handles SVG text, rendering the labels illegible. After investigation, the solution adopted was to recreate as much of the styling as possible in JavaScript.

The solution has slight text alignment errors on tablet and desktop, and larger errors on mobile, but it was agreed with client in Show & Tell (30/07/21) that the use case of running IE in an extremely narrow window is marginal enough that it is not worth potentially significant development time to fix.

Rendering in IE should be specifically checked when future work is done on the usage charts (or any other charts).

### Screenshots
![image](https://user-images.githubusercontent.com/34240850/127666741-28a906a4-2adc-4aa5-ac06-5a18b7c27d6e.png)
![image](https://user-images.githubusercontent.com/34240850/127666784-5716e387-b4e1-4c8a-8ec4-24665622bc8d.png)
![image](https://user-images.githubusercontent.com/34240850/127666834-7a5095f8-545b-460a-8f3c-0af59c22df05.png)


-----
### Developer checks
I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [X] Updated/added documentation in Swiki and/or Readme.
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
