### PR TITLE
HEEDLS-531 - replaced all error redirects with StatusCodeResults

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/ForgotPassword/ForgotPasswordControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/ForgotPassword/ForgotPasswordControllerTests.cs
@@ -104,7 +104,7 @@
             var result = controller.Index(new ForgotPasswordViewModel("recipient@example.com"));
 
             // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions").WithActionName("Error");
+            result.Should().BeStatusCodeResult().WithStatusCode(500);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -208,7 +208,7 @@
             var result = myAccountController.EditDetails(model, action);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions").WithActionName("Error");
+            result.Should().BeStatusCodeResult().WithStatusCode(500);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/CentreConfigurationControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/CentreConfigurationControllerTests.cs
@@ -96,7 +96,7 @@
             var result = controller.EditCentreWebsiteDetails(model);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithActionName("Error").WithControllerName("LearningSolutions");
+            result.Should().BeStatusCodeResult().WithStatusCode(500);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
@@ -162,7 +162,7 @@
             var result = registrationPromptsController.EditRegistrationPrompt(model, action);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions").WithActionName("Error");
+            result.Should().BeStatusCodeResult().WithStatusCode(500);
         }
 
         [Test]
@@ -295,7 +295,7 @@
             var result = registrationPromptsController.AddRegistrationPromptConfigureAnswers(model, action);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions").WithActionName("Error");
+            result.Should().BeStatusCodeResult().WithStatusCode(500);
         }
 
         [Test]
@@ -367,8 +367,7 @@
                         "Test\r\nAnswer"
                     )
                 ).MustHaveHappened();
-                result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions")
-                    .WithActionName("Error");
+                result.Should().BeStatusCodeResult().WithStatusCode(500);
             }
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -165,7 +165,7 @@
             var result = controller.EditAdminField(model, action);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions").WithActionName("Error");
+            result.Should().BeStatusCodeResult().WithStatusCode(500);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/ForgotPasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ForgotPasswordController.cs
@@ -52,7 +52,7 @@
             }
             catch (ResetPasswordInsertException)
             {
-                return RedirectToAction("Error", "LearningSolutions");
+                return new StatusCodeResult(500);
             }
 
             return RedirectToAction("Confirm");

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -84,7 +84,7 @@
                 "save" => EditDetailsPostSave(model),
                 "previewImage" => EditDetailsPostPreviewImage(model),
                 "removeImage" => EditDetailsPostRemoveImage(model),
-                _ => RedirectToAction("Error", "LearningSolutions")
+                _ => new StatusCodeResult(500)
             };
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -222,7 +222,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
             if (candidateNumber == "-1")
             {
-                return RedirectToAction("Error", "LearningSolutions");
+                return new StatusCodeResult(500);
             }
 
             if (candidateNumber == "-4")

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/ConfigurationController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/ConfigurationController.cs
@@ -113,7 +113,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Configu
                     $"Failed Maps API call when trying to get postcode {model.CentrePostcode} " +
                     $"- status of {mapsResponse.Status} - error message: {mapsResponse.ErrorMessage}"
                 );
-                return RedirectToAction("Error", "LearningSolutions");
+                return new StatusCodeResult(500);
             }
 
             var latitude = double.Parse(mapsResponse.Results[0].Geometry.Location.Latitude);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -92,7 +92,7 @@
                 SaveAction => EditRegistrationPromptPostSave(model),
                 AddPromptAction => RegistrationPromptAnswersPostAddPrompt(model),
                 BulkAction => EditRegistrationPromptBulk(model),
-                _ => RedirectToAction("Error", "LearningSolutions")
+                _ => new StatusCodeResult(500)
             };
         }
 
@@ -209,7 +209,7 @@
                 NextAction => AddRegistrationPromptConfigureAnswersPostNext(model),
                 AddPromptAction => RegistrationPromptAnswersPostAddPrompt(model, true),
                 BulkAction => AddRegistrationPromptBulk(model),
-                _ => RedirectToAction("Error", "LearningSolutions")
+                _ => new StatusCodeResult(500)
             };
         }
 
@@ -278,7 +278,7 @@
                 return RedirectToAction("Index");
             }
 
-            return RedirectToAction("Error", "LearningSolutions");
+            return new StatusCodeResult(500);
         }
 
         [HttpGet]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -95,7 +95,7 @@
                 SaveAction => EditAdminFieldPostSave(model),
                 AddPromptAction => AdminFieldAnswersPostAddPrompt(model, true),
                 BulkAction => EditAdminFieldBulk(model),
-                _ => RedirectToAction("Error", "LearningSolutions")
+                _ => new StatusCodeResult(500)
             };
         }
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-531

### Description
Replaced any Redirects to the LearningSolutions Error page to be a StatusCodeResult(500). Looking through the individual cases, they all seemed to be random errors that occurred rather than forbidden or not found pages, so I only used StatusCodeResult(500)

### Screenshots
N/A
-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
