### PR TITLE
DLSV2-331 Fixes issue with optional competencies

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202109201529_AddCompetencyGroupIdToCandidateAssessmentOptionalCompetencies.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202109201529_AddCompetencyGroupIdToCandidateAssessmentOptionalCompetencies.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202109201529)]
+    public class AddCompetencyGroupIdToCandidateAssessmentOptionalCompetencies : AutoReversingMigration
+    {
+        public override void Up()
+        {
+            Alter.Table("CandidateAssessmentOptionalCompetencies").AddColumn("CompetencyGroupID").AsInt32().Nullable().ForeignKey("CompetencyGroups", "ID");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/SelfAssessmentServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SelfAssessmentServiceTests.cs
@@ -89,6 +89,7 @@
             var expectedCompetency = SelfAssessmentHelper.CreateDefaultCompetency(
                 id: 32,
                 competencyGroup: "General questions",
+                competencyGroupId: 7,
                 name: "Taking an active role in my own learning is the most important thing that affects my digital literacy skills development",
                 description: "Taking an active role in my own learning is the most important thing that affects my digital literacy skills development",
                 assessmentQuestions: new List<AssessmentQuestion>()

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/SelfAssessmentHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/SelfAssessmentHelper.cs
@@ -45,6 +45,7 @@
             int rowNo = 1,
             string name = "name",
             string? description = "description",
+            int competencyGroupId = 1,
             string competencyGroup = "competencyGroup",
             string? vocabulary = "Capability",
             List<AssessmentQuestion> assessmentQuestions = null
@@ -56,6 +57,7 @@
                 RowNo = rowNo,
                 Name = name,
                 Description = description,
+                CompetencyGroupID = competencyGroupId,
                 CompetencyGroup = competencyGroup,
                 Vocabulary = vocabulary,
                 AssessmentQuestions = assessmentQuestions ?? new List<AssessmentQuestion>()

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
@@ -9,6 +9,7 @@
         public string Name { get; set; }
         public string? Description { get; set; }
         public string CompetencyGroup { get; set; }
+        public int CompetencyGroupID { get; set; }
         public string? Vocabulary { get; set; }
         public bool Optional { get; set; }
         public bool IncludedInSelfAssessment { get; set; }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1208,6 +1208,7 @@ WHERE (FrameworkID = @frameworkId)", new { frameworkId, assessmentQuestionId }
                                                   C.Name AS Name,
                                                   C.Description AS Description,
                                                   CG.Name       AS CompetencyGroup,
+                                                  CG.ID AS CompetencyGroupID,
                                                   AQ.ID         AS Id,
                                                   AQ.Question,
                                                   AQ.MaxValueDescription,

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -179,7 +179,7 @@
              SelfAssessmentStructure AS SAS ON C.ID = SAS.CompetencyID AND SAS.SelfAssessmentID = CA.SelfAssessmentID INNER JOIN
              CompetencyGroups AS CG ON SAS.CompetencyGroupID = CG.ID AND SAS.SelfAssessmentID = CA.SelfAssessmentID
                         LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
-                            ON CA.ID = CAOC.CandidateAssessmentID";
+                            ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID";
 
         public SelfAssessmentService(IDbConnection connection, ILogger<SelfAssessmentService> logger)
         {

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -29,7 +29,7 @@
         IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(int selfAssessmentId, int candidateId);
         IEnumerable<SelfAssessmentSupervisor> GetResultReviewSupervisorsForSelfAssessmentId(int selfAssessmentId, int candidateId);
         SelfAssessmentSupervisor GetSelfAssessmentSupervisorByCandidateAssessmentSupervisorId(int candidateAssessmentSupervisorId);
-        List<int> GetCandidateAssessmentIncludedOptionalCompetencies(int selfAssessmentId, int candidateId);
+        List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int candidateId);
         Profile? GetFilteredProfileForCandidateById(int candidateId, int selfAssessmentId);
         IEnumerable<Goal> GetFilteredGoalsForCandidateId(int candidateId, int selfAssessmentId);
         IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId);
@@ -41,7 +41,7 @@
         void SetUpdatedFlag(int selfAssessmentId, int candidateId, bool status);
         void SetBookmark(int selfAssessmentId, int candidateId, string bookmark);
         void SetCompleteByDate(int selfAssessmentId, int candidateId, DateTime? completeByDate);
-        void UpdateCandidateAssessmentOptionalCompetencies(int competencyId, bool include, int selfAssessmentId, int candidateId);
+        void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int candidateId);
         //INSERT
         void LogAssetLaunch(int candidateId, int selfAssessmentId, LearningAsset learningAsset);
         void SetResultForCompetency(int competencyId, int selfAssessmentId, int candidateId, int assessmentQuestionId, int? result, string? supportingComments);
@@ -124,6 +124,7 @@
                                                   C.Name AS Name,
                                                   C.Description AS Description,
                                                   CG.Name       AS CompetencyGroup,
+                                                  CG.ID AS CompetencyGroupID,
                                                   COALESCE((SELECT TOP(1) FrameworkConfig FROM Frameworks F INNER JOIN FrameworkCompetencies AS FC ON FC.FrameworkID = F.ID WHERE FC.CompetencyID = C.ID), 'Capability') AS Vocabulary,
                                                   CASE WHEN (SELECT COUNT(*) FROM SelfAssessmentSupervisorRoles WHERE SelfAssessmentID = SAS.SelfAssessmentID) > 0 THEN 1 ELSE 0 END AS HasDelegateNominatedRoles,
                                                   SAS.Optional,
@@ -168,7 +169,7 @@
                             ON SAS.CompetencyGroupID = CG.ID
                                     AND SAS.SelfAssessmentID = @selfAssessmentId
                         LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
-                            ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID";
+                            ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID";
 
         private const string SpecificCompetencyTables = @"Competencies AS C INNER JOIN
              CompetencyAssessmentQuestions AS CAQ ON CAQ.CompetencyID = C.ID INNER JOIN
@@ -673,13 +674,15 @@ WHERE cas.ID = @candidateAssessmentSupervisorId", new { candidateAssessmentSuper
         public IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int candidateId)
         {
             return connection.Query<Competency>(
-                @"SELECT C.ID       AS Id,
+                @"SELECT SAS.ID       AS Id,
                                                   ROW_NUMBER() OVER (ORDER BY SAS.Ordering) as RowNo,
                                                   C.Name AS Name,
                                                   C.Description AS Description,
                                                   CG.Name       AS CompetencyGroup,
+                                                  CG.ID AS CompetencyGroupID,
                                                   'Capability' AS Vocabulary,
-                                                  SAS.Optional
+                                                  SAS.Optional,
+                                                  COALESCE (CAOC.IncludedInSelfAssessment, 0) AS IncludedInSelfAssessment
                     FROM Competencies AS C
                         INNER JOIN CandidateAssessments AS CA
                             ON CA.SelfAssessmentID = @selfAssessmentId
@@ -691,20 +694,22 @@ WHERE cas.ID = @candidateAssessmentSupervisorId", new { candidateAssessmentSuper
                             ON SAS.CompetencyGroupID = CG.ID
                                     AND SAS.SelfAssessmentID = @selfAssessmentId
                         LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
-                            ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID
+                            ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
                     WHERE (SAS.Optional = 1)
                     ORDER BY SAS.Ordering", new { selfAssessmentId, candidateId }
             );
         }
 
-        public List<int> GetCandidateAssessmentIncludedOptionalCompetencies(int selfAssessmentId, int candidateId)
+        public List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int candidateId)
         {
             return connection.Query<int>(
-                @"SELECT CompetencyID
+                @"SELECT SAS.ID
                     FROM CandidateAssessmentOptionalCompetencies AS CAOC
                     INNER JOIN CandidateAssessments  AS CA ON CAOC.CandidateAssessmentID = CA.ID
                             AND CA.SelfAssessmentID = @selfAssessmentId
                                    AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL
+                    INNER JOIN SelfAssessmentStructure AS SAS
+                            ON CAOC.CompetencyID = SAS.CompetencyID AND CAOC.CompetencyGroupID = SAS.CompetencyGroupID AND SAS.SelfAssessmentID = @selfAssessmentId
                     WHERE (CAOC.IncludedInSelfAssessment = 1)", new { selfAssessmentId, candidateId }
             ).ToList();
         }
@@ -712,30 +717,39 @@ WHERE cas.ID = @candidateAssessmentSupervisorId", new { candidateAssessmentSuper
         public void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int candidateId)
         {
             connection.Execute(
-                @"INSERT INTO CandidateAssessmentOptionalCompetencies (CandidateAssessmentId, CompetencyID)
-                    SELECT CA.ID, SAS.CompetencyID
+                               @"UPDATE CandidateAssessmentOptionalCompetencies
+                                   SET IncludedInSelfAssessment = 0
+                    FROM   CandidateAssessmentOptionalCompetencies AS CAOC INNER JOIN
+             CandidateAssessments AS CA ON CAOC.CandidateAssessmentID = CA.ID INNER JOIN
+             SelfAssessmentStructure AS SAS ON CA.SelfAssessmentID = SAS.SelfAssessmentID AND CAOC.CompetencyID = SAS.CompetencyID AND CAOC.CompetencyGroupID = SAS.CompetencyGroupID
+WHERE (CA.CandidateID = @candidateId) AND (CA.RemovedDate IS NULL)
+                                    ", new { selfAssessmentId, candidateId });
+            connection.Execute(
+                @"INSERT INTO CandidateAssessmentOptionalCompetencies (CandidateAssessmentId, CompetencyID, CompetencyGroupID)
+                    SELECT CA.ID, SAS.CompetencyID, SAS.CompetencyGroupID
                     FROM SelfAssessmentStructure AS SAS
                     INNER JOIN CandidateAssessments  AS CA ON SAS.SelfAssessmentID = CA.SelfAssessmentID
                             AND CA.SelfAssessmentID = @selfAssessmentId
                                    AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL AND SAS.Optional = 1
-								   WHERE NOT EXISTS (SELECT * FROM CandidateAssessmentOptionalCompetencies WHERE CandidateAssessmentID = CA.ID AND CompetencyID = SAS.CompetencyID)",
+								   WHERE NOT EXISTS (SELECT * FROM CandidateAssessmentOptionalCompetencies WHERE CandidateAssessmentID = CA.ID AND CompetencyID = SAS.CompetencyID AND CompetencyGroupID = SAS.CompetencyGroupID)",
                 new {selfAssessmentId, candidateId});
         }
 
-        public void UpdateCandidateAssessmentOptionalCompetencies(int competencyId, bool include, int selfAssessmentId, int candidateId)
+        public void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int candidateId)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessmentOptionalCompetencies
-                    SET IncludedInSelfAssessment = @include
-                    FROM   CandidateAssessmentOptionalCompetencies INNER JOIN
-             CandidateAssessments AS CA ON CandidateAssessmentOptionalCompetencies.CandidateAssessmentID = CA.ID AND CA.SelfAssessmentID = @selfAssessmentId AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL
-             WHERE CandidateAssessmentOptionalCompetencies.CompetencyID = @competencyId", new { competencyId, include, selfAssessmentId, candidateId }
+                    SET IncludedInSelfAssessment = 1
+                    FROM   CandidateAssessmentOptionalCompetencies AS CAOC INNER JOIN
+             CandidateAssessments AS CA ON CAOC.CandidateAssessmentID = CA.ID INNER JOIN
+             SelfAssessmentStructure AS SAS ON CA.SelfAssessmentID = SAS.SelfAssessmentID AND CAOC.CompetencyID = SAS.CompetencyID AND CAOC.CompetencyGroupID = SAS.CompetencyGroupID
+WHERE (SAS.ID = @selfAssessmentStructureId) AND (CA.CandidateID = @candidateId) AND (CA.RemovedDate IS NULL)", new { selfAssessmentStructureId, candidateId }
                 );
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not setting CandidateAssessmentOptionalCompetencies include state as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}, competencyId: {competencyId}, include: {include} "
+                    $"Self assessment id: {selfAssessmentStructureId}, candidate id: {candidateId} "
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -317,7 +317,7 @@
                 sessionAddSupervisor.SelfAssessmentSupervisorRoleId = roles.First().ID;
                 TempData.Set(sessionAddSupervisor);
             }
-            
+
             return RedirectToAction("AddSupervisorSummary", new { model.SelfAssessmentID });
         }
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Supervisors/Add/Role")]
@@ -564,14 +564,14 @@
             int candidateId = User.GetCandidateIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateIdKnownNotNull(), selfAssessmentId);
             var optionalCompetencies = selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, candidateId);
-            var includedCompetencyIds = selfAssessmentService.GetCandidateAssessmentIncludedOptionalCompetencies(selfAssessmentId, candidateId);
+            var includedSelfAssessmentStructureIds = selfAssessmentService.GetCandidateAssessmentIncludedSelfAssessmentStructureIds(selfAssessmentId, candidateId);
             var model = new ManageOptionalCompetenciesViewModel()
             {
                 SelfAssessmentId = selfAssessmentId,
                 SelfAssessmentName = assessment.Name,
                 Vocabulary = vocabulary,
                 CompetencyGroups = optionalCompetencies.GroupBy(competency => competency.CompetencyGroup),
-                IncludedCompetencyIds = includedCompetencyIds
+                IncludedSelfAssessmentStructureIds = includedSelfAssessmentStructureIds
             };
             return View("SelfAssessments/ManageOptionalCompetencies", model);
         }
@@ -581,12 +581,14 @@
         {
             int candidateId = User.GetCandidateIdKnownNotNull();
             selfAssessmentService.InsertCandidateAssessmentOptionalCompetenciesIfNotExist(selfAssessmentId, candidateId);
-            var optionalCompetencies = selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, candidateId);
-            foreach(var competency in optionalCompetencies)
+            if (model.IncludedSelfAssessmentStructureIds != null)
             {
-                bool include = (model.IncludedCompetencyIds == null ? false : model.IncludedCompetencyIds.Contains(competency.Id) ? true : false);
-                selfAssessmentService.UpdateCandidateAssessmentOptionalCompetencies(competency.Id, include, selfAssessmentId, candidateId);
+                foreach (int selfAssessmentStructureId in model.IncludedSelfAssessmentStructureIds)
+                {
+                    selfAssessmentService.UpdateCandidateAssessmentOptionalCompetencies(selfAssessmentStructureId, candidateId);
+                }
             }
+
             return RedirectToAction("SelfAssessmentOverview", new { selfAssessmentId });
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/ManageOptionalCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/ManageOptionalCompetenciesViewModel.cs
@@ -11,7 +11,7 @@
         public string? Vocabulary { get; set; }
         public string? SelfAssessmentName { get; set; }
         public IEnumerable<IGrouping<string, Competency>>? CompetencyGroups { get; set; }
-        public List<int>? IncludedCompetencyIds { get; set; }
+        public List<int>? IncludedSelfAssessmentStructureIds { get; set; }
         public string VocabPlural()
         {
             return FrameworkVocabularyHelper.VocabularyPlural(Vocabulary);

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -14,11 +14,11 @@
 <h1>Choose optional @Model.VocabPlural()</h1>
 @if (errorHasOccurred)
 {
-  <vc:error-summary order-of-property-names="@(new[] {nameof(Model.IncludedCompetencyIds) })" />
+  <vc:error-summary order-of-property-names="@(new[] {nameof(Model.IncludedSelfAssessmentStructureIds) })" />
 }
 <h2><small>Which optional competencies would you like to include in your self-assessment?</small></h2>
 <form method="post">
-  <nhs-form-group nhs-validation-for="IncludedCompetencyIds">
+  <nhs-form-group nhs-validation-for="IncludedSelfAssessmentStructureIds">
     @foreach (var competencyGroup in Model.CompetencyGroups)
     {
       <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-4">
@@ -31,7 +31,7 @@
           @foreach (var competency in competencyGroup)
           {
             <div class="nhsuk-checkboxes__item">
-              <input class="nhsuk-checkboxes__input" id="competency-check-@competency.Id" name="IncludedCompetencyIds" checked="@(Model.IncludedCompetencyIds != null ? Model.IncludedCompetencyIds.Contains((int)competency.Id) : false)" type="checkbox" value="@competency.Id">
+              <input class="nhsuk-checkboxes__input" id="competency-check-@competency.Id" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.Id) : false)" type="checkbox" value="@competency.Id">
               <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.Id">
                 @competency.Name
               </label>


### PR DESCRIPTION
### JIRA link
DLSV2-331

### Description
Fixes issue with optional competencies where competency appears more than once in a self assessment.
Uses SelfAssessmentStructure.ID as unique identifier for selected optional competencies, rather than Competencies.ID (because a given competencies.ID can appear more than once in a self-assessment and is therefore not unique)
