### PR TITLE
Heedls 499 deactivate delegate

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
@@ -257,5 +257,20 @@
             // Then
             returnedDelegateUser.Should().BeEquivalentTo(expectedDelegateUsers);
         }
+
+        [Test]
+        public void DeactivateDelegateUser_deactivates_delegate_user()
+        {
+            using var transaction = new TransactionScope();
+
+            // given
+            userDataService.GetDelegateUserById(1)!.Active.Should().BeTrue();
+
+            // when
+            userDataService.DeactivateDelegateUser(1);
+
+            // then
+            userDataService.GetDelegateUserById(1)!.Active.Should().BeFalse();
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -386,5 +386,15 @@
                 }
             );
         }
+
+        public void DeactivateDelegateUser(int delegateId)
+        {
+            connection.Execute(
+                @"UPDATE Candidates
+                    SET Active = 0
+                    WHERE CandidateID = @delegateId",
+                new { delegateId }
+            );
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -69,6 +69,7 @@
         int UpdateDelegateRecord(DelegateRecord record);
         DelegateUser? GetDelegateUserByAliasId(string aliasId, int centreId);
         DelegateUser? GetDelegateUserByCandidateNumber(string candidateNumber, int centreId);
+        void DeactivateDelegateUser(int delegateId);
 
         DelegateUserCard? GetDelegateUserCardById(int id);
         List<DelegateUserCard> GetDelegateUserCardsByCentreId(int centreId);
@@ -86,8 +87,6 @@
 
         int GetDelegateCountWithAnswerForPrompt(int centreId, int promptNumber);
         void DeleteAllAnswersForPrompt(int centreId, int promptNumber);
-
-        void DeactivateDelegateUser(int delegateId);
     }
 
     public partial class UserDataService : IUserDataService

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -86,6 +86,8 @@
 
         int GetDelegateCountWithAnswerForPrompt(int centreId, int promptNumber);
         void DeleteAllAnswersForPrompt(int centreId, int promptNumber);
+
+        void DeactivateDelegateUser(int delegateId);
     }
 
     public partial class UserDataService : IUserDataService

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
@@ -1,0 +1,78 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegates
+{
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+    using FakeItEasy;
+    using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Http;
+    using NUnit.Framework;
+
+    class ViewDelegateControllerTests
+    {
+        private ViewDelegateController viewDelegateController = null!;
+        private IUserDataService userDataService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            var centreCustomPromptsService = A.Fake<ICentreCustomPromptsService>();
+            var centreCustomPromptsHelper = new CentreCustomPromptHelper(centreCustomPromptsService);
+            userDataService = A.Fake<IUserDataService>();
+            var courseService = A.Fake<ICourseService>();
+            var passwordResetService = A.Fake<IPasswordResetService>();
+
+            var httpRequest = A.Fake<HttpRequest>();
+            var httpResponse = A.Fake<HttpResponse>();
+            const string cookieName = "";
+            const string cookieValue = "";
+
+            viewDelegateController = new ViewDelegateController(userDataService, centreCustomPromptsHelper, courseService, passwordResetService)
+                .WithMockHttpContext(httpRequest, cookieName, cookieValue, httpResponse)
+                .WithMockUser(true)
+                .WithMockServices()
+                .WithMockTempData();
+
+        }
+
+
+        [Test]
+        public void Deactivating_delegate_returns_redirect()
+        {
+            // given
+            A.CallTo(() => userDataService.GetDelegateUserCardById(1))
+                .Returns(new DelegateUserCard { CentreId = 2, Id = 1 });
+
+            // when
+            var result = viewDelegateController.DeactivateDelegate(1);
+
+            // then
+            result.Should().BeRedirectToActionResult();
+        }
+
+        [Test]
+        public void Deactivating_nonexistent_delegate_returns_not_found_result()
+        {
+            // when
+            var result = viewDelegateController.DeactivateDelegate(-1);
+
+            // then
+            result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void Deactivating_delegate_on_wrong_centre_returns_not_found_result()
+        {
+
+            // when
+            var result = viewDelegateController.DeactivateDelegate(2);
+
+            // then
+            result.Should().BeNotFoundResult();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
@@ -26,16 +26,9 @@
             var courseService = A.Fake<ICourseService>();
             var passwordResetService = A.Fake<IPasswordResetService>();
 
-            var httpRequest = A.Fake<HttpRequest>();
-            var httpResponse = A.Fake<HttpResponse>();
-            const string cookieName = "";
-            const string cookieValue = "";
-
             viewDelegateController = new ViewDelegateController(userDataService, centreCustomPromptsHelper, courseService, passwordResetService)
-                .WithMockHttpContext(httpRequest, cookieName, cookieValue, httpResponse)
-                .WithMockUser(true)
-                .WithMockServices()
-                .WithMockTempData();
+                .WithDefaultContext()
+                .WithMockUser(true);
 
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -68,5 +68,20 @@
 
             return View("WelcomeEmailSent", model);
         }
+
+        [Route("DeactivateDelegate")]
+        public IActionResult DeactivateDelegate(int delegateId)
+        {
+            var centreId = User.GetCentreId();
+            var delegateUser = userDataService.GetDelegateUserCardById(delegateId);
+            if (delegateUser == null || delegateUser.CentreId != centreId)
+            {
+                return new NotFoundResult();
+            }
+
+            userDataService.DeactivateDelegateUser(delegateId);
+
+            return RedirectToAction("Index");
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -69,6 +69,7 @@
             return View("WelcomeEmailSent", model);
         }
 
+        [HttpPost]
         [Route("DeactivateDelegate")]
         public IActionResult DeactivateDelegate(int delegateId)
         {

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -81,7 +81,7 @@
 
             userDataService.DeactivateDelegateUser(delegateId);
 
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { delegateId } );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -109,7 +109,12 @@
           Promote to admin
         </a>
         <div>
-          <a class="nhsuk-button delete-button view-delegate-button" role="button" asp-controller="ViewDelegate" asp-action="DeactivateDelegate" asp-route-delegateId="@Model.DelegateInfo.Id">
+          <a
+            class="nhsuk-button delete-button view-delegate-button"
+            role="button"
+            asp-controller="ViewDelegate"
+            asp-action="DeactivateDelegate"
+            asp-route-delegateId="@Model.DelegateInfo.Id">
             Deactivate account
           </a>
         </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -109,7 +109,7 @@
           Promote to admin
         </a>
         <div>
-          <a class="nhsuk-button delete-button view-delegate-button" role="button">
+          <a class="nhsuk-button delete-button view-delegate-button" role="button" asp-controller="ViewDelegate" asp-action="DeactivateDelegate" asp-route-delegateId="@Model.DelegateInfo.Id">
             Deactivate account
           </a>
         </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -108,16 +108,13 @@
         <a class="nhsuk-button nhsuk-button--secondary view-delegate-button" role="button">
           Promote to admin
         </a>
-        <div>
-          <a
+        <form asp-action="DeactivateDelegate" asp-route-delegateId="@Model.DelegateInfo.Id">
+          <button
             class="nhsuk-button delete-button view-delegate-button"
-            role="button"
-            asp-controller="ViewDelegate"
-            asp-action="DeactivateDelegate"
-            asp-route-delegateId="@Model.DelegateInfo.Id">
+            type="submit">
             Deactivate account
-          </a>
-        </div>
+          </button>
+        </form>
       } else {
         <a class="nhsuk-button view-delegate-button" role="button">
           Reactivate account


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-499

### Description
The deactivate button on the view delegate page now deactivates the delegate account in question and refreshes the page.

### Screenshots
No visual changes.

-----
### Developer checks
I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [] Updated/added documentation in Swiki and/or Readme.
- [] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
