### PR TITLE
Heedls 513 group delegates

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/GroupsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/GroupsDataServiceTests.cs
@@ -48,5 +48,32 @@
                 result.First(x => x.GroupId == 34).Should().BeEquivalentTo(expectedFirstGroup);
             }
         }
+
+        [Test]
+        public void GetGroupDelegates_returns_expected_delegates()
+        {
+            // Given
+            var expectedFirstGroupDelegate = GroupTestHelper.GetDefaultGroupDelegate();
+
+            // When
+            var result = groupsDataService.GetGroupDelegates(5).ToList();
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Count.Should().Be(24);
+                result.First(x => x.GroupDelegateId == 62).Should().BeEquivalentTo(expectedFirstGroupDelegate);
+            }
+        }
+
+        [Test]
+        public void GetGroupNameForGroupId_returns_expected_name()
+        {
+            // When
+            var result = groupsDataService.GetGroupNameForGroupId(5);
+
+            // Then
+            result.Should().BeEquivalentTo("Activities worker or coordinator");
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/GroupTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/GroupTestHelper.cs
@@ -1,0 +1,29 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.TestHelpers
+{
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
+
+    public static class GroupTestHelper
+    {
+        public static GroupDelegate GetDefaultGroupDelegate(
+            int groupDelegateId = 62,
+            int groupId = 5,
+            int delegateId = 245969,
+            string? firstName = "xxxxx",
+            string lastName = "xxxx",
+            string? emailAddress = "gslectik.m@vao",
+            string candidateNumber = "KT553"
+        )
+        {
+            return new GroupDelegate
+            {
+                GroupDelegateId = groupDelegateId,
+                GroupId = groupId,
+                DelegateId = delegateId,
+                FirstName = firstName,
+                LastName = lastName,
+                EmailAddress = emailAddress,
+                CandidateNumber = candidateNumber
+            };
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -60,7 +60,7 @@
         {
             return connection.Query<GroupDelegate>(
                 @"SELECT
-                        GroupDelegateID
+                        GroupDelegateID,
 	                    GroupID,
 	                    DelegateID,
                         FirstName,

--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -2,12 +2,17 @@
 {
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
 
     public interface IGroupsDataService
     {
         IEnumerable<Group> GetGroupsForCentre(int centreId);
+
+        IEnumerable<GroupDelegate> GetGroupDelegates(int groupId);
+
+        string GetGroupNameForGroupId(int groupId);
     }
 
     public class GroupsDataService : IGroupsDataService
@@ -49,6 +54,35 @@
                     WHERE RemovedDate IS NULL AND g.CentreID = @centreId",
                 new { centreId }
             );
+        }
+
+        public IEnumerable<GroupDelegate> GetGroupDelegates(int groupId)
+        {
+            return connection.Query<GroupDelegate>(
+                @"SELECT
+                        GroupDelegateID
+	                    GroupID,
+	                    DelegateID,
+                        FirstName,
+                        LastName,
+                        EmailAddress,
+                        CandidateNumber	                   
+                    FROM GroupDelegates AS gd
+                    JOIN Candidates AS c ON c.CandidateID = gd.DelegateID
+                    WHERE gd.GroupID = @groupId",
+                new { groupId }
+            );
+        }
+
+        public string GetGroupNameForGroupId(int groupId)
+        {
+            return connection.Query<string>(
+                @"SELECT 
+	                    GroupLabel
+                    FROM Groups
+                    WHERE GroupID = @groupId",
+                new { groupId }
+            ).Single();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/DelegateGroups/GroupDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateGroups/GroupDelegate.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Data.Models.DelegateGroups
+{
+    public class GroupDelegate : BaseSearchableItem
+    {
+        public int GroupDelegateId { get; set; }
+
+        public int GroupId { get; set; }
+
+        public int DelegateId { get; set; }
+
+        public string? FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public string? EmailAddress { get; set; }
+
+        public string CandidateNumber { get; set; }
+
+        public override string SearchableName
+        {
+            get => SearchableNameOverrideForFuzzySharp ?? $"{FirstName} {LastName}";
+            set => SearchableNameOverrideForFuzzySharp = value;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAccessibilityTests.cs
@@ -50,6 +50,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
         [InlineData("/TrackingSystem/CourseSetup/10716/Manage", "Level 1 - Microsoft Excel 2010 - Inductions")]
         [InlineData("/TrackingSystem/Delegates/All", "Delegates")]
         [InlineData("/TrackingSystem/Delegates/Groups", "Groups")]
+        [InlineData("/TrackingSystem/Delegates/Groups/5/Delegates", "Group delegates")]
         [InlineData("/TrackingSystem/Delegates/View/3", "xxxx xxxxxx")]
         [InlineData("/TrackingSystem/Delegates/Approve", "Approve delegate registrations")]
         [InlineData("/TrackingSystem/Delegates/BulkUpload", "Bulk upload/update delegates")]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegateViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegateViewModelTests.cs
@@ -1,0 +1,50 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.TrackingSystem.Delegates.DelegateGroups
+{
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using NUnit.Framework;
+
+    public class GroupDelegateViewModelTests
+    {
+        [Test]
+        public void GroupDelegateViewModel_populates_expected_values_with_both_names()
+        {
+            // Given
+            var groupDelegate = GroupTestHelper.GetDefaultGroupDelegate(firstName: "Test", lastName: "Name");
+
+            // When
+            var result = new GroupDelegateViewModel(groupDelegate);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.GroupDelegateId.Should().Be(62);
+                result.Name.Should().Be("Test Name");
+                result.EmailAddress.Should().Be("gslectik.m@vao");
+                result.CandidateNumber.Should().Be("KT553");
+            }
+        }
+
+        [Test]
+        public void GroupDelegateViewModel_populates_expected_values_with_only_last_name()
+        {
+            // Given
+            var groupDelegate = GroupTestHelper.GetDefaultGroupDelegate(firstName: null, lastName: "Name");
+
+            // When
+            var result = new GroupDelegateViewModel(groupDelegate);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.GroupDelegateId.Should().Be(62);
+                result.Name.Should().Be("Name");
+                result.EmailAddress.Should().Be("gslectik.m@vao");
+                result.CandidateNumber.Should().Be("KT553");
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.TrackingSystem.Delegates.DelegateGroups
+{
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using NUnit.Framework;
+
+    public class GroupDelegatesViewModelTests
+    {
+        private readonly DelegateGroupsSideNavViewModel expectedNavViewModel =
+            new DelegateGroupsSideNavViewModel("Group name", DelegateGroupPage.Delegates);
+
+        private readonly GroupDelegate[] groupDelegates =
+        {
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "a", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "b", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "c", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "d", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "e", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "f", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "g", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "h", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "i", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "j", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "k", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "l", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "m", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "n", lastName: "Surname"),
+            GroupTestHelper.GetDefaultGroupDelegate(firstName: "o", lastName: "Surname")
+        };
+
+        [Test]
+        public void Centre_administrators_should_default_to_returning_the_first_ten_admins()
+        {
+            var model = new GroupDelegatesViewModel(
+                1,
+                "Group name",
+                groupDelegates,
+                1
+            );
+
+            using (new AssertionScope())
+            {
+                model.GroupId.Should().Be(1);
+                model.NavViewModel.Should().BeEquivalentTo(expectedNavViewModel);
+                model.GroupDelegates.Count().Should().Be(10);
+                model.GroupDelegates.FirstOrDefault(groupDelegate => groupDelegate.Name == "k Surname").Should()
+                    .BeNull();
+            }
+        }
+
+        [Test]
+        public void Centre_administrators_should_correctly_return_the_second_page_of_admins()
+        {
+            var model = new GroupDelegatesViewModel(
+                1,
+                "Group name",
+                groupDelegates,
+                2
+            );
+
+            using (new AssertionScope())
+            {
+                model.GroupId.Should().Be(1);
+                model.NavViewModel.Should().BeEquivalentTo(expectedNavViewModel);
+                model.GroupDelegates.Count().Should().Be(5);
+                model.GroupDelegates.First().Name.Should().BeEquivalentTo("k Surname");
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -28,5 +28,16 @@
 
             return View(model);
         }
+
+        [Route("{groupId:int}/Delegates/{page:int=1}")]
+        public IActionResult GroupDelegates(int groupId, int page = 1)
+        {
+            var groupName = groupsDataService.GetGroupNameForGroupId(groupId);
+            var groupDelegates = groupsDataService.GetGroupDelegates(groupId);
+
+            var model = new GroupDelegatesViewModel(groupId, groupName, groupDelegates, page);
+
+            return View(model);
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Models/Enums/DelegateGroupPage.cs
+++ b/DigitalLearningSolutions.Web/Models/Enums/DelegateGroupPage.cs
@@ -1,0 +1,8 @@
+﻿namespace DigitalLearningSolutions.Web.Models.Enums
+{
+    public enum DelegateGroupPage
+    {
+        Delegates,
+        Courses
+    }
+}

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/groupDelegates.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/groupDelegates.scss
@@ -1,0 +1,2 @@
+﻿@import 'delegateCommon';
+@import '../../shared/searchableElements/searchableElements';

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsSideNavViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsSideNavViewModel.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+{
+    using DigitalLearningSolutions.Web.Models.Enums;
+
+    public class DelegateGroupsSideNavViewModel
+    {
+        public DelegateGroupsSideNavViewModel(string groupName, DelegateGroupPage page)
+        {
+            GroupName = groupName;
+            Page = page;
+        }
+
+        public string GroupName { get; set; }
+
+        public DelegateGroupPage Page { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegateViewModel.cs
@@ -1,0 +1,23 @@
+﻿using DigitalLearningSolutions.Data.Models.DelegateGroups;
+
+namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+{
+    public class GroupDelegateViewModel
+    {
+        public GroupDelegateViewModel(GroupDelegate groupDelegate)
+        {
+            GroupDelegateId = groupDelegate.GroupDelegateId;
+            Name = (string.IsNullOrEmpty(groupDelegate.FirstName) ? "" : $"{groupDelegate.FirstName} ") + groupDelegate.LastName;
+            EmailAddress = groupDelegate.EmailAddress;
+            CandidateNumber = groupDelegate.CandidateNumber;
+        }
+
+        public int GroupDelegateId { get; set; }
+
+        public string Name { get; set; }
+        
+        public string? EmailAddress { get; set; }
+
+        public string CandidateNumber { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesViewModel.cs
@@ -1,0 +1,45 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+
+    public class GroupDelegatesViewModel : BaseSearchablePageViewModel
+    {
+        public GroupDelegatesViewModel(
+            int groupId,
+            string groupName,
+            IEnumerable<GroupDelegate> groupDelegates,
+            int page
+        ) : base(null, DefaultSortByOptions.Name.PropertyName, Ascending, page)
+        {
+            GroupId = groupId;
+            NavViewModel = new DelegateGroupsSideNavViewModel(groupName, DelegateGroupPage.Delegates);
+
+            var sortedItems = GenericSortingHelper.SortAllItems(
+                groupDelegates.AsQueryable(),
+                DefaultSortByOptions.Name.PropertyName,
+                Ascending
+            ).ToList();
+            
+            MatchingSearchResults = sortedItems.Count;
+            SetTotalPages();
+            var paginatedItems = GetItemsOnCurrentPage(sortedItems);
+            GroupDelegates = paginatedItems.Select(groupDelegate => new GroupDelegateViewModel(groupDelegate));
+        }
+
+        public int GroupId { get; set; }
+
+        public DelegateGroupsSideNavViewModel NavViewModel { get; set; }
+
+        public IEnumerable<GroupDelegateViewModel> GroupDelegates { get; }
+
+        public override IEnumerable<(string, string)> SortOptions { get; } = new[]
+        {
+            DefaultSortByOptions.Name
+        };
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesViewModel.cs
@@ -14,7 +14,7 @@
             string groupName,
             IEnumerable<GroupDelegate> groupDelegates,
             int page
-        ) : base(null, DefaultSortByOptions.Name.PropertyName, Ascending, page)
+        ) : base(null, page, false)
         {
             GroupId = groupId;
             NavViewModel = new DelegateGroupsSideNavViewModel(groupName, DelegateGroupPage.Delegates);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/GroupDelegates.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/GroupDelegates.cshtml
@@ -1,0 +1,64 @@
+﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+@using Microsoft.Extensions.Configuration
+@model GroupDelegatesViewModel
+
+@{
+  ViewData["Title"] = "Group delegates";
+  ViewData["Application"] = "Tracking System";
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
+  ViewData["HeaderPathName"] = "Tracking System";
+}
+
+<link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/delegates/groupDelegates.css")" asp-append-version="true">
+
+@section NavMenuItems {
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-one-quarter">
+    <nav class="side-nav-menu" aria-label="Side navigation bar">
+      <partial name="_DelegateGroupsSideNavMenu" model="Model.NavViewModel" />
+    </nav>
+  </div>
+
+  <div class="nhsuk-grid-column-three-quarters">
+    
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h1 id="page-heading" class="nhsuk-heading-xl">Group delegates</h1>
+      </div>
+      <div class="nhsuk-grid-column-one-third all-delegates-button-group">
+        <a class="nhsuk-button all-delegates-button" role="button">
+          Add
+        </a>
+      </div>
+    </div>
+
+    <form method="get">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full">
+          @if (!Model.GroupDelegates.Any()) {
+            <p class="nhsuk-u-margin-top-4" role="alert">
+              <b>No delegates found.</b>
+            </p>
+          } else {
+            <div id="searchable-elements">
+              @foreach (var groupDelegate in Model.GroupDelegates) {
+                <partial name="_GroupDelegateCard" model="groupDelegate" />
+              }
+            </div>
+          }
+          @if (Model.TotalPages > 1) {
+            <partial name="SearchablePage/_Pagination" model="Model" />
+          }
+        </div>
+      </div>
+    </form>
+
+    <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
+      <partial name="_DelegateGroupsSideNavMenu" model="Model.NavViewModel" />
+    </nav>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_DelegateGroupsSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_DelegateGroupsSideNavMenu.cshtml
@@ -1,0 +1,18 @@
+﻿@using DigitalLearningSolutions.Web.Models.Enums
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+@model DelegateGroupsSideNavViewModel
+
+<h2 class="side-nav__heading">@Model.GroupName</h2>
+<ul class="nhsuk-list side-nav__list">
+
+  <vc:side-menu-link asp-action="Delegates"
+                     asp-controller="DelegateGroups"
+                     link-text="Delegates"
+                     is-current-page="@(Model.Page == DelegateGroupPage.Delegates)" />
+
+  <vc:side-menu-link asp-action=""
+                     asp-controller=""
+                     link-text="Courses"
+                     is-current-page="@(Model.Page == DelegateGroupPage.Courses)" />
+
+</ul>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_GroupDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_GroupDelegateCard.cshtml
@@ -1,0 +1,42 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+@model GroupDelegateViewModel
+
+<div class="nhsuk-panel" id="@Model.GroupDelegateId-card">
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <span class="nhsuk-details__summary-text" id="@Model.GroupDelegateId-name" name="name">
+        @Model.Name
+      </span>
+    </summary>
+    <div class="nhsuk-details__text">
+      <dl class="nhsuk-summary-list details-list-with-button">
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+            Name
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+            @Model.Name
+          </dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+            Email
+          </dt>
+          <partial name="_SummaryFieldValue" model="Model.EmailAddress" />
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+            ID
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+            @Model.CandidateNumber
+          </dd>
+        </div>
+      </dl>
+
+      <a class="nhsuk-button delete-button nhsuk-u-margin-bottom-1" role="button">
+        Remove from group
+      </a>
+    </div>
+  </details>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
@@ -99,7 +99,7 @@
         </div>
       </dl>
 
-      <a class="nhsuk-button expander-card__button" role="button">
+      <a class="nhsuk-button expander-card__button" role="button" asp-controller="DelegateGroups" asp-action="GroupDelegates" asp-route-groupId="@Model.Id" asp-route-page="1">
         View delegates
       </a>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
@@ -15,7 +15,7 @@
           <dt class="nhsuk-summary-list__key">
             Name
           </dt>
-          <partial name="_SummaryFieldValue" model="Model.Name"/>
+          <partial name="_SummaryFieldValue" model="Model.Name" />
 
           <dd class="nhsuk-summary-list__actions">
             @if (Model.LinkedToField == 0) {
@@ -99,7 +99,12 @@
         </div>
       </dl>
 
-      <a class="nhsuk-button expander-card__button" role="button" asp-controller="DelegateGroups" asp-action="GroupDelegates" asp-route-groupId="@Model.Id" asp-route-page="1">
+      <a class="nhsuk-button expander-card__button"
+         role="button"
+         asp-controller="DelegateGroups"
+         asp-action="GroupDelegates"
+         asp-route-groupId="@Model.Id"
+         asp-route-page="1">
         View delegates
       </a>
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-513

### Description
Adds a new page to display all the delegates within a group as a paginated list of NHS expanders.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/128041844-22407f26-0ae7-4de4-acf2-3302213f79d1.png)
![image](https://user-images.githubusercontent.com/59561751/128041876-d8717427-60cd-4380-9bd7-337bac54d302.png)
![image](https://user-images.githubusercontent.com/59561751/128041924-6054b093-2e00-4aca-b4a1-671299ffd334.png)


-----
### Developer checks
I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
