### PR TITLE
HEEDLS-505 All delegates - Bulk upload journey - fix 2

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUploadResultsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUploadResultsViewModel.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.DelegateUpload;
-    using DigitalLearningSolutions.Web.Helpers;
 
     public class BulkUploadResultsViewModel
     {
@@ -29,29 +28,29 @@
             return reason switch
             {
                 BulkUploadResult.ErrorReason.InvalidJobGroupId =>
-                    "Job group ID was not valid, please ensure a valid Job Group ID number is provided (use the 'Job Groups' worksheet in the downloaded template for a list of valid IDs)",
+                    "JobGroupID was not valid, please ensure a valid JobGroupID number is provided (use the 'Job Groups' worksheet in the downloaded template for a list of valid IDs)",
                 BulkUploadResult.ErrorReason.MissingLastName =>
-                    "Last name was not provided. Last name is a required field and cannot be left blank",
+                    "LastName was not provided. LastName is a required field and cannot be left blank",
                 BulkUploadResult.ErrorReason.MissingFirstName =>
-                    "First name was not provided. First name is a required field and cannot be left blank",
+                    "FirstName was not provided. FirstName is a required field and cannot be left blank",
                 BulkUploadResult.ErrorReason.MissingEmail =>
-                    "Email was not provided. Email is a required field and cannot be left blank",
+                    "EmailAddress was not provided. EmailAddress is a required field and cannot be left blank",
                 BulkUploadResult.ErrorReason.InvalidActive =>
                     "Active field could not be read. The Active field should contain 'TRUE' or 'FALSE'",
                 BulkUploadResult.ErrorReason.NoRecordForDelegateId =>
-                    "No existing delegate record was found with the Delegate ID provided",
+                    "No existing delegate record was found with the DelegateID provided",
                 BulkUploadResult.ErrorReason.UnexpectedErrorForCreate =>
                     "Unexpected error when creating delegate",
                 BulkUploadResult.ErrorReason.UnexpectedErrorForUpdate =>
                     "Unexpected error when updating delegate details",
                 BulkUploadResult.ErrorReason.ParameterError => "Parameter error when updating delegate details",
-                BulkUploadResult.ErrorReason.AliasIdInUse => "The Alias ID is already in use by another delegate",
+                BulkUploadResult.ErrorReason.AliasIdInUse => "The AliasID is already in use by another delegate",
                 BulkUploadResult.ErrorReason.EmailAddressInUse =>
-                    "The Email address is already in use by another delegate",
-                BulkUploadResult.ErrorReason.TooLongFirstName => CommonValidationErrorMessages.TooLongFirstName,
-                BulkUploadResult.ErrorReason.TooLongLastName => CommonValidationErrorMessages.TooLongLastName,
-                BulkUploadResult.ErrorReason.TooLongEmail => "Email address must be 250 characters or fewer",
-                BulkUploadResult.ErrorReason.TooLongAliasId => CommonValidationErrorMessages.TooLongAlias,
+                    "The EmailAddress is already in use by another delegate",
+                BulkUploadResult.ErrorReason.TooLongFirstName => "FirstName must be 250 characters or fewer",
+                BulkUploadResult.ErrorReason.TooLongLastName => "LastName must be 250 characters or fewer",
+                BulkUploadResult.ErrorReason.TooLongEmail => "EmailAddress must be 250 characters or fewer",
+                BulkUploadResult.ErrorReason.TooLongAliasId => "AliasID must be 250 characters or fewer",
                 BulkUploadResult.ErrorReason.TooLongAnswer1 => "Answer1 must be 100 characters or fewer",
                 BulkUploadResult.ErrorReason.TooLongAnswer2 => "Answer2 must be 100 characters or fewer",
                 BulkUploadResult.ErrorReason.TooLongAnswer3 => "Answer3 must be 100 characters or fewer",
@@ -59,8 +58,9 @@
                 BulkUploadResult.ErrorReason.TooLongAnswer5 => "Answer5 must be 100 characters or fewer",
                 BulkUploadResult.ErrorReason.TooLongAnswer6 => "Answer6 must be 100 characters or fewer",
                 BulkUploadResult.ErrorReason.BadFormatEmail =>
-                    "Email address must be in the correct format, like name@example.com",
-                BulkUploadResult.ErrorReason.WhitespaceInEmail => CommonValidationErrorMessages.WhitespaceInEmail,
+                    "EmailAddress must be in the correct format, like name@example.com",
+                BulkUploadResult.ErrorReason.WhitespaceInEmail =>
+                    "EmailAddress must not contain any whitespace characters",
                 _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, null)
             };
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
@@ -19,7 +19,7 @@
 
         [Required(ErrorMessage = "Delegates update file is required")]
         [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format")]
-        [MaxFileSize(5*1000*1000, "Maximum allowed file size is 5000KB")]
+        [MaxFileSize(5*1024*1024, "Maximum allowed file size is 5MB")]
         public IFormFile? DelegatesFile { get; set; }
 
         public DateTime? GetWelcomeEmailDate()


### PR DESCRIPTION
### JIRA link
[HEEDLS-505](https://softwiretech.atlassian.net/browse/HEEDLS-505)

### Description
- Change max filesize to 5MiB
- Use excel sheet header names in bulk upload error messages

### Screenshots
N/A

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
