### PR TITLE
HEEDLS-622 Change content creator application selector permissions

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
@@ -17,8 +17,11 @@
             var contentManagementSystemAccess =
                 User.GetCustomClaimAsBool(CustomClaimTypes.UserAuthenticatedCm) ?? false;
             var superviseAccess = User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) ?? false;
-            var contentCreatorAccess = User.GetCustomClaimAsBool(CustomClaimTypes.UserCentreManager) ?? false;
-            var frameworksAccess = User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) | User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor)  | User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) | User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceContributor) ?? false;
+            var contentCreatorAccess = User.GetCustomClaimAsBool(CustomClaimTypes.UserContentCreator) ?? false;
+            var frameworksAccess = User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) |
+                User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor) |
+                User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) |
+                User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceContributor) ?? false;
 
             var model = new ApplicationSelectorViewModel(
                 learningPortalAccess,
@@ -26,7 +29,8 @@
                 contentManagementSystemAccess,
                 superviseAccess,
                 contentCreatorAccess,
-                frameworksAccess);
+                frameworksAccess
+            );
 
             return View(model);
         }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-622

### Description
Changed the permissions on the Content Creator application selection from Centre manager to Content Creator. (also ran the formatter)
Checked that the card now only appears when AdminUsers.ContentCreator = 1.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
