### PR TITLE
HEEDLS-540 - apply fix for TempData and general cleanup

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
@@ -5,7 +5,7 @@
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
-    using DigitalLearningSolutions.Web.Controllers;
+    using DigitalLearningSolutions.Web.Controllers.Register;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Models;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
@@ -29,10 +29,11 @@
             centreCustomPromptsService = A.Fake<ICentreCustomPromptsService>();
             userDataService = A.Fake<IUserDataService>();
 
-            registrationPromptsController = new RegistrationPromptsController(centreCustomPromptsService, userDataService)
-                .WithDefaultContext()
-                .WithMockUser(true)
-                .WithMockTempData();
+            registrationPromptsController =
+                new RegistrationPromptsController(centreCustomPromptsService, userDataService)
+                    .WithDefaultContext()
+                    .WithMockUser(true)
+                    .WithMockTempData();
 
             httpRequest = A.Fake<HttpRequest>();
             const string cookieName = "AddRegistrationPromptData";
@@ -96,11 +97,8 @@
             var result = registrationPromptsController.EditRegistrationPrompt(model, action);
 
             // Then
-            using (new AssertionScope())
-            {
-                result.As<ViewResult>().Model.Should().BeOfType<EditRegistrationPromptViewModel>();
-                AssertNumberOfConfiguredAnswersOnView(result, 2);
-            }
+            result.As<ViewResult>().Model.Should().BeOfType<EditRegistrationPromptViewModel>().Which.OptionsString
+                .Should().BeEquivalentTo("Test\r\nAnswer");
         }
 
         [Test]
@@ -114,11 +112,8 @@
             var result = registrationPromptsController.EditRegistrationPrompt(model, action);
 
             // Then
-            using (new AssertionScope())
-            {
-                result.As<ViewResult>().Model.Should().BeOfType<EditRegistrationPromptViewModel>();
-                AssertNumberOfConfiguredAnswersOnView(result, 1);
-            }
+            result.As<ViewResult>().Model.Should().BeOfType<EditRegistrationPromptViewModel>().Which.OptionsString
+                .Should().BeEquivalentTo("Answer");
         }
 
         [Test]
@@ -240,7 +235,6 @@
                 AssertSelectPromptViewModelIsExpectedModel(initialSelectPromptModel);
                 AssertPromptAnswersViewModelIsExpectedModel(expectedConfigureAnswerViewModel);
                 result.As<ViewResult>().Model.Should().BeOfType<RegistrationPromptAnswersViewModel>();
-                AssertNumberOfConfiguredAnswersOnView(result, 2);
             }
         }
 
@@ -268,7 +262,6 @@
                 AssertSelectPromptViewModelIsExpectedModel(initialPromptModel);
                 AssertPromptAnswersViewModelIsExpectedModel(expectedViewModel);
                 result.As<ViewResult>().Model.Should().BeOfType<RegistrationPromptAnswersViewModel>();
-                AssertNumberOfConfiguredAnswersOnView(result, 1);
             }
         }
 
@@ -406,13 +399,6 @@
                 AssertPromptAnswersViewModelIsExpectedModel(expectedViewModel);
                 result.Should().BeRedirectToActionResult().WithActionName("AddRegistrationPromptConfigureAnswers");
             }
-        }
-
-        private static void AssertNumberOfConfiguredAnswersOnView(IActionResult result, int expectedCount)
-        {
-            result.Should().BeViewResult();
-            result.As<ViewResult>().Model.As<RegistrationPromptAnswersViewModel>().Options.Count.Should()
-                .Be(expectedCount);
         }
 
         private void AssertSelectPromptViewModelIsExpectedModel(AddRegistrationPromptSelectPromptViewModel promptModel)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Controllers
+﻿namespace DigitalLearningSolutions.Web.Controllers.Register
 {
     using System;
     using System.Linq;
@@ -183,6 +183,7 @@
         [HttpGet]
         public IActionResult Confirmation()
         {
+            TempData.Clear();
             return View();
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -262,6 +262,8 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             var candidateNumber = (string?)TempData.Peek("candidateNumber");
             var approvedNullable = (bool?)TempData.Peek("approved");
             var centreIdNullable = (int?)TempData.Peek("centreId");
+            TempData.Clear();
+
             if (candidateNumber == null || approvedNullable == null || centreIdNullable == null)
             {
                 return RedirectToAction("Index");

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -241,6 +241,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             var emailSent = (bool)TempData.Peek("emailSent");
             var passwordSet = (bool)TempData.Peek("passwordSet");
             TempData.Clear();
+
             if (delegateNumber == null)
             {
                 return RedirectToAction("Index");

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswersViewModel.cs
@@ -1,8 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Configuration.RegistrationPrompts
 {
-    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
-    using DigitalLearningSolutions.Web.Helpers;
 
     public class RegistrationPromptAnswersViewModel
     {
@@ -20,8 +18,6 @@
         }
 
         public string? OptionsString { get; set; }
-
-        public List<string> Options => NewlineSeparatedStringListHelper.SplitNewlineSeparatedList(OptionsString);
 
         [Required(ErrorMessage = "Enter an answer")]
         [MaxLength(100, ErrorMessage = "Answer must be 100 characters or fewer")]

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Configuration
+@using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Configuration.RegistrationPrompts
 @model RegistrationPromptAnswersViewModel
 
@@ -17,13 +18,14 @@
   </tr>
   </thead>
   <tbody class="nhsuk-table__body">
-  @foreach (var answer in Model.Options) {
+  @{ var options = NewlineSeparatedStringListHelper.SplitNewlineSeparatedList(Model.OptionsString); }
+  @foreach (var answer in options) {
     <tr role="row" class="nhsuk-table__row">
       <td class="nhsuk-table__cell word-break">@answer</td>
       <td class="nhsuk-table__cell vertical-align-centre">
         <button name="action"
                 class="nhsuk-button nhsuk-button--secondary nhsuk-u-padding-bottom-1 nhsuk-u-padding-top-1 nhsuk-u-margin-bottom-1 nhsuk-u-margin-top-0"
-                value="@(RegistrationPromptsController.DeleteAction + Model.Options.IndexOf(answer))">
+                value="@(RegistrationPromptsController.DeleteAction + options.IndexOf(answer))">
           Remove
         </button>
       </td>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-540

### Description
The Register and RegisterByAdmin journeys seemed to not clear TempData once they were finished with it. I have made these similar to the RegisterDelegateByCentre by ensuring that the TempData is cleared on the final confirmation screen.
Additionally, I've changed the RegistrationPrompts models so that the only the OptionsString is populated in the TempData. Previously, both the OptionsString and its list equivalent, Options, were stored in TempData, but Options was not used except in a partial view and was artificially bloating TempData. 

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (controller, data services, services, view models etc) and manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme.
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
