### PR TITLE
DLSV2-388 Fixes register invite url

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkNotificationService.cs
@@ -190,7 +190,8 @@
             var dlsUrlBuilder = GetDLSUriBuilder();
             if (supervisorDelegate.CandidateID == null)
             {
-                dlsUrlBuilder.Path += $"Register?centreid={supervisorDelegate.CentreId}&inviteid={supervisorDelegate.InviteHash}";
+                dlsUrlBuilder.Path += "Register";
+                dlsUrlBuilder.Query = $"centreid={supervisorDelegate.CentreId}&inviteid={supervisorDelegate.InviteHash}";
                 builder.TextBody = $@"Dear colleague,
                               You have been invited to register to access the NHS Health Education England, Digital Learning Solutions platform as a supervised delegate by {supervisorDelegate.SupervisorName} ({supervisorDelegate.SupervisorEmail}).
                               To register, visit {dlsUrlBuilder.Uri.ToString()}.


### PR DESCRIPTION
Adds query string as UriBuilder .Query instead of adding it to .Path

### JIRA link
DLSV2-388

### Description
Fixes register invite URL by adding query string as UriBuilder .Query instead of adding it to .Path

Tested in dev with invite to gmail account and link now works.
