### PR TITLE
HEEDLS-497 Make DateInput VC year input shorter

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DateInput/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DateInput/Default.cshtml
@@ -53,7 +53,7 @@
       <div class="nhsuk-date-input__item">
         <div class="nhsuk-form-group">
           <label class="nhsuk-label" for="@Model.YearId">Year</label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4 @yearErrorCss"
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @yearErrorCss"
                  id="@Model.YearId"
                  name="@Model.YearId"
                  value="@Model.YearValue"


### PR DESCRIPTION
### JIRA link
HEEDLS-497

### Description
Make DateInput-VC year input shorter so the day/month/year inputs fit onto a single line.

### Screenshots
![localhost_44363_TrackingSystem_Delegates_Register_WelcomeEmail (2)](https://user-images.githubusercontent.com/44787206/127672509-b62d124a-8205-41ca-bb14-30bb6e04f36d.png)


-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
