### PR TITLE
HEEDLS-632 Remove unnecessary application type from permission based …

### DIFF
--- a/DigitalLearningSolutions.Web/Attributes/ValidateAllowedApplicationTypeAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/ValidateAllowedApplicationTypeAttribute.cs
@@ -49,9 +49,7 @@
             if (!user.HasLearningPortalPermissions() && ApplicationType.LearningPortal.Equals(application) ||
                 !user.HasFrameworksAdminPermissions() && ApplicationType.Frameworks.Equals(application) ||
                 !user.HasSupervisorAdminPermissions() && ApplicationType.Supervisor.Equals(application) ||
-                !user.HasCentreAdminPermissions() && (ApplicationType.TrackingSystem.Equals(application) ||
-                                                      ApplicationType.Main.Equals(application) ||
-                                                      application is null))
+                !user.HasCentreAdminPermissions() && ApplicationType.TrackingSystem.Equals(application))
             {
                 RedirectToHome(context);
             }


### PR DESCRIPTION
…redirection

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-632

### Description
Removed the ApplicationType == Main or null check that was grouped up with the Admin accessing tracking system check causing pages with the Main application type (e.g. accessing My Account from the homepage) to be redirected if the user was not a centre admin (or higher permissions).
Sanity checked that the rest of the conditions produced by the attribute, e.g. redirecting a delegate to the learning portal still worked as expected.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
