### PR TITLE
HEEDLS-577 Add no store attribute for cache control

### DIFF
--- a/DigitalLearningSolutions.Web/Attributes/NoCachingAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/NoCachingAttribute.cs
@@ -2,7 +2,7 @@
 {
     using Microsoft.AspNetCore.Mvc.Filters;
 
-    public class NoStoreAttribute : ActionFilterAttribute
+    public class NoCachingAttribute : ActionFilterAttribute
     {
         public override void OnActionExecuted(ActionExecutedContext context)
         {

--- a/DigitalLearningSolutions.Web/Attributes/NoStoreAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/NoStoreAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Web.Attributes
+{
+    using Microsoft.AspNetCore.Mvc.Filters;
+
+    public class NoStoreAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            context.HttpContext.Response.Headers.Add("Cache-Control", "no-store, max-age=0");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -5,6 +5,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common;
@@ -37,6 +38,7 @@
             centreCustomPromptHelper = customPromptHelper;
         }
 
+        [NoStore]
         public IActionResult Index()
         {
             var userAdminId = User.GetAdminId();
@@ -54,6 +56,7 @@
             return View(model);
         }
 
+        [NoStore]
         [HttpGet]
         public IActionResult EditDetails()
         {
@@ -76,6 +79,7 @@
             return View(model);
         }
 
+        [NoStore]
         [HttpPost]
         public IActionResult EditDetails(EditDetailsViewModel model, string action)
         {

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -38,7 +38,7 @@
             centreCustomPromptHelper = customPromptHelper;
         }
 
-        [NoStore]
+        [NoCaching]
         public IActionResult Index()
         {
             var userAdminId = User.GetAdminId();
@@ -56,7 +56,7 @@
             return View(model);
         }
 
-        [NoStore]
+        [NoCaching]
         [HttpGet]
         public IActionResult EditDetails()
         {
@@ -79,7 +79,7 @@
             return View(model);
         }
 
-        [NoStore]
+        [NoCaching]
         [HttpPost]
         public IActionResult EditDetails(EditDetailsViewModel model, string action)
         {

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -5,6 +5,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models;
@@ -142,6 +143,7 @@
             return RedirectToAction("Summary");
         }
 
+        [NoStore]
         [ServiceFilter(typeof(RedirectEmptySessionData<RegistrationData>))]
         [HttpGet]
         public IActionResult Summary()
@@ -152,6 +154,7 @@
             return View(model);
         }
 
+        [NoStore]
         [ServiceFilter(typeof(RedirectEmptySessionData<RegistrationData>))]
         [HttpPost]
         public IActionResult Summary(SummaryViewModel model)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -143,7 +143,7 @@
             return RedirectToAction("Summary");
         }
 
-        [NoStore]
+        [NoCaching]
         [ServiceFilter(typeof(RedirectEmptySessionData<RegistrationData>))]
         [HttpGet]
         public IActionResult Summary()
@@ -154,7 +154,7 @@
             return View(model);
         }
 
-        [NoStore]
+        [NoCaching]
         [ServiceFilter(typeof(RedirectEmptySessionData<RegistrationData>))]
         [HttpPost]
         public IActionResult Summary(SummaryViewModel model)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -6,6 +6,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models;
@@ -179,6 +180,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return RedirectToAction("Summary");
         }
 
+        [NoStore]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationData>))]
         [HttpGet]
         public IActionResult Summary()
@@ -189,6 +191,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return View(viewModel);
         }
 
+        [NoStore]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationData>))]
         [HttpPost]
         public async Task<IActionResult> Summary(SummaryViewModel model)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -180,7 +180,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return RedirectToAction("Summary");
         }
 
-        [NoStore]
+        [NoCaching]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationData>))]
         [HttpGet]
         public IActionResult Summary()
@@ -191,7 +191,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return View(viewModel);
         }
 
-        [NoStore]
+        [NoCaching]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationData>))]
         [HttpPost]
         public async Task<IActionResult> Summary(SummaryViewModel model)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -195,7 +195,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return RedirectToAction("Summary");
         }
 
-        [NoStore]
+        [NoCaching]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationByCentreData>))]
         [HttpGet]
         public IActionResult Summary()
@@ -206,7 +206,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return View(viewModel);
         }
 
-        [NoStore]
+        [NoCaching]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationByCentreData>))]
         [HttpPost]
         public IActionResult Summary(SummaryViewModel model)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -6,6 +6,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models;
@@ -194,6 +195,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return RedirectToAction("Summary");
         }
 
+        [NoStore]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationByCentreData>))]
         [HttpGet]
         public IActionResult Summary()
@@ -204,6 +206,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             return View(viewModel);
         }
 
+        [NoStore]
         [ServiceFilter(typeof(RedirectEmptySessionData<DelegateRegistrationByCentreData>))]
         [HttpPost]
         public IActionResult Summary(SummaryViewModel model)


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-577

### Description
Add an ActionFilterAttribute to add Cache-Control 'no-store, max-age=0' headers to pages where the attribute is set against their action.

Note that this is likely to be overruled for some pages as there is some built in asp.net(?) functionality setting the header to no-store, no-cache on pages with forms. (I've made a note of this on the ticket too)

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/131689284-db7398e1-89f5-47d1-b5a0-d6939d6f8854.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
