### PR TITLE
HEEDLS-437 Replace the word prompt with field in view

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -41,7 +41,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
       <div class="nhsuk-u-font-weight-bold">
-        Prompt:
+        Field:
       </div>
     </div>
     <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
@@ -56,7 +56,7 @@
         <div class="nhsuk-checkboxes__item">
           <input class="nhsuk-checkboxes__input" id="Mandatory" type="checkbox" asp-for="Mandatory">
           <label class="nhsuk-label nhsuk-checkboxes__label" for="Mandatory">
-            This prompt is mandatory
+            This field is mandatory
           </label>
         </div>
       </div>


### PR DESCRIPTION
### JIRA link
[HEEDLS-437](https://softwiretech.atlassian.net/browse/HEEDLS-437)

### Description
Just a small wording change, replacing the word prompt with field to match the wireframe for the page.

### Screenshots
![localhost_5001_TrackingSystem_CourseSetup_100_AdminFields_1_Edit (1)](https://user-images.githubusercontent.com/70278044/128830863-bc5a255e-68fb-4873-9141-d6b93941b2e7.png)


-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
