### PR TITLE
HEEDLS-585 All delegates - welcome emails - filter - fix

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/filter.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/filter.ts
@@ -116,7 +116,7 @@ function filterElements(
 
 function appendNewFilterToFilterBy(filterSubmit: HTMLInputElement): string {
   const filterValue = getSelectedFilterFromDropdownAndResetDropdown(filterSubmit);
-  if (filterValue) addNewFilterValueToFilterBy(filterValue);
+  addNewFilterValueToFilterBy(filterValue);
   return filterValue;
 }
 
@@ -131,6 +131,8 @@ function getSelectedFilterFromDropdownAndResetDropdown(
 }
 
 function addNewFilterValueToFilterBy(newFilterValue: string): void {
+  if (!newFilterValue) return;
+
   const filterBy = getFilterByValue();
   if (!filterBy.split(filterSeparator).includes(newFilterValue)) {
     const updatedFilterBy = filterBy ? filterBy + filterSeparator + newFilterValue : newFilterValue;

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/filter.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/filter.ts
@@ -116,7 +116,7 @@ function filterElements(
 
 function appendNewFilterToFilterBy(filterSubmit: HTMLInputElement): string {
   const filterValue = getSelectedFilterFromDropdownAndResetDropdown(filterSubmit);
-  addNewFilterValueToFilterBy(filterValue);
+  if (filterValue) addNewFilterValueToFilterBy(filterValue);
   return filterValue;
 }
 

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
@@ -8,11 +8,18 @@ const route = `TrackingSystem/Delegates/Email/AllEmailDelegateItems?${queryParam
 // eslint-disable-next-line no-new
 new SearchSortFilterAndPaginate(route, false, false, true, 'EmailDelegateFilter');
 
+function alertResultCount(): void {
+  const resultCount = document.getElementById('results-count') as HTMLSpanElement;
+  resultCount.setAttribute('role', '');
+  resultCount.setAttribute('role', 'alert');
+}
+
 function selectAll(): void {
   const allCheckboxes = document.querySelectorAll('.delegate-checkbox') as NodeListOf<HTMLInputElement>;
   allCheckboxes.forEach((checkbox) => {
     if (!checkbox.checked) checkbox.click();
   });
+  alertResultCount();
 }
 
 function deselectAll(): void {
@@ -20,6 +27,7 @@ function deselectAll(): void {
   allCheckboxes.forEach((checkbox) => {
     if (checkbox.checked) checkbox.click();
   });
+  alertResultCount();
 }
 
 const selectAllForm = document.getElementById('select-all-form') as HTMLFormElement;

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
@@ -7,7 +7,7 @@ const route = `TrackingSystem/Delegates/Email/AllEmailDelegateItems?${queryParam
 
 // eslint-disable-next-line no-new
 new SearchSortFilterAndPaginate(route, false, false, true, 'EmailDelegateFilter');
-setupSelectAndDeselectButtons();
+setUpSelectAndDeselectButtons();
 
 function alertResultCount(): void {
   // un-assign and re-assign the alert role to results-count so a screen-reader re-reads it
@@ -30,7 +30,7 @@ function deselectAll(): void {
   });
 }
 
-function setupSelectAndDeselectButtons(): void {
+function setUpSelectAndDeselectButtons(): void {
   const selectAllForm = document.getElementById('select-all-form') as HTMLFormElement;
   const selectAllButton = document.getElementById('select-all-button') as HTMLButtonElement;
   const deselectAllButton = document.getElementById('deselect-all-button') as HTMLButtonElement;

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
@@ -19,7 +19,6 @@ function selectAll(): void {
   allCheckboxes.forEach((checkbox) => {
     if (!checkbox.checked) checkbox.click();
   });
-  alertResultCount();
 }
 
 function deselectAll(): void {
@@ -27,7 +26,6 @@ function deselectAll(): void {
   allCheckboxes.forEach((checkbox) => {
     if (checkbox.checked) checkbox.click();
   });
-  alertResultCount();
 }
 
 const selectAllForm = document.getElementById('select-all-form') as HTMLFormElement;
@@ -35,5 +33,11 @@ const selectAllButton = document.getElementById('select-all-button') as HTMLButt
 const deselectAllButton = document.getElementById('deselect-all-button') as HTMLButtonElement;
 
 selectAllForm.addEventListener('submit', (e) => e.preventDefault());
-selectAllButton.addEventListener('click', selectAll);
-deselectAllButton.addEventListener('click', deselectAll);
+selectAllButton.addEventListener('click', () => {
+  selectAll();
+  alertResultCount();
+});
+deselectAllButton.addEventListener('click', () => {
+  deselectAll();
+  alertResultCount();
+});

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
@@ -7,8 +7,10 @@ const route = `TrackingSystem/Delegates/Email/AllEmailDelegateItems?${queryParam
 
 // eslint-disable-next-line no-new
 new SearchSortFilterAndPaginate(route, false, false, true, 'EmailDelegateFilter');
+setupSelectAndDeselectButtons();
 
 function alertResultCount(): void {
+  // un-assign and re-assign the alert role to results-count so a screen-reader re-reads it
   const resultCount = document.getElementById('results-count') as HTMLSpanElement;
   resultCount.setAttribute('role', '');
   resultCount.setAttribute('role', 'alert');
@@ -28,16 +30,22 @@ function deselectAll(): void {
   });
 }
 
-const selectAllForm = document.getElementById('select-all-form') as HTMLFormElement;
-const selectAllButton = document.getElementById('select-all-button') as HTMLButtonElement;
-const deselectAllButton = document.getElementById('deselect-all-button') as HTMLButtonElement;
+function setupSelectAndDeselectButtons(): void {
+  const selectAllForm = document.getElementById('select-all-form') as HTMLFormElement;
+  const selectAllButton = document.getElementById('select-all-button') as HTMLButtonElement;
+  const deselectAllButton = document.getElementById('deselect-all-button') as HTMLButtonElement;
 
-selectAllForm.addEventListener('submit', (e) => e.preventDefault());
-selectAllButton.addEventListener('click', () => {
-  selectAll();
-  alertResultCount();
-});
-deselectAllButton.addEventListener('click', () => {
-  deselectAll();
-  alertResultCount();
-});
+  selectAllForm.addEventListener('submit', (e) => e.preventDefault());
+
+  selectAllButton.addEventListener('click',
+    () => {
+      selectAll();
+      alertResultCount();
+    });
+
+  deselectAllButton.addEventListener('click',
+    () => {
+      deselectAll();
+      alertResultCount();
+    });
+}

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/emailDelegates.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/emailDelegates.scss
@@ -5,7 +5,3 @@
   border-radius: 4px;
   margin-right: nhsuk-spacing(2);
 }
-
-.delegate-label {
-  word-break: break-word;
-}

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/emailDelegates.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/emailDelegates.scss
@@ -5,3 +5,7 @@
   border-radius: 4px;
   margin-right: nhsuk-spacing(2);
 }
+
+.delegate-label {
+  word-break: break-word;
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/_SearchableDelegateCheckbox.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/_SearchableDelegateCheckbox.cshtml
@@ -8,7 +8,7 @@
          name="SelectedDelegateIds"
          value="@Model.Id"
          @(Model.IsDelegateSelected ? "checked" : string.Empty) />
-  <label class="nhsuk-label nhsuk-checkboxes__label searchable-element-title delegate-label" for="@Model.Id-checkbox">
+  <label class="nhsuk-label nhsuk-checkboxes__label searchable-element-title word-break" for="@Model.Id-checkbox">
     @Model.Name (@Model.Email)
   </label>
   <div class="nhsuk-hint nhsuk-checkboxes__hint" id="@Model.Id-hint">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/_SearchableDelegateCheckbox.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/_SearchableDelegateCheckbox.cshtml
@@ -8,7 +8,7 @@
          name="SelectedDelegateIds"
          value="@Model.Id"
          @(Model.IsDelegateSelected ? "checked" : string.Empty) />
-  <label class="nhsuk-label nhsuk-checkboxes__label searchable-element-title" for="@Model.Id-checkbox">
+  <label class="nhsuk-label nhsuk-checkboxes__label searchable-element-title delegate-label" for="@Model.Id-checkbox">
     @Model.Name (@Model.Email)
   </label>
   <div class="nhsuk-hint nhsuk-checkboxes__hint" id="@Model.Id-hint">


### PR DESCRIPTION
### JIRA link
[HEEDLS-585](https://softwiretech.atlassian.net/browse/HEEDLS-585)

### Description
- Fix JS bug: If I add a filter, and then go to add a different filter, but leave it on the default value of “Select [filter name]” and hit the Add Filter button then nothing happens as expected. However, I then cannot add any new filters until I clear all the filters.
- Word break for really long delegate checkbox labels
- Read out results count when selecting/deselect all

### Screenshots
Word wrap:
![](https://user-images.githubusercontent.com/44787206/134692905-79d548b6-2c31-4f0d-b807-b032d292c026.png)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
