### PR TITLE
HEEDLS-586 Adjust padding on iframes

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -106,18 +106,19 @@ h1#page-heading {
   height: 100%;
   flex: 1 1 auto;
   display: flex;
+  min-height: 400px;
 
   @include govuk-media-query($from: desktop) {
-    min-height: 500px;
+    min-height: 550px;
   }
 }
 
 .responsive-iframe-wrapper-padding {
-  padding-bottom: $iframe-padding-bottom;
+  padding-bottom: $iframe-padding-bottom * 2;
 }
 
 .responsive-iframe-wrapper-extra-padding {
-  padding-bottom: $iframe-padding-bottom * 2;
+  padding-bottom: $iframe-padding-bottom * 3;
 }
 
 .nhsuk-heading-xl.heading-margin-2 {

--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -1,6 +1,6 @@
 @import "~nhsuk-frontend/packages/core/all";
 
-$iframe-padding-bottom: nhsuk-spacing(8);
+$iframe-padding-bottom: nhsuk-spacing(8) * 2;
 
 @mixin word-break-ie-fix {
   // IE11 hack
@@ -114,11 +114,11 @@ h1#page-heading {
 }
 
 .responsive-iframe-wrapper-padding {
-  padding-bottom: $iframe-padding-bottom * 2;
+  padding-bottom: $iframe-padding-bottom;
 }
 
 .responsive-iframe-wrapper-extra-padding {
-  padding-bottom: $iframe-padding-bottom * 3;
+  padding-bottom: $iframe-padding-bottom * 1.5;
 }
 
 .nhsuk-heading-xl.heading-margin-2 {
@@ -299,5 +299,5 @@ ul.no-bullets {
 }
 
 .display-none {
-    display: none;
+  display: none;
 }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-586_](https://softwiretech.atlassian.net/browse/HEEDLS-586)

### Description
Previously I added the class "responsive-iframe-wrapper-extra-padding" which doubled the padding-bottom on iframes with long titles, but this didn't account for medium length titles that break over two lines on mobile. I have now doubled the padding-bottom on all iframes which still looks like a suitable amount of spacing, and multiplied that by 1.5 for iframes with long titles. This way if an iframe has TitleIsLong = false, there will be enough spacing for the title to break over 2 lines, and for iframes with TitleIsLong = true,  there will be enough spacing for the title to break over 2 or 3 lines. Since adding extra adding causes the height of the iframe to decrease, I've adjusted it accordingly.

### Screenshots
Long title on desktop
![Terminology_desktop](https://user-images.githubusercontent.com/70278044/134355599-61f8a678-c302-45d6-a7c6-4c5d60cb6eb0.png)
Long title on tablet
![localhost_5001_LearningContent_TerminologyAndClassificationsDeliveryService (1)](https://user-images.githubusercontent.com/70278044/134355791-7edd905c-0431-47e7-b23c-ba6c07b7418f.png)
Medium length title on mobile
![Reasonable_mobile](https://user-images.githubusercontent.com/70278044/134355652-aadfca69-00e4-4759-8be0-dd8dada56dc7.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
