### PR TITLE
HEEDLS-519 - Implemented System Notification Page

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/SystemNotificationsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SystemNotificationsDataServiceTests.cs
@@ -1,0 +1,115 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.DataServices
+{
+    using System;
+    using System.Linq;
+    using System.Transactions;
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using NUnit.Framework;
+
+    public class SystemNotificationsDataServiceTests
+    {
+        private SystemNotificationsDataService systemNotificationsDataService = null!;
+        private SystemNotificationTestHelper systemNotificationTestHelper = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            systemNotificationsDataService = new SystemNotificationsDataService(connection);
+            systemNotificationTestHelper = new SystemNotificationTestHelper(connection);
+        }
+
+        [Test]
+        public void AcknowledgeSystemNotification_creates_new_record()
+        {
+            using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            try
+            {
+                // Given
+                const int notificationId = 1;
+                const int adminId = 5;
+
+                // When
+                systemNotificationsDataService.AcknowledgeNotification(notificationId, adminId);
+                var acknowledgedNotificationIds =
+                    systemNotificationTestHelper.GetSystemNotificationAcknowledgementsForAdmin(adminId);
+
+                // Then
+                acknowledgedNotificationIds.Should().Contain(notificationId);
+            }
+            finally
+            {
+                transaction.Dispose();
+            }
+        }
+
+        [Test]
+        public void GetUnacknowledgedSystemNotifications_returns_correct_notifications()
+        {
+            using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            try
+            {
+                // Given
+                const int adminId = 5;
+                var currentTime = DateTime.UtcNow.Date;
+                var neverExpiresNotification = new SystemNotification(
+                    100,
+                    "Never expires test",
+                    "body",
+                    null,
+                    currentTime,
+                    1
+                );
+                var expiredYesterdayNotification = new SystemNotification(
+                    102,
+                    "Expired yesterday test",
+                    "body",
+                    currentTime.AddDays(-1),
+                    currentTime,
+                    1
+                );
+                var expiresTomorrowNotification = new SystemNotification(
+                    103,
+                    "Expires tomorrow test",
+                    "body",
+                    currentTime.AddDays(1),
+                    currentTime,
+                    1
+                );
+                var alreadyAcknowledgedNotification = new SystemNotification(
+                    104,
+                    "Already acknowledged test",
+                    "body",
+                    null,
+                    currentTime,
+                    1
+                );
+                systemNotificationTestHelper.CreateNewSystemNotification(neverExpiresNotification);
+                systemNotificationTestHelper.CreateNewSystemNotification(expiredYesterdayNotification);
+                systemNotificationTestHelper.CreateNewSystemNotification(expiresTomorrowNotification);
+                systemNotificationTestHelper.CreateNewSystemNotification(alreadyAcknowledgedNotification);
+                systemNotificationsDataService.AcknowledgeNotification(104, adminId);
+
+                // When
+                var systemNotificationsToShow =
+                    systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId).ToList();
+
+                // Then
+                using (new AssertionScope())
+                {
+                    systemNotificationsToShow.Should().HaveCount(2);
+                    systemNotificationsToShow.Should().ContainEquivalentOf(neverExpiresNotification);
+                    systemNotificationsToShow.Should().ContainEquivalentOf(expiresTomorrowNotification);
+                }
+            }
+            finally
+            {
+                transaction.Dispose();
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/SystemNotificationTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/SystemNotificationTestHelper.cs
@@ -1,0 +1,64 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.TestHelpers
+{
+    using System;
+    using System.Collections.Generic;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models;
+    using Microsoft.Data.SqlClient;
+
+    public class SystemNotificationTestHelper
+    {
+        private readonly SqlConnection connection;
+
+        public SystemNotificationTestHelper(SqlConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public IEnumerable<int> GetSystemNotificationAcknowledgementsForAdmin(int adminId)
+        {
+            return connection.Query<int>(
+                @"SELECT SANotificationId
+                        FROM SANotificationAcknowledgements
+                        WHERE AdminUserID = @adminId",
+                new { adminId }
+            );
+        }
+
+        public void CreateNewSystemNotification(
+            SystemNotification notification
+        )
+        {
+            connection.Execute(
+                @"SET IDENTITY_INSERT dbo.SANotifications ON
+                    INSERT INTO SANotifications (SANotificationID, SubjectLine, BodyHtml, ExpiryDate, DateAdded, TargetUserRoleID)
+                    VALUES (@systemNotificationId, @subjectLine, @bodyHtml, @expiryDate, @dateAdded, @targetUserRoleId)
+                    SET IDENTITY_INSERT dbo.SANotifications OFF",
+                new
+                {
+                    notification.SystemNotificationId, notification.SubjectLine, notification.BodyHtml,
+                    notification.ExpiryDate, notification.DateAdded, notification.TargetUserRoleId
+                }
+            );
+        }
+
+        public static SystemNotification GetDefaultSystemNotification(
+            int id = 1,
+            string subject = "test subject",
+            string bodyHtml = "<p>test body</p>",
+            DateTime? expiryDate = null,
+            DateTime? dateAdded = null,
+            int targetUserRoleId = 1
+        )
+        {
+            return new SystemNotification(
+                id,
+                subject,
+                bodyHtml,
+                expiryDate,
+                dateAdded ?? DateTime.UtcNow,
+                targetUserRoleId
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SystemNotificationsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SystemNotificationsDataService.cs
@@ -1,0 +1,52 @@
+﻿namespace DigitalLearningSolutions.Data.DataServices
+{
+    using System.Collections.Generic;
+    using System.Data;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models;
+
+    public interface ISystemNotificationsDataService
+    {
+        public IEnumerable<SystemNotification> GetUnacknowledgedSystemNotifications(int adminId);
+
+        public void AcknowledgeNotification(int notificationId, int adminId);
+    }
+
+    public class SystemNotificationsDataService : ISystemNotificationsDataService
+    {
+        private readonly IDbConnection connection;
+
+        public SystemNotificationsDataService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public IEnumerable<SystemNotification> GetUnacknowledgedSystemNotifications(int adminId)
+        {
+            return connection.Query<SystemNotification>(
+                @"SELECT
+                        SANotificationID AS SystemNotificationId,
+                        SubjectLine,
+                        BodyHtml,
+                        ExpiryDate,
+                        DateAdded,
+                        TargetUserRoleID
+                    FROM dbo.SANotifications
+                    WHERE SANotificationID NOT IN
+                        (SELECT SANotificationID FROM dbo.SANotificationAcknowledgements WHERE AdminUserID = @adminId)
+                        AND (ExpiryDate IS NULL OR ExpiryDate > GETUTCDATE())
+                    ORDER BY DateAdded DESC",
+                new { adminId }
+            );
+        }
+
+        public void AcknowledgeNotification(int notificationId, int adminId)
+        {
+            connection.Execute(
+                @"INSERT INTO dbo.SANotificationAcknowledgements (SANotificationID, AdminUserID)
+                    VALUES (@notificationId, @adminId)",
+                new { notificationId, adminId }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SystemNotification.cs
+++ b/DigitalLearningSolutions.Data/Models/SystemNotification.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Data.Models
+{
+    using System;
+
+    public class SystemNotification
+    {
+        public SystemNotification(
+            int systemNotificationId,
+            string subjectLine,
+            string bodyHtml,
+            DateTime? expiryDate,
+            DateTime dateAdded,
+            int targetUserRoleId
+        )
+        {
+            SystemNotificationId = systemNotificationId;
+            SubjectLine = subjectLine;
+            BodyHtml = bodyHtml;
+            ExpiryDate = expiryDate;
+            DateAdded = dateAdded;
+            TargetUserRoleId = targetUserRoleId;
+        }
+
+        public int SystemNotificationId { get; set; }
+
+        public string SubjectLine { get; set; }
+
+        public string BodyHtml { get; set; }
+
+        public DateTime? ExpiryDate { get; set; }
+
+        public DateTime DateAdded { get; set; }
+
+        public int TargetUserRoleId { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -31,6 +31,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
             "Remove delegate registration prompt"
         )]
         [InlineData("/TrackingSystem/Centre/Reports", "Centre reports")]
+        [InlineData("/TrackingSystem/Centre/SystemNotifications", "New system notifications")]
         [InlineData("/TrackingSystem/Centre/TopCourses", "Top courses")]
         [InlineData("/TrackingSystem/CourseSetup", "Centre course setup")]
         [InlineData("/TrackingSystem/CourseSetup/10716/AdminFields", "Manage course admin fields")]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Dashboard/DashboardControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Dashboard/DashboardControllerTests.cs
@@ -1,0 +1,118 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Centre.Dashboard
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Dashboard;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+    using FakeItEasy;
+    using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Http;
+    using NUnit.Framework;
+
+    public class DashboardControllerTests
+    {
+        private readonly ICentresDataService centresDataService = A.Fake<ICentresDataService>();
+        private readonly ICentresService centresService = A.Fake<ICentresService>();
+        private readonly ICourseDataService courseDataService = A.Fake<ICourseDataService>();
+        private readonly HttpRequest httpRequest = A.Fake<HttpRequest>();
+        private readonly HttpResponse httpResponse = A.Fake<HttpResponse>();
+
+        private readonly ISystemNotificationsDataService systemNotificationsDataService =
+            A.Fake<ISystemNotificationsDataService>();
+
+        private readonly ISupportTicketDataService ticketDataService = A.Fake<ISupportTicketDataService>();
+        private readonly IUserDataService userDataService = A.Fake<IUserDataService>();
+        private DashboardController dashboardController = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            A.CallTo(() => userDataService.GetAdminUserById(A<int>._)).Returns(UserTestHelper.GetDefaultAdminUser());
+            A.CallTo(() => centresDataService.GetCentreDetailsById(A<int>._))
+                .Returns(CentreTestHelper.GetDefaultCentre());
+            A.CallTo(() => userDataService.GetNumberOfApprovedDelegatesAtCentre(A<int>._)).Returns(1);
+            A.CallTo(() => courseDataService.GetNumberOfActiveCoursesAtCentreForCategory(A<int>._, A<int>._))
+                .Returns(1);
+            A.CallTo(() => userDataService.GetNumberOfActiveAdminsAtCentre(A<int>._)).Returns(1);
+            A.CallTo(() => ticketDataService.GetNumberOfUnarchivedTicketsForCentreId(A<int>._)).Returns(1);
+            A.CallTo(() => centresService.GetCentreRankForCentre(A<int>._)).Returns(1);
+
+            dashboardController = new DashboardController(
+                    userDataService,
+                    centresDataService,
+                    courseDataService,
+                    ticketDataService,
+                    centresService,
+                    systemNotificationsDataService
+                ).WithMockHttpContextWithCookie(httpRequest, "testCookie", "testValue", httpResponse)
+                .WithMockUser(true)
+                .WithMockServices()
+                .WithMockTempData();
+        }
+
+        [Test]
+        public void Index_redirects_to_Notifications_page_when_unacknowledged_notifications_have_not_been_skipped()
+        {
+            // Given
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification> { SystemNotificationTestHelper.GetDefaultSystemNotification() });
+
+            // When
+            var result = dashboardController.Index();
+
+            // Then
+            result.Should().BeRedirectToActionResult().WithControllerName("SystemNotifications")
+                .WithActionName("Index");
+        }
+
+        [Test]
+        public void Index_goes_to_Index_page_when_unacknowledged_notifications_have_been_skipped()
+        {
+            // Given
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification> { SystemNotificationTestHelper.GetDefaultSystemNotification() });
+            var controllerWithCorrectCookie =
+                dashboardController = new DashboardController(
+                        userDataService,
+                        centresDataService,
+                        courseDataService,
+                        ticketDataService,
+                        centresService,
+                        systemNotificationsDataService
+                    ).WithMockHttpContextWithCookie(
+                        httpRequest,
+                        SystemNotificationCookieHelper.CookieName,
+                        7.ToString(),
+                        httpResponse
+                    )
+                    .WithMockUser(true)
+                    .WithMockServices()
+                    .WithMockTempData();
+
+            // When
+            var result = controllerWithCorrectCookie.Index();
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName();
+        }
+
+        [Test]
+        public void Index_goes_to_Index_page_when_no_unacknowledged_notifications_exist()
+        {
+            // Given
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification>());
+
+            // When
+            var result = dashboardController.Index();
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotifications/SystemNotificationControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotifications/SystemNotificationControllerTests.cs
@@ -1,0 +1,61 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Centre.SystemNotifications
+{
+    using System;
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+    using FakeItEasy;
+    using FluentAssertions.AspNetCore.Mvc;
+    using FluentAssertions.Execution;
+    using Microsoft.AspNetCore.Http;
+    using NUnit.Framework;
+
+    public class SystemNotificationControllerTests
+    {
+        private readonly IClockService clockService = A.Fake<IClockService>();
+        private readonly HttpRequest httpRequest = A.Fake<HttpRequest>();
+        private readonly HttpResponse httpResponse = A.Fake<HttpResponse>();
+
+        private readonly ISystemNotificationsDataService systemNotificationsDataService =
+            A.Fake<ISystemNotificationsDataService>();
+
+        private SystemNotificationsController controller = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            controller =
+                new SystemNotificationsController(systemNotificationsDataService, clockService)
+                    .WithMockHttpContextWithCookie(httpRequest, "testCookie", "testValue", httpResponse)
+                    .WithMockUser(true)
+                    .WithMockServices();
+        }
+
+        [Test]
+        public void SkipNotifications_sets_cookie_and_redirects_to_dashboard()
+        {
+            // Given
+            var testDate = new DateTime(2021, 8, 23);
+            A.CallTo(() => clockService.UtcNow).Returns(testDate);
+            var expectedExpiry = testDate.AddHours(24);
+
+            // When
+            var result = controller.SkipNotifications();
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeRedirectToActionResult().WithControllerName("Dashboard").WithActionName("Index");
+                A.CallTo(
+                    () => httpResponse.Cookies.Append(
+                        SystemNotificationCookieHelper.CookieName,
+                        7.ToString(),
+                        A<CookieOptions>.That.Matches(co => co.Expires == expectedExpiry)
+                    )
+                ).MustHaveHappened();
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Dashboard/DashboardController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Dashboard/DashboardController.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Dashboard
 {
+    using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Services;
@@ -17,6 +18,7 @@
         private readonly ICentresDataService centresDataService;
         private readonly ICentresService centresService;
         private readonly ICourseDataService courseDataService;
+        private readonly ISystemNotificationsDataService systemNotificationsDataService;
         private readonly ISupportTicketDataService ticketDataService;
         private readonly IUserDataService userDataService;
 
@@ -25,7 +27,8 @@
             ICentresDataService centresDataService,
             ICourseDataService courseDataService,
             ISupportTicketDataService ticketDataService,
-            ICentresService centresService
+            ICentresService centresService,
+            ISystemNotificationsDataService systemNotificationsDataService
         )
         {
             this.userDataService = userDataService;
@@ -33,11 +36,21 @@
             this.courseDataService = courseDataService;
             this.ticketDataService = ticketDataService;
             this.centresService = centresService;
+            this.systemNotificationsDataService = systemNotificationsDataService;
         }
 
         public IActionResult Index()
         {
-            var adminUser = userDataService.GetAdminUserById(User.GetAdminId()!.Value)!;
+            var adminId = User.GetAdminId()!.Value;
+            var unacknowledgedNotifications =
+                systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId).ToList();
+
+            if (!HasSkippedNotificationsCookie(adminId) && unacknowledgedNotifications.Any())
+            {
+                return RedirectToAction("Index", "SystemNotifications");
+            }
+
+            var adminUser = userDataService.GetAdminUserById(adminId)!;
             var centreId = User.GetCentreId();
             var centre = centresDataService.GetCentreDetailsById(centreId)!;
             var delegateCount = userDataService.GetNumberOfApprovedDelegatesAtCentre(centreId);
@@ -56,10 +69,21 @@
                 courseCount,
                 adminCount,
                 supportTicketCount,
-                centreRank
+                centreRank,
+                unacknowledgedNotifications.Count
             );
 
             return View(model);
+        }
+
+        private bool HasSkippedNotificationsCookie(int adminId)
+        {
+            if (Request.Cookies.ContainsKey(SystemNotificationCookieHelper.CookieName))
+            {
+                return Request.Cookies[SystemNotificationCookieHelper.CookieName] == adminId.ToString();
+            }
+
+            return false;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
@@ -1,0 +1,68 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre
+{
+    using System.Linq;
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.SystemNotifications;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.FeatureManagement.Mvc;
+
+    [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
+    [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
+    [Route("/TrackingSystem/Centre/SystemNotifications")]
+    public class SystemNotificationsController : Controller
+    {
+        private readonly IClockService clockService;
+        private readonly ISystemNotificationsDataService systemNotificationsDataService;
+
+        public SystemNotificationsController(
+            ISystemNotificationsDataService systemNotificationsDataService,
+            IClockService clockService
+        )
+        {
+            this.systemNotificationsDataService = systemNotificationsDataService;
+            this.clockService = clockService;
+        }
+
+        [HttpGet]
+        [Route("{page:int=1}")]
+        public IActionResult Index(int page = 1)
+        {
+            var adminId = User.GetAdminId()!.Value;
+            var unacknowledgedNotifications =
+                systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId).ToList();
+            var model = new SystemNotificationsViewModel(unacknowledgedNotifications, page);
+            return View(model);
+        }
+
+        [HttpGet]
+        [Route("SkipNotifications")]
+        public IActionResult SkipNotifications()
+        {
+            var adminId = User.GetAdminId()!.Value;
+            SetSkipSystemNotificationCookie(adminId);
+            return RedirectToAction("Index", "Dashboard");
+        }
+
+        [HttpPost]
+        [Route("{page:int=1}")]
+        public IActionResult AcknowledgeNotification(int systemNotificationId, int page)
+        {
+            var adminId = User.GetAdminId()!;
+            systemNotificationsDataService.AcknowledgeNotification(systemNotificationId, adminId.Value);
+            return RedirectToAction("Index", "SystemNotifications", new { page });
+        }
+
+        private void SetSkipSystemNotificationCookie(int adminId)
+        {
+            var expiry = clockService.UtcNow.AddHours(SystemNotificationCookieHelper.CookieExpiryHours);
+            Response.Cookies.Append(SystemNotificationCookieHelper.CookieName, adminId.ToString(), new CookieOptions
+            {
+                Expires = expiry
+            });
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/SystemNotificationCookieHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SystemNotificationCookieHelper.cs
@@ -1,0 +1,8 @@
+﻿namespace DigitalLearningSolutions.Web.Helpers
+{
+    public static class SystemNotificationCookieHelper
+    {
+        public static readonly int CookieExpiryHours = 24;
+        public static readonly string CookieName = "SkipSystemNotificationsCookie";
+    }
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -197,6 +197,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ISectionService, SectionService>();
             services.AddScoped<ICourseCategoriesDataService, CourseCategoriesDataService>();
             services.AddScoped<ICourseTopicsDataService, CourseTopicsDataService>();
+            services.AddScoped<ISystemNotificationsDataService, SystemNotificationsDataService>();
             RegisterWebServiceFilters(services);
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Dashboard/CentreDashboardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Dashboard/CentreDashboardViewModel.cs
@@ -4,8 +4,7 @@
 
     public class CentreDashboardViewModel
     {
-        public CentreDashboardViewModel
-        (
+        public CentreDashboardViewModel(
             Centre centre,
             string? firstName,
             string? categoryName,
@@ -14,7 +13,8 @@
             int courses,
             int admins,
             int supportTickets,
-            int? centreRank
+            int? centreRank,
+            int unacknowledgedNotifications
         )
         {
             CentreDetails = new DashboardCentreDetailsViewModel(centre, userIpAddress, centreRank);
@@ -24,6 +24,8 @@
             NumberOfCourses = courses;
             NumberOfAdmins = admins;
             NumberOfSupportTickets = supportTickets;
+            ViewNotificationsButtonText = "View " + unacknowledgedNotifications + " notification" +
+                                          (unacknowledgedNotifications == 1 ? "" : "s");
         }
 
         public string FirstName { get; set; }
@@ -39,5 +41,7 @@
         public int NumberOfSupportTickets { get; set; }
 
         public DashboardCentreDetailsViewModel CentreDetails { get; set; }
+
+        public string ViewNotificationsButtonText { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/SystemNotifications/SystemNotificationsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/SystemNotifications/SystemNotificationsViewModel.cs
@@ -1,0 +1,30 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.SystemNotifications
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+
+    public class SystemNotificationsViewModel : BasePaginatedViewModel
+    {
+        private const int NumberOfNotificationsPerPage = 1;
+
+        public SystemNotificationsViewModel(
+            IList<SystemNotification> unacknowledgedNotifications,
+            int page
+        ) : base(
+            page,
+            NumberOfNotificationsPerPage
+        )
+        {
+            MatchingSearchResults = unacknowledgedNotifications.Count;
+            SetTotalPages();
+            var paginatedItems = GetItemsOnCurrentPage(unacknowledgedNotifications);
+            UnacknowledgedNotification =
+                paginatedItems.Select(notification => new UnacknowledgedNotificationViewModel(notification))
+                    .FirstOrDefault();
+        }
+
+        public UnacknowledgedNotificationViewModel? UnacknowledgedNotification { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/SystemNotifications/UnacknowledgedNotificationViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/SystemNotifications/UnacknowledgedNotificationViewModel.cs
@@ -1,0 +1,23 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.SystemNotifications
+{
+    using DigitalLearningSolutions.Data.Models;
+
+    public class UnacknowledgedNotificationViewModel
+    {
+        public UnacknowledgedNotificationViewModel(SystemNotification notification)
+        {
+            SystemNotificationId = notification.SystemNotificationId;
+            Subject = notification.SubjectLine;
+            Body = notification.BodyHtml;
+            ExpiryDate = notification.ExpiryDate?.ToString("dd/MM/yyyy") ?? "This notification never expires";
+        }
+
+        public int SystemNotificationId { get; set; }
+
+        public string Subject { get; set; }
+
+        public string Body { get; set; }
+
+        public string ExpiryDate { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Dashboard/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Dashboard/Index.cshtml
@@ -33,6 +33,10 @@
 
     <partial name="_DashboardBottomCardGroup" />
 
+    <a class="nhsuk-button" role="button" asp-controller="SystemNotifications" asp-action="Index">
+      @Model.ViewNotificationsButtonText
+    </a>
+
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml" model="CentrePage.Dashboard" />
     </nav>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SystemNotifications/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SystemNotifications/Index.cshtml
@@ -1,0 +1,56 @@
+﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.SystemNotifications
+@using Microsoft.Extensions.Configuration
+@model SystemNotificationsViewModel
+
+<link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/pagination.css")" asp-append-version="true">
+
+@{
+  ViewData["Title"] = "New system notifications";
+  ViewData["Application"] = "Tracking System";
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
+  ViewData["HeaderPathName"] = "Tracking System";
+}
+
+@section NavMenuItems {
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl" id="app-page-heading">New system notifications</h1>
+
+    <vc:action-link asp-controller="SystemNotifications"
+                    asp-action="SkipNotifications"
+                    link-text="Show notifications later and take me to dashboard" />
+
+    @if (Model.UnacknowledgedNotification == null)
+    {
+      <p>No new notifications</p>
+    }
+    else
+    {
+      <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2">Subject</p>
+      <p>@Model.UnacknowledgedNotification.Subject</p>
+
+      <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2">Body</p>
+      @Html.Raw(Model.UnacknowledgedNotification.Body)
+
+      <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2">Expiry date</p>
+      <p>@Model.UnacknowledgedNotification.ExpiryDate</p>
+
+      <form asp-action="AcknowledgeNotification"
+            asp-controller="SystemNotifications"
+            asp-all-route-data="@(new Dictionary<string, string> {{ "page", Model.Page.ToString() }})">
+        <input type="hidden" value="@Model.UnacknowledgedNotification.SystemNotificationId" name="systemNotificationId" />
+        <button class="nhsuk-button" type="submit">Acknowledge</button>
+      </form>
+
+      @if (Model.TotalPages > 1)
+      {
+        <partial name="PaginatedPage/_Pagination" model="Model" />
+      }
+    }
+
+  </div>
+</div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-519

### Description
New page for the system notifications. Reachable from a button on the dashboard, but also is automatically redirected when visiting the dashboard if outstanding notifications exist.

### Screenshots
Dashboard new button:
![New dashboard notification button](https://user-images.githubusercontent.com/80777689/130603620-33d0ac92-55fa-4979-a8c6-808272c9621f.PNG)

Desktop when no notifications are outstanding:
![Desktop no notifications](https://user-images.githubusercontent.com/80777689/130603555-4a764b5f-e765-41fc-b4dc-2a4b8e877f8f.jpeg)

Desktop example with no expiry date:
![Desktop no expiry](https://user-images.githubusercontent.com/80777689/130603579-e50c5187-7b23-4b7b-858e-bdca22d92265.jpeg)

Desktop example with expiry date:
![Desktop with expiry](https://user-images.githubusercontent.com/80777689/130603594-d78063b1-6fbc-419a-a824-3b697e315cd6.jpeg)

Same desktop example but on mobile
<img src="https://user-images.githubusercontent.com/80777689/130603607-1000d666-2a91-4a86-b929-9baffddd4d4c.jpeg" width =320px />


-----
### Developer checks
I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
