### PR TITLE
HEEDLS-441 Add word break to tutorial names

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_EditSectionDiagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_EditSectionDiagnostic.cshtml
@@ -33,7 +33,7 @@
                id="diagnostic-enabled-@tutorial.TutorialId"
                checked="@tutorial.DiagnosticEnabled"
                value="true" />
-        <label class="nhsuk-label nhsuk-checkboxes__label" for="diagnostic-enabled-@tutorial.TutorialId">
+        <label class="nhsuk-label nhsuk-checkboxes__label word-break" for="diagnostic-enabled-@tutorial.TutorialId">
           @tutorial.TutorialName
         </label>
       </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_EditSectionLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_EditSectionLearning.cshtml
@@ -31,7 +31,7 @@
                id="learning-enabled-@tutorial.TutorialId"
                checked="@tutorial.LearningEnabled"
                value="true" />
-        <label class="nhsuk-label nhsuk-checkboxes__label" for="learning-enabled-@tutorial.TutorialId">
+        <label class="nhsuk-label nhsuk-checkboxes__label word-break" for="learning-enabled-@tutorial.TutorialId">
           @tutorial.TutorialName
         </label>
       </div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-441

### Description
Added word break to the tutorial names in the edit section screen.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/137717824-cf551887-3844-4d0c-bf25-64c3b34b423a.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
