### PR TITLE
HEEDLS-438 Fix user permissions for course admin fields pages

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
@@ -35,7 +35,7 @@
                 );
 
             // When
-            var returnedCourseAdminFieldsResult = courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0);
+            var returnedCourseAdminFieldsResult = courseAdminFieldsDataService.GetCourseAdminFields(100, 101);
 
             // Then
             returnedCourseAdminFieldsResult.Should().BeEquivalentTo(expectedCourseAdminFieldsResult);
@@ -52,7 +52,7 @@
 
                 // When
                 courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 1, 1, options);
-                var courseAdminFields = courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0);
+                var courseAdminFields = courseAdminFieldsDataService.GetCourseAdminFields(100, 101);
 
                 // Then
                 using (new AssertionScope())
@@ -87,7 +87,7 @@
 
                 // When
                 courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 3, 1, options);
-                var courseCustomPrompts = courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 2);
+                var courseCustomPrompts = courseAdminFieldsDataService.GetCourseAdminFields(100, 101);
                 var customPrompt = courseAdminFieldsDataService.GetCoursePromptsAlphabetical()
                     .Single(c => c.id == 1)
                     .name;

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -371,7 +371,27 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             var result = courseDataService.DoesCourseExistAtCentre(100, 101, null);
 
             // Then
-            result.Should().Be(true);
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void DoesCourseExistAtCentre_returns_false_if_course_does_not_exist_at_centre()
+        {
+            // When
+            var result = courseDataService.DoesCourseExistAtCentre(100, 2, 0);
+
+            // Then
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void DoesCourseExistAtCentre_returns_false_if_course_does_not_exist_with_categoryId()
+        {
+            // When
+            var result = courseDataService.DoesCourseExistAtCentre(100, 101, 99);
+
+            // Then
+            result.Should().BeFalse();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -364,5 +364,16 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             result.Should().HaveCount(260);
             result.First().Should().BeEquivalentTo(expectedFirstCourse);
         }
+
+        [Test]
+        public void GetCentreIdAndCategoryIdForCourse_returns_expected_values()
+        {
+            // When
+            var (centreId, categoryId) = courseDataService.GetCentreIdAndCategoryIdForCourse(1);
+
+            // Then
+            centreId.Should().Be(2);
+            categoryId.Should().Be(2);
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -9,7 +9,6 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions;
-    using FluentAssertions.Execution;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
 
@@ -366,14 +365,13 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         }
 
         [Test]
-        public void GetCentreIdAndCategoryIdForCourse_returns_expected_values()
+        public void DoesCourseExistAtCentre_returns_true_if_course_exists()
         {
             // When
-            var (centreId, categoryId) = courseDataService.GetCentreIdAndCategoryIdForCourse(1);
+            var result = courseDataService.DoesCourseExistAtCentre(100, 101, null);
 
             // Then
-            centreId.Should().Be(2);
-            categoryId.Should().Be(2);
+            result.Should().Be(true);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
@@ -35,11 +35,11 @@
             var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(2, "Priority Access");
             var customPrompts = new List<CustomPrompt> { expectedPrompt1, expectedPrompt2 };
             var expectedCourseAdminFields = CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts);
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsForCourse(100, 101, 0);
+            var result = courseAdminFieldsService.GetCustomPromptsForCourse(100, 101);
 
             // Then
             result.Should().BeEquivalentTo(expectedCourseAdminFields);
@@ -63,7 +63,7 @@
                 answer: answer2
             );
             var expected = new List<CustomPromptWithAnswer> { expected1, expected2 };
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
             var delegateCourseInfo = new DelegateCourseInfo { Answer1 = answer1, Answer2 = answer2 };
 
@@ -112,11 +112,11 @@
             (
                 () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, A<int>._, A<int>._, null)
             ).DoesNothing();
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.AddCustomPromptToCourse(100, 101, 0, 3, null);
+            var result = courseAdminFieldsService.AddCustomPromptToCourse(100, 101, 3, null);
 
             // Then
             A.CallTo
@@ -134,7 +134,7 @@
             (
                 () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, A<int>._, A<int>._, null)
             ).DoesNothing();
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101))
                 .Returns(
                     CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult(
                         "System Access Granted",
@@ -149,7 +149,6 @@
             var result = courseAdminFieldsService.AddCustomPromptToCourse(
                 100,
                 101,
-                0,
                 3,
                 "Adding a fourth prompt"
             );

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -149,5 +149,21 @@
             results[0].DelegateCourseInfo.Should().BeEquivalentTo(info);
             results[0].AttemptStats.Should().Be((0, 0));
         }
+
+        [Test]
+        public void VerifyUserCanAccessCourse_should_call_correct_data_service_method()
+        {
+            // Given
+            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+                .Returns((2, 2));
+
+            // When
+            var result = courseService.VerifyUserCanAccessCourse(1, 2, 2);
+
+            // Then
+            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+                .MustHaveHappened(1, Times.Exactly);
+            result.Should().Be(true);
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -151,19 +151,50 @@
         }
 
         [Test]
-        public void VerifyUserCanAccessCourse_should_call_correct_data_service_method()
+        public void VerifyAdminUserCanAccessCourse_should_call_correct_data_service_method()
         {
             // Given
             A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
                 .Returns((2, 2));
 
             // When
-            var result = courseService.VerifyUserCanAccessCourse(1, 2, 2);
+            var result = courseService.VerifyAdminUserCanAccessCourse(1, 2, 2);
 
             // Then
             A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
             result.Should().Be(true);
+        }
+
+        [Test]
+        public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_centreId()
+        {
+            // Given
+            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+                .Returns((2, 2));
+
+            // When
+            var result = courseService.VerifyAdminUserCanAccessCourse(1, 1, 2);
+
+            // Then
+            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+                .MustHaveHappened(1, Times.Exactly);
+            result.Should().Be(false);
+        }
+
+        [Test]
+        public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_categoryId()
+        {
+            // Given
+            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+                .Returns((2, 2));
+
+            // When
+            var result = courseService.VerifyAdminUserCanAccessCourse(1, 2, 1);
+            // Then
+            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+                .MustHaveHappened(1, Times.Exactly);
+            result.Should().Be(false);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -163,7 +163,7 @@
             // Then
             A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
-            result.Should().Be(true);
+            result.Should().BeTrue();
         }
 
         [Test]
@@ -179,7 +179,7 @@
             // Then
             A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
-            result.Should().Be(false);
+            result.Should().BeFalse();
         }
 
         [Test]
@@ -194,7 +194,7 @@
             // Then
             A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
-            result.Should().Be(false);
+            result.Should().BeFalse();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -109,8 +109,7 @@
                 () => courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
                     info,
                     customisationId,
-                    CentreId,
-                    0
+                    CentreId
                 )
             ).MustHaveHappened(1, Times.Exactly);
             A.CallTo(() => courseDataService.GetDelegateCourseAttemptStats(delegateId, customisationId))
@@ -140,8 +139,7 @@
                 () => courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
                     info,
                     customisationId,
-                    CentreId,
-                    0
+                    CentreId
                 )
             ).MustHaveHappened(1, Times.Exactly);
             A.CallTo(() => courseDataService.GetDelegateCourseAttemptStats(A<int>._, A<int>._)).MustNotHaveHappened();
@@ -154,14 +152,14 @@
         public void VerifyAdminUserCanAccessCourse_should_call_correct_data_service_method()
         {
             // Given
-            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
-                .Returns((2, 2));
+            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
+                .Returns(true);
 
             // When
             var result = courseService.VerifyAdminUserCanAccessCourse(1, 2, 2);
 
             // Then
-            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
             result.Should().BeTrue();
         }
@@ -170,14 +168,14 @@
         public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_centreId()
         {
             // Given
-            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
-                .Returns((2, 2));
+            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
+                .Returns(false);
 
             // When
             var result = courseService.VerifyAdminUserCanAccessCourse(1, 1, 2);
 
             // Then
-            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
             result.Should().BeFalse();
         }
@@ -186,13 +184,13 @@
         public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_categoryId()
         {
             // Given
-            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
-                .Returns((2, 2));
+            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
+                .Returns(false);
 
             // When
             var result = courseService.VerifyAdminUserCanAccessCourse(1, 2, 1);
             // Then
-            A.CallTo(() => courseDataService.GetCentreIdAndCategoryIdForCourse(A<int>._))
+            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
                 .MustHaveHappened(1, Times.Exactly);
             result.Should().BeFalse();
         }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -165,30 +165,15 @@
         }
 
         [Test]
-        public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_centreId()
+        public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_ids()
         {
             // Given
             A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
                 .Returns(false);
 
             // When
-            var result = courseService.VerifyAdminUserCanAccessCourse(1, 1, 2);
+            var result = courseService.VerifyAdminUserCanAccessCourse(1, 1, 1);
 
-            // Then
-            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
-                .MustHaveHappened(1, Times.Exactly);
-            result.Should().BeFalse();
-        }
-
-        [Test]
-        public void VerifyAdminUserCanAccessCourse_should_return_return_false_with_incorrect_categoryId()
-        {
-            // Given
-            A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
-                .Returns(false);
-
-            // When
-            var result = courseService.VerifyAdminUserCanAccessCourse(1, 2, 1);
             // Then
             A.CallTo(() => courseDataService.DoesCourseExistAtCentre(A<int>._, A<int>._, A<int>._))
                 .MustHaveHappened(1, Times.Exactly);

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -8,7 +8,7 @@
 
     public interface ICourseAdminFieldsDataService
     {
-        CourseAdminFieldsResult? GetCourseAdminFields(int customisationId, int centreId, int categoryId);
+        CourseAdminFieldsResult? GetCourseAdminFields(int customisationId, int centreId);
 
         void UpdateCustomPromptForCourse(int customisationId, int promptNumber, string? options);
 
@@ -37,7 +37,7 @@
             this.connection = connection;
         }
 
-        public CourseAdminFieldsResult GetCourseAdminFields(int customisationId, int centreId, int categoryId)
+        public CourseAdminFieldsResult GetCourseAdminFields(int customisationId, int centreId)
         {
             var result = connection.Query<CourseAdminFieldsResult>(
                 @"SELECT
@@ -63,7 +63,7 @@
                     WHERE cu.CentreID = @centreId
                         AND ap.ArchivedDate IS NULL
                         AND cu.CustomisationID = @customisationId",
-                new { customisationId, centreId, categoryId }
+                new { customisationId, centreId }
             ).Single();
 
             return result;

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -23,7 +23,7 @@ namespace DigitalLearningSolutions.Data.DataServices
         CourseNameInfo? GetCourseNameAndApplication(int customisationId);
         CourseDetails? GetCourseDetailsForAdminCategoryId(int customisationId, int centreId, int categoryId);
         IEnumerable<Course> GetCentrallyManagedAndCentreCourses(int centreId, int? categoryId);
-        (int centreId, int categoryId) GetCentreIdAndCategoryIdForCourse(int customisationId);
+        (int? centreId, int? categoryId) GetCentreIdAndCategoryIdForCourse(int customisationId);
     }
 
     public class CourseDataService : ICourseDataService
@@ -347,11 +347,11 @@ namespace DigitalLearningSolutions.Data.DataServices
             );
         }
 
-        public (int centreId, int categoryId) GetCentreIdAndCategoryIdForCourse(int customisationId)
+        public (int? centreId, int? categoryId) GetCentreIdAndCategoryIdForCourse(int customisationId)
         {
             return connection.QueryFirstOrDefault<(int, int)>(
                 @"SELECT c.CentreID,
-                        a.CategoryID
+                        a.CourseCategoryID
                     FROM Customisations AS c
                     JOIN Applications AS a on a.ApplicationID = c.ApplicationID
                     WHERE CustomisationID = @customisationId",

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -356,7 +356,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                         JOIN Applications AS a on a.ApplicationID = c.ApplicationID
                         WHERE CustomisationID = @customisationId
                         AND c.CentreID = @centreId
-                        AND (a.CourseCategoryID = 0 OR @categoryId IS NULL)
+                        AND (a.CourseCategoryID = @categoryId OR @categoryId IS NULL)
                     )
                     THEN CAST(1 AS BIT)
                     ELSE CAST(0 AS BIT) END",

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -349,7 +349,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public bool DoesCourseExistAtCentre(int customisationId, int centreId, int? categoryId)
         {
-            return connection.QueryFirstOrDefault<bool>(
+            return connection.ExecuteScalar<bool>(
                 @"SELECT CASE WHEN EXISTS (
                         SELECT *
                         FROM Customisations AS c

--- a/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
@@ -11,13 +11,12 @@
 
     public interface ICourseAdminFieldsService
     {
-        public CourseAdminFields GetCustomPromptsForCourse(int customisationId, int centreId, int categoryId);
+        public CourseAdminFields GetCustomPromptsForCourse(int customisationId, int centreId);
 
         public List<CustomPromptWithAnswer> GetCustomPromptsWithAnswersForCourse(
             DelegateCourseInfo delegateCourseInfo,
             int customisationId,
-            int centreId,
-            int categoryId = 0
+            int centreId
         );
 
         public void UpdateCustomPromptForCourse(int customisationId, int promptId, string? options);
@@ -27,7 +26,6 @@
         public bool AddCustomPromptToCourse(
             int customisationId,
             int centreId,
-            int categoryId,
             int promptId,
             string? options
         );
@@ -53,11 +51,10 @@
 
         public CourseAdminFields GetCustomPromptsForCourse(
             int customisationId,
-            int centreId,
-            int categoryId = 0
+            int centreId
         )
         {
-            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId, categoryId);
+            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId);
             return new CourseAdminFields(
                 customisationId,
                 centreId,
@@ -68,11 +65,10 @@
         public List<CustomPromptWithAnswer> GetCustomPromptsWithAnswersForCourse(
             DelegateCourseInfo delegateCourseInfo,
             int customisationId,
-            int centreId,
-            int categoryId = 0
+            int centreId
         )
         {
-            var result = GetCourseCustomPromptsResultForCourse(customisationId, centreId, categoryId);
+            var result = GetCourseCustomPromptsResultForCourse(customisationId, centreId);
 
             return PopulateCustomPromptWithAnswerListFromCourseAdminFieldsResult(result, delegateCourseInfo);
         }
@@ -90,15 +86,13 @@
         public bool AddCustomPromptToCourse(
             int customisationId,
             int centreId,
-            int categoryId,
             int promptId,
             string? options
         )
         {
             var courseAdminFields = GetCustomPromptsForCourse(
                 customisationId,
-                centreId,
-                categoryId
+                centreId
             );
 
             var promptNumber = GetNextPromptNumber(courseAdminFields);
@@ -157,12 +151,11 @@
 
         private CourseAdminFieldsResult? GetCourseCustomPromptsResultForCourse(
             int customisationId,
-            int centreId,
-            int categoryId
+            int centreId
         )
         {
-            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId, categoryId);
-            if (result == null || categoryId != 0 && result.CourseCategoryId != categoryId)
+            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId);
+            if (result == null)
             {
                 return null;
             }

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -10,7 +10,7 @@
         public IEnumerable<CourseStatistics> GetTopCourseStatistics(int centreId, int categoryId);
         public IEnumerable<CourseStatistics> GetCentreSpecificCourseStatistics(int centreId, int categoryId);
         public IEnumerable<DelegateCourseDetails> GetAllCoursesForDelegate(int delegateId, int centreId);
-        public bool VerifyUserCanAccessCourse(int customisationId, int centreId, int categoryId);
+        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int categoryId);
     }
 
     public class CourseService : ICourseService
@@ -54,7 +54,7 @@
             );
         }
 
-        public bool VerifyUserCanAccessCourse(int customisationId, int centreId, int categoryId)
+        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int categoryId)
         {
             var (courseCentreId, courseCategoryId) =
                 courseDataService.GetCentreIdAndCategoryIdForCourse(customisationId);

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -10,7 +10,7 @@
         public IEnumerable<CourseStatistics> GetTopCourseStatistics(int centreId, int categoryId);
         public IEnumerable<CourseStatistics> GetCentreSpecificCourseStatistics(int centreId, int categoryId);
         public IEnumerable<DelegateCourseDetails> GetAllCoursesForDelegate(int delegateId, int centreId);
-        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int categoryId);
+        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int? categoryId);
     }
 
     public class CourseService : ICourseService
@@ -54,12 +54,10 @@
             );
         }
 
-        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int categoryId)
+        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int? categoryId)
         {
-            var (courseCentreId, courseCategoryId) =
-                courseDataService.GetCentreIdAndCategoryIdForCourse(customisationId);
-
-            return centreId == courseCentreId && (categoryId == courseCategoryId || categoryId == 0);
+            var nullableCategoryId = categoryId == 0 ? null : categoryId;
+            return courseDataService.DoesCourseExistAtCentre(customisationId, centreId, nullableCategoryId);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -58,7 +58,7 @@
         {
             var ids = courseDataService.GetCentreIdAndCategoryIdForCourse(customisationId);
 
-            if (centreId != ids.centreId || categoryId != ids.categoryId)
+            if (centreId != ids.centreId || (categoryId != ids.categoryId && categoryId != 0))
             {
                 return false;
             }

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -56,14 +56,10 @@
 
         public bool VerifyUserCanAccessCourse(int customisationId, int centreId, int categoryId)
         {
-            var ids = courseDataService.GetCentreIdAndCategoryIdForCourse(customisationId);
+            var (courseCentreId, courseCategoryId) =
+                courseDataService.GetCentreIdAndCategoryIdForCourse(customisationId);
 
-            if (centreId != ids.centreId || (categoryId != ids.categoryId && categoryId != 0))
-            {
-                return false;
-            }
-
-            return true;
+            return centreId == courseCentreId && (categoryId == courseCategoryId || categoryId == 0);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -10,7 +10,7 @@
         public IEnumerable<CourseStatistics> GetTopCourseStatistics(int centreId, int categoryId);
         public IEnumerable<CourseStatistics> GetCentreSpecificCourseStatistics(int centreId, int categoryId);
         public IEnumerable<DelegateCourseDetails> GetAllCoursesForDelegate(int delegateId, int centreId);
-        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int? categoryId);
+        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int categoryId);
     }
 
     public class CourseService : ICourseService
@@ -54,10 +54,10 @@
             );
         }
 
-        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int? categoryId)
+        public bool VerifyAdminUserCanAccessCourse(int customisationId, int centreId, int adminCategoryIdClaim)
         {
-            var nullableCategoryId = categoryId == 0 ? null : categoryId;
-            return courseDataService.DoesCourseExistAtCentre(customisationId, centreId, nullableCategoryId);
+            var categoryIdFilter = adminCategoryIdClaim == 0 ? (int?)null : adminCategoryIdClaim;
+            return courseDataService.DoesCourseExistAtCentre(customisationId, centreId, categoryIdFilter);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -10,12 +10,13 @@
         public IEnumerable<CourseStatistics> GetTopCourseStatistics(int centreId, int categoryId);
         public IEnumerable<CourseStatistics> GetCentreSpecificCourseStatistics(int centreId, int categoryId);
         public IEnumerable<DelegateCourseDetails> GetAllCoursesForDelegate(int delegateId, int centreId);
+        public bool VerifyUserCanAccessCourse(int customisationId, int centreId, int categoryId);
     }
 
     public class CourseService : ICourseService
     {
-        private readonly ICourseDataService courseDataService;
         private readonly ICourseAdminFieldsService courseAdminFieldsService;
+        private readonly ICourseDataService courseDataService;
 
         public CourseService(ICourseDataService courseDataService, ICourseAdminFieldsService courseAdminFieldsService)
         {
@@ -51,6 +52,18 @@
                     return new DelegateCourseDetails(info, customPrompts, attemptStats);
                 }
             );
+        }
+
+        public bool VerifyUserCanAccessCourse(int customisationId, int centreId, int categoryId)
+        {
+            var ids = courseDataService.GetCentreIdAndCategoryIdForCourse(customisationId);
+
+            if (centreId != ids.centreId || categoryId != ids.categoryId)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCourseAdminFieldsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCourseAdminFieldsAccessibilityTests.cs
@@ -35,12 +35,10 @@
 
             Driver.ClickButtonByText("Submit");
             ValidatePageHeading("Add course admin field");
-            var bulkPostResult = new AxeBuilder(Driver).Analyze();
 
             addPageResult.Violations.Should().BeEmpty();
             bulkAdditionResult.Violations.Should().BeEmpty();
             addAnswersResult.Violations.Should().BeEmpty();
-            bulkPostResult.Violations.Should().BeEmpty();
         }
 
         private void AddAnswer(string answerString)

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCourseAdminFieldsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCourseAdminFieldsAccessibilityTests.cs
@@ -35,10 +35,12 @@
 
             Driver.ClickButtonByText("Submit");
             ValidatePageHeading("Add course admin field");
+            var bulkPostResult = new AxeBuilder(Driver).Analyze();
 
             addPageResult.Violations.Should().BeEmpty();
             bulkAdditionResult.Violations.Should().BeEmpty();
             addAnswersResult.Violations.Should().BeEmpty();
+            bulkPostResult.Violations.Should().BeEmpty();
         }
 
         private void AddAnswer(string answerString)

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseAdminFieldsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseAdminFieldsAccessibilityTests.cs
@@ -29,9 +29,11 @@
 
             Driver.ClickButtonByText("Submit");
             ValidatePageHeading("Edit course admin field");
+            var bulkPostResult = new AxeBuilder(Driver).Analyze();
 
             editPageResult.Violations.Should().BeEmpty();
             bulkAdditionResult.Violations.Should().BeEmpty();
+            bulkPostResult.Violations.Should().BeEmpty();
         }
     }
 }

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseAdminFieldsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseAdminFieldsAccessibilityTests.cs
@@ -29,11 +29,9 @@
 
             Driver.ClickButtonByText("Submit");
             ValidatePageHeading("Edit course admin field");
-            var bulkPostResult = new AxeBuilder(Driver).Analyze();
 
             editPageResult.Violations.Should().BeEmpty();
             bulkAdditionResult.Violations.Should().BeEmpty();
-            bulkPostResult.Violations.Should().BeEmpty();
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -59,7 +59,7 @@
         public void PostEditAdminField_save_calls_correct_methods()
         {
             // Given
-            var model = new EditAdminFieldViewModel(1, 1, "Test", "Options");
+            var model = new EditAdminFieldViewModel(1, "Test", "Options");
             const string action = "save";
 
             A.CallTo(
@@ -71,7 +71,7 @@
             ).DoesNothing();
 
             // When
-            var result = controller.EditAdminField(model, action, 1, 1);
+            var result = controller.EditAdminField(1, model, action);
 
             // Then
             A.CallTo(
@@ -88,7 +88,7 @@
         public void PostEditAdminField_add_configures_new_answer()
         {
             // Given
-            var model = new EditAdminFieldViewModel(1, 1, "Test", "Options");
+            var model = new EditAdminFieldViewModel(1, "Test", "Options");
             const string action = "addPrompt";
 
             A.CallTo(
@@ -100,7 +100,7 @@
             ).DoesNothing();
 
             // When
-            var result = controller.EditAdminField(model, action, 1, 1);
+            var result = controller.EditAdminField(1, model, action);
 
             // Then
             using (new AssertionScope())
@@ -114,11 +114,11 @@
         public void PostEditAdminField_delete_removes_configured_answer()
         {
             // Given
-            var model = new EditAdminFieldViewModel(1, 1, "Test", "Test\r\nAnswer");
+            var model = new EditAdminFieldViewModel(1, "Test", "Test\r\nAnswer");
             const string action = "delete0";
 
             // When
-            var result = controller.EditAdminField(model, action, 1, 1);
+            var result = controller.EditAdminField(1, model, action);
 
             // Then
             using (new AssertionScope())
@@ -132,11 +132,11 @@
         public void PostAdminField_bulk_sets_up_temp_data_and_redirects()
         {
             // Given
-            var model = new EditAdminFieldViewModel(1, 1, "Test", "Options");
+            var model = new EditAdminFieldViewModel(1, "Test", "Options");
             const string action = "bulk";
 
             // When
-            var result = controller.EditAdminField(model, action, 1, 1);
+            var result = controller.EditAdminField(1, model, action);
 
             // Then
             using (new AssertionScope())
@@ -150,11 +150,11 @@
         public void PostEditAdminField_returns_error_with_unexpected_action()
         {
             // Given
-            var model = new EditAdminFieldViewModel(1, 1, "Test", "Options");
+            var model = new EditAdminFieldViewModel(1, "Test", "Options");
             const string action = "deletetest";
 
             // When
-            var result = controller.EditAdminField(model, action, 1, 1);
+            var result = controller.EditAdminField(1, model, action);
 
             // Then
             result.Should().BeStatusCodeResult().WithStatusCode(500);
@@ -164,9 +164,9 @@
         public void AdminFieldBulkPost_updates_temp_data_and_redirects_to_edit()
         {
             // Given
-            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false, 1, 1);
-            var initialEditViewModel = new EditAdminFieldViewModel(1, 1, "Test", "Test");
-            var expectedViewModel = new EditAdminFieldViewModel(1, 1, "Test", "Test\r\nAnswer");
+            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false, 1);
+            var initialEditViewModel = new EditAdminFieldViewModel(1, "Test", "Test");
+            var expectedViewModel = new EditAdminFieldViewModel(1, "Test", "Test\r\nAnswer");
             var initialTempData = new EditAdminFieldData(initialEditViewModel);
 
             controller.TempData.Set(initialTempData);
@@ -175,7 +175,7 @@
                 .Returns(true);
 
             // When
-            var result = controller.EditAdminFieldBulkPost(inputViewModel);
+            var result = controller.EditAdminFieldBulkPost(1, inputViewModel);
 
             // Then
             using (new AssertionScope())
@@ -199,7 +199,7 @@
         [Test]
         public void AddAdminField_post_updates_temp_data_and_redirects()
         {
-            var expectedPromptModel = new AddAdminFieldViewModel(1);
+            var expectedPromptModel = new AddAdminFieldViewModel();
             var initialTempData = new AddAdminFieldData(expectedPromptModel);
             controller.TempData.Set(initialTempData);
 
@@ -215,7 +215,7 @@
         public void AddAdminField_save_clears_temp_data_and_redirects_to_index()
         {
             // Given
-            var model = new AddAdminFieldViewModel(100, 1, "Test");
+            var model = new AddAdminFieldViewModel(1, "Test");
             const string action = "save";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -244,7 +244,7 @@
         public void AddAdminField_save_redirects_successfully_without_answers_configured()
         {
             // Given
-            var model = new AddAdminFieldViewModel(100, 1, null);
+            var model = new AddAdminFieldViewModel(1, null);
             const string action = "save";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -273,7 +273,7 @@
         public void AddAdminField_calls_service_and_redirects_to_error_on_failure()
         {
             // Given
-            var model = new AddAdminFieldViewModel(100, 1, "Test");
+            var model = new AddAdminFieldViewModel(1, "Test");
             const string action = "save";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -300,11 +300,11 @@
         [Test]
         public void AddAdminField_add_configures_new_answer_and_updates_temp_data()
         {
-            var initialViewModel = new AddAdminFieldViewModel(1, 1, "Test", "Answer");
+            var initialViewModel = new AddAdminFieldViewModel(1, "Test", "Answer");
             var initialTempData = new AddAdminFieldData(initialViewModel);
             controller.TempData.Set(initialTempData);
 
-            var expectedViewModel = new AddAdminFieldViewModel(1, 1, "Test\r\nAnswer");
+            var expectedViewModel = new AddAdminFieldViewModel(1, "Test\r\nAnswer");
             const string action = "addPrompt";
 
             // When
@@ -323,11 +323,11 @@
         [Test]
         public void AddAdminField_adds_answer_without_admin_field_selected()
         {
-            var initialViewModel = new AddAdminFieldViewModel(1, null, null, "Answer");
+            var initialViewModel = new AddAdminFieldViewModel(null, null, "Answer");
             var initialTempData = new AddAdminFieldData(initialViewModel);
             controller.TempData.Set(initialTempData);
 
-            var expectedViewModel = new AddAdminFieldViewModel(1, null, "Answer");
+            var expectedViewModel = new AddAdminFieldViewModel(null, "Answer");
             const string action = "addPrompt";
 
             // When
@@ -344,7 +344,7 @@
         public void AddAdminField_delete_removes_configured_answer()
         {
             // Given
-            var model = new AddAdminFieldViewModel(1, 1, "Test\r\nAnswer");
+            var model = new AddAdminFieldViewModel(1, "Test\r\nAnswer");
             const string action = "delete0";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -363,7 +363,7 @@
         [Test]
         public void AddAdminField_removes_answer_without_admin_field_selected()
         {
-            var model = new AddAdminFieldViewModel(1, null, "Test\r\nAnswer");
+            var model = new AddAdminFieldViewModel(null, "Test\r\nAnswer");
             const string action = "delete0";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -383,7 +383,7 @@
         public void AddAdminField_bulk_sets_up_temp_data_and_redirects()
         {
             // Given
-            var model = new AddAdminFieldViewModel(1, 1, "Options");
+            var model = new AddAdminFieldViewModel(1, "Options");
             const string action = "bulk";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -403,7 +403,7 @@
         public void AddAdminField_bulk_redirects_without_admin_field_selected()
         {
             // Given
-            var model = new AddAdminFieldViewModel(1, null, "Options");
+            var model = new AddAdminFieldViewModel(null, "Options");
             const string action = "bulk";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -423,7 +423,7 @@
         public void AddAdminField_returns_error_with_unexpected_action()
         {
             // Given
-            var model = new AddAdminFieldViewModel(1);
+            var model = new AddAdminFieldViewModel();
             const string action = "deletetest";
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
@@ -440,14 +440,14 @@
         {
             // Given
             var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false, 1);
-            var initialAddViewModel = new AddAdminFieldViewModel(1, 1, "Test");
-            var expectedViewModel = new AddAdminFieldViewModel(1, 1, "Test\r\nAnswer");
+            var initialAddViewModel = new AddAdminFieldViewModel(1, "Test");
+            var expectedViewModel = new AddAdminFieldViewModel(1, "Test\r\nAnswer");
             var initialTempData = new AddAdminFieldData(initialAddViewModel);
 
             controller.TempData.Set(initialTempData);
 
             // When
-            var result = controller.AddAdminFieldAnswersBulk(inputViewModel, 1);
+            var result = controller.AddAdminFieldAnswersBulk(1, inputViewModel);
 
             // Then
             using (new AssertionScope())
@@ -471,7 +471,7 @@
         public void RemoveAdminField_returns_remove_view_if_admin_field_has_user_answers()
         {
             // Given
-            var removeViewModel = new RemoveAdminFieldViewModel(100, "System Access Granted", 1);
+            var removeViewModel = new RemoveAdminFieldViewModel("System Access Granted", 1);
 
             // When
             var result = controller.RemoveAdminField(100, 1, removeViewModel);
@@ -484,7 +484,7 @@
         public void RemoveAdminField_does_not_remove_admin_field_without_confirmation()
         {
             // Given
-            var removeViewModel = new RemoveAdminFieldViewModel(100, "System Access Granted", 1);
+            var removeViewModel = new RemoveAdminFieldViewModel("System Access Granted", 1);
             removeViewModel.Confirm = false;
             var expectedErrorMessage = "You must confirm before deleting this field";
 
@@ -501,7 +501,7 @@
         public void RemoveAdminField_removes_admin_field_with_confirmation_and_redirects()
         {
             // Given
-            var removeViewModel = new RemoveAdminFieldViewModel(100, "System Access Granted", 1);
+            var removeViewModel = new RemoveAdminFieldViewModel("System Access Granted", 1);
             removeViewModel.Confirm = true;
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -23,6 +23,7 @@
             A.Fake<ICourseAdminFieldsDataService>();
 
         private readonly ICourseAdminFieldsService courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
+        private readonly ICourseService courseService = A.Fake<ICourseService>();
         private AdminFieldsController controller = null!;
 
         [SetUp]
@@ -30,7 +31,8 @@
         {
             controller = new AdminFieldsController(
                     courseAdminFieldsService,
-                    courseAdminFieldsDataService
+                    courseAdminFieldsDataService,
+                    courseService
                 )
                 .WithDefaultContext()
                 .WithMockUser(true, 101)
@@ -43,7 +45,7 @@
             // Given
             var samplePrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1, "System Access Granted", "Yes\r\nNo");
             var customPrompts = new List<CustomPrompt> { samplePrompt1 };
-            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._, A<int>._))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts));
 
             // When
@@ -169,6 +171,9 @@
 
             controller.TempData.Set(initialTempData);
 
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+                .Returns(true);
+
             // When
             var result = controller.EditAdminFieldBulkPost(inputViewModel);
 
@@ -219,7 +224,6 @@
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
                     101,
-                    0,
                     1,
                     "Test"
                 )
@@ -249,7 +253,6 @@
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
                     101,
-                    0,
                     1,
                     null
                 )
@@ -279,7 +282,6 @@
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
                     101,
-                    0,
                     1,
                     "Test"
                 )

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -142,7 +142,7 @@
             using (new AssertionScope())
             {
                 AssertEditTempDataIsExpected(model);
-                result.Should().BeRedirectToActionResult().WithActionName("EditAdminFieldBulk");
+                result.Should().BeRedirectToActionResult().WithActionName("EditAdminFieldAnswersBulk");
             }
         }
 
@@ -161,10 +161,10 @@
         }
 
         [Test]
-        public void EditAdminFieldBulkPost_updates_temp_data_and_redirects_to_edit()
+        public void EditAdminFieldAnswersBulk_updates_temp_data_and_redirects_to_edit()
         {
             // Given
-            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false, 1);
+            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false);
             var initialEditViewModel = new EditAdminFieldViewModel(1, "Test", "Test");
             var expectedViewModel = new EditAdminFieldViewModel(1, "Test", "Test\r\nAnswer");
             var initialTempData = new EditAdminFieldData(initialEditViewModel);
@@ -175,7 +175,7 @@
                 .Returns(true);
 
             // When
-            var result = controller.EditAdminFieldBulkPost(1, inputViewModel);
+            var result = controller.EditAdminFieldAnswersBulk(1, 1, inputViewModel);
 
             // Then
             using (new AssertionScope())
@@ -395,7 +395,7 @@
             using (new AssertionScope())
             {
                 AssertAddTempDataIsExpected(model);
-                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldBulkPost");
+                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldAnswersBulk");
             }
         }
 
@@ -415,7 +415,7 @@
             using (new AssertionScope())
             {
                 AssertAddTempDataIsExpected(model);
-                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldBulkPost");
+                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldAnswersBulk");
             }
         }
 
@@ -436,10 +436,10 @@
         }
 
         [Test]
-        public void AddAdminFieldBulkPost_updates_temp_data_and_redirects_to_add()
+        public void AddAdminFieldAnswersBulk_updates_temp_data_and_redirects_to_add()
         {
             // Given
-            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false, 1);
+            var inputViewModel = new AddBulkAdminFieldAnswersViewModel("Test\r\nAnswer", 1);
             var initialAddViewModel = new AddAdminFieldViewModel(1, "Test");
             var expectedViewModel = new AddAdminFieldViewModel(1, "Test\r\nAnswer");
             var initialTempData = new AddAdminFieldData(initialAddViewModel);
@@ -447,7 +447,7 @@
             controller.TempData.Set(initialTempData);
 
             // When
-            var result = controller.AddAdminFieldBulkPost(1, inputViewModel);
+            var result = controller.AddAdminFieldAnswersBulk(1, inputViewModel);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -395,7 +395,7 @@
             using (new AssertionScope())
             {
                 AssertAddTempDataIsExpected(model);
-                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldAnswersBulk");
+                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldBulkPost");
             }
         }
 
@@ -415,7 +415,7 @@
             using (new AssertionScope())
             {
                 AssertAddTempDataIsExpected(model);
-                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldAnswersBulk");
+                result.Should().BeRedirectToActionResult().WithActionName("AddAdminFieldBulkPost");
             }
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -31,8 +31,7 @@
         {
             controller = new AdminFieldsController(
                     courseAdminFieldsService,
-                    courseAdminFieldsDataService,
-                    courseService
+                    courseAdminFieldsDataService
                 )
                 .WithDefaultContext()
                 .WithMockUser(true, 101)

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -23,12 +23,13 @@
             A.Fake<ICourseAdminFieldsDataService>();
 
         private readonly ICourseAdminFieldsService courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
+        private readonly ICourseService courseService = A.Fake<ICourseService>();
         private AdminFieldsController controller = null!;
 
         [SetUp]
         public void Setup()
         {
-            controller = new AdminFieldsController(courseAdminFieldsService, courseAdminFieldsDataService)
+            controller = new AdminFieldsController(courseAdminFieldsService, courseAdminFieldsDataService, courseService)
                 .WithDefaultContext()
                 .WithMockUser(true, 101)
                 .WithMockTempData();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -164,7 +164,7 @@
         public void EditAdminFieldAnswersBulk_updates_temp_data_and_redirects_to_edit()
         {
             // Given
-            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false);
+            var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer");
             var initialEditViewModel = new EditAdminFieldViewModel(1, "Test", "Test");
             var expectedViewModel = new EditAdminFieldViewModel(1, "Test", "Test\r\nAnswer");
             var initialTempData = new EditAdminFieldData(initialEditViewModel);

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -23,7 +23,6 @@
             A.Fake<ICourseAdminFieldsDataService>();
 
         private readonly ICourseAdminFieldsService courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
-        private readonly ICourseService courseService = A.Fake<ICourseService>();
         private AdminFieldsController controller = null!;
 
         [SetUp]
@@ -31,34 +30,11 @@
         {
             controller = new AdminFieldsController(
                     courseAdminFieldsService,
-                    courseAdminFieldsDataService,
-                    courseService
+                    courseAdminFieldsDataService
                 )
                 .WithDefaultContext()
                 .WithMockUser(true, 101)
                 .WithMockTempData();
-        }
-
-        [Test]
-        public void All_admin_field_pages_return_not_found_if_user_cannot_access_course()
-        {
-            // Given
-            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
-                .Returns(false);
-
-            // When
-            var indexResult = controller.Index(2);
-            var editResult = controller.EditAdminField(2, 1);
-            var editBulkResult = controller.EditAdminFieldBulk(2, 1);
-            var addResult = controller.AddAdminField(2);
-            var removeResult = controller.RemoveAdminField(2, 1);
-
-            // Then
-            indexResult.Should().BeNotFoundResult();
-            editResult.Should().BeNotFoundResult();
-            editBulkResult.Should().BeNotFoundResult();
-            addResult.Should().BeNotFoundResult();
-            removeResult.Should().BeNotFoundResult();
         }
 
         [Test]
@@ -67,8 +43,6 @@
             // Given
             var samplePrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1, "System Access Granted", "Yes\r\nNo");
             var customPrompts = new List<CustomPrompt> { samplePrompt1 };
-            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
-                .Returns(true);
             A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts));
 
@@ -95,7 +69,7 @@
             ).DoesNothing();
 
             // When
-            var result = controller.EditAdminField(model, action);
+            var result = controller.EditAdminField(model, action, 1, 1);
 
             // Then
             A.CallTo(
@@ -124,7 +98,7 @@
             ).DoesNothing();
 
             // When
-            var result = controller.EditAdminField(model, action);
+            var result = controller.EditAdminField(model, action, 1, 1);
 
             // Then
             using (new AssertionScope())
@@ -142,7 +116,7 @@
             const string action = "delete0";
 
             // When
-            var result = controller.EditAdminField(model, action);
+            var result = controller.EditAdminField(model, action, 1, 1);
 
             // Then
             using (new AssertionScope())
@@ -160,7 +134,7 @@
             const string action = "bulk";
 
             // When
-            var result = controller.EditAdminField(model, action);
+            var result = controller.EditAdminField(model, action, 1, 1);
 
             // Then
             using (new AssertionScope())
@@ -178,7 +152,7 @@
             const string action = "deletetest";
 
             // When
-            var result = controller.EditAdminField(model, action);
+            var result = controller.EditAdminField(model, action, 1, 1);
 
             // Then
             result.Should().BeStatusCodeResult().WithStatusCode(500);
@@ -223,8 +197,6 @@
             var expectedPromptModel = new AddAdminFieldViewModel(1);
             var initialTempData = new AddAdminFieldData(expectedPromptModel);
             controller.TempData.Set(initialTempData);
-            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
-                .Returns(true);
 
             // When
             var result = controller.AddAdminField(1);
@@ -243,8 +215,6 @@
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
 
-            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
-                .Returns(true);
             A.CallTo(
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
@@ -359,8 +329,7 @@
             const string action = "addPrompt";
 
             // When
-            var result =
-                controller.AddAdminField(1, initialViewModel, action);
+            controller.AddAdminField(1, initialViewModel, action);
 
             // Then
             using (new AssertionScope())
@@ -476,7 +445,7 @@
             controller.TempData.Set(initialTempData);
 
             // When
-            var result = controller.AddAdminFieldAnswersBulk(inputViewModel);
+            var result = controller.AddAdminFieldAnswersBulk(inputViewModel, 1);
 
             // Then
             using (new AssertionScope())
@@ -489,10 +458,6 @@
         [Test]
         public void RemoveAdminField_removes_admin_field_with_no_user_answers()
         {
-            // Given
-            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
-                .Returns(true);
-
             // When
             var result = controller.RemoveAdminField(100, 2);
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -161,7 +161,7 @@
         }
 
         [Test]
-        public void AdminFieldBulkPost_updates_temp_data_and_redirects_to_edit()
+        public void EditAdminFieldBulkPost_updates_temp_data_and_redirects_to_edit()
         {
             // Given
             var inputViewModel = new BulkAdminFieldAnswersViewModel("Test\r\nAnswer", false, 1);
@@ -447,7 +447,7 @@
             controller.TempData.Set(initialTempData);
 
             // When
-            var result = controller.AddAdminFieldAnswersBulk(1, inputViewModel);
+            var result = controller.AddAdminFieldBulkPost(1, inputViewModel);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -43,7 +43,7 @@
         public void All_admin_field_pages_return_not_found_if_user_cannot_access_course()
         {
             // Given
-            A.CallTo(() => courseService.VerifyUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(false);
 
             // When
@@ -67,7 +67,7 @@
             // Given
             var samplePrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1, "System Access Granted", "Yes\r\nNo");
             var customPrompts = new List<CustomPrompt> { samplePrompt1 };
-            A.CallTo(() => courseService.VerifyUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(true);
             A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts));
@@ -223,7 +223,7 @@
             var expectedPromptModel = new AddAdminFieldViewModel(1);
             var initialTempData = new AddAdminFieldData(expectedPromptModel);
             controller.TempData.Set(initialTempData);
-            A.CallTo(() => courseService.VerifyUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(true);
 
             // When
@@ -243,7 +243,7 @@
             var initialTempData = new AddAdminFieldData(model);
             controller.TempData.Set(initialTempData);
 
-            A.CallTo(() => courseService.VerifyUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(true);
             A.CallTo(
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
@@ -490,7 +490,7 @@
         public void RemoveAdminField_removes_admin_field_with_no_user_answers()
         {
             // Given
-            A.CallTo(() => courseService.VerifyUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(true);
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
@@ -23,18 +23,7 @@
         public void Returns_NotFound_if_service_returns_false()
         {
             // Given
-            var homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
-                .WithMockUser(true, 101);
-            var context = new ActionExecutingContext(
-                new ActionContext(
-                    new DefaultHttpContext(),
-                    new RouteData(new RouteValueDictionary()),
-                    new ActionDescriptor()
-                ),
-                new List<IFilterMetadata>(),
-                new Dictionary<string, object>(),
-                homeController
-            );
+            var context = SetupContext();
             context.RouteData.Values["customisationId"] = 2;
             A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(false);
@@ -43,13 +32,6 @@
             new VerifyAdminUserCanAccessCourse(courseService).OnActionExecuting(context);
 
             // Then
-            A.CallTo(
-                () => courseService.VerifyAdminUserCanAccessCourse(
-                    A<int>._,
-                    A<int>._,
-                    A<int>._
-                )
-            ).MustHaveHappened();
             context.Result.Should().BeNotFoundResult();
         }
 
@@ -57,6 +39,20 @@
         public void Does_not_return_NotFound_if_service_returns_true()
         {
             // Given
+            var context = SetupContext();
+            context.RouteData.Values["customisationId"] = 24286;
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+                .Returns(true);
+
+            // When
+            new VerifyAdminUserCanAccessCourse(courseService).OnActionExecuting(context);
+
+            // Then
+            context.Result.Should().BeNull();
+        }
+
+        private ActionExecutingContext SetupContext()
+        {
             var homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
                 .WithMockUser(true, 101);
             var context = new ActionExecutingContext(
@@ -69,22 +65,7 @@
                 new Dictionary<string, object>(),
                 homeController
             );
-            context.RouteData.Values["customisationId"] = 24286;
-            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
-                .Returns(true);
-
-            // When
-            new VerifyAdminUserCanAccessCourse(courseService).OnActionExecuting(context);
-
-            // Then
-            A.CallTo(
-                () => courseService.VerifyAdminUserCanAccessCourse(
-                    A<int>._,
-                    A<int>._,
-                    A<int>._
-                )
-            ).MustHaveHappened();
-            context.Result.Should().BeNull();
+            return context;
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
@@ -1,0 +1,90 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Controllers;
+    using DigitalLearningSolutions.Web.ServiceFilter;
+    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+    using FakeItEasy;
+    using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Configuration;
+    using NUnit.Framework;
+
+    public class VerifyAdminUserCanAccessCourseTests
+    {
+        private readonly ICourseService courseService = A.Fake<ICourseService>();
+
+        [Test]
+        public void Returns_NotFound_if_service_returns_false()
+        {
+            // Given
+            var homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
+                .WithMockUser(true, 101);
+            var context = new ActionExecutingContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(new RouteValueDictionary()),
+                    new ActionDescriptor()
+                ),
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                homeController
+            );
+            context.RouteData.Values["customisationId"] = 2;
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+                .Returns(false);
+
+            // When
+            new VerifyAdminUserCanAccessCourse(courseService).OnActionExecuting(context);
+
+            // Then
+            A.CallTo(
+                () => courseService.VerifyAdminUserCanAccessCourse(
+                    A<int>._,
+                    A<int>._,
+                    A<int>._
+                )
+            ).MustHaveHappened();
+            context.Result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void Does_not_return_NotFound_if_service_returns_true()
+        {
+            // Given
+            var homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
+                .WithMockUser(true, 101);
+            var context = new ActionExecutingContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(new RouteValueDictionary()),
+                    new ActionDescriptor()
+                ),
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                homeController
+            );
+            context.RouteData.Values["customisationId"] = 24286;
+            A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
+                .Returns(true);
+
+            // When
+            new VerifyAdminUserCanAccessCourse(courseService).OnActionExecuting(context);
+
+            // Then
+            A.CallTo(
+                () => courseService.VerifyAdminUserCanAccessCourse(
+                    A<int>._,
+                    A<int>._,
+                    A<int>._
+                )
+            ).MustHaveHappened();
+            context.Result.Should().BeNull();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
@@ -18,12 +18,30 @@
     public class VerifyAdminUserCanAccessCourseTests
     {
         private readonly ICourseService courseService = A.Fake<ICourseService>();
+        private ActionExecutingContext context = null!;
+        private HomeController homeController = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
+                .WithMockUser(true, 101);
+            context = new ActionExecutingContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(new RouteValueDictionary()),
+                    new ActionDescriptor()
+                ),
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                homeController
+            );
+        }
 
         [Test]
         public void Returns_NotFound_if_service_returns_false()
         {
             // Given
-            var context = SetupContext();
             context.RouteData.Values["customisationId"] = 2;
             A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(false);
@@ -39,7 +57,6 @@
         public void Does_not_return_NotFound_if_service_returns_true()
         {
             // Given
-            var context = SetupContext();
             context.RouteData.Values["customisationId"] = 24286;
             A.CallTo(() => courseService.VerifyAdminUserCanAccessCourse(A<int>._, A<int>._, A<int>._))
                 .Returns(true);
@@ -49,23 +66,6 @@
 
             // Then
             context.Result.Should().BeNull();
-        }
-
-        private ActionExecutingContext SetupContext()
-        {
-            var homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
-                .WithMockUser(true, 101);
-            var context = new ActionExecutingContext(
-                new ActionContext(
-                    new DefaultHttpContext(),
-                    new RouteData(new RouteValueDictionary()),
-                    new ActionDescriptor()
-                ),
-                new List<IFilterMetadata>(),
-                new Dictionary<string, object>(),
-                homeController
-            );
-            return context;
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessCourseTests.cs
@@ -19,12 +19,11 @@
     {
         private readonly ICourseService courseService = A.Fake<ICourseService>();
         private ActionExecutingContext context = null!;
-        private HomeController homeController = null!;
 
         [SetUp]
         public void Setup()
         {
-            homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
+            var homeController = new HomeController(A.Fake<IConfiguration>()).WithDefaultContext().WithMockTempData()
                 .WithMockUser(true, 101);
             context = new ActionExecutingContext(
                 new ActionContext(

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -28,17 +28,14 @@
         private static readonly DateTimeOffset CookieExpiry = DateTimeOffset.UtcNow.AddDays(7);
         private readonly ICourseAdminFieldsDataService courseAdminFieldsDataService;
         private readonly ICourseAdminFieldsService courseAdminFieldsService;
-        private readonly ICourseService courseService;
 
         public AdminFieldsController(
             ICourseAdminFieldsService courseAdminFieldsService,
-            ICourseAdminFieldsDataService courseAdminFieldsDataService,
-            ICourseService courseService
+            ICourseAdminFieldsDataService courseAdminFieldsDataService
         )
         {
             this.courseAdminFieldsService = courseAdminFieldsService;
             this.courseAdminFieldsDataService = courseAdminFieldsDataService;
-            this.courseService = courseService;
         }
 
         [HttpGet]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -113,25 +113,25 @@
         [Route("{customisationId:int}/AdminFields/{promptNumber:int}/Edit/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<EditAdminFieldData>))]
-        public IActionResult EditAdminFieldBulk(int customisationId, int promptNumber)
+        public IActionResult EditAdminFieldAnswersBulk(int customisationId, int promptNumber)
         {
             var data = TempData.Peek<EditAdminFieldData>()!;
 
             var model = new BulkAdminFieldAnswersViewModel(
                 data.EditModel.OptionsString,
-                false,
-                promptNumber
+                false
             );
 
             return View("BulkAdminFieldAnswers", model);
         }
 
         [HttpPost]
-        [Route("{customisationId:int}/AdminFields/Edit/Bulk")]
+        [Route("{customisationId:int}/AdminFields/{promptNumber:int}/Edit/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<EditAdminFieldData>))]
-        public IActionResult EditAdminFieldBulkPost(
+        public IActionResult EditAdminFieldAnswersBulk(
             int customisationId,
+            int promptNumber,
             BulkAdminFieldAnswersViewModel model
         )
         {
@@ -148,7 +148,7 @@
 
             return RedirectToAction(
                 "EditAdminField",
-                new { customisationId, promptNumber = model.PromptNumber }
+                new { customisationId, promptNumber }
             );
         }
 
@@ -206,30 +206,29 @@
         [Route("{customisationId:int}/AdminFields/Add/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<AddAdminFieldData>))]
-        public IActionResult AddAdminFieldBulkPost(int customisationId)
+        public IActionResult AddAdminFieldAnswersBulk(int customisationId)
         {
             var data = TempData.Peek<AddAdminFieldData>()!;
-            var model = new BulkAdminFieldAnswersViewModel(
-                data.AddModel.OptionsString,
-                true
+            var model = new AddBulkAdminFieldAnswersViewModel(
+                data.AddModel.OptionsString
             );
 
-            return View("BulkAdminFieldAnswers", model);
+            return View("AddBulkAdminFieldAnswers", model);
         }
 
         [HttpPost]
         [Route("{customisationId:int}/AdminFields/Add/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<AddAdminFieldData>))]
-        public IActionResult AddAdminFieldBulkPost(
+        public IActionResult AddAdminFieldAnswersBulk(
             int customisationId,
-            BulkAdminFieldAnswersViewModel model
+            AddBulkAdminFieldAnswersViewModel model
         )
         {
             ValidateBulkOptionsString(model.OptionsString);
             if (!ModelState.IsValid)
             {
-                return View("BulkAdminFieldAnswers", model);
+                return View("AddBulkAdminFieldAnswers", model);
             }
 
             var addData = TempData.Peek<AddAdminFieldData>()!;
@@ -299,7 +298,7 @@
             SetEditAdminFieldTempData(model);
 
             return RedirectToAction(
-                "EditAdminFieldBulk",
+                "EditAdminFieldAnswersBulk",
                 new { customisationId, promptNumber = model.PromptNumber }
             );
         }
@@ -352,7 +351,7 @@
             SetAddAdminFieldTempData(model);
 
             return RedirectToAction(
-                "AddAdminFieldBulkPost",
+                "AddAdminFieldAnswersBulk",
                 new { customisationId }
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -118,8 +118,7 @@
             var data = TempData.Peek<EditAdminFieldData>()!;
 
             var model = new BulkAdminFieldAnswersViewModel(
-                data.EditModel.OptionsString,
-                false
+                data.EditModel.OptionsString
             );
 
             return View("BulkAdminFieldAnswers", model);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -45,7 +45,10 @@
         [Route("{customisationId}/AdminFields")]
         public IActionResult Index(int customisationId)
         {
-            ReturnNotFoundIfUserCannotAccessCourse(customisationId);
+            if (!VerifyAdminUserCanAccessCourse(customisationId))
+            {
+                return NotFound();
+            }
 
             var centreId = User.GetCentreId();
             var categoryId = User.GetAdminCategoryId()!;
@@ -73,7 +76,10 @@
         [Route("{customisationId}/AdminFields/{promptNumber:int}/Edit")]
         public IActionResult EditAdminField(int customisationId, int promptNumber)
         {
-            ReturnNotFoundIfUserCannotAccessCourse(customisationId);
+            if (!VerifyAdminUserCanAccessCourse(customisationId))
+            {
+                return NotFound();
+            }
 
             var centreId = User.GetCentreId();
             var categoryId = User.GetAdminCategoryId()!;
@@ -115,7 +121,10 @@
         [ServiceFilter(typeof(RedirectEmptySessionData<EditAdminFieldData>))]
         public IActionResult EditAdminFieldBulk(int customisationId, int promptNumber)
         {
-            ReturnNotFoundIfUserCannotAccessCourse(customisationId);
+            if (!VerifyAdminUserCanAccessCourse(customisationId))
+            {
+                return NotFound();
+            }
 
             var data = TempData.Peek<EditAdminFieldData>()!;
 
@@ -171,7 +180,10 @@
         [ServiceFilter(typeof(RedirectEmptySessionData<AddAdminFieldData>))]
         public IActionResult AddAdminField(int customisationId)
         {
-            ReturnNotFoundIfUserCannotAccessCourse(customisationId);
+            if (!VerifyAdminUserCanAccessCourse(customisationId))
+            {
+                return NotFound();
+            }
 
             var addAdminFieldData = TempData.Peek<AddAdminFieldData>()!;
 
@@ -213,7 +225,10 @@
         [ServiceFilter(typeof(RedirectEmptySessionData<AddAdminFieldData>))]
         public IActionResult AddAdminFieldAnswersBulk(int customisationId)
         {
-            ReturnNotFoundIfUserCannotAccessCourse(customisationId);
+            if (!VerifyAdminUserCanAccessCourse(customisationId))
+            {
+                return NotFound();
+            }
 
             var data = TempData.Peek<AddAdminFieldData>()!;
             var model = new BulkAdminFieldAnswersViewModel(
@@ -253,7 +268,10 @@
         [Route("{customisationId:int}/AdminFields/{promptNumber:int}/Remove")]
         public IActionResult RemoveAdminField(int customisationId, int promptNumber)
         {
-            ReturnNotFoundIfUserCannotAccessCourse(customisationId);
+            if (!VerifyAdminUserCanAccessCourse(customisationId))
+            {
+                return NotFound();
+            }
 
             var answerCount =
                 courseAdminFieldsDataService.GetAnswerCountForCourseAdminField(customisationId, promptNumber);
@@ -536,17 +554,12 @@
             }
         }
 
-        private NotFoundResult? ReturnNotFoundIfUserCannotAccessCourse(int customisationId)
+        private bool VerifyAdminUserCanAccessCourse(int customisationId)
         {
             var centreId = User.GetCentreId();
             var categoryId = User.GetAdminCategoryId()!;
 
-            if (!courseService.VerifyUserCanAccessCourse(customisationId, centreId, categoryId.Value))
-            {
-                return NotFound();
-            }
-
-            return null;
+            return courseService.VerifyAdminUserCanAccessCourse(customisationId, centreId, categoryId.Value);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -127,7 +127,7 @@
         }
 
         [HttpPost]
-        [Route("{customisationId:int}/AdminFields/{promptNumber:int}/Edit/Bulk")]
+        [Route("{customisationId:int}/AdminFields/Edit/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<EditAdminFieldData>))]
         public IActionResult EditAdminFieldBulkPost(
@@ -206,7 +206,7 @@
         [Route("{customisationId:int}/AdminFields/Add/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<AddAdminFieldData>))]
-        public IActionResult AddAdminFieldAnswersBulk(int customisationId)
+        public IActionResult AddAdminFieldBulkPost(int customisationId)
         {
             var data = TempData.Peek<AddAdminFieldData>()!;
             var model = new BulkAdminFieldAnswersViewModel(
@@ -221,7 +221,7 @@
         [Route("{customisationId:int}/AdminFields/Add/Bulk")]
         [ServiceFilter(typeof(VerifyAdminUserCanAccessCourse))]
         [ServiceFilter(typeof(RedirectEmptySessionData<AddAdminFieldData>))]
-        public IActionResult AddAdminFieldAnswersBulk(
+        public IActionResult AddAdminFieldBulkPost(
             int customisationId,
             BulkAdminFieldAnswersViewModel model
         )
@@ -352,7 +352,7 @@
             SetAddAdminFieldTempData(model);
 
             return RedirectToAction(
-                "AddAdminFieldAnswersBulk",
+                "AddAdminFieldBulkPost",
                 new { customisationId }
             );
         }

--- a/DigitalLearningSolutions.Web/Extensions/HtmlHelperExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/HtmlHelperExtensions.cs
@@ -1,5 +1,9 @@
 ﻿namespace DigitalLearningSolutions.Web.Extensions
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
     using Microsoft.AspNetCore.Mvc.Rendering;
 
     public static class HtmlHelperExtensions
@@ -17,6 +21,17 @@
             return (controller == null || controller == currentController) && action == currentAction
                 ? selectedCssClass
                 : string.Empty;
+        }
+
+        public static Dictionary<string, string?> GetRouteValues(
+            this IHtmlHelper htmlHelper
+        )
+        {
+            var routeValues = htmlHelper.ViewContext.HttpContext.Request.RouteValues;
+            return routeValues.ToDictionary(
+                kvp => kvp.Key,
+                kvp => Convert.ToString(kvp.Value, CultureInfo.InvariantCulture)
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessCourse.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessCourse.cs
@@ -1,0 +1,38 @@
+﻿namespace DigitalLearningSolutions.Web.ServiceFilter
+{
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+
+    public class VerifyAdminUserCanAccessCourse : IActionFilter
+    {
+        private readonly ICourseService courseService;
+
+        public VerifyAdminUserCanAccessCourse(
+            ICourseService courseService
+        )
+        {
+            this.courseService = courseService;
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context) { }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!(context.Controller is Controller controller))
+            {
+                return;
+            }
+
+            var centreId = controller.User.GetCentreId();
+            var categoryId = controller.User.GetAdminCategoryId()!;
+            var customisationId = int.Parse(context.RouteData.Values["customisationId"].ToString()!);
+
+            if (!courseService.VerifyAdminUserCanAccessCourse(customisationId, centreId, categoryId.Value))
+            {
+                context.Result = new NotFoundResult();
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -246,6 +246,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<RedirectEmptySessionData<EditAdminFieldData>>();
             services.AddScoped<RedirectEmptySessionData<AddAdminFieldData>>();
             services.AddScoped<RedirectEmptySessionData<WelcomeEmailSentViewModel>>();
+            services.AddScoped<VerifyAdminUserCanAccessCourse>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AddAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AddAdminFieldViewModel.cs
@@ -9,20 +9,12 @@
             IncludeAnswersTableCaption = true;
         }
 
-        public AddAdminFieldViewModel(int customisationId)
-        {
-            CustomisationId = customisationId;
-            IncludeAnswersTableCaption = true;
-        }
-
         public AddAdminFieldViewModel(
-            int customisationId,
             int? adminFieldId,
             string? options,
             string? answer = null
         )
         {
-            CustomisationId = customisationId;
             AdminFieldId = adminFieldId;
             OptionsString = options;
             IncludeAnswersTableCaption = true;

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AddBulkAdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AddBulkAdminFieldAnswersViewModel.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
+{
+    public class AddBulkAdminFieldAnswersViewModel : BulkAdminFieldAnswersViewModel
+    {
+        public AddBulkAdminFieldAnswersViewModel() { }
+
+        public AddBulkAdminFieldAnswersViewModel(
+            string? optionsString
+        )
+        {
+            OptionsString = optionsString;
+        }
+
+        public AddBulkAdminFieldAnswersViewModel(
+            string? optionsString,
+            int promptNumber
+        )
+        {
+            OptionsString = optionsString;
+            PromptNumber = promptNumber;
+        }
+
+        private int PromptNumber { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AddBulkAdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AddBulkAdminFieldAnswersViewModel.cs
@@ -20,6 +20,6 @@
             PromptNumber = promptNumber;
         }
 
-        private int PromptNumber { get; set; }
+        private int PromptNumber { get; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldAnswersViewModel.cs
@@ -9,19 +9,15 @@
         public AdminFieldAnswersViewModel() { }
 
         public AdminFieldAnswersViewModel(
-            int customisationId,
             string optionsString,
             string? answer = null,
             bool includeAnswersTableCaption = false
         )
         {
-            CustomisationId = customisationId;
             OptionsString = optionsString;
             Answer = answer;
             IncludeAnswersTableCaption = includeAnswersTableCaption;
         }
-
-        public int CustomisationId { get; set; }
 
         public string? OptionsString { get; set; }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/BulkAdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/BulkAdminFieldAnswersViewModel.cs
@@ -7,32 +7,26 @@
         public BulkAdminFieldAnswersViewModel(
             string? optionsString,
             bool isAddPromptJourney,
-            int customisationId,
             int promptNumber
         )
         {
             OptionsString = optionsString;
             IsAddPromptJourney = isAddPromptJourney;
-            CustomisationId = customisationId;
             PromptNumber = promptNumber;
         }
 
         public BulkAdminFieldAnswersViewModel(
             string? optionsString,
-            bool isAddPromptJourney,
-            int customisationId
+            bool isAddPromptJourney
         )
         {
             OptionsString = optionsString;
             IsAddPromptJourney = isAddPromptJourney;
-            CustomisationId = customisationId;
         }
 
         public string? OptionsString { get; set; }
 
         public bool IsAddPromptJourney { get; set; }
-
-        public int CustomisationId { get; set; }
 
         public int PromptNumber { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/BulkAdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/BulkAdminFieldAnswersViewModel.cs
@@ -5,29 +5,12 @@
         public BulkAdminFieldAnswersViewModel() { }
 
         public BulkAdminFieldAnswersViewModel(
-            string? optionsString,
-            bool isAddPromptJourney,
-            int promptNumber
+            string? optionsString
         )
         {
             OptionsString = optionsString;
-            IsAddPromptJourney = isAddPromptJourney;
-            PromptNumber = promptNumber;
-        }
-
-        public BulkAdminFieldAnswersViewModel(
-            string? optionsString,
-            bool isAddPromptJourney
-        )
-        {
-            OptionsString = optionsString;
-            IsAddPromptJourney = isAddPromptJourney;
         }
 
         public string? OptionsString { get; set; }
-
-        public bool IsAddPromptJourney { get; set; }
-
-        public int PromptNumber { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/EditAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/EditAdminFieldViewModel.cs
@@ -7,9 +7,8 @@
     {
         public EditAdminFieldViewModel() { }
 
-        public EditAdminFieldViewModel(CustomPrompt customPrompt, int customisationId)
+        public EditAdminFieldViewModel(CustomPrompt customPrompt)
         {
-            CustomisationId = customisationId;
             PromptNumber = customPrompt.CustomPromptNumber;
             Prompt = customPrompt.CustomPromptText;
             OptionsString = NewlineSeparatedStringListHelper.JoinNewlineSeparatedList(customPrompt.Options);
@@ -17,13 +16,11 @@
         }
 
         public EditAdminFieldViewModel(
-            int customisationId,
             int customPromptNumber,
             string text,
             string? options
         )
         {
-            CustomisationId = customisationId;
             PromptNumber = customPromptNumber;
             Prompt = text;
             OptionsString = options;

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/RemoveAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/RemoveAdminFieldViewModel.cs
@@ -4,14 +4,11 @@
     {
         public RemoveAdminFieldViewModel() { }
 
-        public RemoveAdminFieldViewModel(int customisationId, string promptName, int answerCount)
+        public RemoveAdminFieldViewModel(string promptName, int answerCount)
         {
-            CustomisationId = customisationId;
             PromptName = promptName;
             AnswerCount = answerCount;
         }
-
-        public int CustomisationId { get; set; }
 
         public string? PromptName { get; set; }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
@@ -10,7 +10,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = "Add Course Admin Field";
+  ViewData["Title"] = "Add course admin field";
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
@@ -14,7 +14,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> { { "customisationId", Model.CustomisationId.ToString() } };
+  var cancelLinkData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
@@ -1,5 +1,6 @@
 ﻿@inject IConfiguration configuration
 @using DigitalLearningSolutions.Web.Controllers.TrackingSystem.CourseSetup
+@using DigitalLearningSolutions.Web.Extensions
 @using DigitalLearningSolutions.Web.ViewComponents
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @using Microsoft.AspNetCore.Mvc.TagHelpers
@@ -14,7 +15,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
+  var cancelLinkData = Html.GetRouteValues();
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
@@ -1,4 +1,5 @@
 ﻿@inject IConfiguration configuration
+@using DigitalLearningSolutions.Web.Extensions
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @using Microsoft.Extensions.Configuration
 @model AddBulkAdminFieldAnswersViewModel
@@ -9,7 +10,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
+  var cancelLinkData = Html.GetRouteValues();
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
@@ -1,7 +1,7 @@
 ﻿@inject IConfiguration configuration
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @using Microsoft.Extensions.Configuration
-@model BulkAdminFieldAnswersViewModel
+@model AddBulkAdminFieldAnswersViewModel
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
@@ -9,10 +9,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> {
-    { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! },
-    { "promptNumber", ViewContext.HttpContext.Request.RouteValues["promptNumber"].ToString()! }
-  };
+  var cancelLinkData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
 }
 
 @section NavMenuItems {
@@ -27,7 +24,7 @@
 
     <h1 class="nhsuk-heading-xl">Configure answers in bulk</h1>
 
-    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditAdminFieldAnswersBulk">
+    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddAdminFieldAnswersBulk">
 
       <vc:text-area asp-for="@nameof(Model.OptionsString)"
                     label="Enter each response option on a separate line (max 1000 characters in total). The order of responses will be the order they appear on the dropdown for users."
@@ -41,7 +38,7 @@
       <button class="nhsuk-button" type="submit">Submit</button>
     </form>
 
-    <vc:cancel-link asp-controller="AdminFields" asp-action="EditAdminField" asp-all-route-data="@cancelLinkData" />
+    <vc:cancel-link asp-controller="AdminFields" asp-action="AddAdminField" asp-all-route-data="@cancelLinkData" />
 
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
@@ -1,4 +1,5 @@
 ﻿@inject IConfiguration configuration
+@using DigitalLearningSolutions.Web.Extensions
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @using Microsoft.Extensions.Configuration
 @model BulkAdminFieldAnswersViewModel
@@ -9,10 +10,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> {
-    { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! },
-    { "promptNumber", ViewContext.HttpContext.Request.RouteValues["promptNumber"].ToString()! }
-  };
+  var cancelLinkData = Html.GetRouteValues();
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
@@ -10,11 +10,11 @@
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
   var editCancelLinkData = new Dictionary<string, string> {
-    { "customisationId", Model.CustomisationId.ToString() },
+    { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! },
     { "promptNumber", Model.PromptNumber.ToString() }
   };
   var addCancelLinkData = new Dictionary<string, string> {
-    { "customisationId", Model.CustomisationId.ToString() }
+    { "customisationId", ViewContext.HttpContext.Request.Query["customisationId"].ToString() }
   };
 }
 
@@ -33,7 +33,6 @@
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="@(Model.IsAddPromptJourney ? "AddAdminFieldAnswersBulk" : "EditAdminFieldBulkPost")">
 
       <input type="hidden" asp-for="IsAddPromptJourney" />
-      <input type="hidden" asp-for="CustomisationId" />
       <input type="hidden" asp-for="PromptNumber" />
 
       <vc:text-area asp-for="@nameof(Model.OptionsString)"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
@@ -33,6 +33,7 @@
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="@(Model.IsAddPromptJourney ? "AddAdminFieldAnswersBulk" : "EditAdminFieldBulkPost")">
 
       <input type="hidden" asp-for="IsAddPromptJourney" />
+      <input type="hidden" asp-for="CustomisationId" />
       <input type="hidden" asp-for="PromptNumber" />
 
       <vc:text-area asp-for="@nameof(Model.OptionsString)"
@@ -43,7 +44,7 @@
                     hint-text=""
                     css-class=""
                     character-count="1000" />
-      <input type="hidden" asp-for="CustomisationId" />
+
       <button class="nhsuk-button" type="submit">Submit</button>
     </form>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -10,7 +10,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = "Edit Course Admin Field";
+  ViewData["Title"] = "Edit course admin field";
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -14,7 +14,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> { { "customisationId", Model.CustomisationId.ToString() } };
+  var cancelLinkData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -1,5 +1,6 @@
 ﻿@inject IConfiguration configuration
 @using DigitalLearningSolutions.Web.Controllers.TrackingSystem.CourseSetup
+@using DigitalLearningSolutions.Web.Extensions
 @using DigitalLearningSolutions.Web.ViewComponents
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @using Microsoft.AspNetCore.Mvc.TagHelpers
@@ -14,7 +15,7 @@
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
-  var cancelLinkData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
+  var cancelLinkData = Html.GetRouteValues();
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/Index.cshtml
@@ -1,5 +1,8 @@
 ﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Web.Extensions
+@using DigitalLearningSolutions.Web.ViewComponents
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Microsoft.Extensions.Configuration
 @model AdminFieldsViewModel
 
@@ -11,7 +14,7 @@
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";
   var canAddNewField = Model.CustomFields.Count < 3;
-  var backLinkData = new Dictionary<string, string> { { "customisationId", Model.CustomisationId.ToString() } };
+  var backLinkData = Html.GetRouteValues();
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/Index.cshtml
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="@Url.Content("~/css/shared/cardWithButtons.css")" asp-append-version="true">
 
 @{
-  ViewData["Title"] = "Manage Course Admin Fields";
+  ViewData["Title"] = "Manage course admin fields";
   ViewData["Application"] = "Tracking System";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
   ViewData["HeaderPathName"] = "Tracking System";

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
@@ -1,5 +1,8 @@
 ﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Web.Extensions
+@using DigitalLearningSolutions.Web.ViewComponents
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Microsoft.Extensions.Configuration
 @model RemoveAdminFieldViewModel
 
@@ -11,7 +14,7 @@
   ViewData["HeaderPathName"] = "Tracking System";
   var confirmError = ViewData.ModelState[nameof(RemoveAdminFieldViewModel.Confirm)]?.Errors?.Count > 0;
   var confirmFormErrorClass = confirmError ? "nhsuk-form-group--error" : "";
-  var cancelLinkRouteData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
+  var cancelLinkRouteData = Html.GetRouteValues();
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/RemoveAdminField.cshtml
@@ -11,7 +11,7 @@
   ViewData["HeaderPathName"] = "Tracking System";
   var confirmError = ViewData.ModelState[nameof(RemoveAdminFieldViewModel.Confirm)]?.Errors?.Count > 0;
   var confirmFormErrorClass = confirmError ? "nhsuk-form-group--error" : "";
-  var cancelLinkRouteData = new Dictionary<string, string> { { "customisationId", Model.CustomisationId.ToString() } };
+  var cancelLinkRouteData = new Dictionary<string, string> { { "customisationId", ViewContext.HttpContext.Request.RouteValues["customisationId"].ToString()! } };
 }
 
 @section NavMenuItems {


### PR DESCRIPTION
### JIRA link
[_HEEDLS-438_](https://softwiretech.atlassian.net/browse/HEEDLS-438)

### Description
Added a check in AdminFieldsController that verifies the user can access the selected course on the following pages: Manage admin fields, Edit admin field, Configure answers in bulk (in edit and add journeys), Remove admin field, and Add admin field. Only AdminUsers with the correct CentreID and CategoryID should be able to access these pages. This means that they have the same CentreID as the customisation, and either have the same CategoryID as the customisation's course category OR CategoryID = 0, which means they can manage all courses. If a customisationID that the user cannot access is entered in the url they should be directed to a NotFound page.

I also fixed the capitalization of the (ViewData["Title"]) on all the course admin fields pages.

### Screenshots
![image](https://user-images.githubusercontent.com/70278044/134198721-53d81b58-ed26-4238-9247-59330246a21e.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
