### PR TITLE
HEEDLS-519 - Change system notification cookie management

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotificationControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotificationControllerTests.cs
@@ -1,8 +1,11 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Centre
 {
     using System;
+    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -15,10 +18,10 @@
     public class SystemNotificationControllerTests
     {
         private readonly IClockService clockService = A.Fake<IClockService>();
+        private SystemNotificationsController controller = null!;
         private HttpRequest httpRequest = null!;
         private HttpResponse httpResponse = null!;
         private ISystemNotificationsDataService systemNotificationsDataService = null!;
-        private SystemNotificationsController controller = null!;
 
         [SetUp]
         public void Setup()
@@ -30,7 +33,35 @@
                 new SystemNotificationsController(systemNotificationsDataService, clockService)
                     .WithMockHttpContext(httpRequest, response: httpResponse)
                     .WithMockUser(true)
-                    .WithMockServices();
+                    .WithMockServices()
+                    .WithMockTempData();
+        }
+
+        [Test]
+        public void Index_sets_cookie_when_unacknowledged_notifications_exist()
+        {
+            // Given
+            var testDate = new DateTime(2021, 8, 23);
+            A.CallTo(() => clockService.UtcNow).Returns(testDate);
+            var expectedExpiry = testDate.AddHours(24);
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification> { SystemNotificationTestHelper.GetDefaultSystemNotification() });
+
+            // When
+            var result = controller.SkipNotifications();
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeRedirectToActionResult().WithControllerName("Dashboard").WithActionName("Index");
+                A.CallTo(
+                    () => httpResponse.Cookies.Append(
+                        SystemNotificationCookieHelper.CookieName,
+                        "7",
+                        A<CookieOptions>.That.Matches(co => co.Expires == expectedExpiry)
+                    )
+                ).MustHaveHappened();
+            }
         }
 
         [Test]
@@ -69,7 +100,8 @@
             controller.SkipNotifications();
 
             // Then
-            A.CallTo(() => systemNotificationsDataService.AcknowledgeNotification(A<int>._, A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => systemNotificationsDataService.AcknowledgeNotification(A<int>._, A<int>._))
+                .MustNotHaveHappened();
         }
 
         [Test]
@@ -82,53 +114,62 @@
             using (new AssertionScope())
             {
                 A.CallTo(() => systemNotificationsDataService.AcknowledgeNotification(1, 7)).MustHaveHappened();
-                result.Should().BeRedirectToActionResult().WithControllerName("SystemNotifications").WithActionName("Index");
+                result.Should().BeRedirectToActionResult().WithControllerName("SystemNotifications")
+                    .WithActionName("Index");
             }
         }
 
         [Test]
-        public void Post_deletes_cookie_if_one_exists_for_user()
+        public void Index_deletes_cookie_if_one_exists_for_user_and_no_unacknowledged_notifications_exist()
         {
             // Given
             A.CallTo(() => httpRequest.Cookies).Returns(
                 ControllerContextHelper.SetUpFakeRequestCookieCollection(SystemNotificationCookieHelper.CookieName, "7")
             );
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification>());
 
             // When
-            controller.AcknowledgeNotification(1, 1);
+            controller.Index();
 
             // Then
             A.CallTo(() => httpResponse.Cookies.Delete(SystemNotificationCookieHelper.CookieName)).MustHaveHappened();
         }
 
         [Test]
-        public void Post_does_not_delete_cookie_if_one_exists_for_someone_other_than_current_user()
+        public void Index_does_not_delete_cookie_if_one_exists_for_someone_other_than_current_user()
         {
             // Given
             A.CallTo(() => httpRequest.Cookies).Returns(
                 ControllerContextHelper.SetUpFakeRequestCookieCollection(SystemNotificationCookieHelper.CookieName, "8")
             );
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification>());
 
             // When
-            controller.AcknowledgeNotification(1, 1);
+            controller.Index();
 
             // Then
-            A.CallTo(() => httpResponse.Cookies.Delete(SystemNotificationCookieHelper.CookieName)).MustNotHaveHappened();
+            A.CallTo(() => httpResponse.Cookies.Delete(SystemNotificationCookieHelper.CookieName))
+                .MustNotHaveHappened();
         }
 
         [Test]
-        public void Post_does_not_delete_cookie_if_one_does_not_exist()
+        public void Index_does_not_delete_cookie_if_one_does_not_exist()
         {
             // Given
             A.CallTo(() => httpRequest.Cookies).Returns(
                 A.Fake<IRequestCookieCollection>()
             );
+            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+                .Returns(new List<SystemNotification>());
 
             // When
-            controller.AcknowledgeNotification(1, 1);
+            controller.Index();
 
             // Then
-            A.CallTo(() => httpResponse.Cookies.Delete(SystemNotificationCookieHelper.CookieName)).MustNotHaveHappened();
+            A.CallTo(() => httpResponse.Cookies.Delete(SystemNotificationCookieHelper.CookieName))
+                .MustNotHaveHappened();
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotificationControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotificationControllerTests.cs
@@ -48,12 +48,12 @@
                 .Returns(new List<SystemNotification> { SystemNotificationTestHelper.GetDefaultSystemNotification() });
 
             // When
-            var result = controller.SkipNotifications();
+            var result = controller.Index();
 
             // Then
             using (new AssertionScope())
             {
-                result.Should().BeRedirectToActionResult().WithControllerName("Dashboard").WithActionName("Index");
+                result.Should().BeViewResult().WithDefaultViewName();
                 A.CallTo(
                     () => httpResponse.Cookies.Append(
                         SystemNotificationCookieHelper.CookieName,
@@ -62,46 +62,6 @@
                     )
                 ).MustHaveHappened();
             }
-        }
-
-        [Test]
-        public void SkipNotifications_sets_cookie_and_redirects_to_dashboard()
-        {
-            // Given
-            var testDate = new DateTime(2021, 8, 23);
-            A.CallTo(() => clockService.UtcNow).Returns(testDate);
-            var expectedExpiry = testDate.AddHours(24);
-
-            // When
-            var result = controller.SkipNotifications();
-
-            // Then
-            using (new AssertionScope())
-            {
-                result.Should().BeRedirectToActionResult().WithControllerName("Dashboard").WithActionName("Index");
-                A.CallTo(
-                    () => httpResponse.Cookies.Append(
-                        SystemNotificationCookieHelper.CookieName,
-                        "7",
-                        A<CookieOptions>.That.Matches(co => co.Expires == expectedExpiry)
-                    )
-                ).MustHaveHappened();
-            }
-        }
-
-        [Test]
-        public void SkipNotifications_does_not_acknowledge_notifications()
-        {
-            // Given
-            var testDate = new DateTime(2021, 8, 23);
-            A.CallTo(() => clockService.UtcNow).Returns(testDate);
-
-            // When
-            controller.SkipNotifications();
-
-            // Then
-            A.CallTo(() => systemNotificationsDataService.AcknowledgeNotification(A<int>._, A<int>._))
-                .MustNotHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
@@ -33,6 +33,19 @@
             var adminId = User.GetAdminId()!.Value;
             var unacknowledgedNotifications =
                 systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId).ToList();
+
+            if (unacknowledgedNotifications.Count == 0)
+            {
+                if (Request.Cookies.HasSkippedNotificationsCookie(adminId))
+                {
+                    Response.Cookies.DeleteSkipSystemNotificationCookie();
+                }
+            }
+            else
+            {
+                Response.Cookies.SetSkipSystemNotificationCookie(adminId, clockService.UtcNow);
+            }
+
             var model = new SystemNotificationsViewModel(unacknowledgedNotifications, page);
             return View(model);
         }
@@ -52,11 +65,6 @@
         {
             var adminId = User.GetAdminId()!.Value;
             systemNotificationsDataService.AcknowledgeNotification(systemNotificationId, adminId);
-
-            if (Request.Cookies.HasSkippedNotificationsCookie(adminId))
-            {
-                Response.Cookies.DeleteSkipSystemNotificationCookie();
-            }
 
             return RedirectToAction("Index", "SystemNotifications", new { page });
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
@@ -50,15 +50,6 @@
             return View(model);
         }
 
-        [HttpGet]
-        [Route("SkipNotifications")]
-        public IActionResult SkipNotifications()
-        {
-            var adminId = User.GetAdminId()!.Value;
-            Response.Cookies.SetSkipSystemNotificationCookie(adminId, clockService.UtcNow);
-            return RedirectToAction("Index", "Dashboard");
-        }
-
         [HttpPost]
         [Route("{page:int}")]
         public IActionResult AcknowledgeNotification(int systemNotificationId, int page)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
@@ -34,16 +34,13 @@
             var unacknowledgedNotifications =
                 systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId).ToList();
 
-            if (unacknowledgedNotifications.Count == 0)
-            {
-                if (Request.Cookies.HasSkippedNotificationsCookie(adminId))
-                {
-                    Response.Cookies.DeleteSkipSystemNotificationCookie();
-                }
-            }
-            else
+            if (unacknowledgedNotifications.Count > 0)
             {
                 Response.Cookies.SetSkipSystemNotificationCookie(adminId, clockService.UtcNow);
+            }
+            else if (Request.Cookies.HasSkippedNotificationsCookie(adminId))
+            {
+                Response.Cookies.DeleteSkipSystemNotificationCookie();
             }
 
             var model = new SystemNotificationsViewModel(unacknowledgedNotifications, page);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SystemNotifications/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SystemNotifications/Index.cshtml
@@ -20,8 +20,8 @@
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl" id="app-page-heading">New system notifications</h1>
 
-    <vc:action-link asp-controller="SystemNotifications"
-                    asp-action="SkipNotifications"
+    <vc:action-link asp-controller="Dashboard"
+                    asp-action="Index"
                     link-text="Show notifications later and take me to dashboard" />
 
     @if (Model.UnacknowledgedNotification == null) {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-519

### Description
Updated the SystemNotificationController so that the cookie set when first visiting the page (Show Later link no longer needs to be clicked, allowing the user to immediately return to the dashboard). Also deleted the cookie when no more unacknowledged notifications exist.

### Screenshots
N/A

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
