### PR TITLE
Heedls 541c edit filters again

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/ActivityDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ActivityDataServiceTests.cs
@@ -73,16 +73,26 @@
         {
             // when
             var result = service.GetFilteredActivity(
-                    101,
-                    DateTime.Parse("2014-01-01 00:00:00.000"),
-                    DateTime.Parse("2014-03-31 23:59:59.999"),
-                    jobGroupId,
-                    courseCategoryId,
-                    customisationId
-                );
+                101,
+                DateTime.Parse("2014-01-01 00:00:00.000"),
+                DateTime.Parse("2014-03-31 23:59:59.999"),
+                jobGroupId,
+                courseCategoryId,
+                customisationId
+            );
 
             // then
             result.Count().Should().Be(expectedCount);
+        }
+
+        [Test]
+        public void GetStartOfActivityForCentre_returns_earliest_activity_date_for_centre()
+        {
+            // when
+            var result = service.GetStartOfActivityForCentre(101);
+
+            // then
+            result.Should().Be(DateTime.Parse("2010-09-22 06:52:21.880"));
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -333,7 +333,6 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         [Test]
         public void GetCourseNameAndApplication_returns_null_for_nonexistent_course()
         {
-
             // When
             var result = courseDataService.GetCourseNameAndApplication(-1);
 
@@ -364,6 +363,28 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
                 result.Should().HaveCount(69);
                 result.First(c => c.CustomisationId == 1).Should().BeEquivalentTo(expectedFirstCourse);
             }
+        }
+
+        [Test]
+        public void GetCoursesAtCentreForCategoryID_should_return_courses_correctly()
+        {
+            // Given
+            const int centreId = 101;
+            int? categoryId = null;
+
+            // When
+            var result = courseDataService.GetCoursesAtCentreForCategoryId(centreId, categoryId).ToList();
+
+            // Then
+            var expectedFirstCourse = new CourseNameInfo
+            {
+                CustomisationId = 100,
+                ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD",
+                CustomisationName = "Standard"
+            };
+
+            result.Should().HaveCount(260);
+            result.First().Should().BeEquivalentTo(expectedFirstCourse);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -341,46 +341,24 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         }
 
         [Test]
-        public void GetCoursesAtCentreForAdminCategoryId_returns_expected_values()
-        {
-            // Given
-            var expectedFirstCourse = new Course
-            {
-                CustomisationId = 1,
-                CentreId = 2,
-                ApplicationId = 1,
-                ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD",
-                CustomisationName = "Standard",
-                Active = false
-            };
-
-            // When
-            var result = courseDataService.GetCoursesAtCentreForAdminCategoryId(2, 0).ToList();
-
-            // Then
-            using (new AssertionScope())
-            {
-                result.Should().HaveCount(69);
-                result.First(c => c.CustomisationId == 1).Should().BeEquivalentTo(expectedFirstCourse);
-            }
-        }
-
-        [Test]
-        public void GetCoursesAtCentreForCategoryID_should_return_courses_correctly()
+        public void GetCentrallyManagedAndCentreCourses_returns_expected_values()
         {
             // Given
             const int centreId = 101;
             int? categoryId = null;
 
             // When
-            var result = courseDataService.GetCoursesAtCentreForCategoryId(centreId, categoryId).ToList();
+            var result = courseDataService.GetCentrallyManagedAndCentreCourses(centreId, categoryId).ToList();
 
             // Then
-            var expectedFirstCourse = new CourseNameInfo
+            var expectedFirstCourse = new Course
             {
                 CustomisationId = 100,
+                CentreId = 101,
+                ApplicationId = 1,
                 ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD",
-                CustomisationName = "Standard"
+                CustomisationName = "Standard",
+                Active = false
             };
 
             result.Should().HaveCount(260);

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseDelegatesServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseDelegatesServiceTests.cs
@@ -5,7 +5,6 @@
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Services;
-    using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions;
     using FluentAssertions.Execution;
@@ -35,7 +34,7 @@
             // Given
             const int centreId = 2;
             const int categoryId = 1;
-            A.CallTo(() => courseDataService.GetCoursesAtCentreForAdminCategoryId(centreId, categoryId))
+            A.CallTo(() => courseDataService.GetCentrallyManagedAndCentreCourses(centreId, categoryId))
                 .Returns(new List<Course> { new Course { CustomisationId = 1 } });
             A.CallTo(() => courseDelegatesDataService.GetDelegatesOnCourse(A<int>._, A<int>._))
                 .Returns(new List<CourseDelegate> { new CourseDelegate() });
@@ -60,7 +59,7 @@
         public void GetCoursesAndCourseDelegatesForCentre_contains_empty_lists_with_no_courses_in_category()
         {
             // Given
-            A.CallTo(() => courseDataService.GetCoursesAtCentreForAdminCategoryId(2, 7)).Returns(new List<Course>());
+            A.CallTo(() => courseDataService.GetCentrallyManagedAndCentreCourses(2, 7)).Returns(new List<Course>());
 
             // When
             var result = courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(2, 7, null);
@@ -83,7 +82,7 @@
             const int customisationId = 2;
             const int centreId = 2;
             const int categoryId = 1;
-            A.CallTo(() => courseDataService.GetCoursesAtCentreForAdminCategoryId(centreId, categoryId))
+            A.CallTo(() => courseDataService.GetCentrallyManagedAndCentreCourses(centreId, categoryId))
                 .Returns(new List<Course> { new Course { CustomisationId = 1 } });
             A.CallTo(() => courseDelegatesDataService.GetDelegatesOnCourse(A<int>._, A<int>._))
                 .Returns(new List<CourseDelegate> { new CourseDelegate() });

--- a/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
@@ -11,11 +11,13 @@
         IEnumerable<ActivityLog> GetFilteredActivity(
             int centreId,
             DateTime startDate,
-            DateTime endDate,
+            DateTime? endDate,
             int? jobGroupId,
             int? courseCategoryId,
             int? customisationId
         );
+
+        DateTime GetStartOfActivityForCentre(int centreId);
     }
 
     public class ActivityDataService : IActivityDataService
@@ -30,7 +32,7 @@
         public IEnumerable<ActivityLog> GetFilteredActivity(
             int centreId,
             DateTime startDate,
-            DateTime endDate,
+            DateTime? endDate,
             int? jobGroupId,
             int? courseCategoryId,
             int? customisationId
@@ -47,7 +49,7 @@
                         Evaluated
                     FROM tActivityLog
                         WHERE (LogDate >= @startDate
-                            AND LogDate <= @endDate
+                            AND (@endDate IS NULL OR LogDate <= @endDate)
                             AND CentreID = @centreId
                             AND (@jobGroupId IS NULL OR JobGroupID = @jobGroupId)
                             AND (@customisationId IS NULL OR CustomisationID = @customisationId)
@@ -62,6 +64,16 @@
                     customisationId,
                     courseCategoryId
                 }
+            );
+        }
+
+        public DateTime GetStartOfActivityForCentre(int centreId)
+        {
+            return connection.QuerySingleOrDefault<DateTime>(
+                @"SELECT MIN(LogDate)
+                    FROM tActivityLog
+                    WHERE CentreID = @centreId",
+                new { centreId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseNameInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseNameInfo.cs
@@ -2,6 +2,7 @@
 {
     public class CourseNameInfo : BaseSearchableItem
     {
+        public int CustomisationId { get; set; }
         public string CustomisationName { get; set; } = null!;
         public string ApplicationName { get; set; } = null!;
 

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseNameInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseNameInfo.cs
@@ -2,7 +2,6 @@
 {
     public class CourseNameInfo : BaseSearchableItem
     {
-        public int CustomisationId { get; set; }
         public string CustomisationName { get; set; } = null!;
         public string ApplicationName { get; set; } = null!;
 

--- a/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityFilterData.cs
+++ b/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityFilterData.cs
@@ -27,7 +27,7 @@
         public int? CourseCategoryId { get; set; }
         public int? CustomisationId { get; set; }
         public DateTime StartDate { get; set; }
-        public DateTime EndDate { get; set; }
+        public DateTime? EndDate { get; set; }
         public ReportInterval ReportInterval { get; set; }
 
         public static ActivityFilterData GetDefaultFilterData(AdminUser user)

--- a/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityFilterData.cs
+++ b/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityFilterData.cs
@@ -8,7 +8,7 @@
     {
         public ActivityFilterData(
             DateTime startDate,
-            DateTime endDate,
+            DateTime? endDate,
             int? jobGroupId,
             int? courseCategoryId,
             int? customisationId,
@@ -36,7 +36,7 @@
 
             return new ActivityFilterData(
                 DateTime.UtcNow.Date.AddYears(-1),
-                DateTime.UtcNow,
+                null,
                 null,
                 categoryIdFilter,
                 null,

--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -54,7 +54,7 @@
 
             var dateSlots = DateHelper.GetPeriodsBetweenDates(
                 filterData.StartDate,
-                filterData.EndDate,
+                filterData.EndDate ?? DateTime.UtcNow,
                 filterData.ReportInterval
             );
 

--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -91,7 +91,7 @@
                 .GetCategoriesForCentreAndCentrallyManagedCourses(centreId)
                 .Select(cc => (cc.CourseCategoryID, cc.CategoryName));
             var courses = courseDataService
-                .GetCoursesAtCentreForCategoryId(centreId, courseCategoryId)
+                .GetCentrallyManagedAndCentreCourses(centreId, courseCategoryId)
                 .OrderBy(c => c.CourseName)
                 .Select(c => (c.CustomisationId, c.CourseName));
 

--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -83,7 +83,8 @@
                 GetCourseNameForActivityFilter(filterData.CustomisationId));
         }
 
-        public (IEnumerable<(int id, string name)> jobGroups, IEnumerable<(int id, string name)> categories,
+        public (IEnumerable<(int id, string name)> jobGroups,
+            IEnumerable<(int id, string name)> categories,
             IEnumerable<(int id, string name)> courses) GetFilterOptions(int centreId, int? courseCategoryId)
         {
             var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();

--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -15,6 +15,10 @@
         (string jobGroupName, string courseCategoryName, string courseName) GetFilterNames(
             ActivityFilterData filterData
         );
+
+        (IEnumerable<(int id, string name)> jobGroups, IEnumerable<(int id, string name)> categories,
+            IEnumerable<(int id, string name)>
+            courses) GetFilterOptions(int centreId, int? courseCategoryId);
     }
 
     public class ActivityService : IActivityService
@@ -77,6 +81,21 @@
             return (GetJobGroupNameForActivityFilter(filterData.JobGroupId),
                 GetCourseCategoryNameForActivityFilter(filterData.CourseCategoryId),
                 GetCourseNameForActivityFilter(filterData.CustomisationId));
+        }
+
+        public (IEnumerable<(int id, string name)> jobGroups, IEnumerable<(int id, string name)> categories,
+            IEnumerable<(int id, string name)> courses) GetFilterOptions(int centreId, int? courseCategoryId)
+        {
+            var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
+            var courseCategories = courseCategoriesDataService
+                .GetCategoriesForCentreAndCentrallyManagedCourses(centreId)
+                .Select(cc => (cc.CourseCategoryID, cc.CategoryName));
+            var courses = courseDataService
+                .GetCoursesAtCentreForCategoryId(centreId, courseCategoryId)
+                .OrderBy(c => c.CourseName)
+                .Select(c => (c.CustomisationId, c.CourseName));
+
+            return (jobGroups, courseCategories, courses);
         }
 
         private string GetJobGroupNameForActivityFilter(int? jobGroupId)

--- a/DigitalLearningSolutions.Data/Services/CourseDelegatesService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseDelegatesService.cs
@@ -9,7 +9,7 @@
     {
         CourseDelegatesData GetCoursesAndCourseDelegatesForCentre(
             int centreId,
-            int categoryId,
+            int? categoryId,
             int? customisationId
         );
     }
@@ -30,11 +30,11 @@
 
         public CourseDelegatesData GetCoursesAndCourseDelegatesForCentre(
             int centreId,
-            int categoryId,
+            int? categoryId,
             int? customisationId
         )
         {
-            var courses = courseDataService.GetCoursesAtCentreForAdminCategoryId(centreId, categoryId).ToList();
+            var courses = courseDataService.GetCentrallyManagedAndCentreCourses(centreId, categoryId).ToList();
             var activeCoursesAlphabetical = courses.Where(c => c.Active).OrderBy(c => c.CourseName);
             var inactiveCoursesAlphabetical =
                 courses.Where(c => !c.Active).OrderBy(c => c.CourseName);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
@@ -24,7 +24,9 @@
         public IActionResult Index(int? customisationId = null)
         {
             var centreId = User.GetCentreId();
-            var categoryId = User.GetAdminCategoryId()!.Value;
+            int? categoryId = User.GetAdminCategoryId()!.Value;
+            // admins have a non-nullable category ID where 0 = all categories
+            categoryId = categoryId == 0 ? null : categoryId;
             var courseDelegatesData =
                 courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(centreId, categoryId, customisationId);
 

--- a/DigitalLearningSolutions.Web/Helpers/SelectListHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SelectListHelper.cs
@@ -1,10 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using DigitalLearningSolutions.Data.Enums;
-    using DigitalLearningSolutions.Web.Models.Enums;
     using Microsoft.AspNetCore.Mvc.Rendering;
 
     public static class SelectListHelper

--- a/DigitalLearningSolutions.Web/Styles/shared/components/dateRange.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/components/dateRange.scss
@@ -1,0 +1,11 @@
+﻿@import "~nhsuk-frontend/packages/core/all";
+
+.flex-container {
+  @include mq($from: tablet) {
+    display: flex;
+  }
+}
+
+.conjunction {
+    align-self: flex-end;
+}

--- a/DigitalLearningSolutions.Web/Styles/shared/components/dateRange.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/components/dateRange.scss
@@ -6,6 +6,17 @@
   }
 }
 
+.inner-flex-container {
+  display: inline-flex;
+  white-space: nowrap;
+}
+
 .conjunction {
-    align-self: flex-end;
+  align-self: flex-end;
+  justify-content: flex-end;
+
+  @include mq($until: tablet) {
+    display: flex;
+    min-width: nhsuk-spacing(7)
+  }
 }

--- a/DigitalLearningSolutions.Web/ViewComponents/DateRangeInputViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/DateRangeInputViewComponent.cs
@@ -1,0 +1,113 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class DateRangeInputViewComponent : ViewComponent
+    {
+        /// <summary>
+        ///     Render DateInput view component.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="label"></param>
+        /// <param name="startDayId"></param>
+        /// <param name="startMonthId"></param>
+        /// <param name="startYearId"></param>
+        /// <param name="endDayId"></param>
+        /// <param name="endMonthId"></param>
+        /// <param name="endYearId"></param>
+        /// <param name="endDateCheckboxId"></param>
+        /// <param name="endDateCheckboxLabel"></param>
+        /// <param name="cssClass">Leave blank for no custom css class.</param>
+        /// <param name="hintText">Leave blank for no hint.</param>
+        /// <param name="endDateCheckboxHintText">Leave blank for no hint.</param>
+        /// <returns></returns>
+        public IViewComponentResult Invoke(
+            string id,
+            string label,
+            string startDayId,
+            string startMonthId,
+            string startYearId,
+            string endDayId,
+            string endMonthId,
+            string endYearId,
+            string endDateCheckboxId,
+            string endDateCheckboxLabel,
+            string cssClass,
+            string hintText,
+            string endDateCheckboxHintText
+        )
+        {
+            var model = ViewData.Model;
+
+            var startDayProperty = model.GetType().GetProperty(startDayId);
+            var startMonthProperty = model.GetType().GetProperty(startMonthId);
+            var startYearProperty = model.GetType().GetProperty(startYearId);
+            var startDayValue = startDayProperty?.GetValue(model)?.ToString();
+            var startMonthValue = startMonthProperty?.GetValue(model)?.ToString();
+            var startYearValue = startYearProperty?.GetValue(model)?.ToString();
+            var startDayErrors = ViewData.ModelState[startDayProperty?.Name]?.Errors;
+            var startMonthErrors = ViewData.ModelState[startMonthProperty?.Name]?.Errors;
+            var startYearErrors = ViewData.ModelState[startYearProperty?.Name]?.Errors;
+
+            var endDayProperty = model.GetType().GetProperty(endDayId);
+            var endMonthProperty = model.GetType().GetProperty(endMonthId);
+            var endYearProperty = model.GetType().GetProperty(endYearId);
+            var endDayValue = endDayProperty?.GetValue(model)?.ToString();
+            var endMonthValue = endMonthProperty?.GetValue(model)?.ToString();
+            var endYearValue = endYearProperty?.GetValue(model)?.ToString();
+            var endDayErrors = ViewData.ModelState[startDayProperty?.Name]?.Errors;
+            var endMonthErrors = ViewData.ModelState[startMonthProperty?.Name]?.Errors;
+            var endYearErrors = ViewData.ModelState[startYearProperty?.Name]?.Errors;
+
+            var checkboxProperty = model.GetType().GetProperty(endDateCheckboxId);
+            var checkboxValue = (bool)checkboxProperty?.GetValue(model)!;
+            var checkboxErrors = ViewData.ModelState[checkboxProperty?.Name]?.Errors;
+
+            var errorMessage = checkboxErrors?.Count > 0 ? checkboxErrors[0].ErrorMessage :
+                startDayErrors?.Count > 0 ? startDayErrors[0].ErrorMessage :
+                startMonthErrors?.Count > 0 ? startMonthErrors[0].ErrorMessage :
+                startYearErrors?.Count > 0 ? startYearErrors[0].ErrorMessage :
+                endDayErrors?.Count > 0 ? endDayErrors[0].ErrorMessage :
+                endMonthErrors?.Count > 0 ? endMonthErrors[0].ErrorMessage :
+                endYearErrors?.Count > 0 ? endYearErrors[0].ErrorMessage : null;
+
+            var checkboxViewModel = new CheckboxesItemViewModel(
+                endDateCheckboxId,
+                endDateCheckboxId,
+                endDateCheckboxLabel,
+                checkboxValue,
+                endDateCheckboxHintText
+                );
+
+            var viewModel = new DateRangeInputViewModel(
+                id,
+                label,
+                startDayId,
+                startMonthId,
+                startYearId,
+                endDayId,
+                endMonthId,
+                endYearId,
+                startDayValue,
+                startMonthValue,
+                startYearValue,
+                endDayValue,
+                endMonthValue,
+                endYearValue,
+                startDayErrors?.Count > 0,
+                startMonthErrors?.Count > 0,
+                startYearErrors?.Count > 0,
+                endDayErrors?.Count > 0,
+                endMonthErrors?.Count > 0,
+                endYearErrors?.Count > 0,
+                checkboxViewModel,
+                checkboxErrors?.Count > 0,
+                errorMessage,
+                string.IsNullOrEmpty(cssClass) ? null : cssClass,
+                string.IsNullOrEmpty(hintText) ? null : hintText
+            );
+            return View(viewModel);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewComponents/SelectListViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/SelectListViewComponent.cs
@@ -25,7 +25,7 @@
             var hasError = ViewData.ModelState[property?.Name]?.Errors?.Count > 0;
             var errorMessage = hasError ? ViewData.ModelState[property?.Name]?.Errors[0].ErrorMessage : null;
 
-            var textBoxViewModel = new SelectListViewModel(
+            var selectListViewModel = new SelectListViewModel(
                 aspFor,
                 aspFor,
                 label,
@@ -37,7 +37,7 @@
                 errorMessage,
                 hasError,
                 deselectable ?? false);
-            return View(textBoxViewModel);
+            return View(selectListViewModel);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DateRangeInputViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DateRangeInputViewModel.cs
@@ -31,7 +31,7 @@
             bool hasEndDayError,
             bool hasEndMonthError,
             bool hasEndYearError,
-            CheckboxesItemViewModel endDateCheckboxViewModel,
+            CheckboxesItemViewModel? endDateCheckboxViewModel,
             bool hasCheckboxError,
             string? errorMessage,
             string? cssClass = null,

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DateRangeInputViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DateRangeInputViewModel.cs
@@ -1,0 +1,92 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+{
+    public class DateRangeInputViewModel
+    {
+        public readonly bool HasEndDayError;
+        public readonly bool HasEndMonthError;
+        public readonly bool HasEndYearError;
+        public readonly bool HasStartDayError;
+        public readonly bool HasStartMonthError;
+        public readonly bool HasStartYearError;
+        public readonly bool HasCheckboxError;
+
+        public DateRangeInputViewModel(
+            string id,
+            string label,
+            string startDayId,
+            string startMonthId,
+            string startYearId,
+            string endDayId,
+            string endMonthId,
+            string endYearId,
+            string? startDayValue,
+            string? startMonthValue,
+            string? startYearValue,
+            string? endDayValue,
+            string? endMonthValue,
+            string? endYearValue,
+            bool hasStartDayError,
+            bool hasStartMonthError,
+            bool hasStartYearError,
+            bool hasEndDayError,
+            bool hasEndMonthError,
+            bool hasEndYearError,
+            CheckboxesItemViewModel endDateCheckboxViewModel,
+            bool hasCheckboxError,
+            string? errorMessage,
+            string? cssClass = null,
+            string? hintText = null
+        )
+        {
+            Id = id;
+            Label = label;
+            StartDayId = startDayId;
+            StartMonthId = startMonthId;
+            StartYearId = startYearId;
+            EndDayId = endDayId;
+            EndMonthId = endMonthId;
+            EndYearId = endYearId;
+            StartDayValue = startDayValue;
+            StartMonthValue = startMonthValue;
+            StartYearValue = startYearValue;
+            EndDayValue = endDayValue;
+            EndMonthValue = endMonthValue;
+            EndYearValue = endYearValue;
+            HasStartDayError = hasStartDayError;
+            HasStartMonthError = hasStartMonthError;
+            HasStartYearError = hasStartYearError;
+            HasEndDayError = hasEndDayError;
+            HasEndMonthError = hasEndMonthError;
+            HasEndYearError = hasEndYearError;
+            EndDateCheckbox = endDateCheckboxViewModel;
+            HasCheckboxError = hasCheckboxError;
+            CssClass = cssClass;
+            HintText = hintText;
+            ErrorMessage = errorMessage;
+        }
+
+        public string Id { get; set; }
+        public string Label { get; set; }
+        public string StartDayId { get; set; }
+        public string StartMonthId { get; set; }
+        public string StartYearId { get; set; }
+        public string EndDayId { get; set; }
+        public string EndMonthId { get; set; }
+        public string EndYearId { get; set; }
+        public string? StartDayValue { get; set; }
+        public string? StartMonthValue { get; set; }
+        public string? StartYearValue { get; set; }
+        public string? EndDayValue { get; set; }
+        public string? EndMonthValue { get; set; }
+        public string? EndYearValue { get; set; }
+        public string? CssClass { get; set; }
+        public string? HintText { get; set; }
+
+        public CheckboxesItemViewModel? EndDateCheckbox { get; set; }
+
+        public bool HasError => HasStartDayError || HasStartMonthError || HasStartYearError || HasEndDayError ||
+                                HasEndMonthError || HasEndYearError;
+
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
@@ -1,0 +1,66 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Reports
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Models.TrackingSystem;
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+
+    public class EditFiltersViewModel
+    {
+        public EditFiltersViewModel(
+            ActivityFilterData filterData,
+            int userCategoryId,
+            IEnumerable<(int, string)> jobGroupOptions,
+            IEnumerable<(int, string)> courseCategoryOptions,
+            IEnumerable<(int, string)> courseOptions,
+            DateTime dataStartDate
+        )
+        {
+            JobGroupId = filterData.JobGroupId;
+            CourseCategoryId = filterData.CourseCategoryId;
+            CustomisationId = filterData.CustomisationId;
+            StartDay = filterData.StartDate.Day;
+            StartMonth = filterData.StartDate.Month;
+            StartYear = filterData.StartDate.Year;
+            EndDay = filterData.EndDate?.Day;
+            EndMonth = filterData.EndDate?.Month;
+            EndYear = filterData.EndDate?.Year;
+            NoEndDate = !filterData.EndDate.HasValue;
+            ReportInterval = filterData.ReportInterval;
+            CanFilterCourseCategories = userCategoryId == 0;
+
+            DataStart = dataStartDate;
+
+            JobGroupOptions = SelectListHelper.MapOptionsToSelectListItems(jobGroupOptions, JobGroupId);
+            CourseCategoryOptions = SelectListHelper.MapOptionsToSelectListItems(courseCategoryOptions, CourseCategoryId);
+            CustomisationOptions = SelectListHelper.MapOptionsToSelectListItems(courseOptions, CustomisationId);
+            var reportIntervals =
+                ((int[])Enum.GetValues(typeof(ReportInterval))).Select(
+                    i => (i, Enum.GetName(typeof(ReportInterval), i))
+                );
+            ReportIntervalOptions = SelectListHelper.MapOptionsToSelectListItems(reportIntervals!, (int)ReportInterval);
+        }
+
+        public int? JobGroupId { get; set; }
+        public int? CourseCategoryId { get; set; }
+        public int? CustomisationId { get; set; }
+        public int? StartDay { get; set; }
+        public int? StartMonth { get; set; }
+        public int? StartYear { get; set; }
+        public int? EndDay { get; set; }
+        public int? EndMonth { get; set; }
+        public int? EndYear { get; set; }
+        public bool NoEndDate { get; set; }
+        public ReportInterval ReportInterval { get; set; }
+        public DateTime DataStart { get; set; }
+        public bool CanFilterCourseCategories { get; set; }
+
+        public IEnumerable<SelectListItem> JobGroupOptions { get; set; }
+        public IEnumerable<SelectListItem> CourseCategoryOptions { get; set; }
+        public IEnumerable<SelectListItem> CustomisationOptions { get; set; }
+        public IEnumerable<SelectListItem> ReportIntervalOptions { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
@@ -37,10 +37,9 @@
             JobGroupOptions = SelectListHelper.MapOptionsToSelectListItems(jobGroupOptions, JobGroupId);
             CourseCategoryOptions = SelectListHelper.MapOptionsToSelectListItems(courseCategoryOptions, CourseCategoryId);
             CustomisationOptions = SelectListHelper.MapOptionsToSelectListItems(courseOptions, CustomisationId);
-            var reportIntervals =
-                ((int[])Enum.GetValues(typeof(ReportInterval))).Select(
-                    i => (i, Enum.GetName(typeof(ReportInterval), i))
-                );
+            var reportIntervals = Enum.GetValues(typeof(ReportInterval))
+                .Cast<int>()
+                .Select(i => (i, Enum.GetName(typeof(ReportInterval), i)));
             ReportIntervalOptions = SelectListHelper.MapOptionsToSelectListItems(reportIntervals!, (int)ReportInterval);
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/ReportsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/ReportsViewModel.cs
@@ -62,7 +62,7 @@
             CourseName = courseNameString;
             ReportIntervalName = Enum.GetName(typeof(ReportInterval), filterData.ReportInterval)!;
             DateRange =
-                $"{filterData.StartDate.ToString(DateHelper.StandardDateFormat)} - {filterData.EndDate.ToString(DateHelper.StandardDateFormat)}";
+                $"{filterData.StartDate.ToString(DateHelper.StandardDateFormat)} - {filterData.EndDate?.ToString(DateHelper.StandardDateFormat) ?? "Today"}";
             ShowCourseCategoryFilter = userManagingAllCourses;
         }
 

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
@@ -1,0 +1,142 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@model DateRangeInputViewModel
+
+@{
+  var errorCss = Model.HasError ? "nhsuk-form-group--error" : "";
+  var startDayErrorCss = Model.HasStartDayError ? "nhsuk-input--error" : "";
+  var startMonthErrorCss = Model.HasStartMonthError ? "nhsuk-input--error" : "";
+  var startYearErrorCss = Model.HasStartYearError ? "nhsuk-input--error" : "";
+  var endDayErrorCss = Model.HasEndDayError ? "nhsuk-input--error" : "";
+  var endMonthErrorCss = Model.HasEndMonthError ? "nhsuk-input--error" : "";
+  var endYearErrorCss = Model.HasEndYearError ? "nhsuk-input--error" : "";
+}
+
+<link rel="stylesheet" href="@Url.Content("~/css/shared/components/dateRange.css")">
+
+<div class="@Model.CssClass @errorCss" id="@Model.Id">
+  <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Id-hint" role="group">
+    <legend class="nhsuk-fieldset__legend nhsuk-label">
+      @Model.Label
+    </legend>
+    @if (Model.HintText != null)
+    {
+      <div class="nhsuk-hint" id="@Model.Id-hint">
+        @Model.HintText
+      </div>
+    }
+
+    @if (Model.HasError)
+    {
+      <span class="error-message--margin-bottom-1 nhsuk-error-message">
+        <span class="nhsuk-u-visually-hidden">Error:</span> @Model.ErrorMessage
+      </span>
+    }
+
+    @if (Model.EndDateCheckbox != null) {
+      <div class="nhsuk-checkboxes">
+        <div class="nhsuk-checkboxes__item">
+          <input class="nhsuk-checkboxes__input"
+                 type="checkbox"
+                 id="@Model.EndDateCheckbox.Id"
+                 name="@Model.EndDateCheckbox.Name"
+                 aria-describedby="@Model.EndDateCheckbox.Id-item-hint"
+                 value="true"
+                 @(Model.EndDateCheckbox.Value ? "checked" : string.Empty) />
+          <label class="nhsuk-label nhsuk-checkboxes__label" for="@Model.EndDateCheckbox.Id">
+            @Model.EndDateCheckbox.Label
+          </label>
+          @if (Model.EndDateCheckbox.HintText != null)
+          {
+            <div class="nhsuk-hint nhsuk-checkboxes__hint" id="@Model.EndDateCheckbox.Id-item-hint">
+              @Model.EndDateCheckbox.HintText
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+    <div class="flex-container">
+      <div class="nhsuk-date-input">
+        <div class="nhsuk-date-input__item">
+          <div class="nhsuk-form-group">
+            <label class="nhsuk-label" for="@Model.StartDayId">Day</label>
+            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @startDayErrorCss"
+                   id="@Model.StartDayId"
+                   name="@Model.StartDayId"
+                   value="@Model.StartDayValue"
+                   type="text"
+                   pattern="[0-9]*"
+                   inputmode="numeric" />
+          </div>
+        </div>
+        <div class="nhsuk-date-input__item">
+          <div class="nhsuk-form-group">
+            <label class="nhsuk-label" for="@Model.StartMonthId">Month</label>
+            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @startMonthErrorCss"
+                   id="@Model.StartMonthId"
+                   name="@Model.StartMonthId"
+                   value="@Model.StartMonthValue"
+                   type="text"
+                   pattern="[0-9]*"
+                   inputmode="numeric" />
+          </div>
+        </div>
+        <div class="nhsuk-date-input__item">
+          <div class="nhsuk-form-group">
+            <label class="nhsuk-label" for="@Model.StartYearId">Year</label>
+            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @startYearErrorCss"
+                   id="@Model.StartYearId"
+                   name="@Model.StartYearId"
+                   value="@Model.StartYearValue"
+                   type="text"
+                   pattern="[0-9]*"
+                   inputmode="numeric" />
+          </div>
+        </div>
+      </div>
+
+      <div class="flex-container">
+        <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">to</div>
+      </div>
+
+      <div class="nhsuk-date-input">
+        <div class="nhsuk-date-input__item">
+          <div class="nhsuk-form-group">
+            <label class="nhsuk-label" for="@Model.EndDayId">Day</label>
+            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @endDayErrorCss"
+                   id="@Model.EndDayId"
+                   name="@Model.EndDayId"
+                   value="@Model.EndDayValue"
+                   type="text"
+                   pattern="[0-9]*"
+                   inputmode="numeric" />
+          </div>
+        </div>
+        <div class="nhsuk-date-input__item">
+          <div class="nhsuk-form-group">
+            <label class="nhsuk-label" for="@Model.EndMonthId">Month</label>
+            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @endMonthErrorCss"
+                   id="@Model.EndMonthId"
+                   name="@Model.EndMonthId"
+                   value="@Model.EndMonthValue"
+                   type="text"
+                   pattern="[0-9]*"
+                   inputmode="numeric" />
+          </div>
+        </div>
+        <div class="nhsuk-date-input__item">
+          <div class="nhsuk-form-group">
+            <label class="nhsuk-label" for="@Model.EndYearId">Year</label>
+            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @endYearErrorCss"
+                   id="@Model.EndYearId"
+                   name="@Model.EndYearId"
+                   value="@Model.EndYearValue"
+                   type="text"
+                   pattern="[0-9]*"
+                   inputmode="numeric" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
@@ -33,7 +33,7 @@
     }
 
     @if (Model.EndDateCheckbox != null) {
-      <div class="nhsuk-checkboxes">
+      <div class="nhsuk-checkboxes nhsuk-checkboxes--conditional">
         <div class="nhsuk-checkboxes__item">
           <input class="nhsuk-checkboxes__input"
                  type="checkbox"
@@ -41,6 +41,8 @@
                  name="@Model.EndDateCheckbox.Name"
                  aria-describedby="@Model.EndDateCheckbox.Id-item-hint"
                  value="true"
+                 aria-controls="conditional-end-date-1"
+                 aria-expanded="false"
                  @(Model.EndDateCheckbox.Value ? "checked" : string.Empty) />
           <label class="nhsuk-label nhsuk-checkboxes__label" for="@Model.EndDateCheckbox.Id">
             @Model.EndDateCheckbox.Label
@@ -95,11 +97,11 @@
         </div>
       </div>
 
-      <div class="flex-container">
+      <div class="flex-container nhsuk-checkboxes__conditional--hidden" id="conditional-end-date-1">
         <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">to</div>
       </div>
 
-      <div class="nhsuk-date-input">
+      <div class="nhsuk-date-input nhsuk-checkboxes__conditional--hidden" id="conditional-end-date-2">
         <div class="nhsuk-date-input__item">
           <div class="nhsuk-form-group">
             <label class="nhsuk-label" for="@Model.EndDayId">Day</label>

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
@@ -9,6 +9,8 @@
   var endDayErrorCss = Model.HasEndDayError ? "nhsuk-input--error" : "";
   var endMonthErrorCss = Model.HasEndMonthError ? "nhsuk-input--error" : "";
   var endYearErrorCss = Model.HasEndYearError ? "nhsuk-input--error" : "";
+
+  var hideEndDateOnLoad = Model.EndDateCheckbox != null && Model.EndDateCheckbox.Value;
 }
 
 <link rel="stylesheet" href="@Url.Content("~/css/shared/components/dateRange.css")">
@@ -58,53 +60,50 @@
     }
 
     <div class="flex-container">
-      <div class="flex-container">
+      <div class="inner-flex-container">
         <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">from</div>
-      </div>
-      <div class="nhsuk-date-input">
-        <div class="nhsuk-date-input__item">
-          <div class="nhsuk-form-group">
-            <label class="nhsuk-label" for="@Model.StartDayId">Day</label>
-            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @startDayErrorCss"
-                   id="@Model.StartDayId"
-                   name="@Model.StartDayId"
-                   value="@Model.StartDayValue"
-                   type="text"
-                   pattern="[0-9]*"
-                   inputmode="numeric" />
+        <div class="nhsuk-date-input">
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label" for="@Model.StartDayId">Day</label>
+              <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @startDayErrorCss"
+                     id="@Model.StartDayId"
+                     name="@Model.StartDayId"
+                     value="@Model.StartDayValue"
+                     type="text"
+                     pattern="[0-9]*"
+                     inputmode="numeric" />
+            </div>
           </div>
-        </div>
-        <div class="nhsuk-date-input__item">
-          <div class="nhsuk-form-group">
-            <label class="nhsuk-label" for="@Model.StartMonthId">Month</label>
-            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @startMonthErrorCss"
-                   id="@Model.StartMonthId"
-                   name="@Model.StartMonthId"
-                   value="@Model.StartMonthValue"
-                   type="text"
-                   pattern="[0-9]*"
-                   inputmode="numeric" />
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label" for="@Model.StartMonthId">Month</label>
+              <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @startMonthErrorCss"
+                     id="@Model.StartMonthId"
+                     name="@Model.StartMonthId"
+                     value="@Model.StartMonthValue"
+                     type="text"
+                     pattern="[0-9]*"
+                     inputmode="numeric" />
+            </div>
           </div>
-        </div>
-        <div class="nhsuk-date-input__item">
-          <div class="nhsuk-form-group">
-            <label class="nhsuk-label" for="@Model.StartYearId">Year</label>
-            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @startYearErrorCss"
-                   id="@Model.StartYearId"
-                   name="@Model.StartYearId"
-                   value="@Model.StartYearValue"
-                   type="text"
-                   pattern="[0-9]*"
-                   inputmode="numeric" />
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label" for="@Model.StartYearId">Year</label>
+              <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @startYearErrorCss"
+                     id="@Model.StartYearId"
+                     name="@Model.StartYearId"
+                     value="@Model.StartYearValue"
+                     type="text"
+                     pattern="[0-9]*"
+                     inputmode="numeric" />
+            </div>
           </div>
         </div>
       </div>
 
-      <div class="flex-container nhsuk-checkboxes__conditional--hidden" id="conditional-end-date">
-        <div class="flex-container">
-          <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">to</div>
-        </div>
-
+      <div class="inner-flex-container @(hideEndDateOnLoad ? "nhsuk-checkboxes__conditional--hidden" : "")" id="conditional-end-date">
+        <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">to</div>
         <div class="nhsuk-date-input">
           <div class="nhsuk-date-input__item">
             <div class="nhsuk-form-group">

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
@@ -41,7 +41,7 @@
                  name="@Model.EndDateCheckbox.Name"
                  aria-describedby="@Model.EndDateCheckbox.Id-item-hint"
                  value="true"
-                 aria-controls="conditional-end-date-1"
+                 aria-controls="conditional-end-date"
                  aria-expanded="false"
                  @(Model.EndDateCheckbox.Value ? "checked" : string.Empty) />
           <label class="nhsuk-label nhsuk-checkboxes__label" for="@Model.EndDateCheckbox.Id">
@@ -97,45 +97,47 @@
         </div>
       </div>
 
-      <div class="flex-container nhsuk-checkboxes__conditional--hidden" id="conditional-end-date-1">
-        <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">to</div>
-      </div>
+      <div class="flex-container nhsuk-checkboxes__conditional--hidden" id="conditional-end-date">
+        <div class="flex-container">
+          <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">to</div>
+        </div>
 
-      <div class="nhsuk-date-input nhsuk-checkboxes__conditional--hidden" id="conditional-end-date-2">
-        <div class="nhsuk-date-input__item">
-          <div class="nhsuk-form-group">
-            <label class="nhsuk-label" for="@Model.EndDayId">Day</label>
-            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @endDayErrorCss"
-                   id="@Model.EndDayId"
-                   name="@Model.EndDayId"
-                   value="@Model.EndDayValue"
-                   type="text"
-                   pattern="[0-9]*"
-                   inputmode="numeric" />
+        <div class="nhsuk-date-input">
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label" for="@Model.EndDayId">Day</label>
+              <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @endDayErrorCss"
+                     id="@Model.EndDayId"
+                     name="@Model.EndDayId"
+                     value="@Model.EndDayValue"
+                     type="text"
+                     pattern="[0-9]*"
+                     inputmode="numeric" />
+            </div>
           </div>
-        </div>
-        <div class="nhsuk-date-input__item">
-          <div class="nhsuk-form-group">
-            <label class="nhsuk-label" for="@Model.EndMonthId">Month</label>
-            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @endMonthErrorCss"
-                   id="@Model.EndMonthId"
-                   name="@Model.EndMonthId"
-                   value="@Model.EndMonthValue"
-                   type="text"
-                   pattern="[0-9]*"
-                   inputmode="numeric" />
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label" for="@Model.EndMonthId">Month</label>
+              <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @endMonthErrorCss"
+                     id="@Model.EndMonthId"
+                     name="@Model.EndMonthId"
+                     value="@Model.EndMonthValue"
+                     type="text"
+                     pattern="[0-9]*"
+                     inputmode="numeric" />
+            </div>
           </div>
-        </div>
-        <div class="nhsuk-date-input__item">
-          <div class="nhsuk-form-group">
-            <label class="nhsuk-label" for="@Model.EndYearId">Year</label>
-            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @endYearErrorCss"
-                   id="@Model.EndYearId"
-                   name="@Model.EndYearId"
-                   value="@Model.EndYearValue"
-                   type="text"
-                   pattern="[0-9]*"
-                   inputmode="numeric" />
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label" for="@Model.EndYearId">Year</label>
+              <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-3 @endYearErrorCss"
+                     id="@Model.EndYearId"
+                     name="@Model.EndYearId"
+                     value="@Model.EndYearValue"
+                     type="text"
+                     pattern="[0-9]*"
+                     inputmode="numeric" />
+            </div>
           </div>
         </div>
       </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DateRangeInput/Default.cshtml
@@ -1,4 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
 @model DateRangeInputViewModel
 
 @{
@@ -58,6 +58,9 @@
     }
 
     <div class="flex-container">
+      <div class="flex-container">
+        <div class="nhsuk-hint conjunction nhsuk-u-margin-bottom-4 nhsuk-u-margin-right-4">from</div>
+      </div>
       <div class="nhsuk-date-input">
         <div class="nhsuk-date-input__item">
           <div class="nhsuk-form-group">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
@@ -1,5 +1,5 @@
 ﻿@inject IConfiguration Configuration
-@using DigitalLearningSolutions.Data.Helpers
+@using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Reports
 @using Microsoft.Extensions.Configuration
 @model EditFiltersViewModel
@@ -45,12 +45,12 @@
 
             <div class="nhsuk-radios nhsuk-radios--conditional">
               <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="course-filter-type-1" name="course-filter-type" type="radio" value="course" aria-controls="course-filter-type-1" aria-expanded="false">
+                <input class="nhsuk-radios__input" id="course-filter-type-1" name="course-filter-type" type="radio" value="course" aria-controls="conditional-course-filter-type-1" aria-expanded="false">
                 <label class="nhsuk-label nhsuk-radios__label" for="course-filter-type-1">
                   Course
                 </label>
               </div>
-              <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-contact-2">
+              <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-course-filter-type-1">
 
                 <vc:select-list asp-for="CustomisationId"
                                 label="Choose a course"
@@ -64,12 +64,12 @@
               </div>
 
               <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="course-filter-type-2" name="course-filter-type" type="radio" value="course category" aria-controls="course-filter-type-2" aria-expanded="false">
+                <input class="nhsuk-radios__input" id="course-filter-type-2" name="course-filter-type" type="radio" value="course category" aria-controls="conditional-course-filter-type-2" aria-expanded="false">
                 <label class="nhsuk-label nhsuk-radios__label" for="course-filter-type-2">
                   Course category
                 </label>
               </div>
-              <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-contact-1">
+              <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-course-filter-type-2">
                 <vc:select-list asp-for="CourseCategoryId"
                                 label="Choose course category from the list below"
                                 value="@Model.CourseCategoryId.ToString()"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
@@ -1,0 +1,123 @@
+﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Data.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Reports
+@using Microsoft.Extensions.Configuration
+@model EditFiltersViewModel
+
+@{
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+  ViewData["Title"] = "Edit report filters";
+  ViewData["Application"] = "Tracking System";
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
+  ViewData["HeaderPathName"] = "Tracking System";
+  var reportIntervalValue = (int)Model.ReportInterval;
+}
+
+@section NavMenuItems {
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
+}
+
+<link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/reports.css")">
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.JobGroupId), nameof(Model.CourseCategoryId), nameof(Model.CustomisationId), nameof(Model.StartDay), nameof(Model.StartMonth), nameof(Model.StartYear), nameof(Model.EndDay), nameof(Model.EndMonth), nameof(Model.EndYear), nameof(Model.ReportInterval) })" />
+    }
+    <h1 id="page-heading" class="nhsuk-heading-xl">Edit report filters</h1>
+    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditFilters">
+
+      <vc:select-list asp-for="JobGroupId"
+                      label="Choose job group filter"
+                      value="@Model.JobGroupId.ToString()"
+                      hint-text=""
+                      deselectable="false"
+                      css-class="nhsuk-u-width-one-half"
+                      default-option="All"
+                      select-list-options="@Model.JobGroupOptions" />
+
+      @if (Model.CanFilterCourseCategories) {
+        <div class="nhsuk-form-group">
+          <fieldset class="nhsuk-fieldset" aria-describedby="contact-hint">
+            <div class="nhsuk-hint" id="contact-hint">
+              Choose whether to filter based on course or course category
+            </div>
+
+            <div class="nhsuk-radios nhsuk-radios--conditional">
+              <div class="nhsuk-radios__item">
+                <input class="nhsuk-radios__input" id="course-filter-type-1" name="course-filter-type" type="radio" value="course" aria-controls="course-filter-type-1" aria-expanded="false">
+                <label class="nhsuk-label nhsuk-radios__label" for="course-filter-type-1">
+                  Course
+                </label>
+              </div>
+              <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-contact-2">
+
+                <vc:select-list asp-for="CustomisationId"
+                                label="Choose a course"
+                                value="@Model.CustomisationId.ToString()"
+                                hint-text=""
+                                deselectable="false"
+                                css-class="nhsuk-u-width-one-half"
+                                default-option="All"
+                                select-list-options="@Model.CustomisationOptions" />
+
+              </div>
+
+              <div class="nhsuk-radios__item">
+                <input class="nhsuk-radios__input" id="course-filter-type-2" name="course-filter-type" type="radio" value="course category" aria-controls="course-filter-type-2" aria-expanded="false">
+                <label class="nhsuk-label nhsuk-radios__label" for="course-filter-type-2">
+                  Course category
+                </label>
+              </div>
+              <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-contact-1">
+                <vc:select-list asp-for="CourseCategoryId"
+                                label="Choose course category from the list below"
+                                value="@Model.CourseCategoryId.ToString()"
+                                hint-text=""
+                                deselectable="false"
+                                css-class="nhsuk-u-width-one-half"
+                                default-option="All"
+                                select-list-options="@Model.CourseCategoryOptions" />
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      } else {
+        <vc:select-list asp-for="CustomisationId"
+                        label="Choose a course filter"
+                        value="@Model.CustomisationId.ToString()"
+                        hint-text=""
+                        deselectable="false"
+                        css-class="nhsuk-u-width-one-half"
+                        default-option="All"
+                        select-list-options="@Model.CustomisationOptions" />
+      }
+
+      <vc:date-range-input id="date-range"
+                           label="Reporting date range"
+                           start-day-id="StartDay"
+                           start-month-id="StartMonth"
+                           start-year-id="StartYear"
+                           end-day-id="EndDay"
+                           end-month-id="EndMonth"
+                           end-year-id="EndYear"
+                           end-date-checkbox-id="NoEndDate"
+                           end-date-checkbox-label="No end date"
+                           css-class="date-range-css"
+                           hint-text="The reporting in your centre starts on @Model.DataStart.ToString(DateHelper.StandardDateFormat). Please select any date range between that date and now."
+                           end-date-checkbox-hint-text="Check this box to include all data between the start date and now."/>
+
+      <vc:select-list asp-for="ReportInterval"
+                      label="Report by"
+                      value="@reportIntervalValue.ToString()"
+                      hint-text=""
+                      deselectable="false"
+                      css-class="nhsuk-u-width-one-half"
+                      default-option=""
+                      select-list-options="@Model.ReportIntervalOptions" />
+
+      <button class="nhsuk-button" type="submit" value="save">Apply filters</button>
+      <vc:cancel-link asp-controller="Reports" asp-action="Index" />
+    </form>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
@@ -31,7 +31,7 @@
                       label="Choose job group filter"
                       value="@Model.JobGroupId.ToString()"
                       hint-text=""
-                      deselectable="false"
+                      deselectable="true"
                       css-class="nhsuk-u-width-one-half"
                       default-option="All"
                       select-list-options="@Model.JobGroupOptions" />
@@ -56,7 +56,7 @@
                                 label="Choose a course"
                                 value="@Model.CustomisationId.ToString()"
                                 hint-text=""
-                                deselectable="false"
+                                deselectable="true"
                                 css-class="nhsuk-u-width-one-half"
                                 default-option="All"
                                 select-list-options="@Model.CustomisationOptions" />
@@ -74,7 +74,7 @@
                                 label="Choose course category from the list below"
                                 value="@Model.CourseCategoryId.ToString()"
                                 hint-text=""
-                                deselectable="false"
+                                deselectable="true"
                                 css-class="nhsuk-u-width-one-half"
                                 default-option="All"
                                 select-list-options="@Model.CourseCategoryOptions" />
@@ -87,7 +87,7 @@
                         label="Choose a course filter"
                         value="@Model.CustomisationId.ToString()"
                         hint-text=""
-                        deselectable="false"
+                        deselectable="true"
                         css-class="nhsuk-u-width-one-half"
                         default-option="All"
                         select-list-options="@Model.CustomisationOptions" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_FilterDisplayCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_FilterDisplayCard.cshtml
@@ -45,7 +45,7 @@
         </div>
       </dl>
 
-      <a class="nhsuk-button nhsuk-button--secondary" role="button">
+      <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Reports" asp-action="EditFilters" role="button">
         Edit filters
       </a>
     </div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-541

### Description
This is the frontend component for the edit filters page for HEEDLS-541. It has some backend changes to populate the select lists, and to enable the uncapped end date filter, but no logic to handle actually sending a filter edit request, which will be dealt with in a future review. It also makes some changes to the Course Delegates controller and services to remove duplication and improve an SQL query.

### Screenshots
![image](https://user-images.githubusercontent.com/34240850/132357911-e1465906-74a2-4f2a-92d5-2e08d1235ae5.png)
![image](https://user-images.githubusercontent.com/34240850/132357585-341060ca-0cc8-4c43-a4c7-a399f584d92d.png)

-----
### Developer checks
I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [X] Updated/added documentation in Swiki and/or Readme.
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
