### PR TITLE
HEEDLS-443 Add aria-labels to buttons in manage course page expandables

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
@@ -81,6 +81,7 @@
             if (model.AutoRefresh)
             {
                 // TODO in HEEDLS-442: Redirect to "Edit auto-refresh options" page
+                return RedirectToAction("Index", new { customisationId = model.CustomisationId });
             }
 
             var completeWithinMonthsInt =

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseDetailsExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseDetailsExpandable.cshtml
@@ -67,7 +67,7 @@
 
     </dl>
 
-    <a class="nhsuk-button nhsuk-u-margin-right-2" role="button" href="">
+    <a class="nhsuk-button nhsuk-u-margin-right-2" role="button" href="" aria-label="Edit course details">
       Edit
     </a>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseOptionsExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseOptionsExpandable.cshtml
@@ -39,7 +39,7 @@
       </div>
     </dl>
 
-    <a class="nhsuk-button nhsuk-u-margin-right-2" role="button" href="">
+    <a class="nhsuk-button nhsuk-u-margin-right-2" role="button" href="" aria-label="Edit course options">
       Edit
     </a>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_LearningPathwayDefaultsExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_LearningPathwayDefaultsExpandable.cshtml
@@ -71,7 +71,8 @@
     <a class="nhsuk-button nhsuk-u-margin-right-2" role="button"
        asp-controller="ManageCourse"
        asp-action="EditLearningPathwayDefaults"
-       asp-route-customisationId="@Model.CustomisationId">
+       asp-route-customisationId="@Model.CustomisationId"
+       aria-label="Edit Learning Pathway defaults">
       Edit
     </a>
 


### PR DESCRIPTION
### JIRA link
_HEEDLS-443_

### Description
Quick fix to make the buttons in the in manage course page expandables more specific - e.g. reading out "Edit Learning Pathway defaults" rather than just "Edit".

Also changed what happens if auto-refresh is checked when the user clicks save to match the instructions in the ticket. It will now redirect back to the manage course page without saving the details. This will be changed in 442 soon to direct the user to the Edit auto-refresh options page.

### Screenshots
None

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
