### PR TITLE
HEEDLS-516 Change the course count on the group expanders

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -28,13 +28,24 @@
 
         public IEnumerable<Group> GetGroupsForCentre(int centreId)
         {
+            const string courseCountSql = @"SELECT COUNT(*)
+                FROM GroupCustomisations AS gc
+                JOIN Customisations AS c ON c.CustomisationID = gc.CustomisationID
+                INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = c.ApplicationID
+                INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = ca.ApplicationID
+                WHERE gc.GroupID = g.GroupID
+                AND ca.CentreId = @centreId
+                AND gc.InactivatedDate IS NULL
+                AND ap.ArchivedDate IS NULL
+                AND c.Active = 1";
+
             return connection.Query<Group>(
-                @"SELECT
+                @$"SELECT
 	                    GroupID,
 	                    GroupLabel,
 	                    GroupDescription,
 	                    (SELECT COUNT(*) FROM GroupDelegates AS gd WHERE gd.GroupID = g.GroupID) AS DelegateCount,
-	                    (SELECT COUNT(*) FROM GroupCustomisations AS gc WHERE gc.GroupID = g.GroupID AND InactivatedDate IS NULL) AS CoursesCount,
+	                    ({courseCountSql}) AS CoursesCount,
 	                    au.Forename AS AddedByFirstName,
 	                    au.Surname AS AddedByLastName,
 	                    LinkedToField,


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-516

### Description
Changed the course count on the group cards to match the query being used to get the courses for the Group Courses page - filtering to only course that have GroupCustomisations.InactivatedDate null, Customisations.Active true and Application.ArchivedDate null.

### Screenshots
N/A

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
