### PR TITLE
HEEDLS-513 Add word break class to sidebar heading

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_DelegateGroupsSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_DelegateGroupsSideNavMenu.cshtml
@@ -8,7 +8,7 @@
   };
 }
 
-<h2 class="side-nav__heading">@Model.GroupName</h2>
+<h2 class="side-nav__heading word-break">@Model.GroupName</h2>
 <ul class="nhsuk-list side-nav__list">
 
   <vc:side-menu-link asp-action="GroupDelegates"


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-513

### Description
Added the word-break css class to the sidebar heading since it could contain long group names

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/129763533-8f35ae92-ec4b-49a8-9f23-d53822f4c6a1.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
