### PR TITLE
DLSV2-368 and DLSV2-367 Improved labelling in self assessment interface

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -9,5 +9,7 @@
         public DateTime? SubmittedDate { get; set; }
         public bool IsSupervised { get; set; }
         public string? Vocabulary { get; set; }
+        public string? VerificationRoleName { get; set; }
+        public string? SignOffRoleName { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -457,12 +457,11 @@
         {
             SessionRequestVerification sessionRequestVerification = TempData.Peek<SessionRequestVerification>();
             TempData.Set(sessionRequestVerification);
+            var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateIdKnownNotNull(), selfAssessmentId);
             var supervisors = selfAssessmentService.GetResultReviewSupervisorsForSelfAssessmentId(selfAssessmentId, User.GetCandidateIdKnownNotNull()).ToList();
             var model = new VerificationPickSupervisorViewModel()
             {
-                Vocabulary = sessionRequestVerification.Vocabulary,
-                SelfAssessmentId = sessionRequestVerification.SelfAssessmentID,
-                SelfAssessmentName = sessionRequestVerification.SelfAssessmentName,
+                SelfAssessment = selfAssessment,
                 Supervisors = supervisors,
                 CandidateAssessmentSupervisorId = sessionRequestVerification.CandidateAssessmentSupervisorId
             };
@@ -476,15 +475,14 @@
             TempData.Set(sessionRequestVerification);
             if (!ModelState.IsValid)
             {
-                model.Vocabulary = sessionRequestVerification.Vocabulary;
-                model.SelfAssessmentId = sessionRequestVerification.SelfAssessmentID;
-                model.SelfAssessmentName = sessionRequestVerification.SelfAssessmentName;
+                var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateIdKnownNotNull(), sessionRequestVerification.SelfAssessmentID);
+                model.SelfAssessment = selfAssessment;
                 model.Supervisors = selfAssessmentService.GetResultReviewSupervisorsForSelfAssessmentId(sessionRequestVerification.SelfAssessmentID, User.GetCandidateIdKnownNotNull()).ToList(); ;
                 return View("SelfAssessments/VerificationPickSupervisor", model);
             }
             sessionRequestVerification.CandidateAssessmentSupervisorId = model.CandidateAssessmentSupervisorId;
             TempData.Set(sessionRequestVerification);
-            return RedirectToAction("VerificationPickResults", new { model.SelfAssessmentId });
+            return RedirectToAction("VerificationPickResults", new { sessionRequestVerification.SelfAssessmentID });
         }
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Verification/Results")]
         public IActionResult VerificationPickResults(int selfAssessmentId)
@@ -516,7 +514,7 @@
             SessionRequestVerification sessionRequestVerification = TempData.Peek<SessionRequestVerification>();
             sessionRequestVerification.ResultIds = model.ResultIds;
             TempData.Set(sessionRequestVerification);
-            return RedirectToAction("VerificationSummary", new { model.SelfAssessmentId });
+            return RedirectToAction("VerificationSummary", new { sessionRequestVerification.SelfAssessmentID });
         }
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Verification/Summary")]
         public IActionResult VerificationSummary(int selfAssessmentId)
@@ -524,14 +522,13 @@
             SessionRequestVerification sessionRequestVerification = TempData.Peek<SessionRequestVerification>();
             TempData.Set(sessionRequestVerification);
             var supervisor = selfAssessmentService.GetSelfAssessmentSupervisorByCandidateAssessmentSupervisorId(sessionRequestVerification.CandidateAssessmentSupervisorId);
-            string supervisorString = $"{supervisor.SupervisorName} ({supervisor.SupervisorEmail}) - {supervisor.RoleName}";
+            string supervisorString = $"{supervisor.SupervisorName} ({supervisor.SupervisorEmail})";
+            var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateIdKnownNotNull(), sessionRequestVerification.SelfAssessmentID);
             var model = new VerificationSummaryViewModel()
             {
                 Supervisor = supervisorString,
-                SelfAssessmentId = selfAssessmentId,
-                ResultCount = sessionRequestVerification.ResultIds.Count(),
-                SelfAssessmentName = sessionRequestVerification.SelfAssessmentName,
-                Vocabulary = sessionRequestVerification.Vocabulary
+                SelfAssessment = selfAssessment,
+                ResultCount = sessionRequestVerification.ResultIds.Count()
             };
             return View("SelfAssessments/VerificationSummary", model);
         }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/VerificationPickSupervisorViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/VerificationPickSupervisorViewModel.cs
@@ -7,15 +7,20 @@
 
     public class VerificationPickSupervisorViewModel
     {
-        public int SelfAssessmentId { get; set; }
-        public string? Vocabulary { get; set; }
-        public string? SelfAssessmentName { get; set; }
+        public CurrentSelfAssessment? SelfAssessment { get; set; }
         public List<SelfAssessmentSupervisor>? Supervisors { get; set; }
         [Range(1, int.MaxValue, ErrorMessage = "Please choose a supervisor")]
         public int CandidateAssessmentSupervisorId { get; set; }
         public string VocabPlural()
         {
-            return FrameworkVocabularyHelper.VocabularyPlural(Vocabulary);
+            if (SelfAssessment != null)
+            {
+                return FrameworkVocabularyHelper.VocabularyPlural(SelfAssessment.Vocabulary);
+            }
+            else
+            {
+                return "Capabilities";
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/VerificationSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/VerificationSummaryViewModel.cs
@@ -1,16 +1,22 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 {
+    using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Web.Helpers;
     public class VerificationSummaryViewModel
     {
-        public int SelfAssessmentId { get; set; }
         public string Supervisor { get; set; }
-        public string? Vocabulary { get; set; }
-        public string? SelfAssessmentName { get; set; }
+        public CurrentSelfAssessment? SelfAssessment { get; set; }
         public int ResultCount { get; set; }
         public string VocabPlural()
         {
-            return FrameworkVocabularyHelper.VocabularyPlural(Vocabulary);
+            if (SelfAssessment != null)
+            {
+                return FrameworkVocabularyHelper.VocabularyPlural(SelfAssessment.Vocabulary);
+            }
+            else
+            {
+                return "Capabilities";
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -137,7 +137,7 @@
     }
     else
     {
-  <p class="nhsuk-body-l">All @Model.VocabPlural().ToLower() must be self-assessed and verified by your @Model.SelfAssessment.VerificationRoleName, before requesting @Model.SelfAssessment.SignOffRoleName sign off of this activity.</p>
+  <p class="nhsuk-body-l">All @Model.VocabPlural().ToLower() must be self-assessed and verified by your @Model.SelfAssessment.VerificationRoleName, before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.</p>
     }
 
   </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -74,11 +74,11 @@
     @if (Model.SupervisorSignOffs.Any())
     {
       <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-bottom-4">
-        <caption class="nhsuk-table__caption"><h2>Supervisor Sign-off</h2></caption>
+        <caption class="nhsuk-table__caption"><h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2></caption>
         <thead role="rowgroup" class="nhsuk-table__head">
           <tr role="row">
             <th role="columnheader" class="" scope="col">
-              Supervisor
+              @Model.SelfAssessment.SignOffRoleName
             </th>
             <th role="columnheader" class="" scope="col">
               Status
@@ -93,7 +93,7 @@
           {
             <tr role="row" class="nhsuk-table__row">
               <td role="cell" class="nhsuk-table__cell">
-                <span class="nhsuk-table-responsive__heading">Supervisor </span>@supervisorSignOff.SupervisorName (@supervisorSignOff.SupervisorEmail)
+                <span class="nhsuk-table-responsive__heading">@Model.SelfAssessment.SignOffRoleName </span>@supervisorSignOff.SupervisorName (@supervisorSignOff.SupervisorEmail)
               </td>
               <td role="cell" class="nhsuk-table__cell">
                 <span class="nhsuk-table-responsive__heading">Status </span>
@@ -124,20 +124,20 @@
     }
     else
     {
-      <h2>Supervisor Sign-off</h2>
+  <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
     }
     @if (Model.AllQuestionsVerified())
     {
       @if (!Model.SupervisorSignOffs.Any())
       {
-        <p class="nhsuk-body-l">You have not yet requested supervisor sign-off for this self assessment.</p>
+  <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
 
       }
-      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2">Request supervisor sign-off</a>
+  <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2">Request @Model.SelfAssessment.SignOffRoleName sign-off</a>
     }
     else
     {
-      <p class="nhsuk-body-l">All @Model.VocabPlural().ToLower() must be self-assessed and verified by a supervisor, before requesting supervisor sign off of this activity.</p>
+  <p class="nhsuk-body-l">All @Model.VocabPlural().ToLower() must be self-assessed and verified by your @Model.SelfAssessment.VerificationRoleName, before requesting @Model.SelfAssessment.SignOffRoleName sign off of this activity.</p>
     }
 
   </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickResults.cshtml
@@ -95,7 +95,7 @@
 else
 {
 <p>
-  There are no self assessment results ready for supervisor verification.
+  There are no self assessment results ready for verification.
 </p>
 <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">Cancel</a>
 <a class="nhsuk-button nhsuk-button--secondary" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickSupervisor.cshtml
@@ -4,15 +4,15 @@
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   Layout = "SelfAssessments/_Layout";
   ViewData["Title"] = "Self Assessment";
-  ViewData["SelfAssessmentTitle"] = @Model.SelfAssessmentName;
+  ViewData["SelfAssessmentTitle"] = @Model.SelfAssessment.Name;
 }
 @section breadcrumbs {
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@Model.SelfAssessmentName</a></li>
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@Model.VocabPlural()</a></li>
+  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.SelfAssessment.Name</a></li>
+  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.VocabPlural()</a></li>
   <li class="nhsuk-breadcrumb__item">Request verification</li>
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
-<h1>Request @Model.Vocabulary.ToLower() verification</h1>
+<h1>Request @Model.SelfAssessment.Vocabulary.ToLower() verification</h1>
 @if (errorHasOccurred)
 {
   <vc:error-summary order-of-property-names="@(new[] {nameof(Model.CandidateAssessmentSupervisorId) })" />
@@ -23,10 +23,10 @@
     <fieldset class="nhsuk-fieldset">
       <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
         <h2 class="nhsuk-fieldset__heading">
-          Which supervisor?
+          Which @Model.SelfAssessment.VerificationRoleName?
         </h2>
         <div class="nhsuk-hint">
-          Choose the supervisor you wish to request verification of @Model.VocabPlural().ToLower() from.
+          Choose the @Model.SelfAssessment.VerificationRoleName you wish to request verification of @Model.VocabPlural().ToLower() from.
         </div>
 
       </legend>
@@ -50,11 +50,11 @@
     </button>
   </form>
 
-  <p>Can't see the supervisor you need? <a asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentId">Click here</a> to manage supervisors.</p>
+  <p>Can't see the  @Model.SelfAssessment.VerificationRoleName you need? <a asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Click here</a> to manage supervisors.</p>
   <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link"
        asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()"
-       asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
       <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
       </svg>
@@ -66,7 +66,7 @@ else
 {
   <p>There are no supervisors identified who can verify @Model.VocabPlural().ToLower() for this self assessment.</p>
   <div class="nhsuk-action-link">
-    <a class="nhsuk-action-link__link" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+    <a class="nhsuk-action-link__link" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
       <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
         <path d="M0 0h24v24H0z" fill="none"></path>
         <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
@@ -4,40 +4,40 @@
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   Layout = "SelfAssessments/_Layout";
   ViewData["Title"] = "Self Assessment";
-  ViewData["SelfAssessmentTitle"] = @Model.SelfAssessmentName;
+  ViewData["SelfAssessmentTitle"] = @Model.SelfAssessment.Name;
 }
 @section breadcrumbs {
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@Model.SelfAssessmentName</a></li>
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@Model.VocabPlural()</a></li>
+  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.SelfAssessment.Name</a></li>
+  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.VocabPlural()</a></li>
   <li class="nhsuk-breadcrumb__item">Request verification</li>
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
-<h1>Request @Model.Vocabulary.ToLower() verification</h1>
+<h1>Request @Model.SelfAssessment.Vocabulary.ToLower() verification</h1>
 <h2>Summary</h2>
 <dl class="nhsuk-summary-list">
   <div class="nhsuk-summary-list__row">
   <dt class="nhsuk-summary-list__key">
-    Supervisor
+    @Model.SelfAssessment.VerificationRoleName
   </dt>
   <dd class="nhsuk-summary-list__value">
     @Model.Supervisor
   </dd>
   <dd class="nhsuk-summary-list__actions">
-    <a asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+    <a asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
       Change
     </a>
   </dd>
   </div>
   <div class="nhsuk-summary-list__row">
   <dt class="nhsuk-summary-list__key">
-    @Model.Vocabulary self assessments to verify
+    Results to verify
   </dt>
   <dd class="nhsuk-summary-list__value">
-    @Model.ResultCount results
+    @Model.ResultCount
   </dd>
   <dd class="nhsuk-summary-list__actions">
 
-    <a asp-action="VerificationPickResults" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+    <a asp-action="VerificationPickResults" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
       Change
     </a>
   </dd>
@@ -47,7 +47,7 @@
   <button class="nhsuk-button" type="submit">Submit</button>
 </form>
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-action="SelfAssessmentOverview" asp-route-selfAssessmentId="@Model.SelfAssessmentId" asp-route-vocabulary="@Model.VocabPlural()">
+  <a class="nhsuk-back-link__link" asp-action="SelfAssessmentOverview" asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
     </svg>


### PR DESCRIPTION
### JIRA link
DLSV2-368 and DLSV2-367

### Description
DLSV2-367 - Uses name of activity in place of "this activity" in sign-off request not available text
DLSV2-368 - Reads sign-off and verifier roles in for self-assessment and uses them in place of generic "supervisor" throughout sign-off and verification flows.