### PR TITLE
HEEDLS-440 - fixed styling on view course content page and added text…

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/TutorialTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/TutorialTestHelper.cs
@@ -7,8 +7,8 @@
         public static Tutorial GetDefaultTutorial(
             int tutorialId = 1,
             string tutorialName = "tutorial",
-            bool status = false,
-            bool diagStatus = false
+            bool status = true,
+            bool diagStatus = true
         )
         {
             return new Tutorial

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/TutorialTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/TutorialTestHelper.cs
@@ -1,0 +1,23 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.TestHelpers
+{
+    using DigitalLearningSolutions.Data.Models;
+
+    public static class TutorialTestHelper
+    {
+        public static Tutorial GetDefaultTutorial(
+            int tutorialId = 1,
+            string tutorialName = "tutorial",
+            bool status = false,
+            bool diagStatus = false
+        )
+        {
+            return new Tutorial
+            {
+                TutorialId = tutorialId,
+                TutorialName = tutorialName,
+                Status = status,
+                DiagStatus = diagStatus
+            };
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseContentViewModelTests.cs
@@ -7,9 +7,9 @@
     using FluentAssertions;
     using NUnit.Framework;
 
-    internal class CourseContentViewModelTests
+    public class CourseContentViewModelTests
     {
-        private static readonly Tutorial DisabledTutorial = TutorialTestHelper.GetDefaultTutorial();
+        private static readonly Tutorial DisabledTutorial = TutorialTestHelper.GetDefaultTutorial(status:false, diagStatus:false);
 
         private static readonly Section DisabledSection =
             new Section(1, "disabled", new List<Tutorial> { DisabledTutorial, DisabledTutorial });
@@ -18,7 +18,7 @@
         public void CourseHasContent_is_true_when_at_least_one_section_has_learning_assessment_tutorial()
         {
             // Given
-            var enabledTutorial = TutorialTestHelper.GetDefaultTutorial(status: true);
+            var enabledTutorial = TutorialTestHelper.GetDefaultTutorial(diagStatus: false);
             var enabledSection = new Section(1, "test", new List<Tutorial> { enabledTutorial, DisabledTutorial });
 
             // When
@@ -37,7 +37,7 @@
         public void CourseHasContent_is_true_when_at_least_one_section_has_diagnostic_assessment_tutorial()
         {
             // Given
-            var enabledTutorial = TutorialTestHelper.GetDefaultTutorial(diagStatus: true);
+            var enabledTutorial = TutorialTestHelper.GetDefaultTutorial(status: false);
             var enabledSection = new Section(1, "test", new List<Tutorial> { enabledTutorial, DisabledTutorial });
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseContentViewModelTests.cs
@@ -1,0 +1,85 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.TrackingSystem.CourseSetup
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup.CourseContent;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    internal class CourseContentViewModelTests
+    {
+        private static readonly Tutorial DisabledTutorial = TutorialTestHelper.GetDefaultTutorial();
+
+        private static readonly Section DisabledSection =
+            new Section(1, "disabled", new List<Tutorial> { DisabledTutorial, DisabledTutorial });
+
+        [Test]
+        public void CourseHasContent_is_true_when_at_least_one_section_has_learning_assessment_tutorial()
+        {
+            // Given
+            var enabledTutorial = TutorialTestHelper.GetDefaultTutorial(status: true);
+            var enabledSection = new Section(1, "test", new List<Tutorial> { enabledTutorial, DisabledTutorial });
+
+            // When
+            var viewModel = new CourseContentViewModel(
+                1,
+                "course",
+                false,
+                new List<Section> { enabledSection, DisabledSection }
+            );
+
+            // Then
+            viewModel.CourseHasContent.Should().BeTrue();
+        }
+
+        [Test]
+        public void CourseHasContent_is_true_when_at_least_one_section_has_diagnostic_assessment_tutorial()
+        {
+            // Given
+            var enabledTutorial = TutorialTestHelper.GetDefaultTutorial(diagStatus: true);
+            var enabledSection = new Section(1, "test", new List<Tutorial> { enabledTutorial, DisabledTutorial });
+
+            // When
+            var viewModel = new CourseContentViewModel(
+                1,
+                "course",
+                false,
+                new List<Section> { enabledSection, DisabledSection }
+            );
+
+            // Then
+            viewModel.CourseHasContent.Should().BeTrue();
+        }
+
+        [Test]
+        public void CourseHasContent_is_true_when_all_tutorials_disabled_but_has_post_learning_assessment()
+        {
+            // When
+            var viewModel = new CourseContentViewModel(1, "course", true, new List<Section> { DisabledSection });
+
+            // Then
+            viewModel.CourseHasContent.Should().BeTrue();
+        }
+
+        [Test]
+        public void CourseHasContent_is_false_when_all_tutorials_disabled_and_has_no_post_learning_assessment()
+        {
+            // When
+            var viewModel = new CourseContentViewModel(1, "course", false, new List<Section> { DisabledSection });
+
+            // Then
+            viewModel.CourseHasContent.Should().BeFalse();
+        }
+
+        [Test]
+        public void CourseHasContent_is_false_when_no_sections_are_present()
+        {
+            // When
+            var viewModel = new CourseContentViewModel(1, "course", true, new List<Section>());
+
+            // Then
+            viewModel.CourseHasContent.Should().BeFalse();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseContent/CourseContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseContent/CourseContentViewModel.cs
@@ -21,5 +21,9 @@
         public int CustomisationId { get; set; }
         public string CourseName { get; set; }
         public IEnumerable<CourseSectionViewModel> Sections { get; set; }
+
+        public bool CourseHasContent => Sections.Any(
+            s => s.Tutorials.Any(t => t.DiagnosticEnabled || t.LearningEnabled) || s.PostLearningAssessment
+        );
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/Index.cshtml
@@ -34,9 +34,12 @@
       </div>
     </div>
 
-    @foreach (var section in Model.Sections)
-    {
-      <partial name="_CourseSectionExpandable" model="section" />
+    @if (Model.Sections.Any(s => s.Tutorials.Any(t => t.DiagnosticEnabled || t.LearningEnabled) || s.PostLearningAssessment)) {
+      @foreach (var section in Model.Sections) {
+        <partial name="_CourseSectionExpandable" model="section" />
+      }
+    } else {
+      <p>No course content enabled.</p>
     }
 
     <a class="nhsuk-button nhsuk-u-margin-top-4" role="button" href="">Edit course content</a>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/Index.cshtml
@@ -34,7 +34,7 @@
       </div>
     </div>
 
-    @if (Model.Sections.Any(s => s.Tutorials.Any(t => t.DiagnosticEnabled || t.LearningEnabled) || s.PostLearningAssessment)) {
+    @if (Model.CourseHasContent) {
       @foreach (var section in Model.Sections) {
         <partial name="_CourseSectionExpandable" model="section" />
       }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_CourseSectionExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_CourseSectionExpandable.cshtml
@@ -9,11 +9,11 @@
           @Model.SectionName
         </span>
       </summary>
-      <div class="nhsuk-details__text nhsuk-u-padding-bottom-0">
+      <div class="nhsuk-details__text nhsuk-u-padding-bottom-3">
         <dl class="nhsuk-summary-list">
           @foreach (var tutorial in Model.Tutorials) {
             @if (tutorial.DiagnosticEnabled || tutorial.LearningEnabled) {
-              <div class="nhsuk-summary-list__row">
+              <div class="nhsuk-summary-list__row basic-summary-list__row">
                 <dt class="nhsuk-summary-list__key">
                   @tutorial.TutorialName
                 </dt>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_CourseSectionExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_CourseSectionExpandable.cshtml
@@ -9,7 +9,7 @@
           @Model.SectionName
         </span>
       </summary>
-      <div class="nhsuk-details__text nhsuk-u-padding-bottom-3">
+      <div class="nhsuk-details__text nhsuk-u-margin-bottom-0">
         <dl class="nhsuk-summary-list">
           @foreach (var tutorial in Model.Tutorials) {
             @if (tutorial.DiagnosticEnabled || tutorial.LearningEnabled) {


### PR DESCRIPTION
… when no content enabled.

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-440

### Description
Updated styling on course content cards to add extra padding to bottom and remove bottom line separator from list. Also added text for when no course content is available. 

### Screenshots
(See comments for updated styling with mobile)
Updated card styling:
![Updated Card styling](https://user-images.githubusercontent.com/80777689/129010790-841f4d37-4417-45ac-8860-d811a62fae0e.PNG)

No course content text:
![No course content enabled](https://user-images.githubusercontent.com/80777689/129010942-f5a5b28f-4f64-44a5-ac8a-0371fda63ddb.jpeg)


-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
