### PR TITLE
HEEDLS-556 - fix bugs in limit admin roles processing

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Helpers/LinkedFieldHelperTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Helpers/LinkedFieldHelperTests.cs
@@ -5,6 +5,7 @@
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions;
@@ -16,12 +17,15 @@
         private const string NewAnswer = "new answer";
         private const string OldJobGroupName = "old job group";
         private const string NewJobGroupName = "new job group";
+        private ICentreCustomPromptsService centreCustomPromptsService = null!;
         private IJobGroupsDataService jobGroupsDataService = null!;
 
         [SetUp]
         public void SetUp()
         {
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
+            centreCustomPromptsService = A.Fake<ICentreCustomPromptsService>();
+
             A.CallTo(() => jobGroupsDataService.GetJobGroupName(1)).Returns(OldJobGroupName);
             A.CallTo(() => jobGroupsDataService.GetJobGroupName(2)).Returns(NewJobGroupName);
         }
@@ -31,20 +35,32 @@
         public void Changed_answer_maps_to_linked_field_correctly(
             CentreAnswersData oldAnswers,
             CentreAnswersData newAnswers,
+            string expectedLinkedFieldName,
             int expectedLinkedFieldNumber,
             string expectedOldValue,
             string expectedNewValue
         )
         {
             // Given
+            A.CallTo(() => centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(A<int>._, A<int>._))
+                .Returns(expectedLinkedFieldName);
+
             var expectedResult = new List<LinkedFieldChange>
-                { new LinkedFieldChange(expectedLinkedFieldNumber, expectedOldValue, expectedNewValue) };
+            {
+                new LinkedFieldChange(
+                    expectedLinkedFieldNumber,
+                    expectedLinkedFieldName,
+                    expectedOldValue,
+                    expectedNewValue
+                )
+            };
 
             // When
             var result = LinkedFieldHelper.GetLinkedFieldChanges(
                 oldAnswers,
                 newAnswers,
-                jobGroupsDataService
+                jobGroupsDataService,
+                centreCustomPromptsService
             );
 
             // Then
@@ -57,43 +73,43 @@
             {
                 UserTestHelper.GetDefaultCentreAnswersData(answer1: OldAnswer),
                 UserTestHelper.GetDefaultCentreAnswersData(answer1: NewAnswer),
-                1, OldAnswer, NewAnswer
+                "prompt 1", 1, OldAnswer, NewAnswer
             };
             yield return new object[]
             {
                 UserTestHelper.GetDefaultCentreAnswersData(answer2: OldAnswer),
                 UserTestHelper.GetDefaultCentreAnswersData(answer2: NewAnswer),
-                2, OldAnswer, NewAnswer
+                "prompt 2", 2, OldAnswer, NewAnswer
             };
             yield return new object[]
             {
                 UserTestHelper.GetDefaultCentreAnswersData(answer3: OldAnswer),
                 UserTestHelper.GetDefaultCentreAnswersData(answer3: NewAnswer),
-                3, OldAnswer, NewAnswer
+                "prompt 3", 3, OldAnswer, NewAnswer
             };
             yield return new object[]
             {
                 UserTestHelper.GetDefaultCentreAnswersData(jobGroupId: 1),
                 UserTestHelper.GetDefaultCentreAnswersData(jobGroupId: 2),
-                4, OldJobGroupName, NewJobGroupName
+                "Job Group", 4, OldJobGroupName, NewJobGroupName
             };
             yield return new object[]
             {
                 UserTestHelper.GetDefaultCentreAnswersData(answer4: OldAnswer),
                 UserTestHelper.GetDefaultCentreAnswersData(answer4: NewAnswer),
-                5, OldAnswer, NewAnswer
+                "prompt 4", 5, OldAnswer, NewAnswer
             };
             yield return new object[]
             {
                 UserTestHelper.GetDefaultCentreAnswersData(answer5: OldAnswer),
                 UserTestHelper.GetDefaultCentreAnswersData(answer5: NewAnswer),
-                6, OldAnswer, NewAnswer
+                "prompt 5", 6, OldAnswer, NewAnswer
             };
             yield return new object[]
             {
                 UserTestHelper.GetDefaultCentreAnswersData(answer6: OldAnswer),
                 UserTestHelper.GetDefaultCentreAnswersData(answer6: NewAnswer),
-                7, OldAnswer, NewAnswer
+                "prompt 6", 7, OldAnswer, NewAnswer
             };
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
@@ -150,6 +150,52 @@
         }
 
         [Test]
+        public void
+            SynchroniseUserChangesWithGroups_removes_delegate_from_synchronised_old_answer_group_when_group_label_includes_prompt_name()
+        {
+            // Given
+            var centreAnswersData = UserTestHelper.GetDefaultCentreAnswersData(answer1: "new answer");
+            A.CallTo(() => clockService.UtcNow).Returns(testDate);
+            A.CallTo(
+                () => centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(
+                    reusableDelegateDetails.CentreId,
+                    1
+                )
+            ).Returns("Prompt Name");
+            var synchronisedGroup = GroupTestHelper.GetDefaultGroup(
+                5,
+                "Prompt Name - old answer",
+                linkedToField: 1,
+                changesToRegistrationDetailsShouldChangeGroupMembership: true
+            );
+            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
+                new List<Group> { synchronisedGroup }
+            );
+
+            // When
+            groupsService.SynchroniseUserChangesWithGroups(
+                reusableDelegateDetails,
+                reusableAccountDetailsData,
+                centreAnswersData
+            );
+
+            // Then
+            A.CallTo(
+                () => groupsDataService.DeleteGroupDelegatesRecordForDelegate(
+                    synchronisedGroup.GroupId,
+                    reusableDelegateDetails.Id
+                )
+            ).MustHaveHappened();
+            A.CallTo(
+                () => groupsDataService.RemoveRelatedProgressRecordsForGroupDelegate(
+                    synchronisedGroup.GroupId,
+                    reusableDelegateDetails.Id,
+                    testDate
+                )
+            ).MustHaveHappened();
+        }
+
+        [Test]
         public void SynchroniseUserChangesWithGroups_adds_delegate_to_synchronised_new_answer_group()
         {
             // Given
@@ -158,6 +204,48 @@
             var synchronisedGroup = GroupTestHelper.GetDefaultGroup(
                 5,
                 "new answer",
+                linkedToField: 1,
+                changesToRegistrationDetailsShouldChangeGroupMembership: true
+            );
+            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
+                new List<Group> { synchronisedGroup }
+            );
+
+            // When
+            groupsService.SynchroniseUserChangesWithGroups(
+                reusableDelegateDetails,
+                reusableAccountDetailsData,
+                centreAnswersData
+            );
+
+            // Then
+            A.CallTo(
+                () => groupsDataService.AddDelegateToGroup(
+                    reusableDelegateDetails.Id,
+                    synchronisedGroup.GroupId,
+                    testDate,
+                    1
+                )
+            ).MustHaveHappened();
+        }
+
+        [Test]
+        public void
+            SynchroniseUserChangesWithGroups_adds_delegate_to_synchronised_new_answer_group_when_group_label_includes_prompt_name()
+        {
+            // Given
+            var centreAnswersData = UserTestHelper.GetDefaultCentreAnswersData(answer1: "new answer");
+            A.CallTo(() => clockService.UtcNow).Returns(testDate);
+            A.CallTo(
+                () => centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(
+                    reusableDelegateDetails.CentreId,
+                    1
+                )
+            ).Returns("Prompt Name");
+
+            var synchronisedGroup = GroupTestHelper.GetDefaultGroup(
+                5,
+                "Prompt Name - new answer",
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );

--- a/DigitalLearningSolutions.Data.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -27,6 +27,7 @@
         private readonly GroupCourse reusableGroupCourse = GroupTestHelper.GetDefaultGroupCourse();
         private readonly Progress reusableProgressRecord = ProgressTestHelper.GetDefaultProgress();
         private readonly DateTime testDate = new DateTime(2021, 12, 11);
+        private ICentreCustomPromptsService centreCustomPromptsService = null!;
         private IClockService clockService = null!;
         private IConfiguration configuration = null!;
         private IEmailService emailService = null!;
@@ -46,6 +47,8 @@
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
             progressDataService = A.Fake<IProgressDataService>();
             configuration = A.Fake<IConfiguration>();
+            centreCustomPromptsService = A.Fake<ICentreCustomPromptsService>();
+
             A.CallTo(() => configuration[ConfigHelper.AppRootPathName]).Returns("baseUrl");
             DatabaseModificationsDoNothing();
             groupsService = new GroupsService(
@@ -55,7 +58,8 @@
                 emailService,
                 jobGroupsDataService,
                 progressDataService,
-                configuration
+                configuration,
+                centreCustomPromptsService
             );
         }
 

--- a/DigitalLearningSolutions.Data/Helpers/LinkedFieldHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/LinkedFieldHelper.cs
@@ -4,35 +4,43 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Services;
 
     public static class LinkedFieldHelper
     {
         public static List<LinkedFieldChange> GetLinkedFieldChanges(
             CentreAnswersData oldAnswers,
             CentreAnswersData newAnswers,
-            IJobGroupsDataService jobGroupsDataService
+            IJobGroupsDataService jobGroupsDataService,
+            ICentreCustomPromptsService centreCustomPromptsService
         )
         {
             var changedLinkedFieldsWithAnswers = new List<LinkedFieldChange>();
 
             if (newAnswers.Answer1 != oldAnswers.Answer1)
             {
+                var prompt1Name =
+                    centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(oldAnswers.CentreId, 1);
                 changedLinkedFieldsWithAnswers.Add(
-                    new LinkedFieldChange(1, oldAnswers.Answer1, newAnswers.Answer1)
+                    new LinkedFieldChange(1, prompt1Name, oldAnswers.Answer1, newAnswers.Answer1)
                 );
             }
 
             if (newAnswers.Answer2 != oldAnswers.Answer2)
             {
+                var prompt2Name =
+                    centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(oldAnswers.CentreId, 2);
                 changedLinkedFieldsWithAnswers.Add(
-                    new LinkedFieldChange(2, oldAnswers.Answer2, newAnswers.Answer2)
+                    new LinkedFieldChange(2, prompt2Name, oldAnswers.Answer2, newAnswers.Answer2)
                 );
             }
 
             if (newAnswers.Answer3 != oldAnswers.Answer3)
             {
+                var prompt3Name =
+                    centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(oldAnswers.CentreId, 3);
                 changedLinkedFieldsWithAnswers.Add(
-                    new LinkedFieldChange(3, oldAnswers.Answer3, newAnswers.Answer3)
+                    new LinkedFieldChange(3, prompt3Name, oldAnswers.Answer3, newAnswers.Answer3)
                 );
             }
 
@@ -40,27 +48,33 @@
             {
                 var oldJobGroup = jobGroupsDataService.GetJobGroupName(oldAnswers.JobGroupId);
                 var newJobGroup = jobGroupsDataService.GetJobGroupName(newAnswers.JobGroupId);
-                changedLinkedFieldsWithAnswers.Add(new LinkedFieldChange(4, oldJobGroup, newJobGroup));
+                changedLinkedFieldsWithAnswers.Add(new LinkedFieldChange(4, "Job Group", oldJobGroup, newJobGroup));
             }
 
             if (newAnswers.Answer4 != oldAnswers.Answer4)
             {
+                var prompt4Name =
+                    centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(oldAnswers.CentreId, 4);
                 changedLinkedFieldsWithAnswers.Add(
-                    new LinkedFieldChange(5, oldAnswers.Answer4, newAnswers.Answer4)
+                    new LinkedFieldChange(5, prompt4Name, oldAnswers.Answer4, newAnswers.Answer4)
                 );
             }
 
             if (newAnswers.Answer5 != oldAnswers.Answer5)
             {
+                var prompt5Name =
+                    centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(oldAnswers.CentreId, 5);
                 changedLinkedFieldsWithAnswers.Add(
-                    new LinkedFieldChange(6, oldAnswers.Answer5, newAnswers.Answer5)
+                    new LinkedFieldChange(6, prompt5Name, oldAnswers.Answer5, newAnswers.Answer5)
                 );
             }
 
             if (newAnswers.Answer6 != oldAnswers.Answer6)
             {
+                var prompt6Name =
+                    centreCustomPromptsService.GetPromptNameForCentreAndPromptNumber(oldAnswers.CentreId, 6);
                 changedLinkedFieldsWithAnswers.Add(
-                    new LinkedFieldChange(7, oldAnswers.Answer6, newAnswers.Answer6)
+                    new LinkedFieldChange(7, prompt6Name, oldAnswers.Answer6, newAnswers.Answer6)
                 );
             }
 

--- a/DigitalLearningSolutions.Data/Models/LinkedFieldChange.cs
+++ b/DigitalLearningSolutions.Data/Models/LinkedFieldChange.cs
@@ -2,14 +2,16 @@
 {
     public class LinkedFieldChange
     {
-        public LinkedFieldChange(int linkedFieldNumber, string? oldValue, string? newValue)
+        public LinkedFieldChange(int linkedFieldNumber, string? linkedFieldName, string? oldValue, string? newValue)
         {
             LinkedFieldNumber = linkedFieldNumber;
+            LinkedFieldName = linkedFieldName;
             OldValue = oldValue;
             NewValue = newValue;
         }
 
         public int LinkedFieldNumber { get; set; }
+        public string? LinkedFieldName { get; set; }
         public string? OldValue { get; set; }
         public string? NewValue { get; set; }
     }

--- a/DigitalLearningSolutions.Data/Models/LinkedFieldChange.cs
+++ b/DigitalLearningSolutions.Data/Models/LinkedFieldChange.cs
@@ -2,7 +2,7 @@
 {
     public class LinkedFieldChange
     {
-        public LinkedFieldChange(int linkedFieldNumber, string? linkedFieldName, string? oldValue, string? newValue)
+        public LinkedFieldChange(int linkedFieldNumber, string linkedFieldName, string? oldValue, string? newValue)
         {
             LinkedFieldNumber = linkedFieldNumber;
             LinkedFieldName = linkedFieldName;
@@ -11,7 +11,7 @@
         }
 
         public int LinkedFieldNumber { get; set; }
-        public string? LinkedFieldName { get; set; }
+        public string LinkedFieldName { get; set; }
         public string? OldValue { get; set; }
         public string? NewValue { get; set; }
     }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-556

### Description
Fixed the two bugs mentioned in the ticket.
The first (not being added/removed from group) was due to the group labels stored in the DB containing the prompt name for the example tested. The fix for this involves grabbing the prompt name and adding it to the answer given if the answer alone does not match the group label.
The second (progress record not being removed) was due to GroupDelegateRecords being deleted before they had a chance to be used in the RemoveProgress... query. Swapping the order in which these are performed resolves this.

### Screenshots
N/A

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
