### PR TITLE
Heedls 439 remove course admin fields

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/RemoveRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/RemoveRegistrationPrompt.cshtml
@@ -43,7 +43,7 @@
     @if (Model.DelegateCount == 1) {
       <p class="nhsuk-body-m">@Model.DelegateCount user has responded to this prompt. Deleting the prompt will permanently delete their response.</p>
     } else {
-      <p class="nhsuk-body-m">@Model.DelegateCount users have responded to this prompt. Deleting the prompt will permanently delete all of their responses.</p>
+      <p class="nhsuk-body-m">@Model.DelegateCount users have responded to this prompt. Deleting the prompt will permanently delete their responses.</p>
     }
 
     <form class="nhsuk-u-margin-bottom-5" method="post" asp-action="RemoveRegistrationPrompt">
@@ -61,7 +61,7 @@
                 @if (Model.DelegateCount == 1) {
                   @:I am sure that I wish to delete this prompt and @Model.DelegateCount delegate response
                 } else {
-                  @:I am sure that I wish to delete this prompt and all @Model.DelegateCount delegate responses
+                  @:I am sure that I wish to delete this prompt and @Model.DelegateCount delegate responses
                 }
               </label>
             </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
@@ -5,7 +5,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Delete admin field" : "Delete admin field";
+  ViewData["Title"] = errorHasOccurred ? "Error: Delete course admin field" : "Delete course admin field";
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
@@ -5,7 +5,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Remove admin field" : "Remove admin field";
+  ViewData["Title"] = errorHasOccurred ? "Error: Delete admin field" : "Delete admin field";
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
@@ -44,7 +44,7 @@
     @if (Model.AnswerCount == 1) {
       <p class="nhsuk-body-m">An admin has responded to this field for @Model.AnswerCount delegate. Deleting the field will permanently delete their response.</p>
     } else {
-      <p class="nhsuk-body-m">Admins have responded to this field for @Model.AnswerCount delegates. Deleting the field will permanently delete all of their responses.</p>
+      <p class="nhsuk-body-m">Admins have responded to this field for @Model.AnswerCount delegates. Deleting the field will permanently delete their responses.</p>
     }
 
     <form class="nhsuk-u-margin-bottom-5" method="post" asp-action="RemoveAdminField">
@@ -62,7 +62,7 @@
                 @if (Model.AnswerCount == 1) {
                   @:I am sure that I wish to delete this field and @Model.AnswerCount admin response
                 } else {
-                  @:I am sure that I wish to delete this field and all @Model.AnswerCount admin responses
+                  @:I am sure that I wish to delete this field and @Model.AnswerCount admin responses
                 }
               </label>
             </div>


### PR DESCRIPTION
### JIRA link
[HEEDLS-439](https://softwiretech.atlassian.net/browse/HEEDLS-439)

### Description
Just a small MR to change the title of the page to Delete course admin field and remove the word 'all' from the messages on the page so they make grammatical sense when there are only 2 responses, e.g. ‘and 2 admin responses’ rather than ‘and all 2 admin responses’. I have also changed this wording on the Remove registration prompts page to make it consistent.

### Screenshots
Screenshot for wording change
![localhost_5001_TrackingSystem_CourseSetup_100_AdminFields_1_Remove (3)](https://user-images.githubusercontent.com/70278044/130417430-c52dbeb6-5c15-476f-a722-d425569a2cba.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
