### PR TITLE
DLSV2-333 Competency group expanders on overview page

### DIFF
--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -252,7 +252,7 @@ INNER JOIN CandidateAssessments AS CA
                             ON CA.SelfAssessmentID = @selfAssessmentId
                                    AND CA.CandidateID = @candidateId
 LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
-                            ON CA.ID = CAOC.CandidateAssessmentID
+                            ON CA.ID = CAOC.CandidateAssessmentID AND sas.ID = CAOC.CompetencyID AND sas.ID = CAOC.CompetencyGroupID
                       WHERE (sas.SelfAssessmentID = @selfAssessmentId) AND ((sas.Optional = 0) OR (CAOC.IncludedInSelfAssessment = 1))
                      ),
                      {LatestAssessmentResults}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -165,6 +165,7 @@
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
             const int competencyNumber = 1;
             const int competencyId = 3;
+            const int competencyGroupId = 1;
             const int assessmentQuestionId = 2;
             const int assessmentQuestionResult = 4;
             const int minValue = 0;
@@ -184,7 +185,7 @@
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)).Returns(selfAssessment);
 
             // When
-            controller.SelfAssessmentCompetency(SelfAssessmentId, assessmentQuestions, competencyNumber, competencyId);
+            controller.SelfAssessmentCompetency(SelfAssessmentId, assessmentQuestions, competencyNumber, competencyId, competencyGroupId);
 
             // Then
             A.CallTo(() => selfAssessmentService.SetResultForCompetency(
@@ -204,6 +205,7 @@
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
             const int competencyNumber = 1;
             const int competencyId = 3;
+            const int competencyGroupId = 1;
             const int assessmentQuestionId = 2;
             const int assessmentQuestionResult = 4;
             var assessmentQuestions = new Collection<AssessmentQuestion>()
@@ -217,7 +219,7 @@
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)).Returns(selfAssessment);
 
             // When
-            var result = controller.SelfAssessmentCompetency(SelfAssessmentId, assessmentQuestions, competencyNumber, competencyId);
+            var result = controller.SelfAssessmentCompetency(SelfAssessmentId, assessmentQuestions, competencyNumber, competencyId, competencyGroupId);
 
             // Then
             result.Should().BeRedirectToActionResult()
@@ -232,7 +234,7 @@
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)).Returns(null);
 
             // When
-            var result = controller.SelfAssessmentCompetency(1, null, 1, 1);
+            var result = controller.SelfAssessmentCompetency(1, null, 1, 1, 1);
 
             // Then
             result.Should()

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -79,7 +79,7 @@
 
         [HttpPost]
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{competencyNumber:int}")]
-        public IActionResult SelfAssessmentCompetency(int selfAssessmentId, ICollection<AssessmentQuestion> assessmentQuestions, int competencyNumber, int competencyId)
+        public IActionResult SelfAssessmentCompetency(int selfAssessmentId, ICollection<AssessmentQuestion> assessmentQuestions, int competencyNumber, int competencyId, int? competencyGroupId)
         {
             var candidateID = User.GetCandidateIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateID, selfAssessmentId);
@@ -110,12 +110,12 @@
             }
             else
             {
-                return new RedirectResult(Url.Action("SelfAssessmentOverview", new { selfAssessmentId = selfAssessmentId }) + "#comp-" + competencyNumber.ToString());
+                return new RedirectResult(Url.Action("SelfAssessmentOverview", new { selfAssessmentId = selfAssessmentId, competencyGroupId = competencyGroupId }) + "#comp-" + competencyNumber.ToString());
             }
         }
-
+        [Route("LearningPortal/SelfAssessment/{selfAssessmentId:int}/Overview/{competencyGroupId}")]
         [Route("LearningPortal/SelfAssessment/{selfAssessmentId:int}/Overview")]
-        public IActionResult SelfAssessmentOverview(int selfAssessmentId)
+        public IActionResult SelfAssessmentOverview(int selfAssessmentId, int? competencyGroupId = null)
         {
             int candidateId = User.GetCandidateIdKnownNotNull();
             string destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId.ToString() + "/Overview";

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -10,6 +10,7 @@
   <li class="nhsuk-breadcrumb__item">@Model.Competency.Vocabulary @Model.CompetencyNumber</li>
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/pagination.css")" asp-append-version="true">
 <h1 class="competency-group-header nhsuk-u-font-size-32">@Model.Competency.CompetencyGroup</h1>
 <div class=" nhsuk-u-margin-top-8 nhsuk-u-margin-bottom-8">
   @if (Model.Competency.Description != null && Model.Assessment.UseDescriptionExpanders)
@@ -40,7 +41,7 @@
         }
         }
     </div>
-<form asp-action="SelfAssessmentCompetency" asp-route-competencyNumber="@Model.CompetencyNumber" asp-route-competencyId="@Model.Competency.Id">
+<form asp-action="SelfAssessmentCompetency" asp-route-competencyNumber="@Model.CompetencyNumber" asp-route-competencyId="@Model.Competency.Id" asp-rout-competencyGroupId="@Model.Competency.CompetencyGroupID">
   @foreach (var question in @Model.Competency.AssessmentQuestions.Select((value, i) => new { i, value }))
   {
     if (question.value.AssessmentQuestionInputTypeID == 2)
@@ -66,33 +67,50 @@
 <div class="nhsuk-grid-row">
   @if (Model.Assessment.LinearNavigation)
   {
-    <div class="nhsuk-back-link grid-column-85">
-      <a class="nhsuk-back-link__link"
-         asp-action=@(Model.CompetencyNumber == 1 ? "SelfAssessment" : "SelfAssessmentCompetency")
-         asp-route-selfAssessmentId="@Model.Assessment.Id"
-         asp-route-competencyNumber=@(Model.CompetencyNumber == 1 ? "" : (Model.CompetencyNumber - 1).ToString())>
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-        </svg>
-        @(@Model.CompetencyNumber == 1 ? "Go back" : "Previous question")
-      </a>
-      <a class="nhsuk-back-link__link skip-link"
-         asp-action="SelfAssessmentCompetency"
-         asp-route-selfAssessmentId="@Model.Assessment.Id"
-         asp-route-competencyNumber="@(Model.CompetencyNumber + 1)">
-        Skip
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="skip-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-        </svg>
-      </a>
-    </div>
+    <nav class="nhsuk-pagination" role="navigation" aria-label="Pagination">
+      <div class="nhsuk-pagination__list">
+        <div class="pagination-button-container">
+          <div class="nhsuk-pagination-item--previous")>
+            <a class="nhsuk-back-link__link"
+               asp-action=@(Model.CompetencyNumber == 1 ? "SelfAssessment" : "SelfAssessmentCompetency")
+               asp-route-selfAssessmentId="@Model.Assessment.Id"
+               asp-route-competencyNumber=@(Model.CompetencyNumber == 1 ? "" : (Model.CompetencyNumber - 1).ToString())>
+              <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+              </svg>
+              @(@Model.CompetencyNumber == 1 ? "Go back" : "Previous question")
+            </a>
+          </div>
+        </div>
+        <div class="page-indicator-container">
+          <a class="nhsuk-back-link__link nhsuk-u-margin-left-9 nhsuk-u-margin-left-9"
+             asp-action="SelfAssessmentOverview"
+             asp-route-selfAssessmentId="@Model.Assessment.Id" asp-route-competencyGroupId="@Model.Competency.CompetencyGroupID" asp-fragment="comp-@Model.CompetencyNumber">
+            Return to Overview
+          </a>
+        </div>
+        <div class="pagination-button-container">
+          <div class="nhsuk-pagination-item--next">
+            <a class="nhsuk-back-link__link skip-link"
+               asp-action="SelfAssessmentCompetency"
+               asp-route-selfAssessmentId="@Model.Assessment.Id"
+               asp-route-competencyNumber="@(Model.CompetencyNumber + 1)">
+              Skip
+              <svg class="nhsuk-icon nhsuk-icon__chevron-left" id="skip-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
   }
   else
   {
     <div class="nhsuk-back-link nhsuk-grid-column-full">
       <a class="nhsuk-back-link__link"
          asp-action="SelfAssessmentOverview"
-         asp-route-selfAssessmentId="@Model.Assessment.Id" asp-fragment="comp-@Model.CompetencyNumber">
+         asp-route-selfAssessmentId="@Model.Assessment.Id" asp-route-competencyGroupId="@Model.Competency.CompetencyGroupID" asp-fragment="comp-@Model.CompetencyNumber">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
         </svg>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -29,38 +29,33 @@
 {
   foreach (var competencyGroup in Model.CompetencyGroups)
   {
-    @if (Model.SelfAssessment.LinearNavigation)
-    {
-      <div class="nhsuk-panel competency-group-panel">
-        <details class="nhsuk-details nhsuk-expander">
-          <summary class="nhsuk-details__summary">
-            <span class="competency-group-title nhsuk-details__summary-text">
-              @competencyGroup.Key
-            </span>
-          </summary>
-          <div class="nhsuk-details__text">
-            <partial name="SelfAssessments/_MeanScores"
-                     view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
 
-            <partial name="SelfAssessments/_OverviewTable" view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation } })" model="competencyGroup" />
+<div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
+  <details class="nhsuk-details nhsuk-expander" @((int)Model.CompetencyGroups.Count() == 1 ? "open" : (ViewContext.RouteData.Values.ContainsKey("competencyGroupId") ? (ViewContext.RouteData.Values["competencyGroupId"].Equals(competencyGroup.First().CompetencyGroupID.ToString()) ? "open" : "") : ""))>
+    <summary class="nhsuk-details__summary">
+      <span class="competency-group-title nhsuk-details__summary-text">
+        @competencyGroup.Key
+      </span>
+    </summary>
+    <div class="nhsuk-details__text">
+      @if (Model.SelfAssessment.LinearNavigation)
+      {
+        <partial name="SelfAssessments/_MeanScores"
+                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+      }
 
-          </div>
-        </details>
-        <div class="outer-score-container">
-          <partial name="SelfAssessments/_MeanScores"
-                   view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
-        </div>
-      </div>
-    }
-    else
-    {
-      <div class="nhsuk-grid-row nhsuk-u-margin-bottom-4">
-        <div class="nhsuk-grid-column-full">
-          <partial name="SelfAssessments/_OverviewTable" view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation } })" model="competencyGroup" />
-        </div>
-      </div>
+      <partial name="SelfAssessments/_OverviewTable" view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation } })" model="competencyGroup" />
 
-    }
+    </div>
+  </details>
+  @if (Model.SelfAssessment.LinearNavigation)
+  {
+    <div class="outer-score-container nhsuk-u-padding-bottom-4">
+      <partial name="SelfAssessments/_MeanScores"
+               view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+    </div>}
+  </div>
+   
   }
 }
 


### PR DESCRIPTION
### JIRA link
DLSV2-333

### Description
- Adds expanders to the competency groups on the self-assessment overview page.
- Uses an optional competency group id parameter to auto expand the required competency group on load.
- Fixes issues with competency navigation layout and loading DLSV2-340.
