### PR TITLE
HEEDLS-505 All delegates - bulk upload journey - fix

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -49,7 +49,8 @@
             var candidateNumber = connection.QueryFirstOrDefault<string>(
                 "uspSaveNewCandidate_V10",
                 values,
-                commandType: CommandType.StoredProcedure);
+                commandType: CommandType.StoredProcedure
+            );
 
             return candidateNumber;
         }
@@ -63,7 +64,7 @@
                 delegateRegistrationModel.Email,
                 CentreID = delegateRegistrationModel.Centre,
                 JobGroupID = delegateRegistrationModel.JobGroup,
-                Active = 1,
+                delegateRegistrationModel.Active,
                 Approved = 1,
                 delegateRegistrationModel.Answer1,
                 delegateRegistrationModel.Answer2,
@@ -81,7 +82,8 @@
             var candidateNumber = connection.QueryFirstOrDefault<string>(
                 "uspSaveNewCandidate_V10",
                 values,
-                commandType: CommandType.StoredProcedure);
+                commandType: CommandType.StoredProcedure
+            );
 
             return candidateNumber;
         }
@@ -119,7 +121,7 @@
             );
 
             transaction.Complete();
-        
+
             return adminUserId;
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -15,6 +15,7 @@
                 @"SELECT
                         cd.CandidateID AS Id,
                         cd.CandidateNumber,
+                        cd.AliasID,
                         ct.CentreName,
                         cd.CentreID,
                         cd.DateRegistered,
@@ -268,6 +269,7 @@
             var user = connection.Query<DelegateUser>(
                 @"SELECT
                         cd.CandidateID AS Id,
+                        cd.AliasID,
                         cd.CandidateNumber,
                         ct.CentreName,
                         cd.CentreID,
@@ -303,6 +305,7 @@
             var user = connection.Query<DelegateUser>(
                 @"SELECT
                         cd.CandidateID AS Id,
+                        cd.AliasID,
                         cd.CandidateNumber,
                         ct.CentreName,
                         cd.CentreID,

--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
@@ -64,25 +64,21 @@
             {
                 Error = BulkUploadResult.ErrorReason.InvalidJobGroupId;
             }
-
-            if (string.IsNullOrEmpty(LastName))
+            else if (string.IsNullOrEmpty(LastName))
             {
                 Error = BulkUploadResult.ErrorReason.InvalidLastName;
             }
-
-            if (string.IsNullOrEmpty(FirstName))
+            else if (string.IsNullOrEmpty(FirstName))
             {
                 Error = BulkUploadResult.ErrorReason.InvalidFirstName;
             }
-
-            if (string.IsNullOrEmpty(Email))
-            {
-                Error = BulkUploadResult.ErrorReason.InvalidEmail;
-            }
-
-            if (!Active.HasValue)
+            else if (!Active.HasValue)
             {
                 Error = BulkUploadResult.ErrorReason.InvalidActive;
+            }
+            else if (string.IsNullOrEmpty(Email))
+            {
+                Error = BulkUploadResult.ErrorReason.InvalidEmail;
             }
 
             return !Error.HasValue;

--- a/DigitalLearningSolutions.Data/Models/Register/DelegateRegistrationModel.cs
+++ b/DigitalLearningSolutions.Data/Models/Register/DelegateRegistrationModel.cs
@@ -19,7 +19,8 @@
             string? answer5,
             string? answer6,
             string? aliasId = null,
-            DateTime? notifyDate = null
+            DateTime? notifyDate = null,
+            bool active = true
         ) : base(firstName, lastName, email, centre, jobGroup, passwordHash)
         {
             Answer1 = answer1;
@@ -30,6 +31,7 @@
             Answer6 = answer6;
             AliasId = aliasId;
             NotifyDate = notifyDate;
+            Active = active;
         }
 
         public DelegateRegistrationModel(
@@ -59,7 +61,8 @@
             row.Answer5,
             row.Answer6,
             row.AliasId,
-            welcomeEmailDate
+            welcomeEmailDate,
+            row.Active!.Value
         ) { }
 
         public string? Answer1 { get; set; }
@@ -77,5 +80,7 @@
         public string? AliasId { get; set; }
 
         public DateTime? NotifyDate { get; set; }
+
+        public bool Active { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/DelegateUploadFileService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DigitalLearningSolutions.Data.Tests")]
+
 namespace DigitalLearningSolutions.Data.Services
 {
     using System;
@@ -154,22 +155,30 @@ namespace DigitalLearningSolutions.Data.Services
 
         private void UpdateDelegate(DelegateTableRow delegateRow, DelegateUser delegateUser)
         {
-            userDataService.UpdateDelegate(
-                delegateUser.Id,
-                delegateRow.FirstName!,
-                delegateRow.LastName!,
-                delegateRow.JobGroupId!.Value,
-                delegateRow.Active!.Value,
-                delegateRow.Answer1,
-                delegateRow.Answer2,
-                delegateRow.Answer3,
-                delegateRow.Answer4,
-                delegateRow.Answer5,
-                delegateRow.Answer6,
-                delegateRow.AliasId,
-                delegateRow.Email!
-            );
-            delegateRow.RowStatus = RowStatus.Updated;
+            try
+            {
+                userDataService.UpdateDelegate(
+                    delegateUser.Id,
+                    delegateRow.FirstName!,
+                    delegateRow.LastName!,
+                    delegateRow.JobGroupId!.Value,
+                    delegateRow.Active!.Value,
+                    delegateRow.Answer1,
+                    delegateRow.Answer2,
+                    delegateRow.Answer3,
+                    delegateRow.Answer4,
+                    delegateRow.Answer5,
+                    delegateRow.Answer6,
+                    delegateRow.AliasId,
+                    delegateRow.Email!
+                );
+
+                delegateRow.RowStatus = RowStatus.Updated;
+            }
+            catch
+            {
+                delegateRow.Error = BulkUploadResult.ErrorReason.UnexpectedErrorForUpdate;
+            }
         }
 
         private void RegisterDelegate(DelegateTableRow delegateRow, DateTime? welcomeEmailDate, int centreId)
@@ -179,6 +188,8 @@ namespace DigitalLearningSolutions.Data.Services
             switch (status)
             {
                 case "-1":
+                    delegateRow.Error = BulkUploadResult.ErrorReason.UnexpectedErrorForCreate;
+                    break;
                 case "-2":
                 case "-3":
                 case "-4":

--- a/DigitalLearningSolutions.Web/Attributes/MaxFileSizeAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/MaxFileSizeAttribute.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Web.Attributes
+{
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    ///     Validates whether a property of type <see cref="IFormFile" /> has
+    ///     file size smaller than a maximum file size
+    /// </summary>
+    public class MaxFileSizeAttribute : ValidationAttribute
+    {
+        private readonly string? errorMessage;
+        private readonly int maxFileSize;
+
+        public MaxFileSizeAttribute(int maxFileSize, string? errorMessage = null)
+        {
+            this.maxFileSize = maxFileSize;
+            this.errorMessage = errorMessage;
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            if (value is IFormFile file && file.Length > maxFileSize)
+            {
+                return new ValidationResult(errorMessage ?? GetErrorMessage());
+            }
+
+            return ValidationResult.Success;
+        }
+
+        public string GetErrorMessage()
+        {
+            return $"Maximum allowed file size is {maxFileSize} bytes.";
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -2,11 +2,8 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Exceptions;
-    using DigitalLearningSolutions.Data.Models.DelegateUpload;
     using DigitalLearningSolutions.Data.Services;
-    using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
-    using DigitalLearningSolutions.Web.ServiceFilter;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -50,7 +47,7 @@
         public IActionResult StartUpload()
         {
             TempData.Clear();
-            var model = new UploadDelegatesViewModel();
+            var model = new UploadDelegatesViewModel(DateTime.Today);
             return View("StartUpload", model);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -55,12 +55,12 @@
         [HttpPost]
         public IActionResult StartUpload(UploadDelegatesViewModel model)
         {
-            model.ClearDateIfNotSendEmail();
-
             if (!ModelState.IsValid)
             {
                 return View("StartUpload", model);
             }
+
+            model.ClearDateIfNotSendEmail();
 
             try
             {

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
@@ -17,9 +17,9 @@
             Year = welcomeEmailDate.Year;
         }
 
-        [Required(ErrorMessage = "Delegates update file is required.")]
-        [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format.")]
-        [MaxFileSize(5*1000*1000, "Maximum allowed file size is 5000KB.")]
+        [Required(ErrorMessage = "Delegates update file is required")]
+        [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format")]
+        [MaxFileSize(5*1000*1000, "Maximum allowed file size is 5000KB")]
         public IFormFile? DelegatesFile { get; set; }
 
         public DateTime? GetWelcomeEmailDate()

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
@@ -19,6 +19,7 @@
 
         [Required(ErrorMessage = "Delegates update file is required.")]
         [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format.")]
+        [MaxFileSize(5*1000*1000, "Maximum allowed file size is 5000KB.")]
         public IFormFile? DelegatesFile { get; set; }
 
         public DateTime? GetWelcomeEmailDate()

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
@@ -8,6 +8,15 @@
 
     public class UploadDelegatesViewModel : WelcomeEmailViewModel
     {
+        public UploadDelegatesViewModel() { }
+
+        public UploadDelegatesViewModel(DateTime welcomeEmailDate)
+        {
+            Day = welcomeEmailDate.Day;
+            Month = welcomeEmailDate.Month;
+            Year = welcomeEmailDate.Year;
+        }
+
         [Required(ErrorMessage = "Delegates update file is required.")]
         [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format.")]
         public IFormFile? DelegatesFile { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
@@ -10,7 +10,7 @@
   ViewData["HeaderPathName"] = "Tracking System";
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   const string dateInputId = "welcome-email-date";
-  var exampleDate = DateTime.Today.AddDays(1);
+  var exampleDate = DateTime.Today;
   var emailDateCss = "nhsuk-checkboxes__conditional"
                      + (Model.ShouldSendEmail ? "" : " nhsuk-checkboxes__conditional--hidden")
                      + (errorHasOccurred ? " nhsuk-u-padding-left-5" : "");
@@ -51,7 +51,7 @@
                        hint-text="For example, @exampleDate.Day @exampleDate.Month @exampleDate.Year" />
       </div>
 
-      <vc:file-input asp-for="@nameof(Model.DelegatesFile)" label="File with update information" hint-text="" css-class="nhsuk-u-width-one-half" />
+      <vc:file-input asp-for="@nameof(Model.DelegatesFile)" label="File with updated information" hint-text="" css-class="nhsuk-u-width-one-half" />
 
       <button class="nhsuk-button" type="submit">Upload and process</button>
     </form>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/UploadCompleted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/UploadCompleted.cshtml
@@ -20,11 +20,11 @@
 
     <h2>Summary of results:</h2>
     <ul>
-      <li>@Model.ProcessedCount lines processed</li>
-      <li>@Model.RegisteredCount new delegates registered</li>
-      <li>@Model.UpdatedCount delegate records updated</li>
-      <li>@Model.SkippedCount delegate records skipped (no changes)</li>
-      <li>@Model.ErrorCount lines skipped due to errors</li>
+      <li>@Model.ProcessedCount @(Model.ProcessedCount == 1 ? "line" : "lines") processed</li>
+      <li>@Model.RegisteredCount new @(Model.RegisteredCount == 1 ? "delegate" : "delegates") registered</li>
+      <li>@Model.UpdatedCount delegate @(Model.UpdatedCount == 1 ? "record" : "records") updated</li>
+      <li>@Model.SkippedCount delegate @(Model.SkippedCount == 1 ? "record" : "records") skipped (no changes)</li>
+      <li>@Model.ErrorCount @(Model.ErrorCount == 1 ? "line" : "lines") skipped due to errors</li>
     </ul>
 
     @if (Model.ErrorCount > 0) {


### PR DESCRIPTION
### JIRA link
[HEEDLS-505](https://softwiretech.atlassian.net/browse/HEEDLS-505)

### Description
- Checking 'send welcome email' reveals the datepicker pre-populated with today's date.
- File upload has a 5000KB limit.
- “File with update information” changed to “… updated information”.
- Potential errors are checked sequentially in correct order.
- Unexpected error message shown for single row update error instead of redirecting to 500.
- Unexpected error message shown for single row create error instead of redirecting to 500.
- AliasID is included when fetching existing delegate user, and in compariosn to check if update is needed.
- Correct singular/plural wording in Upload complete page.

**Note:**
- One of the bugs identified was that when registering a new delegate, if a value is too long it gets silently truncated. This is due to how the values are passed in and stored in the stored procedure. Once the stored proc is updated, the changes from this PR will be sufficient to catch that case too.

### Screenshots
Upload complete page (singular/plural wording change):
![image](https://user-images.githubusercontent.com/44787206/132209247-5244f713-b264-4686-b190-39f558693a2e.png)


-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
