### PR TITLE
HEEDLS-586 Add extra padding to iframes with long titles

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
@@ -35,7 +35,7 @@
             var model = new LearningContentViewModel(
                 TerminologyAndClassificationsDeliveryServiceBrand,
                 TerminologyAndClassificationsDeliveryServiceTitle,
-                true
+                titleIsLong: true
             );
             return View("Index", model);
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningContentController.cs
@@ -11,24 +11,32 @@
         private const string ItSkillsPathwayTitle = "IT skills pathway";
         private const string ReasonableAdjustmentFlagBrand = "ReasonableAdjustmentFlag";
         private const string ReasonableAdjustmentFlagTitle = "Reasonable adjustment flag";
-        private const string TerminologyAndClassificationsDeliveryServiceBrand = "TerminologyandClassificationsDeliveryService";
-        private const string TerminologyAndClassificationsDeliveryServiceTitle = "Terminology and classifications delivery service";
-        
+
+        private const string TerminologyAndClassificationsDeliveryServiceBrand =
+            "TerminologyandClassificationsDeliveryService";
+
+        private const string TerminologyAndClassificationsDeliveryServiceTitle =
+            "Terminology and classifications delivery service";
+
         public IActionResult ItSkillsPathway()
         {
             var model = new LearningContentViewModel(ItSkillsPathwayBrand, ItSkillsPathwayTitle);
             return View("Index", model);
         }
-        
+
         public IActionResult ReasonableAdjustmentFlag()
         {
             var model = new LearningContentViewModel(ReasonableAdjustmentFlagBrand, ReasonableAdjustmentFlagTitle);
             return View("Index", model);
         }
-        
+
         public IActionResult TerminologyAndClassificationsDeliveryService()
         {
-            var model = new LearningContentViewModel(TerminologyAndClassificationsDeliveryServiceBrand, TerminologyAndClassificationsDeliveryServiceTitle);
+            var model = new LearningContentViewModel(
+                TerminologyAndClassificationsDeliveryServiceBrand,
+                TerminologyAndClassificationsDeliveryServiceTitle,
+                true
+            );
             return View("Index", model);
         }
     }

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -110,7 +110,11 @@ h1#page-heading {
 }
 
 .responsive-iframe-wrapper-padding {
-  padding-bottom: nhsuk-spacing(7);
+  padding-bottom: nhsuk-spacing(8);
+}
+
+.responsive-iframe-wrapper-extra-padding {
+  padding-bottom: nhsuk-spacing(8) * 2;
 }
 
 .nhsuk-heading-xl.heading-margin-2 {

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -1,5 +1,7 @@
 @import "~nhsuk-frontend/packages/core/all";
 
+$iframe-padding-bottom: nhsuk-spacing(8);
+
 @mixin word-break-ie-fix {
   // IE11 hack
   @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
@@ -54,16 +56,16 @@ ul > li > ul > li {
 }
 
 .small-edit-button, a.small-edit-button {
-    margin-bottom: nhsuk-spacing(2);
-    margin-top: nhsuk-spacing(0);
-    padding-bottom: 0;
-    padding-top: 0;
+  margin-bottom: nhsuk-spacing(2);
+  margin-top: nhsuk-spacing(0);
+  padding-bottom: 0;
+  padding-top: 0;
 }
 
 .nhsuk-button {
-    @include mq($until: tablet) {
-        margin-top: nhsuk-spacing(3);
-    }
+  @include mq($until: tablet) {
+    margin-top: nhsuk-spacing(3);
+  }
 }
 
 input:invalid {
@@ -87,6 +89,7 @@ input[type=file].nhsuk-input--error {
 h1#page-heading {
   margin-bottom: 16px;
 }
+
 .page-subheading {
   margin-bottom: 16px;
 }
@@ -110,11 +113,11 @@ h1#page-heading {
 }
 
 .responsive-iframe-wrapper-padding {
-  padding-bottom: nhsuk-spacing(8);
+  padding-bottom: $iframe-padding-bottom;
 }
 
 .responsive-iframe-wrapper-extra-padding {
-  padding-bottom: nhsuk-spacing(8) * 2;
+  padding-bottom: $iframe-padding-bottom * 2;
 }
 
 .nhsuk-heading-xl.heading-margin-2 {
@@ -170,8 +173,8 @@ h1#page-heading {
   text-align: center;
   margin-bottom: 0;
 
-  @include govuk-media-query($until: desktop){
-      margin-top: nhsuk-spacing(2);
+  @include govuk-media-query($until: desktop) {
+    margin-top: nhsuk-spacing(2);
   }
 }
 
@@ -199,8 +202,8 @@ ul.no-bullets {
   margin-bottom: 0;
 }
 
-.nhsuk-details__text>.nhsuk-button{
-    margin-bottom: 0;
+.nhsuk-details__text > .nhsuk-button {
+  margin-bottom: 0;
 }
 
 @mixin hidden-submit-ie-fix {
@@ -228,7 +231,7 @@ ul.no-bullets {
 }
 
 .vertical-align-centre {
-    vertical-align: middle
+  vertical-align: middle
 }
 
 .side-nav-menu {
@@ -257,22 +260,22 @@ ul.no-bullets {
   }
 }
 
- .side-nav__link {
-   text-decoration: none;
+.side-nav__link {
+  text-decoration: none;
 
-   &:visited {
-     color: $nhsuk-link-color;
-   }
+  &:visited {
+    color: $nhsuk-link-color;
+  }
 
-   &:hover {
-     color: $nhsuk-link-hover-color;
-     text-decoration: underline;
-   }
- }
+  &:hover {
+    color: $nhsuk-link-hover-color;
+    text-decoration: underline;
+  }
+}
 
- .side-nav__list {
-   @include nhsuk-responsive-margin(0, "bottom");
- }
+.side-nav__list {
+  @include nhsuk-responsive-margin(0, "bottom");
+}
 
 .side-nav__item {
   @include nhsuk-responsive-padding(1, "bottom");
@@ -291,5 +294,5 @@ ul.no-bullets {
 }
 
 .nhsuk-error-message.error-message--margin-bottom-1 {
-    margin-bottom: nhsuk-spacing(1);
+  margin-bottom: nhsuk-spacing(1);
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningContent/LearningContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningContent/LearningContentViewModel.cs
@@ -3,14 +3,14 @@
     public class LearningContentViewModel
     {
         public readonly string Brand;
-        public readonly bool LongTitle;
+        public readonly bool TitleIsLong;
         public readonly string Title;
 
-        public LearningContentViewModel(string brand, string title, bool longTitle = false)
+        public LearningContentViewModel(string brand, string title, bool titleIsLong = false)
         {
             Brand = brand;
             Title = title;
-            LongTitle = longTitle;
+            TitleIsLong = titleIsLong;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningContent/LearningContentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningContent/LearningContentViewModel.cs
@@ -3,12 +3,14 @@
     public class LearningContentViewModel
     {
         public readonly string Brand;
+        public readonly bool LongTitle;
         public readonly string Title;
 
-        public LearningContentViewModel(string brand, string title)
+        public LearningContentViewModel(string brand, string title, bool longTitle = false)
         {
             Brand = brand;
             Title = title;
+            LongTitle = longTitle;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
@@ -1,9 +1,9 @@
-﻿@using DigitalLearningSolutions.Web.Helpers
+﻿@inject IConfiguration Configuration
+
+@using DigitalLearningSolutions.Web.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.LearningContent
 @using Microsoft.Extensions.Configuration
-
-@inject IConfiguration Configuration
-
-@model DigitalLearningSolutions.Web.ViewModels.LearningContent.LearningContentViewModel
+@model LearningContentViewModel
 @{
   ViewData["Title"] = "Learning Content";
   var url = ConfigHelper.GetAppConfig()["CurrentSystemBaseUrl"] + "/Learning?brand=" + Model.Brand + "&nonav=true";
@@ -17,9 +17,13 @@
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-controller="Home" asp-action="LearningContent">Learning content</a></li>
+        <li class="nhsuk-breadcrumb__item">
+          <a class="nhsuk-breadcrumb__link" asp-controller="Home" asp-action="LearningContent">Learning content</a>
+        </li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-controller="Home" asp-action="LearningContent">Back to learning content</a></p>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="Home" asp-action="LearningContent">Back to learning content</a>
+      </p>
     </div>
   </nav>
 }
@@ -30,6 +34,6 @@
   </div>
 </div>
 
-<div class="nhsuk-grid-row responsive-iframe-wrapper @(@Model.Title.Length > 35 ? "responsive-iframe-wrapper-extra-padding" : "responsive-iframe-wrapper-padding")">
+<div class="nhsuk-grid-row responsive-iframe-wrapper @(Model.LongTitle ? "responsive-iframe-wrapper-extra-padding" : "responsive-iframe-wrapper-padding")">
   <iframe class="responsive-iframe" title="@Model.Title" src="@url"></iframe>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
@@ -34,6 +34,6 @@
   </div>
 </div>
 
-<div class="nhsuk-grid-row responsive-iframe-wrapper @(Model.LongTitle ? "responsive-iframe-wrapper-extra-padding" : "responsive-iframe-wrapper-padding")">
+<div class="nhsuk-grid-row responsive-iframe-wrapper @(Model.TitleIsLong ? "responsive-iframe-wrapper-extra-padding" : "responsive-iframe-wrapper-padding")">
   <iframe class="responsive-iframe" title="@Model.Title" src="@url"></iframe>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningContent/Index.cshtml
@@ -30,6 +30,6 @@
   </div>
 </div>
 
-<div class="nhsuk-grid-row responsive-iframe-wrapper responsive-iframe-wrapper-padding">
+<div class="nhsuk-grid-row responsive-iframe-wrapper @(@Model.Title.Length > 35 ? "responsive-iframe-wrapper-extra-padding" : "responsive-iframe-wrapper-padding")">
   <iframe class="responsive-iframe" title="@Model.Title" src="@url"></iframe>
 </div>


### PR DESCRIPTION
### JIRA link
[HEEDLS-586](https://softwiretech.atlassian.net/browse/HEEDLS-586)

### Description
Added extra padding to iframes with long titles. Previously the "Terminology and classifications delivery service" page's iframe was running over the footer because its title goes onto a second line. I've added logic that checks if the page title is long, and if so, doubles the padding-bottom which makes the space between the iframe and the footer identical to those with shorter titles on desktop, with negligible differences on tablet and mobile. I also made the padding-bottom on all learning content iframes a bit wider as it looked a bit too close to me.

### Screenshots
Iframe with long title:
![Terminology_laptop](https://user-images.githubusercontent.com/70278044/132356566-e9672948-adc4-44f9-9aea-6e0d1e7fee7c.png)
![Terminology_tablet](https://user-images.githubusercontent.com/70278044/132356592-265eb98b-49cf-493e-b156-8d9139c31a9b.png)
![Terminology_mobile](https://user-images.githubusercontent.com/70278044/132356607-0fe24c4c-8d4e-414f-9bc6-cbecd720efc3.png)

Iframe with short title:
![ItSkills_laptop](https://user-images.githubusercontent.com/70278044/132357090-cf8eccfe-ebd1-453a-9716-31bae77bf755.png)
![ItSkills_tablet](https://user-images.githubusercontent.com/70278044/132357114-9757c277-f12f-4029-9822-3acfe7547e42.png)
![ItSkills_mobile](https://user-images.githubusercontent.com/70278044/132357125-0d5dd6f6-63ae-4afe-af39-7675269c55b3.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
