### PR TITLE
HEEDLS-488 - implemented IE fix for hidden submit buttons

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -209,8 +209,8 @@ ul.no-bullets {
 }
 
 .hidden-submit {
-    display: none;
-    @include hidden-submit-ie-fix;
+  display: none;
+  @include hidden-submit-ie-fix;
 }
 
 .divider {

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -199,8 +199,18 @@ ul.no-bullets {
     margin-bottom: 0;
 }
 
+@mixin hidden-submit-ie-fix {
+  // IE11 hack
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    display: block;
+    position: absolute;
+    left: -100%;
+  }
+}
+
 .hidden-submit {
-  display: none;
+    display: none;
+    @include hidden-submit-ie-fix;
 }
 
 .divider {

--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -34,7 +34,7 @@
 
 <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditDetails" enctype="multipart/form-data">
   <div class="hidden-submit">
-    <button name="action" class="nhsuk-button" value="save">Save</button>
+    <button name="action" class="nhsuk-button" value="save" aria-hidden="true" tabindex="-1">Save</button>
   </div>
 
   <div class="nhsuk-grid-row divider">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/EditCentreDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/EditCentreDetails.cshtml
@@ -29,7 +29,7 @@
     <h1 class="nhsuk-heading-xl">Edit centre details</h1>
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditCentreDetails" enctype="multipart/form-data">
       <div class="hidden-submit">
-        <button name="action" class="nhsuk-button" value="save">Save</button>
+        <button name="action" class="nhsuk-button" value="save" aria-hidden="true" tabindex="-1">Save</button>
       </div>
 
       <div class="nhsuk-grid-row divider">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -26,7 +26,7 @@
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
       <div class="hidden-submit">
-        <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
+        <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction" aria-hidden="true" tabindex="-1">Add</button>
       </div>
 
       <input type="hidden" asp-for="OptionsString" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -28,7 +28,7 @@
 
 <form method="post" novalidate asp-action="EditRegistrationPrompt">
   <div class="hidden-submit">
-    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction">Add</button>
+    <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction" aria-hidden="true" tabindex="-1">Add</button>
   </div>
 
   <input type="hidden" asp-for="OptionsString" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -33,7 +33,7 @@
 
 <form method="post" novalidate asp-action="EditAdminField">
   <div class="hidden-submit">
-    <button name="action" class="nhsuk-button" value="@AdminFieldsController.AddPromptAction">Add</button>
+    <button name="action" class="nhsuk-button" value="@AdminFieldsController.AddPromptAction" aria-hidden="true" tabindex="-1">Add</button>
   </div>
 
   <input type="hidden" asp-for="OptionsString" />


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-488

### Description
Styled the hidden submits to not be hidden on IE, but pushed off the screen so that IE recognises it as the default button to hit when Enter is pressed. I've applied the change to anywhere the hidden-submit css class could be found, so if there are other areas that have been missed with unique classes, do let me know.

### Screenshots
N/A

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
