### PR TITLE
HEEDLS-566 - implemented delegate progress page

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
@@ -35,7 +35,29 @@
                 );
 
             // When
-            var returnedCourseAdminFieldsResult = courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0);
+            var returnedCourseAdminFieldsResult = courseAdminFieldsDataService.GetCourseAdminFields(100, 101);
+
+            // Then
+            returnedCourseAdminFieldsResult.Should().BeEquivalentTo(expectedCourseAdminFieldsResult);
+        }
+
+        [Test]
+        public void GetCourseAdminFields_returns_populated_CourseAdminFieldsResult_for_AllCentres_course_when_allowed()
+        {
+            // Given
+            var expectedCourseAdminFieldsResult =
+                CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult(
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    2
+                );
+
+            // When
+            var returnedCourseAdminFieldsResult = courseAdminFieldsDataService.GetCourseAdminFields(14038, 101, true);
 
             // Then
             returnedCourseAdminFieldsResult.Should().BeEquivalentTo(expectedCourseAdminFieldsResult);
@@ -52,7 +74,7 @@
 
                 // When
                 courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 1, 1, options);
-                var courseAdminFields = courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0);
+                var courseAdminFields = courseAdminFieldsDataService.GetCourseAdminFields(100, 101);
 
                 // Then
                 using (new AssertionScope())
@@ -87,7 +109,7 @@
 
                 // When
                 courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 3, 1, options);
-                var courseCustomPrompts = courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 2);
+                var courseCustomPrompts = courseAdminFieldsDataService.GetCourseAdminFields(100, 101);
                 var customPrompt = courseAdminFieldsDataService.GetCoursePromptsAlphabetical()
                     .Single(c => c.id == 1)
                     .name;

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -9,12 +9,47 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions;
-    using FluentAssertions.Execution;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
 
     public class CourseDataServiceTests
     {
+        private static readonly DateTime EnrollmentDate = new DateTime(2019, 04, 11, 14, 33, 37).AddMilliseconds(140);
+
+        private static readonly DelegateCourseInfo ExpectedCourseInfo = new DelegateCourseInfo(
+            27915,
+            101,
+            false,
+            4,
+            "LinkedIn",
+            "Cohort Testing",
+            1,
+            "Kevin",
+            "Whittaker (Developer)",
+            EnrollmentDate,
+            EnrollmentDate,
+            null,
+            null,
+            null,
+            null,
+            3,
+            1,
+            "Kevin",
+            "Whittaker (Developer)",
+            0,
+            0,
+            null,
+            true,
+            null,
+            null,
+            null,
+            20,
+            "xxxx",
+            "xxxxxx",
+            "",
+            101
+        );
+
         private CourseDataService courseDataService = null!;
 
         [OneTimeSetUp]
@@ -283,29 +318,18 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             var results = courseDataService.GetDelegateCoursesInfo(20).ToList();
 
             // Then
-            var enrollmentDate = new DateTime(2019, 04, 11, 14, 33, 37).AddMilliseconds(140);
-            var expected = new DelegateCourseInfo(
-                27915,
-                "LinkedIn",
-                "Cohort Testing",
-                "Kevin",
-                "Whittaker (Developer)",
-                enrollmentDate,
-                enrollmentDate,
-                null,
-                null,
-                null,
-                3,
-                0,
-                0,
-                null,
-                true,
-                null,
-                null,
-                null
-            );
             results.Should().HaveCount(4);
-            results[3].Should().BeEquivalentTo(expected);
+            results[3].Should().BeEquivalentTo(ExpectedCourseInfo);
+        }
+
+        [Test]
+        public void GetDelegateCourseInfo_should_return_delegate_course_info_correctly()
+        {
+            // When
+            var result = courseDataService.GetDelegateCourseInfo(284998);
+
+            // Then
+            result.Should().BeEquivalentTo(ExpectedCourseInfo);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/Models/DelegateCourseDetailsTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Models/DelegateCourseDetailsTests.cs
@@ -1,0 +1,34 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Models
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class DelegateCourseDetailsTests
+    {
+        [Test]
+        [TestCase(0, 0, 0)]
+        [TestCase(5, 5, 100)]
+        [TestCase(10, 5, 50)]
+        [TestCase(1000, 994, 99)]
+        [TestCase(1000, 995, 100)]
+        public void ViewModel_calculates_pass_rate_correctly(
+            int attemptsMade,
+            int attemptsPassed,
+            double expectedPassRate
+        )
+        {
+            // Given
+            var details = new DelegateCourseDetails(
+                new DelegateCourseInfo(),
+                new List<CustomPromptWithAnswer>(),
+                (attemptsMade, attemptsPassed)
+            );
+
+            // Then
+            details.AttemptStats.Should().Be((attemptsMade, attemptsPassed, expectedPassRate));
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
@@ -35,11 +35,11 @@
             var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(2, "Priority Access");
             var customPrompts = new List<CustomPrompt> { expectedPrompt1, expectedPrompt2 };
             var expectedCourseAdminFields = CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts);
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, false))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsForCourse(100, 101, 0);
+            var result = courseAdminFieldsService.GetCustomPromptsForCourse(100, 101);
 
             // Then
             result.Should().BeEquivalentTo(expectedCourseAdminFields);
@@ -63,7 +63,7 @@
                 answer: answer2
             );
             var expected = new List<CustomPromptWithAnswer> { expected1, expected2 };
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, false))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
             var delegateCourseInfo = new DelegateCourseInfo { Answer1 = answer1, Answer2 = answer2 };
 
@@ -112,11 +112,11 @@
             (
                 () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, A<int>._, A<int>._, null)
             ).DoesNothing();
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, false))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.AddCustomPromptToCourse(100, 101, 0, 3, null);
+            var result = courseAdminFieldsService.AddCustomPromptToCourse(100, 101, 3, null);
 
             // Then
             A.CallTo
@@ -134,7 +134,7 @@
             (
                 () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, A<int>._, A<int>._, null)
             ).DoesNothing();
-            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, 0))
+            A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100, 101, false))
                 .Returns(
                     CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult(
                         "System Access Granted",
@@ -149,7 +149,6 @@
             var result = courseAdminFieldsService.AddCustomPromptToCourse(
                 100,
                 101,
-                0,
                 3,
                 "Adding a fourth prompt"
             );

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -87,67 +87,61 @@
         }
 
         [Test]
-        public void GetAllCoursesForDelegate_should_call_correct_data_service_and_helper_methods()
+        public void GetDelegateAttemptsAndCourseCustomPrompts_should_call_correct_data_service_and_helper_methods()
         {
             // Given
             const int delegateId = 20;
             const int customisationId = 111;
-            var attemptStats = (7, 4);
+            var returnedAttemptStats = (10, 5);
+            var expectedAttemptStats = (10, 5, 50);
             var info = new DelegateCourseInfo
-                { CustomisationId = customisationId, IsAssessed = true };
-            A.CallTo(() => courseDataService.GetDelegateCoursesInfo(delegateId))
-                .Returns(new List<DelegateCourseInfo> { info });
+                { DelegateId = delegateId, CustomisationId = customisationId, IsAssessed = true };
             A.CallTo(() => courseDataService.GetDelegateCourseAttemptStats(delegateId, customisationId))
-                .Returns(attemptStats);
+                .Returns(returnedAttemptStats);
 
             // When
-            var results = courseService.GetAllCoursesForDelegate(delegateId, CentreId).ToList();
+            var results = courseService.GetDelegateAttemptsAndCourseCustomPrompts(info, CentreId);
 
             // Then
-            A.CallTo(() => courseDataService.GetDelegateCoursesInfo(delegateId)).MustHaveHappened(1, Times.Exactly);
             A.CallTo(
                 () => courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
                     info,
                     customisationId,
                     CentreId,
-                    0
+                    0,
+                    false
                 )
             ).MustHaveHappened(1, Times.Exactly);
             A.CallTo(() => courseDataService.GetDelegateCourseAttemptStats(delegateId, customisationId))
                 .MustHaveHappened(1, Times.Exactly);
-            results.Should().HaveCount(1);
-            results[0].DelegateCourseInfo.Should().BeEquivalentTo(info);
-            results[0].AttemptStats.Should().Be(attemptStats);
+            results.DelegateCourseInfo.Should().BeEquivalentTo(info);
+            results.AttemptStats.Should().Be(expectedAttemptStats);
         }
 
         [Test]
-        public void GetAllCoursesForDelegate_should_not_fetch_attempt_stats_if_course_not_assessed()
+        public void GetDelegateAttemptsAndCourseCustomPrompts_should_not_fetch_attempt_stats_if_course_not_assessed()
         {
             // Given
-            const int delegateId = 20;
             const int customisationId = 111;
             var info = new DelegateCourseInfo
                 { CustomisationId = customisationId, IsAssessed = false };
-            A.CallTo(() => courseDataService.GetDelegateCoursesInfo(delegateId))
-                .Returns(new List<DelegateCourseInfo> { info });
 
             // When
-            var results = courseService.GetAllCoursesForDelegate(delegateId, CentreId).ToList();
+            var result = courseService.GetDelegateAttemptsAndCourseCustomPrompts(info, CentreId);
 
             // Then
-            A.CallTo(() => courseDataService.GetDelegateCoursesInfo(delegateId)).MustHaveHappened(1, Times.Exactly);
             A.CallTo(
                 () => courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
                     info,
                     customisationId,
                     CentreId,
-                    0
+                    0,
+                    false
                 )
             ).MustHaveHappened(1, Times.Exactly);
             A.CallTo(() => courseDataService.GetDelegateCourseAttemptStats(A<int>._, A<int>._)).MustNotHaveHappened();
-            results.Should().HaveCount(1);
-            results[0].DelegateCourseInfo.Should().BeEquivalentTo(info);
-            results[0].AttemptStats.Should().Be((0, 0));
+            result.DelegateCourseInfo.Should().BeEquivalentTo(info);
+            result.AttemptStats.Should().Be((0, 0, 0));
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -8,7 +8,11 @@
 
     public interface ICourseAdminFieldsDataService
     {
-        CourseAdminFieldsResult? GetCourseAdminFields(int customisationId, int centreId, int categoryId);
+        CourseAdminFieldsResult? GetCourseAdminFields(
+            int customisationId,
+            int centreId,
+            bool allowAllCentreCourses = false
+        );
 
         void UpdateCustomPromptForCourse(int customisationId, int promptNumber, string? options);
 
@@ -37,7 +41,11 @@
             this.connection = connection;
         }
 
-        public CourseAdminFieldsResult GetCourseAdminFields(int customisationId, int centreId, int categoryId)
+        public CourseAdminFieldsResult GetCourseAdminFields(
+            int customisationId,
+            int centreId,
+            bool allowAllCentreCourses = false
+        )
         {
             var result = connection.Query<CourseAdminFieldsResult>(
                 @"SELECT
@@ -60,10 +68,10 @@
                     LEFT JOIN CoursePrompts AS cp3
                         ON cu.CourseField3PromptID = cp3.CoursePromptID
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = cu.ApplicationID
-                    WHERE cu.CentreID = @centreId
+                    WHERE (cu.CentreID = @centreId OR (cu.AllCentres = 1 AND @allowAllCentreCourses = 1))
                         AND ap.ArchivedDate IS NULL
                         AND cu.CustomisationID = @customisationId",
-                new { customisationId, centreId, categoryId }
+                new { customisationId, centreId, allowAllCentreCourses }
             ).Single();
 
             return result;

--- a/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
@@ -12,21 +12,21 @@
 
     public class CourseDelegatesDataService : ICourseDelegatesDataService
     {
-        private readonly IDbConnection connection;
-
         private const string AllAttemptsQuery =
             @"(SELECT COUNT(aa.AssessAttemptID)
                 FROM dbo.AssessAttempts AS aa
                 INNER JOIN dbo.Candidates AS can ON can.CandidateID = aa.CandidateID
                 WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] IS NOT NULL
-                AND can.CentreID = @centreId) AS AllAttempts";
+                AND can.CentreID = @centreId AND can.CandidateId = c.CandidateId) AS AllAttempts";
 
         private const string AttemptsPassedQuery =
             @"(SELECT COUNT(aa.AssessAttemptID)
                 FROM dbo.AssessAttempts AS aa
                 INNER JOIN dbo.Candidates AS can ON can.CandidateID = aa.CandidateID
                 WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] = 1
-                AND can.CentreID = @centreId) AS AttemptsPassed";
+                AND can.CentreID = @centreId AND can.CandidateId = c.CandidateId) AS AttemptsPassed";
+
+        private readonly IDbConnection connection;
 
         public CourseDelegatesDataService(IDbConnection connection)
         {

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseDetails.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseDetails.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.Courses
 {
+    using System;
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
@@ -13,11 +14,14 @@
         {
             DelegateCourseInfo = delegateCourseInfo;
             CustomPrompts = customPrompts;
-            AttemptStats = attemptStats;
+            var passRate = attemptStats.totalAttempts == 0
+                ? 0
+                : Math.Round(100 * attemptStats.attemptsPassed / (double)attemptStats.totalAttempts);
+            AttemptStats = (attemptStats.totalAttempts, attemptStats.attemptsPassed, passRate);
         }
 
         public DelegateCourseInfo DelegateCourseInfo { get; set; }
         public List<CustomPromptWithAnswer> CustomPrompts { get; set; }
-        public (int totalAttempts, int attemptsPassed) AttemptStats { get; set; }
+        public (int totalAttempts, int attemptsPassed, double passRate) AttemptStats { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -2,14 +2,18 @@
 {
     using System;
 
-    public class DelegateCourseInfo
+    public class DelegateCourseInfo : CourseNameInfo
     {
         public DelegateCourseInfo() { }
 
         public DelegateCourseInfo(
             int customisationId,
+            int customisationCentreId,
+            bool allCentres,
+            int courseCategoryId,
             string applicationName,
             string customisationName,
+            int? supervisorAdminId,
             string? supervisorForename,
             string? supervisorSurname,
             DateTime enrolled,
@@ -17,19 +21,32 @@
             DateTime? completeBy,
             DateTime? completed,
             DateTime? evaluated,
+            DateTime? removedDate,
             int enrolmentMethodId,
+            int? enrolledByAdminId,
+            string? enrolledByForename,
+            string? enrolledBySurname,
             int loginCount,
             int learningTime,
             int? diagnosticScore,
             bool isAssessed,
             string? answer1,
             string? answer2,
-            string? answer3
+            string? answer3,
+            int delegateId,
+            string? delegateFirstName,
+            string delegateLastName,
+            string? delegateEmail,
+            int delegateCentreId
         )
         {
             CustomisationId = customisationId;
+            CustomisationCentreId = customisationCentreId;
+            AllCentresCourse = allCentres;
+            CourseCategoryId = courseCategoryId;
             ApplicationName = applicationName;
             CustomisationName = customisationName;
+            SupervisorAdminId = supervisorAdminId;
             SupervisorForename = supervisorForename;
             SupervisorSurname = supervisorSurname;
             Enrolled = enrolled;
@@ -37,7 +54,11 @@
             CompleteBy = completeBy;
             Completed = completed;
             Evaluated = evaluated;
+            RemovedDate = removedDate;
             EnrolmentMethodId = enrolmentMethodId;
+            EnrolledByAdminId = enrolledByAdminId;
+            EnrolledByForename = enrolledByForename;
+            EnrolledBySurname = enrolledBySurname;
             LoginCount = loginCount;
             LearningTime = learningTime;
             DiagnosticScore = diagnosticScore;
@@ -45,11 +66,18 @@
             Answer1 = answer1;
             Answer2 = answer2;
             Answer3 = answer3;
+            DelegateId = delegateId;
+            DelegateFirstName = delegateFirstName;
+            DelegateLastName = delegateLastName;
+            DelegateEmail = delegateEmail;
+            DelegateCentreId = delegateCentreId;
         }
 
         public int CustomisationId { get; set; }
-        public string ApplicationName { get; set; }
-        public string CustomisationName { get; set; }
+        public int CustomisationCentreId { get; set; }
+        public bool AllCentresCourse { get; set; }
+        public int CourseCategoryId { get; set; }
+        public int? SupervisorAdminId { get; set; }
         public string? SupervisorForename { get; set; }
         public string? SupervisorSurname { get; set; }
         public DateTime Enrolled { get; set; }
@@ -57,7 +85,11 @@
         public DateTime? CompleteBy { get; set; }
         public DateTime? Completed { get; set; }
         public DateTime? Evaluated { get; set; }
+        public DateTime? RemovedDate { get; set; }
         public int EnrolmentMethodId { get; set; }
+        public int? EnrolledByAdminId { get; set; }
+        public string? EnrolledByForename { get; set; }
+        public string? EnrolledBySurname { get; set; }
         public int LoginCount { get; set; }
         public int LearningTime { get; set; }
         public int? DiagnosticScore { get; set; }
@@ -65,5 +97,10 @@
         public string? Answer1 { get; set; }
         public string? Answer2 { get; set; }
         public string? Answer3 { get; set; }
+        public int DelegateId { get; set; }
+        public string? DelegateFirstName { get; set; }
+        public string DelegateLastName { get; set; }
+        public string? DelegateEmail { get; set; }
+        public int DelegateCentreId { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CourseAdminFieldsResult.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CourseAdminFieldsResult.cs
@@ -1,7 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
 {
-    using System.Collections.Generic;
-
     public class CourseAdminFieldsResult
     {
         public string? CustomField1Prompt { get; set; }

--- a/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
@@ -11,13 +11,14 @@
 
     public interface ICourseAdminFieldsService
     {
-        public CourseAdminFields GetCustomPromptsForCourse(int customisationId, int centreId, int categoryId);
+        public CourseAdminFields GetCustomPromptsForCourse(int customisationId, int centreId);
 
         public List<CustomPromptWithAnswer> GetCustomPromptsWithAnswersForCourse(
             DelegateCourseInfo delegateCourseInfo,
             int customisationId,
             int centreId,
-            int categoryId = 0
+            int categoryId = 0,
+            bool allowAllCentreCourses = false
         );
 
         public void UpdateCustomPromptForCourse(int customisationId, int promptId, string? options);
@@ -27,7 +28,6 @@
         public bool AddCustomPromptToCourse(
             int customisationId,
             int centreId,
-            int categoryId,
             int promptId,
             string? options
         );
@@ -53,11 +53,10 @@
 
         public CourseAdminFields GetCustomPromptsForCourse(
             int customisationId,
-            int centreId,
-            int categoryId = 0
+            int centreId
         )
         {
-            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId, categoryId);
+            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId);
             return new CourseAdminFields(
                 customisationId,
                 centreId,
@@ -69,10 +68,16 @@
             DelegateCourseInfo delegateCourseInfo,
             int customisationId,
             int centreId,
-            int categoryId = 0
+            int categoryId = 0,
+            bool allowAllCentreCourses = false
         )
         {
-            var result = GetCourseCustomPromptsResultForCourse(customisationId, centreId, categoryId);
+            var result = GetCourseCustomPromptsResultForCourse(
+                customisationId,
+                centreId,
+                categoryId,
+                allowAllCentreCourses
+            );
 
             return PopulateCustomPromptWithAnswerListFromCourseAdminFieldsResult(result, delegateCourseInfo);
         }
@@ -90,15 +95,13 @@
         public bool AddCustomPromptToCourse(
             int customisationId,
             int centreId,
-            int categoryId,
             int promptId,
             string? options
         )
         {
             var courseAdminFields = GetCustomPromptsForCourse(
                 customisationId,
-                centreId,
-                categoryId
+                centreId
             );
 
             var promptNumber = GetNextPromptNumber(courseAdminFields);
@@ -158,10 +161,15 @@
         private CourseAdminFieldsResult? GetCourseCustomPromptsResultForCourse(
             int customisationId,
             int centreId,
-            int categoryId
+            int categoryId,
+            bool allowAllCentreCourses = false
         )
         {
-            var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId, centreId, categoryId);
+            var result = courseAdminFieldsDataService.GetCourseAdminFields(
+                customisationId,
+                centreId,
+                allowAllCentreCourses
+            );
             if (result == null || categoryId != 0 && result.CourseCategoryId != categoryId)
             {
                 return null;

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -56,6 +56,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
         [InlineData("/TrackingSystem/Delegates/BulkUpload", "Bulk upload/update delegates")]
         [InlineData("/TrackingSystem/Delegates/Email", "Send welcome messages")]
         [InlineData("/TrackingSystem/Delegates/CourseDelegates", "Course delegates")]
+        [InlineData("/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/243104", "Delegate progress")]
         [InlineData("/NotificationPreferences", "Notification preferences")]
         [InlineData("/NotificationPreferences/Edit/AdminUser", "Update notification preferences")]
         [InlineData("/NotificationPreferences/Edit/DelegateUser", "Update notification preferences")]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -40,7 +40,7 @@
             // Given
             var samplePrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1, "System Access Granted", "Yes\r\nNo");
             var customPrompts = new List<CustomPrompt> { samplePrompt1 };
-            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._, A<int>._))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts));
 
             // When
@@ -216,7 +216,6 @@
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
                     101,
-                    0,
                     1,
                     "Test"
                 )
@@ -246,7 +245,6 @@
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
                     101,
-                    0,
                     1,
                     null
                 )
@@ -276,7 +274,6 @@
                 () => courseAdminFieldsService.AddCustomPromptToCourse(
                     100,
                     101,
-                    0,
                     1,
                     "Test"
                 )
@@ -326,8 +323,7 @@
             const string action = "addPrompt";
 
             // When
-            var result =
-                controller.AddAdminField(1, initialViewModel, action);
+            controller.AddAdminField(1, initialViewModel, action);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -1,0 +1,146 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegates
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
+    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates;
+    using FakeItEasy;
+    using FluentAssertions.AspNetCore.Mvc;
+    using NUnit.Framework;
+
+    public class CourseDelegatesControllerTests
+    {
+        private CourseDelegatesController controller = null!;
+        private ICourseDelegatesService courseDelegatesService = null!;
+        private ICourseService courseService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            courseDelegatesService = A.Fake<ICourseDelegatesService>();
+            courseService = A.Fake<ICourseService>();
+            controller = new CourseDelegatesController(courseDelegatesService, courseService)
+                .WithDefaultContext()
+                .WithMockUser(true);
+        }
+
+        [Test]
+        public void DelegateProgress_returns_NotFound_when_requested_record_does_not_exist()
+        {
+            // Given
+            A.CallTo(() => courseService.GetDelegateCourseProgress(A<int>._, A<int>._)).Returns(null);
+
+            // When
+            var result = controller.DelegateProgress(1);
+
+            // Then
+            result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void DelegateProgress_returns_NotFound_when_requested_record_delegate_is_at_different_centre()
+        {
+            // Given
+            var delegateCourseInfo = new DelegateCourseInfo
+            {
+                DelegateCentreId = 1
+            };
+            A.CallTo(() => courseService.GetDelegateCourseProgress(A<int>._, A<int>._))
+                .Returns(new DelegateCourseDetails(delegateCourseInfo, new List<CustomPromptWithAnswer>(), (0, 0)));
+
+            // When
+            var result = controller.DelegateProgress(1);
+
+            // Then
+            result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void
+            DelegateProgress_returns_NotFound_when_requested_record_course_is_at_different_centre_and_not_an_all_centre_course()
+        {
+            // Given
+            var delegateCourseInfo = new DelegateCourseInfo
+            {
+                DelegateCentreId = 2,
+                CustomisationCentreId = 1,
+                AllCentresCourse = false
+            };
+            A.CallTo(() => courseService.GetDelegateCourseProgress(A<int>._, A<int>._))
+                .Returns(new DelegateCourseDetails(delegateCourseInfo, new List<CustomPromptWithAnswer>(), (0, 0)));
+
+            // When
+            var result = controller.DelegateProgress(1);
+
+            // Then
+            result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void DelegateProgress_returns_NotFound_when_requested_record_course_category_does_not_match()
+        {
+            // Given
+            var delegateCourseInfo = new DelegateCourseInfo
+            {
+                DelegateCentreId = 2,
+                CustomisationCentreId = 2,
+                AllCentresCourse = false,
+                CourseCategoryId = 3
+            };
+            A.CallTo(() => courseService.GetDelegateCourseProgress(A<int>._, A<int>._))
+                .Returns(new DelegateCourseDetails(delegateCourseInfo, new List<CustomPromptWithAnswer>(), (0, 0)));
+
+            // When
+            var result = controller.WithMockUser(true, adminCategoryId: 1).DelegateProgress(1);
+
+            // Then
+            result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void DelegateProgress_returns_DelegateProgress_page_when_requested_record_is_valid_at_centre()
+        {
+            // Given
+            var delegateCourseInfo = new DelegateCourseInfo
+            {
+                DelegateCentreId = 2,
+                CustomisationCentreId = 2,
+                AllCentresCourse = false,
+                CourseCategoryId = 1
+            };
+            A.CallTo(() => courseService.GetDelegateCourseProgress(A<int>._, A<int>._))
+                .Returns(new DelegateCourseDetails(delegateCourseInfo, new List<CustomPromptWithAnswer>(), (0, 0)));
+
+            // When
+            var result = controller.WithMockUser(true, adminCategoryId: 1).DelegateProgress(1);
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName().ModelAs<DelegateProgressViewModel>();
+        }
+
+        [Test]
+        public void
+            DelegateProgress_returns_DelegateProgress_page_when_requested_record_is_valid_and_course_is_all_centre_course()
+        {
+            // Given
+            var delegateCourseInfo = new DelegateCourseInfo
+            {
+                DelegateCentreId = 2,
+                CustomisationCentreId = 3,
+                AllCentresCourse = true,
+                CourseCategoryId = 1
+            };
+            A.CallTo(() => courseService.GetDelegateCourseProgress(A<int>._, A<int>._))
+                .Returns(new DelegateCourseDetails(delegateCourseInfo, new List<CustomPromptWithAnswer>(), (0, 0)));
+
+            // When
+            var result = controller.WithMockUser(true, adminCategoryId: 1).DelegateProgress(1);
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName().ModelAs<DelegateProgressViewModel>();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgressViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgressViewModelTests.cs
@@ -1,0 +1,103 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.TrackingSystem.Delegates
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using NUnit.Framework;
+
+    public class DelegateProgressViewModelTests
+    {
+        [Test]
+        public void ViewModel_sets_full_names_correctly()
+        {
+            // Given
+            var missingNamesDelegateInfo = new DelegateCourseInfo
+            {
+                DelegateFirstName = null,
+                DelegateLastName = "Osbourne",
+                DelegateEmail = "Prince@Darkness",
+                SupervisorAdminId = null,
+                SupervisorForename = "Tony",
+                SupervisorSurname = "Iommi",
+                EnrolledByAdminId = null,
+                EnrolledByForename = "Geezer",
+                EnrolledBySurname = "Butler"
+            };
+            var missingNamesViewModel = new DelegateProgressViewModel(
+                new DelegateCourseDetails(missingNamesDelegateInfo, new List<CustomPromptWithAnswer>(), (0, 0))
+            );
+            var fullNamesDelegateInfo = new DelegateCourseInfo
+            {
+                DelegateFirstName = "Ozzy",
+                DelegateLastName = "Osbourne",
+                DelegateEmail = "Prince@Darkness",
+                SupervisorAdminId = 1,
+                SupervisorForename = "Tony",
+                SupervisorSurname = "Iommi",
+                EnrolledByAdminId = 1,
+                EnrolledByForename = "Geezer",
+                EnrolledBySurname = "Butler"
+            };
+            var fullNamesViewModel = new DelegateProgressViewModel(
+                new DelegateCourseDetails(fullNamesDelegateInfo, new List<CustomPromptWithAnswer>(), (0, 0))
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                missingNamesViewModel.DelegateFullName.Should().Be("Osbourne");
+                missingNamesViewModel.DelegateNameAndEmail.Should().Be("Osbourne (Prince@Darkness)");
+                missingNamesViewModel.SupervisorFullName.Should().Be("None");
+                missingNamesViewModel.EnrolledByFullName.Should().BeNull();
+                fullNamesViewModel.DelegateFullName.Should().Be("Ozzy Osbourne");
+                fullNamesViewModel.DelegateNameAndEmail.Should().Be("Ozzy Osbourne (Prince@Darkness)");
+                fullNamesViewModel.SupervisorFullName.Should().Be("Tony Iommi");
+                fullNamesViewModel.EnrolledByFullName.Should().Be("Geezer Butler");
+            }
+        }
+
+        [Test]
+        public void ViewModel_does_not_include_email_if_not_set()
+        {
+            // Given
+            var delegateInfo = new DelegateCourseInfo
+            {
+                DelegateFirstName = "Bill",
+                DelegateLastName = "Ward",
+                DelegateEmail = null
+            };
+            var viewModel = new DelegateProgressViewModel(
+                new DelegateCourseDetails(delegateInfo, new List<CustomPromptWithAnswer>(), (0, 0))
+            );
+
+            // Then
+            viewModel.DelegateNameAndEmail.Should().Be("Bill Ward");
+        }
+
+        [Test]
+        [TestCase(1, "Self")]
+        [TestCase(2, "Enrolled by Ronnie Dio")]
+        [TestCase(3, "Group")]
+        [TestCase(4, "System")]
+        public void ViewModel_sets_Enrolment_method_text_correctly(int enrolmentMethodId, string expectedText)
+        {
+            // Given
+            var delegateInfo = new DelegateCourseInfo
+            {
+                EnrolmentMethodId = enrolmentMethodId,
+                EnrolledByAdminId = 1,
+                EnrolledByForename = "Ronnie",
+                EnrolledBySurname = "Dio"
+            };
+            var viewModel = new DelegateProgressViewModel(
+                new DelegateCourseDetails(delegateInfo, new List<CustomPromptWithAnswer>(), (0, 0))
+            );
+
+            // Then
+            viewModel.EnrolmentMethod.Should().Be(expectedText);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -43,11 +43,9 @@
         public IActionResult Index(int customisationId)
         {
             var centreId = User.GetCentreId();
-            var categoryId = User.GetAdminCategoryId()!;
             var courseAdminFields = courseAdminFieldsService.GetCustomPromptsForCourse(
                 customisationId,
-                centreId,
-                categoryId.Value
+                centreId
             );
 
             var model = new AdminFieldsViewModel(courseAdminFields.AdminFields, customisationId);
@@ -68,11 +66,9 @@
         public IActionResult EditAdminField(int customisationId, int promptNumber)
         {
             var centreId = User.GetCentreId();
-            var categoryId = User.GetAdminCategoryId()!;
             var courseAdminField = courseAdminFieldsService.GetCustomPromptsForCourse(
                     customisationId,
-                    centreId,
-                    categoryId.Value
+                    centreId
                 ).AdminFields
                 .Single(cp => cp.CustomPromptNumber == promptNumber);
 
@@ -320,12 +316,10 @@
             }
 
             var centreId = User.GetCentreId();
-            var categoryId = User.GetAdminCategoryId()!;
 
             if (courseAdminFieldsService.AddCustomPromptToCourse(
                 model.CustomisationId,
                 centreId,
-                categoryId.Value,
                 model.AdminFieldId!.Value,
                 model.OptionsString
             ))

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 {
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates;
@@ -13,12 +14,15 @@
     public class CourseDelegatesController : Controller
     {
         private readonly ICourseDelegatesService courseDelegatesService;
+        private readonly ICourseService courseService;
 
         public CourseDelegatesController(
-            ICourseDelegatesService courseDelegatesService
+            ICourseDelegatesService courseDelegatesService,
+            ICourseService courseService
         )
         {
             this.courseDelegatesService = courseDelegatesService;
+            this.courseService = courseService;
         }
 
         public IActionResult Index(int? customisationId = null)
@@ -33,6 +37,49 @@
             var model = new CourseDelegatesViewModel(courseDelegatesData);
 
             return View(model);
+        }
+
+        [Route("DelegateProgress/{progressId:int}")]
+        public IActionResult DelegateProgress(int progressId)
+        {
+            var centreId = User.GetCentreId();
+            var courseDelegatesData =
+                courseService.GetDelegateCourseProgress(progressId, centreId);
+
+            if (!ProgressRecordIsValidAndAccessibleToUser(courseDelegatesData?.DelegateCourseInfo, centreId))
+            {
+                return NotFound();
+            }
+
+            var model = new DelegateProgressViewModel(courseDelegatesData!);
+            return View(model);
+        }
+
+        private bool ProgressRecordIsValidAndAccessibleToUser(DelegateCourseInfo? details, int centreId)
+        {
+            if (details == null)
+            {
+                return false;
+            }
+
+            if (details.DelegateCentreId != centreId)
+            {
+                return false;
+            }
+
+            if (details.CustomisationCentreId != centreId && !details.AllCentresCourse)
+            {
+                return false;
+            }
+
+            var categoryId = User.GetAdminCategoryId()!.Value;
+
+            if (details.CourseCategoryId != categoryId && categoryId != 0)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
@@ -1,0 +1,114 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Web.ViewModels.Common;
+
+    public class DelegateProgressViewModel
+    {
+        public DelegateProgressViewModel(
+            DelegateCourseDetails details
+        )
+        {
+            CustomisationId = details.DelegateCourseInfo.CustomisationId;
+            CustomisationCentreId = details.DelegateCourseInfo.CustomisationCentreId;
+            AllCentresCourse = details.DelegateCourseInfo.AllCentresCourse;
+            CourseCategoryId = details.DelegateCourseInfo.CourseCategoryId;
+            CourseName = details.DelegateCourseInfo.CourseName;
+            SupervisorAdminId = details.DelegateCourseInfo.SupervisorAdminId;
+            SupervisorForename = details.DelegateCourseInfo.SupervisorForename;
+            SupervisorSurname = details.DelegateCourseInfo.SupervisorSurname;
+            Enrolled = details.DelegateCourseInfo.Enrolled;
+            LastUpdated = details.DelegateCourseInfo.LastUpdated;
+            CompleteBy = details.DelegateCourseInfo.CompleteBy;
+            Completed = details.DelegateCourseInfo.Completed;
+            Evaluated = details.DelegateCourseInfo.Evaluated;
+            EnrolmentMethodId = details.DelegateCourseInfo.EnrolmentMethodId;
+            EnrolledByAdminId = details.DelegateCourseInfo.EnrolledByAdminId;
+            EnrolledByForename = details.DelegateCourseInfo.EnrolledByForename;
+            EnrolledBySurname = details.DelegateCourseInfo.EnrolledBySurname;
+            LoginCount = details.DelegateCourseInfo.LoginCount;
+            LearningTime = details.DelegateCourseInfo.LearningTime;
+            DiagnosticScore = details.DelegateCourseInfo.DiagnosticScore;
+            IsAssessed = details.DelegateCourseInfo.IsAssessed;
+            DelegateId = details.DelegateCourseInfo.DelegateId;
+            DelegateFirstName = details.DelegateCourseInfo.DelegateFirstName;
+            DelegateLastName = details.DelegateCourseInfo.DelegateLastName;
+            DelegateEmail = details.DelegateCourseInfo.DelegateEmail;
+            DelegateCentreId = details.DelegateCourseInfo.DelegateCentreId;
+            AllAttempts = details.AttemptStats.totalAttempts;
+            AttemptsPassed = details.AttemptStats.attemptsPassed;
+            PassRate = details.AttemptStats.passRate;
+            CustomFields = details.CustomPrompts.Select(
+                    cp =>
+                        new CustomFieldViewModel(
+                            cp.CustomPromptNumber,
+                            cp.CustomPromptText,
+                            cp.Mandatory,
+                            cp.Answer
+                        )
+                )
+                .ToList();
+        }
+
+        public int CustomisationId { get; set; }
+        public int CustomisationCentreId { get; set; }
+        public bool AllCentresCourse { get; set; }
+        public int CourseCategoryId { get; set; }
+        public string CourseName { get; set; }
+        public int? SupervisorAdminId { get; set; }
+        public string? SupervisorForename { get; set; }
+        public string? SupervisorSurname { get; set; }
+        public DateTime Enrolled { get; set; }
+        public DateTime LastUpdated { get; set; }
+        public DateTime? CompleteBy { get; set; }
+        public DateTime? Completed { get; set; }
+        public DateTime? Evaluated { get; set; }
+        public DateTime? RemovedDate { get; set; }
+        public int EnrolmentMethodId { get; set; }
+        public int? EnrolledByAdminId { get; set; }
+        public string? EnrolledByForename { get; set; }
+        public string? EnrolledBySurname { get; set; }
+        public int LoginCount { get; set; }
+        public int LearningTime { get; set; }
+        public int? DiagnosticScore { get; set; }
+        public bool IsAssessed { get; set; }
+        public int DelegateId { get; set; }
+        public string? DelegateFirstName { get; set; }
+        public string DelegateLastName { get; set; }
+        public string? DelegateEmail { get; set; }
+        public int DelegateCentreId { get; set; }
+        public int AllAttempts { get; set; }
+        public int AttemptsPassed { get; set; }
+        public double PassRate { get; set; }
+        public IEnumerable<CustomFieldViewModel> CustomFields { get; set; }
+
+        public string DelegateFullName =>
+            DelegateFirstName == null ? DelegateLastName : $"{DelegateFirstName} {DelegateLastName}";
+
+        public string DelegateNameAndEmail =>
+            DelegateEmail == null ? DelegateFullName : $"{DelegateFullName} ({DelegateEmail})";
+
+        public string SupervisorFullName =>
+            SupervisorAdminId == null ? "None" : $"{SupervisorForename} {SupervisorSurname}";
+
+        public string? EnrolledByFullName =>
+            EnrolledByAdminId == null ? null : $"{EnrolledByForename} {EnrolledBySurname}";
+
+        public string EnrolmentMethod
+        {
+            get
+            {
+                return EnrolmentMethodId switch
+                {
+                    1 => "Self",
+                    2 => "Enrolled by " + EnrolledByFullName,
+                    3 => "Group",
+                    _ => "System"
+                };
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/DelegateProgress.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/DelegateProgress.cshtml
@@ -1,0 +1,56 @@
+﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Web.Models.Enums
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates
+@using Microsoft.Extensions.Configuration
+@model DelegateProgressViewModel
+
+@{
+  ViewData["Title"] = "Delegate progress";
+  ViewData["Application"] = ApplicationType.TrackingSystem.Name;
+  ViewData["HeaderPath"] = ApplicationType.TrackingSystem.HeaderPath;
+  ViewData["HeaderPathName"] = ApplicationType.TrackingSystem.HeaderPathName;
+  var routeParamsForBackLink = new Dictionary<string, string?> {
+    {
+      "customisationId", Model.CustomisationId.ToString()
+    }
+  };
+}
+
+@section NavMenuItems {
+  <partial name="~/Views/TrackingSystem/Shared/_NavMenuItems.cshtml" />
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
+
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">
+        Delegate
+      </div>
+      <div class="nhsuk-grid-column-three-quarters nhsuk-body-l nhsuk-u-font-weight-bold">
+        @Model.DelegateNameAndEmail
+      </div>
+    </div>
+
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">
+        Course
+      </div>
+      <div class="nhsuk-grid-column-three-quarters nhsuk-body-l nhsuk-u-font-weight-bold">
+        @Model.CourseName
+      </div>
+    </div>
+
+    <partial name="_DelegateProgressSummary" model="Model" />
+
+    <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2" role="button">
+      View detailed progress
+    </a>
+    <a class="nhsuk-button nhsuk-button--secondary" role="button">
+      View learning log
+    </a>
+
+    <vc:back-link asp-controller="CourseDelegates" asp-action="Index" link-text="Go back" asp-all-route-data="@routeParamsForBackLink" />
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_DelegateProgressSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_DelegateProgressSummary.cshtml
@@ -1,0 +1,165 @@
+﻿@using DigitalLearningSolutions.Web.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates
+@model DelegateProgressViewModel
+
+<dl class="nhsuk-summary-list">
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Supervisor
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.SupervisorFullName
+    </dd>
+    <dd class="nhsuk-summary-list__actions">
+      <a href="#">
+        Edit<span class="nhsuk-u-visually-hidden"> supervisor</span>
+      </a>
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Enrolled
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.Enrolled.ToString(DateHelper.StandardDateAndTimeFormat)
+    </dd>
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Complete by
+    </dt>
+    <partial name="_SummaryFieldValue" model="Model.CompleteBy?.ToString(DateHelper.StandardDateFormat)" />
+    <dd class="nhsuk-summary-list__actions">
+      <a href="#">
+        Edit<span class="nhsuk-u-visually-hidden"> complete by date</span>
+      </a>
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Last updated
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.LastUpdated.ToString(DateHelper.StandardDateAndTimeFormat)
+    </dd>
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Completion date
+    </dt>
+    <partial name="_SummaryFieldValue" model="Model.Completed?.ToString(DateHelper.StandardDateAndTimeFormat)" />
+    <dd class="nhsuk-summary-list__actions">
+      <a href="#">
+        Edit<span class="nhsuk-u-visually-hidden"> completion date</span>
+      </a>
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Evaluation date
+    </dt>
+    <partial name="_SummaryFieldValue" model="Model.Evaluated?.ToString(DateHelper.StandardDateAndTimeFormat)" />
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Removed date
+    </dt>
+    <partial name="_SummaryFieldValue" model="Model.RemovedDate?.ToString(DateHelper.StandardDateFormat)" />
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Enrolment method
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.EnrolmentMethod
+    </dd>
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Logins
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.LoginCount
+    </dd>
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Learning time (mins)
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.LearningTime
+    </dd>
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Diagnostic score
+    </dt>
+    <partial name="_SummaryFieldValue" model="Model.DiagnosticScore?.ToString()" />
+    <dd class="nhsuk-summary-list__actions" />
+  </div>
+
+  @if (Model.IsAssessed) {
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Assessments passed
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @Model.AttemptsPassed
+      </dd>
+      <dd class="nhsuk-summary-list__actions" />
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Assessment attempts
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @Model.AllAttempts
+      </dd>
+      <dd class="nhsuk-summary-list__actions" />
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Pass rate
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @Model.PassRate%
+      </dd>
+      <dd class="nhsuk-summary-list__actions" />
+    </div>
+  }
+
+  @foreach (var prompt in Model.CustomFields) {
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        @prompt.CustomPrompt
+      </dt>
+      <partial name="_SummaryFieldValue" model="prompt.Answer" />
+      <dd class="nhsuk-summary-list__actions">
+        <a href="#">
+          Edit<span class="nhsuk-u-visually-hidden"> @prompt.CustomPrompt</span>
+        </a>
+      </dd>
+    </div>
+  }
+
+</dl>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -65,7 +65,11 @@
         </div>
       </dl>
 
-      <a class="nhsuk-button expander-card__button" role="button">
+      <a class="nhsuk-button expander-card__button"
+         role="button"
+         asp-controller="CourseDelegates"
+         asp-action="DelegateProgress"
+         asp-route-progressId="@Model.ProgressId">
         View progress
       </a>
       @if (Model.Locked) {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-566

### Description
Implemented a new page for showing delegate progress details.
This reused some code in pre-existing methods, so I have done a little refactoring to make things nicer.
I've also refactored the GetCourseAdminFields data service method (and the methods that call it) to no longer require a categoryId parameter that was not being used, and instead take in a bool to determine whether or not courses with the AllCentres column as 1 should be recovered.


### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
