### PR TITLE
HEEDLS-624 Add links that are the same as the side nav to support text

### DIFF
--- a/DigitalLearningSolutions.Data/Helpers/ConfigHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/ConfigHelper.cs
@@ -5,10 +5,16 @@
     public static class ConfigHelper
     {
         public const string AppRootPathName = "AppRootPath";
+        public const string CurrentSystemBaseUrlName = "CurrentSystemBaseUrl";
 
         public static string GetAppRootPath(this IConfiguration config)
         {
             return config[AppRootPathName];
+        }
+
+        public static string GetCurrentSystemBaseUrl(this IConfiguration config)
+        {
+            return config[CurrentSystemBaseUrlName];
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Support/SupportControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Support/SupportControllerTests.cs
@@ -6,17 +6,20 @@
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
     using FakeItEasy;
     using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.FeatureManagement;
     using NUnit.Framework;
 
     public class SupportControllerTests
     {
         private IFeatureManager featureManager = null!;
+        private IConfiguration configuration = null!;
 
         [SetUp]
         public void Setup()
         {
             featureManager = A.Fake<IFeatureManager>();
+            configuration = A.Fake<IConfiguration>();
             A.CallTo(() => featureManager.IsEnabledAsync(FeatureFlags.RefactoredTrackingSystem))
                 .Returns(true);
         }
@@ -25,7 +28,7 @@
         public async Task Frameworks_Support_page_should_be_shown_for_valid_claims()
         {
             // Given
-            var controller = new SupportController(featureManager)
+            var controller = new SupportController(featureManager, configuration)
                 .WithDefaultContext()
                 .WithMockUser(true, isCentreAdmin: false, isFrameworkDeveloper: true);
 
@@ -40,7 +43,7 @@
         public async Task Invalid_application_name_should_redirect_to_404_page()
         {
             // Given
-            var controller = new SupportController(featureManager)
+            var controller = new SupportController(featureManager, configuration)
                 .WithDefaultContext()
                 .WithMockUser(true, isCentreAdmin: true, isFrameworkDeveloper: true);
 
@@ -55,7 +58,7 @@
         public async Task Home_page_should_be_shown_when_accessing_tracking_system_support_without_appropriate_claims()
         {
             // Given
-            var controller = new SupportController(featureManager)
+            var controller = new SupportController(featureManager, configuration)
                 .WithDefaultContext()
                 .WithMockUser(true, isCentreAdmin: false, isFrameworkDeveloper: true);
 
@@ -72,7 +75,7 @@
             // Given
             A.CallTo(() => featureManager.IsEnabledAsync(FeatureFlags.RefactoredTrackingSystem))
                 .Returns(false);
-            var controller = new SupportController(featureManager)
+            var controller = new SupportController(featureManager, configuration)
                 .WithDefaultContext()
                 .WithMockUser(true, isCentreAdmin: false, isFrameworkDeveloper: true);
 
@@ -87,7 +90,7 @@
         public async Task Home_page_should_be_shown_when_accessing_frameworks_support_without_appropriate_claims()
         {
             // Given
-            var controller = new SupportController(featureManager)
+            var controller = new SupportController(featureManager, configuration)
                 .WithDefaultContext()
                 .WithMockUser(true, isCentreAdmin: true, isFrameworkDeveloper: false);
 

--- a/DigitalLearningSolutions.Web/Controllers/Support/SupportController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/SupportController.cs
@@ -1,20 +1,24 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.Support
 {
     using System.Threading.Tasks;
+    using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
     using DigitalLearningSolutions.Web.ViewModels.Support;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.FeatureManagement;
 
     public class SupportController : Controller
     {
+        private readonly IConfiguration configuration;
         private readonly IFeatureManager featureManager;
 
-        public SupportController(IFeatureManager featureManager)
+        public SupportController(IFeatureManager featureManager, IConfiguration configuration)
         {
             this.featureManager = featureManager;
+            this.configuration = configuration;
         }
 
         [Route("/{application}/Support")]
@@ -36,7 +40,11 @@
 
             if (trackingSystemSupportEnabled || frameworksSupportEnabled)
             {
-                var model = new SupportViewModel(application, SupportPage.Support);
+                var model = new SupportViewModel(
+                    application,
+                    SupportPage.Support,
+                    configuration.GetCurrentSystemBaseUrl()
+                );
                 return View("Support", model);
             }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Support/SupportViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Support/SupportViewModel.cs
@@ -4,14 +4,23 @@
 
     public class SupportViewModel
     {
-        public SupportViewModel(ApplicationType application, SupportPage currentPage)
+        private readonly string currentSystemBaseUrl;
+
+        public SupportViewModel(ApplicationType application, SupportPage currentPage, string currentSystemBaseUrl)
         {
             CurrentPage = currentPage;
-
+            this.currentSystemBaseUrl = currentSystemBaseUrl;
             Application = application;
         }
 
         public SupportPage CurrentPage { get; set; }
         public ApplicationType Application { get; set; }
+
+        public string HelpUrl => $"{currentSystemBaseUrl}/help/Introduction.html";
+        public string FaqUrl => $"{currentSystemBaseUrl}/tracking/faqs";
+        public string ResourcesUrl => $"{currentSystemBaseUrl}/tracking/resources";
+        public string SupportTicketsUrl => $"{currentSystemBaseUrl}/tracking/tickets";
+        public string ChangeRequestsUrl =>
+            "https://github.com/TechnologyEnhancedLearning/DLSV2/projects/1?fullscreen=true";
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Support/Shared/_SupportSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Shared/_SupportSideNavMenu.cshtml
@@ -1,7 +1,5 @@
-﻿@inject IConfiguration configuration
-@using DigitalLearningSolutions.Web.Models.Enums
+﻿@using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.Support
-@using Microsoft.Extensions.Configuration
 @model SupportViewModel
 
 @{
@@ -25,21 +23,21 @@
   else
   {
     <li class="side-nav__item">
-      <a class="side-nav__link" href="@configuration["CurrentSystemBaseUrl"]/help/Introduction.html" target="_blank">
+      <a class="side-nav__link" href="@Model.HelpUrl" target="_blank">
         Help documentation
       </a>
     </li>
   }
 
-  <vc:side-menu-link-with-href href="@configuration["CurrentSystemBaseUrl"]/tracking/faqs"
+  <vc:side-menu-link-with-href href="@Model.FaqUrl"
                                link-text="FAQs"
                                is-current-page="@(Model.CurrentPage == SupportPage.Faqs)" />
 
-  <vc:side-menu-link-with-href href="@configuration["CurrentSystemBaseUrl"]/tracking/resources"
+  <vc:side-menu-link-with-href href="@Model.ResourcesUrl"
                                link-text="Resources"
                                is-current-page="@(Model.CurrentPage == SupportPage.Resources)" />
 
-  <vc:side-menu-link-with-href href="@configuration["CurrentSystemBaseUrl"]/tracking/tickets"
+  <vc:side-menu-link-with-href href="@Model.SupportTicketsUrl"
                                link-text="Support tickets"
                                is-current-page="@(Model.CurrentPage == SupportPage.SupportTickets)" />
 
@@ -52,7 +50,7 @@
   else
   {
     <li class="side-nav__item">
-      <a class="side-nav__link" href="https://github.com/TechnologyEnhancedLearning/DLSV2/projects/1?fullscreen=true" target="_blank" rel="noreferrer">
+      <a class="side-nav__link" href="@Model.ChangeRequestsUrl" target="_blank" rel="noreferrer">
         Change requests
       </a>
     </li>

--- a/DigitalLearningSolutions.Web/Views/Support/Support.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Support.cshtml
@@ -1,7 +1,5 @@
-﻿@inject IConfiguration configuration
-@using DigitalLearningSolutions.Web.Models.Enums
+﻿@using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.Support
-@using Microsoft.Extensions.Configuration
 @model SupportViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/support/support.css")" asp-append-version="true">
@@ -34,26 +32,26 @@
     <p class="nhsuk-lede-text nhsuk-u-margin-top-4">Access Digital Learning Solutions support in 5 easy steps...</p>
     <ol>
       <li>
-        <a href="@configuration["CurrentSystemBaseUrl"]/help/Introduction.html" target="_blank">Check the online Help documentation</a>. It is searchable and comprehensive.
+        <a href="@Model.HelpUrl" target="_blank">Check the online Help documentation</a>. It is searchable and comprehensive.
       </li>
       <li>
-        <a href="@configuration["CurrentSystemBaseUrl"]/tracking/faqs">Search our Frequently Asked Questions (FAQs)</a>.
+        <a href="@Model.FaqUrl">Search our Frequently Asked Questions (FAQs)</a>.
         If you've got a question about the platform, the chances are somebody has asked it before.
         Find answers to the most common questions.
       </li>
       <li>
-        <a href="@configuration["CurrentSystemBaseUrl"]/tracking/resources">Look through our Resources</a>.
+        <a href="@Model.ResourcesUrl">Look through our Resources</a>.
         These contain in-depth guides to some of the more complex parts of the platform
         and materials to help you publicise and support use of the platform with your users.
       </li>
       <li>
         If you are still experiencing issues having gone through 1-3 above,
-        then please <a href="@configuration["CurrentSystemBaseUrl"]/tracking/tickets">raise a support ticket</a> and we will assist you further.
+        then please <a href="@Model.SupportTicketsUrl">raise a support ticket</a> and we will assist you further.
       </li>
       <li>
         If you have suggestions that you believe would help improve the platform,
-        please also <a href="@configuration["CurrentSystemBaseUrl"]/tracking/tickets">raise a support ticket</a>.
-        You can then <a href="https://github.com/TechnologyEnhancedLearning/DLSV2/projects/1?fullscreen=true" target="_blank" rel="noreferrer">track these on our GitHub Change requests page</a>.
+        please also <a href="@Model.SupportTicketsUrl">raise a support ticket</a>.
+        You can then <a href="@Model.ChangeRequestsUrl" target="_blank" rel="noreferrer">track these on our GitHub Change requests page</a>.
       </li>
     </ol>
 

--- a/DigitalLearningSolutions.Web/Views/Support/Support.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Support.cshtml
@@ -1,5 +1,7 @@
-﻿@using DigitalLearningSolutions.Web.Models.Enums
+﻿@inject IConfiguration configuration
+@using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.Support
+@using Microsoft.Extensions.Configuration
 @model SupportViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/support/support.css")" asp-append-version="true">
@@ -32,26 +34,26 @@
     <p class="nhsuk-lede-text nhsuk-u-margin-top-4">Access Digital Learning Solutions support in 5 easy steps...</p>
     <ol>
       <li>
-        Check the online Help documentation. It is searchable and comprehensive.
+        <a href="@configuration["CurrentSystemBaseUrl"]/help/Introduction.html" target="_blank">Check the online Help documentation</a>. It is searchable and comprehensive.
       </li>
       <li>
-        Search our Frequently Asked Questions (FAQs).
+        <a href="@configuration["CurrentSystemBaseUrl"]/tracking/faqs">Search our Frequently Asked Questions (FAQs)</a>.
         If you've got a question about the platform, the chances are somebody has asked it before.
         Find answers to the most common questions.
       </li>
       <li>
-        Look through our Resources.
+        <a href="@configuration["CurrentSystemBaseUrl"]/tracking/resources">Look through our Resources</a>.
         These contain in-depth guides to some of the more complex parts of the platform
         and materials to help you publicise and support use of the platform with your users.
       </li>
       <li>
         If you are still experiencing issues having gone through 1-3 above,
-        then please raise a support ticket and we will assist you further.
+        then please <a href="@configuration["CurrentSystemBaseUrl"]/tracking/tickets">raise a support ticket</a> and we will assist you further.
       </li>
       <li>
         If you have suggestions that you believe would help improve the platform,
-        please also raise a support ticket.
-        You can then track these on our GitHub Change requests page.
+        please also <a href="@configuration["CurrentSystemBaseUrl"]/tracking/tickets">raise a support ticket</a>.
+        You can then <a href="https://github.com/TechnologyEnhancedLearning/DLSV2/projects/1?fullscreen=true" target="_blank" rel="noreferrer">track these on our GitHub Change requests page</a>.
       </li>
     </ol>
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-624

### Description
Add links to the text of the support page, linking to the same place as the side nav menu items.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/136195413-6c810e60-07fd-482b-b3f5-f34f88ab65fc.png)
![image](https://user-images.githubusercontent.com/59561751/136195443-bb52e62e-1136-4ca6-9ae6-8ac7c4e2b4e1.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
