### PR TITLE
HEEDLS-511-DelegateGroupEditGroupDiscription

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/GroupsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/GroupsDataServiceTests.cs
@@ -182,5 +182,37 @@
             // Then
             result.Should().BeNull();
         }
+
+        [Test]
+        public void UpdateGroupDescription_updates_record()
+        {
+            // Given
+            const int centerId = 101;
+            const int groupId = 5;
+            const string expectedDescription = "Test group description";
+
+            // When
+            groupsDataService.UpdateGroupDescription(groupId, centerId, expectedDescription);
+
+            //Then
+            var result = groupsDataService.GetGroup(groupId, centerId);
+            result?.GroupDescription.Should().Be(expectedDescription);
+        }
+
+        [Test]
+        public void UpdateGroupDescription_with_incorrect_centreId_does_not_update_record()
+        {
+            // Given
+            const int centerId = 107;   //Incorrect centre id
+            const int groupId = 5;
+            const string expectedDescription = "Test group description";
+
+            // When
+            groupsDataService.UpdateGroupDescription(groupId, centerId, expectedDescription);
+
+            //Then
+            var result = groupsDataService.GetGroup(groupId, centerId);
+            result?.GroupDescription.Should().NotBe(expectedDescription);
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -22,6 +22,10 @@
         int? GetRelatedProgressIdForGroupDelegate(int groupId, int delegateId);
 
         void DeleteGroupDelegatesRecordForDelegate(int groupId, int delegateId);
+
+        Group? GetGroup(int groupId, int centreId);
+
+        bool UpdateGroupDescription(int groupId, int centreId, string groupDescription);
     }
 
     public class GroupsDataService : IGroupsDataService
@@ -179,6 +183,30 @@
                       AND DelegateID = @delegateId",
                 new {groupId, delegateId}
             );
+        }
+
+        public Group? GetGroup(int groupId, int centreId)
+        {
+            return connection.Query<Group>(
+                @"SELECT
+                        GroupLabel,
+                        GroupDescription
+                    FROM Groups
+                    WHERE GroupID = @groupId AND CentreId = @centreId",
+                new { groupId, centreId }
+            ).SingleOrDefault();
+        }
+
+        public bool UpdateGroupDescription(int groupId, int centreId, string groupDescription)
+        {
+            var numberOfAffectedRows = connection.Execute(
+                @"UPDATE Groups
+                    SET
+                        GroupDescription = @groupDescription
+                    WHERE GroupID = @groupId AND CentreId = @centreId",
+                new { groupDescription, groupId, centreId }
+            );
+            return numberOfAffectedRows > 0;
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateGroupsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateGroupsControllerTests.cs
@@ -313,5 +313,39 @@
             A.CallTo(() => groupsDataService.DeleteGroupDelegatesRecordForDelegate(1, 2)).MustHaveHappened();
             result.Should().BeRedirectToActionResult().WithActionName("GroupDelegates");
         }
+
+        [Test]
+        public void EditDelegatesGroupDescription_should_return_not_found_with_invalid_group_for_centre()
+        {
+            // Given
+            var model = new EditDelegateGroupDescriptionViewModel();
+            A.CallTo(() => groupsDataService.UpdateGroupDescription(A<int>._, A<int>._, A<string>._))
+                .Returns(false);
+
+            // When
+            var result = delegateGroupsController.EditDelegateGroupDescription(model, 6);
+
+            // Them
+            A.CallTo(() => groupsDataService.UpdateGroupDescription(A<int>._, A<int>._, A<string>._))
+                .MustHaveHappened();
+            result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void EditDelegatesGroupDescription_should_redirect_to__index_action()
+        {
+            // Given
+            var model = new EditDelegateGroupDescriptionViewModel();
+            A.CallTo(() => groupsDataService.UpdateGroupDescription(A<int>._, A<int>._, A<string>._))
+                .Returns(true);
+
+            // When
+            var result = delegateGroupsController.EditDelegateGroupDescription(model, 6);
+
+            // Them
+            A.CallTo(() => groupsDataService.UpdateGroupDescription(A<int>._, A<int>._, A<string>._))
+                .MustHaveHappened();
+            result.Should().BeRedirectToActionResult().WithActionName("Index");
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -176,6 +176,38 @@
             return View(model);
         }
 
+        [Route("{groupId:int}/EditDelegateGroupDescription")]
+        [HttpGet]
+        public IActionResult EditDelegateGroupDescription(int groupId)
+        {
+            var centreId = User.GetCentreId();
+            var group = groupsDataService.GetGroup(groupId, centreId);
+
+            if (group is null)
+            {
+                return NotFound();
+            }
+
+            var model = new EditDelegateGroupDescriptionViewModel(group);
+            return View(model);
+        }
+
+        [Route("{groupId:int}/EditDelegateGroupDescription")]
+        [HttpPost]
+        public IActionResult EditDelegateGroupDescription(EditDelegateGroupDescriptionViewModel model, int groupId)
+        {
+            var centreId = User.GetCentreId();
+            if (!groupsDataService.UpdateGroupDescription(
+                groupId,
+                centreId,
+                model.Description!))
+            {
+                return NotFound();
+            }
+
+            return RedirectToAction("Index");
+        }
+
         private IEnumerable<CustomPrompt> GetRegistrationPromptsWithSetOptions(int centreId)
         {
             return centreCustomPromptsService.GetCustomPromptsForCentreByCentreId(centreId).CustomPrompts

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/EditDelegateGroupDescriptionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/EditDelegateGroupDescriptionViewModel.cs
@@ -1,0 +1,20 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+{
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
+
+    public class EditDelegateGroupDescriptionViewModel
+    {
+        public int GroupId { get; set; }
+        public string? GroupLabel { get; set; }
+        public string? Description { get; set; }
+
+        public EditDelegateGroupDescriptionViewModel() { }
+
+        public EditDelegateGroupDescriptionViewModel(Group group)
+        {
+            GroupId = group.GroupId;
+            GroupLabel = group.GroupLabel;
+            Description = group.GroupDescription;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/EditDelegateGroupDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/EditDelegateGroupDescription.cshtml
@@ -1,0 +1,40 @@
+﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups
+@using Microsoft.Extensions.Configuration
+@model EditDelegateGroupDescriptionViewModel
+
+@{
+  ViewData["Title"] = $"Edit description for {Model.GroupLabel} group (optional)";
+  ViewData["Application"] = "Tracking System";
+  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/TrackingSystem/Centre/Dashboard";
+  ViewData["HeaderPathName"] = "Tracking System";
+}
+
+<link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/delegates/groupDelegates.css")" asp-append-version="true">
+
+@section NavMenuItems {
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-l">@ViewData["Title"]</h1>
+    <div class="nhsuk-grid-column-two-thirds">
+      <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditDelegateGroupDescription">
+
+        <vc:text-area asp-for="@nameof(Model.Description)"
+                      label=""
+                      populate-with-current-value="true"
+                      rows="8"
+                      spell-check="true"
+                      hint-text=""
+                      css-class=""
+                      character-count="1000" />
+
+        <button class="nhsuk-button" type="submit" value="save">Save</button>
+      </form>
+      <vc:cancel-link asp-controller="DelegateGroups" asp-action="Index" />
+    </div>
+
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/_SearchableDelegateGroupCard.cshtml
@@ -32,7 +32,7 @@
           </dt>
           <partial name="_SummaryFieldValue" model="Model.Description" />
           <dd class="nhsuk-summary-list__actions">
-            <a href="#">
+            <a asp-controller="DelegateGroups" asp-action="EditDelegateGroupDescription" asp-route-groupId="@Model.Id">
               Edit<span class="nhsuk-u-visually-hidden"> description</span>
             </a>
           </dd>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-511

### Description
Added new view that is accessed from delegates group page. The new page allows users to be able to edit the description 

### Screenshots
![image](https://user-images.githubusercontent.com/90783892/134660265-54e3e8d8-8e7c-4c05-8da7-60e584ab70cd.png)
![image](https://user-images.githubusercontent.com/90783892/134660346-f808cb45-8708-4eac-8ef3-be81480bacfb.png)


-----
### Developer checks
I have:
- [x ] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [x ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ x] Scanned over my own MR to ensure everything is as expected.
