### PR TITLE
DLSV2-336 Makes expanders for competency descriptions optional per self-assessment

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202109221053_SelfAssessmentsAddUseDescriptionExpanders.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202109221053_SelfAssessmentsAddUseDescriptionExpanders.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202109221053)]
+    public class SelfAssessmentsAddUseDescriptionExpanders : AutoReversingMigration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments").AddColumn("UseDescriptionExpanders").AsBoolean().NotNullable().WithDefaultValue(true);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessment.cs
@@ -6,5 +6,6 @@
         public int NumberOfCompetencies { get; set; }
         public bool LinearNavigation { get; set; }
         public bool HasDelegateNominatedRoles { get; set; }
+        public bool UseDescriptionExpanders { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -225,7 +225,7 @@ SA.UseFilteredApi,
                              CA.CompleteByDate,
                              CA.UserBookmark,
                              CA.UnprocessedUpdates,
-CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, CAST(CASE WHEN SA.SupervisorSelfAssessmentReview = 1 OR SA.SupervisorResultsReview = 1 THEN 1 ELSE 0 END AS BIT) AS IsSupervised,
+CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders, CAST(CASE WHEN SA.SupervisorSelfAssessmentReview = 1 OR SA.SupervisorResultsReview = 1 THEN 1 ELSE 0 END AS BIT) AS IsSupervised,
                                                   CASE WHEN (SELECT COUNT(*) FROM SelfAssessmentSupervisorRoles WHERE SelfAssessmentID = @selfAssessmentId) > 0 THEN 1 ELSE 0 END AS HasDelegateNominatedRoles
                       FROM CandidateAssessments CA
                                JOIN SelfAssessments SA
@@ -235,7 +235,7 @@ CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, CAST(CASE WHEN SA.Supervi
                                INNER JOIN Competencies AS C
                                           ON SAS.CompetencyID = C.ID
                       WHERE CA.CandidateID = @candidateId AND CA.SelfAssessmentID = @selfAssessmentId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
-                      GROUP BY CA.SelfAssessmentID, SA.Name, SA.Description, SA.UseFilteredApi, CA.StartedDate, CA.LastAccessed, CA.CompleteByDate, CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview",
+                      GROUP BY CA.SelfAssessmentID, SA.Name, SA.Description, SA.UseFilteredApi, CA.StartedDate, CA.LastAccessed, CA.CompleteByDate, CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview",
                 new { candidateId, selfAssessmentId }
             );
         }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
 <h1 class="competency-group-header nhsuk-u-font-size-32">@Model.Competency.CompetencyGroup</h1>
 <div class=" nhsuk-u-margin-top-8 nhsuk-u-margin-bottom-8">
-  @if (Model.Competency.Description != null)
+  @if (Model.Competency.Description != null && Model.Assessment.UseDescriptionExpanders)
   {
     <details class="nhsuk-details">
       <summary class="nhsuk-details__summary">
@@ -32,8 +32,14 @@
     <h2 class="nhsuk-u-margin-bottom-0 nhsuk-u-font-size-24">
       @Model.Competency.Name
     </h2>
-  }
-</div>
+    @if (Model.Competency.Description != null)
+    {
+<p class="nhsuk-body-l">
+  @(Html.Raw(@Model.Competency.Description))
+</p>
+        }
+        }
+    </div>
 <form asp-action="SelfAssessmentCompetency" asp-route-competencyNumber="@Model.CompetencyNumber" asp-route-competencyId="@Model.Competency.Id">
   @foreach (var question in @Model.Competency.AssessmentQuestions.Select((value, i) => new { i, value }))
   {


### PR DESCRIPTION
### JIRA link
DLSV2-336

### Description
Makes expanders for competency descriptions optional per self-assessment.
- Migration to add UseDescriptionExpanders bit field to SelfAssessments table
- Reads new field into self assessment model / view model and interprets it in view
