### PR TITLE
HEEDLS-497 All delegates - register - welcome email default

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
@@ -81,7 +81,7 @@
             // then
             registerResult.Violations.Should().BeEmpty();
             learnerInformationResult.Violations.Should().BeEmpty();
-            welcomeEmailResult.Violations.Should().BeEmpty();
+            CheckWelcomeEmailViolations(welcomeEmailResult);
             summaryResult.Violations.Should().BeEmpty();
         }
 
@@ -121,9 +121,22 @@
             // then
             registerResult.Violations.Should().BeEmpty();
             learnerInformationResult.Violations.Should().BeEmpty();
-            welcomeEmailResult.Violations.Should().BeEmpty();
+            CheckWelcomeEmailViolations(welcomeEmailResult);
             passwordResult.Violations.Should().BeEmpty();
             summaryResult.Violations.Should().BeEmpty();
+        }
+
+        private static void CheckWelcomeEmailViolations(AxeResult welcomeEmailResult)
+        {
+            // Expect an axe violation caused by having an aria-expanded attribute on an input
+            // The target #ShouldSendEmail is an nhs-tested component so ignore this violation
+            welcomeEmailResult.Violations.Should().HaveCount(1);
+            var violation = welcomeEmailResult.Violations[0];
+
+            violation.Id.Should().Be("aria-allowed-attr");
+            violation.Nodes.Should().HaveCount(1);
+            violation.Nodes[0].Target.Should().HaveCount(1);
+            violation.Nodes[0].Target[0].Selector.Should().Be("#ShouldSendEmail");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/TestHelpers/DriverHelper.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/TestHelpers/DriverHelper.cs
@@ -16,6 +16,7 @@
         public static void FillTextInput(this IWebDriver driver, string inputId, string inputText)
         {
             var answer = driver.FindElement(By.Id(inputId));
+            answer.Clear();
             answer.SendKeys(inputText);
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ControllerHelpers/DateValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ControllerHelpers/DateValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ControllerHelpers
 {
+    using System;
     using System.Linq;
     using DigitalLearningSolutions.Web.Helpers;
     using FluentAssertions;
@@ -12,6 +13,20 @@
         {
             // When
             var result = DateValidator.ValidateDate(1, 1, 3000);
+
+            // Then
+            result.HasDayError.Should().BeFalse();
+            result.HasMonthError.Should().BeFalse();
+            result.HasYearError.Should().BeFalse();
+            result.ErrorMessage.Should().BeNull();
+        }
+
+        [Test]
+        public void ValidateDate_returns_valid_for_todays_date()
+        {
+            // When
+            var today = DateTime.Today;
+            var result = DateValidator.ValidateDate(today.Day, today.Month, today.Year);
 
             // Then
             result.HasDayError.Should().BeFalse();
@@ -125,7 +140,7 @@
         }
 
         [Test]
-        public void ValidateDate_returns_appropriate_error_if_date_not_in_future()
+        public void ValidateDate_returns_appropriate_error_if_date_in_past()
         {
             // When
             var result = DateValidator.ValidateDate(1, 1, 2000);
@@ -134,7 +149,7 @@
             result.HasDayError.Should().BeTrue();
             result.HasMonthError.Should().BeTrue();
             result.HasYearError.Should().BeTrue();
-            result.ErrorMessage.Should().Be("Date must be in the future");
+            result.ErrorMessage.Should().Be("Date must not be in the past");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -248,10 +248,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void SetCentreDelegateRegistrationData(int centreId)
         {
-            var centreDelegateRegistrationData = new DelegateRegistrationByCentreData(centreId)
-            {
-                WelcomeEmailDate = DateTime.Today
-            };
+            var centreDelegateRegistrationData = new DelegateRegistrationByCentreData(centreId, DateTime.Today);
             var id = centreDelegateRegistrationData.Id;
 
             Response.Cookies.Append(

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -248,7 +248,10 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void SetCentreDelegateRegistrationData(int centreId)
         {
-            var centreDelegateRegistrationData = new DelegateRegistrationByCentreData(centreId);
+            var centreDelegateRegistrationData = new DelegateRegistrationByCentreData(centreId)
+            {
+                WelcomeEmailDate = DateTime.Today
+            };
             var id = centreDelegateRegistrationData.Id;
 
             Response.Cookies.Append(

--- a/DigitalLearningSolutions.Web/Helpers/DateValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/DateValidator.cs
@@ -44,9 +44,9 @@
             try
             {
                 var date = new DateTime(year, month, day);
-                if (date <= DateTime.Today)
+                if (date < DateTime.Today)
                 {
-                    return new DateValidationResult(name + " must be in the future");
+                    return new DateValidationResult(name + " must not be in the past");
                 }
             }
             catch (ArgumentOutOfRangeException)

--- a/DigitalLearningSolutions.Web/Models/DelegateRegistrationByCentreData.cs
+++ b/DigitalLearningSolutions.Web/Models/DelegateRegistrationByCentreData.cs
@@ -7,7 +7,11 @@
     public class DelegateRegistrationByCentreData : DelegateRegistrationData
     {
         public DelegateRegistrationByCentreData() { }
-        public DelegateRegistrationByCentreData(int centreId) : base(centreId) { }
+
+        public DelegateRegistrationByCentreData(int centreId, DateTime welcomeEmailDate) : base(centreId)
+        {
+            WelcomeEmailDate = welcomeEmailDate;
+        }
 
         public string? Alias { get; set; }
         public DateTime? WelcomeEmailDate { get; set; }

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
@@ -33,7 +33,7 @@
                  type="checkbox"
                  value="true"
                  aria-controls="@dateInputId"
-                 aria-expanded="@Model.ShouldSendEmail">
+                 aria-expanded="@(Model.ShouldSendEmail ? "true" : "false")">
           <label class="nhsuk-label nhsuk-checkboxes__label" for="ShouldSendEmail">
             Send welcome email to registered delegate
           </label>


### PR DESCRIPTION
### JIRA link
[HEEDLS-497](https://softwiretech.atlassian.net/browse/HEEDLS-497)

### Description
Set default welcome email date to today's date (and should send by default).
Update DateValidator to accept today's date (previously only accepted dates in the future).
Modify relevant accessibility test to ignore the axe violation caused by aria-expanded on `#ShouldSendEmail` (nhs-tested component).

### Screenshots
No visible frontend changes to see.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
