### PR TITLE
HEEDLS-506 Add word break to the delegate groups cards

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
 @model SearchableDelegateGroupViewModel
 
-<div class="searchable-element nhsuk-panel" id="@Model.Id-card">
+<div class="searchable-element nhsuk-panel word-break" id="@Model.Id-card">
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text searchable-element-title" id="@Model.Id-name" name="name">


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-506

### Description
Add word break css to the delegate group cards to fix long names breaking the layout

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/128857891-f74c50ee-6684-4126-956c-e756a2374ea6.png)
![image](https://user-images.githubusercontent.com/59561751/128857913-a76d9097-8cdf-402d-9553-a620a0dc9f03.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
