### PR TITLE
DLSV2-352 Removes status-tag span class from questions

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
@@ -3,12 +3,8 @@
 
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Questions </span>
-  <span class="status-tag">
-
     @Model.Question
-
-  </span>
-</td>
+  </td>
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Responses </span>
   <partial name="Shared/_AssessmentQuestionResponse" model="Model" />


### PR DESCRIPTION
To allow them to wrap

### JIRA link
DLSV2-352

### Description
Small fix to allow question column text to wrap to avoid squashing competency column.
