### PR TITLE
HEEDLS-492 All delegates - Filter - fix 2

### DIFF
--- a/DigitalLearningSolutions.Web/ViewComponents/CurrentFiltersViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/CurrentFiltersViewComponent.cs
@@ -42,7 +42,7 @@
             IEnumerable<FilterOptionViewModel> filterOptions
         )
         {
-            return filterOptions.Single(filterOption => filterOption.FilterValue == currentFilter).DisplayText;
+            return filterOptions.First(filterOption => filterOption.FilterValue == currentFilter).DisplayText;
         }
 
         private static string GetFilterValue(
@@ -50,7 +50,7 @@
             IEnumerable<FilterOptionViewModel> filterOptions
         )
         {
-            return filterOptions.Single(filterOption => filterOption.FilterValue == currentFilter).FilterValue;
+            return filterOptions.First(filterOption => filterOption.FilterValue == currentFilter).FilterValue;
         }
 
         private static bool FilterOptionsContainsFilter(


### PR DESCRIPTION
### JIRA link
[HEEDLS-492](https://softwiretech.atlassian.net/browse/HEEDLS-492)

### Description
If a filter contains duplicate filter values, and we attempt to filter by one of those values, a 500 error is thrown. Fix it.

### Screenshots
N/A

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
