### PR TITLE
HEEDLS-585 - fix inconsistent announcement of result counts

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -161,9 +161,15 @@ export class SearchSortFilterAndPaginate {
 
   static updateResultCount(count: number): void {
     const resultCount = <HTMLSpanElement>document.getElementById('results-count');
+    const oldResultCountMessage = resultCount.innerHTML;
     resultCount.hidden = false;
     resultCount.setAttribute('aria-hidden', 'false');
-    resultCount.textContent = count === 1 ? '1 matching result' : `${count.toString()} matching results`;
+    let newResultCountMessage = count === 1 ? '1 matching result' : `${count.toString()} matching results`;
+
+    if (newResultCountMessage === oldResultCountMessage) {
+      newResultCountMessage += '&nbsp';
+    }
+    resultCount.innerHTML = newResultCountMessage;
   }
 
   private static scrollToTop() : void {

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
@@ -10,10 +10,17 @@ new SearchSortFilterAndPaginate(route, false, false, true, 'EmailDelegateFilter'
 setUpSelectAndDeselectButtons();
 
 function alertResultCount(): void {
-  // un-assign and re-assign the alert role to results-count so a screen-reader re-reads it
+  // change the content of the search results
+  // so that an "identical" result is announced by the aria-live attribute
   const resultCount = document.getElementById('results-count') as HTMLSpanElement;
-  resultCount.setAttribute('role', '');
-  resultCount.setAttribute('role', 'alert');
+  const resultCountMessage = resultCount.innerHTML;
+  const indexOfSpace = resultCountMessage.search('&nbsp');
+
+  if (indexOfSpace === -1) {
+    resultCount.innerHTML = `${resultCountMessage}&nbsp`;
+  } else {
+    resultCount.innerHTML = resultCountMessage.substring(0, indexOfSpace);
+  }
 }
 
 function selectAll(): void {

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_SearchResultsCount.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_SearchResultsCount.cshtml
@@ -5,5 +5,5 @@
   @{
     var count = Model.MatchingSearchResults;
   }
-  <span role="alert" id="results-count">@count matching @(count == 1 ? "result" : "results")</span>
+  <span aria-live="polite" id="results-count">@count matching @(count == 1 ? "result" : "results")</span>
 </p>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-585

### Description
Changed the JS for the Select/Deselect All buttons so that the result count is actually read out consistently across browsers. I've also taken the liberty to fix a similar issue with the JS search/filter result announcements. See comments on individual files for details.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
