### PR TITLE
HEEDLS-435 - Updated displays for nullable course details

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseSummaryCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseSummaryCard.cshtml
@@ -24,9 +24,7 @@
         <dt class="nhsuk-summary-list__key">
           Last accessed
         </dt>
-        <dd class="nhsuk-summary-list__value">
-          @Model.LastAccessed
-        </dd>
+        <partial name="_SummaryFieldValue" model="Model.LastAccessed"/>
       </div>
       <div class="nhsuk-summary-list__row basic-summary-list__row">
         <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_LearningPathwayDefaultsExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_LearningPathwayDefaultsExpandable.cshtml
@@ -50,9 +50,7 @@
           <dt class="nhsuk-summary-list__key">
             Course to refresh to
           </dt>
-          <dd class="nhsuk-summary-list__value">
-            @Model.RefreshToCourseName
-          </dd>
+          <partial name="_SummaryFieldValue" model="Model.RefreshToCourseName"/>
         </div>
 
         <div class="nhsuk-summary-list__row details-list-with-button__row">


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/secure/RapidBoard.jspa?rapidView=671&modal=detail&selectedIssue=HEEDLS-435

### Description
Updated a couple of course details displays to display a dash when null.

### Screenshots
![Updated Last Accessed Desktop](https://user-images.githubusercontent.com/80777689/129193796-30d60b49-778a-4a99-92db-f842f0200cbc.PNG)
<img src="https://user-images.githubusercontent.com/80777689/129193798-90fab371-68df-4f94-88f7-da137fd8a13d.PNG" width=320px />


-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
