### PR TITLE
HEEDLS-587 Display alternate message if too many data points are sele…

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/reports.ts
@@ -5,6 +5,10 @@ import getPathForEndpoint from '../common';
 const toggleableActivityButtonId = 'js-toggle-row-button';
 const toggleableActivityRowClass = 'js-toggleable-activity-row';
 
+// These constants are used in /Views/TrackingSystem/Centre/Reports/Index.cshtml
+const activityGraphId = 'activity-graph';
+const activityGraphDataErrorId = 'activity-graph-data-error';
+
 const path = getPathForEndpoint('TrackingSystem/Centre/Reports/Data');
 const activityToggleableRowDisplayNone = 'none';
 const activityToggleableRowDisplayTableRow = 'table-row';
@@ -31,7 +35,7 @@ function constructChartistData(data: Array<IActivityDataRowModel>): Chartist.ICh
   return { labels, series };
 }
 
-function generateChart(request: XMLHttpRequest) {
+function saveChartData(request: XMLHttpRequest) {
   let { response } = request;
   // IE does not support automatic parsing to JSON with XMLHttpRequest.responseType
   // so we need to manually parse the JSON string if not already parsed
@@ -39,7 +43,6 @@ function generateChart(request: XMLHttpRequest) {
     response = JSON.parse(response);
   }
   chartData = constructChartistData(response);
-  drawChartOrDataPointMessage();
 }
 
 function drawChartOrDataPointMessage() {
@@ -91,12 +94,12 @@ function drawChart() {
       }
     });
 
-  const dataPointErrorContainer = document.getElementById('activity-graph-data-error');
+  const dataPointErrorContainer = getActivityGraphDataErrorElement();
   if (dataPointErrorContainer !== null) {
     dataPointErrorContainer.hidden = true;
     dataPointErrorContainer.style.display = 'none';
   }
-  const chartContainer = document.getElementById('activity-graph');
+  const chartContainer = getActivityGraphElement();
   if (chartContainer !== null) {
     chartContainer.hidden = false;
     chartContainer.style.display = 'block';
@@ -104,16 +107,24 @@ function drawChart() {
 }
 
 function displayTooManyDataPointsMessage() {
-  const dataPointErrorContainer = document.getElementById('activity-graph-data-error');
+  const dataPointErrorContainer = getActivityGraphDataErrorElement();
   if (dataPointErrorContainer !== null) {
     dataPointErrorContainer.hidden = false;
     dataPointErrorContainer.style.display = 'block';
   }
-  const chartContainer = document.getElementById('activity-graph');
+  const chartContainer = getActivityGraphElement();
   if (chartContainer !== null) {
     chartContainer.hidden = true;
     chartContainer.style.display = 'none';
   }
+}
+
+function getActivityGraphElement(): HTMLElement | null {
+  return document.getElementById(activityGraphId);
+}
+
+function getActivityGraphDataErrorElement(): HTMLElement | null {
+  return document.getElementById(activityGraphDataErrorId);
 }
 
 function toggleVisibleActivityRows() {
@@ -152,11 +163,12 @@ function viewLessRows(): void {
   });
 }
 
-function makeChartistRequest() {
+function fetchChartDataAndDrawGraph() {
   const request = new XMLHttpRequest();
 
   request.onload = () => {
-    generateChart(request);
+    saveChartData(request);
+    drawChartOrDataPointMessage();
   };
 
   request.open('GET', path, true);
@@ -179,5 +191,5 @@ function setUpToggleActivityRowsButton() {
 
 setUpToggleActivityRowsButton();
 viewLessRows();
-makeChartistRequest();
+fetchChartDataAndDrawGraph();
 window.onresize = drawChartOrDataPointMessage;

--- a/DigitalLearningSolutions.Web/ViewComponents/InsetTextViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/InsetTextViewComponent.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class InsetTextViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(
+            string text,
+            string cssClass
+        )
+        {
+            var model = new InsetTextViewModel(text, string.IsNullOrEmpty(cssClass) ? null : cssClass);
+            return View(model);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/InsetTextViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/InsetTextViewComponent.cs
@@ -1,0 +1,15 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+{
+    public class InsetTextViewModel
+    {
+        public InsetTextViewModel(string text, string? cssClass = null)
+        {
+            Text = text;
+            CssClass = cssClass;
+        }
+
+        public string Text { get; set; }
+
+        public string? CssClass { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/InsetText/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/InsetText/Default.cshtml
@@ -1,0 +1,7 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@model InsetTextViewModel
+
+<div class="nhsuk-inset-text @Model.CssClass">
+  <span class="nhsuk-u-visually-hidden">Information: </span>
+  <p>@Model.Text</p>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -37,7 +37,10 @@
       <partial name="_ActivityGraph.cshtml" />
     </div>
     <div id="activity-graph-data-error" class="js-only-block" hidden>
-      Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart.
+      <div class="nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
+        <span class="nhsuk-u-visually-hidden">Information: </span>
+        <p>Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart.</p>
+      </div>
     </div>
     <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -37,7 +37,8 @@
       <partial name="_ActivityGraph.cshtml" />
     </div>
     <div id="activity-graph-data-error" class="js-only-block" hidden>
-      <partial name="_ActivityGraphDataPointError" />
+      <vc:inset-text text="Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart."
+                     css-class="nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4" />
     </div>
     <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -37,10 +37,7 @@
       <partial name="_ActivityGraph.cshtml" />
     </div>
     <div id="activity-graph-data-error" class="js-only-block" hidden>
-      <div class="nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
-        <span class="nhsuk-u-visually-hidden">Information: </span>
-        <p>Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart.</p>
-      </div>
+      <partial name="_ActivityGraphDataPointError" />
     </div>
     <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />
 
@@ -57,8 +54,7 @@
     <p>Summary of evaluation responses collected from delegates on completion of learning activities.</p>
 
     <ul class="nhsuk-card-group">
-      @foreach (var evaluationSummary in Model.EvaluationSummaryBreakdown)
-      {
+      @foreach (var evaluationSummary in Model.EvaluationSummaryBreakdown) {
         <li class="nhsuk-card-group__item">
           <partial name="_EvaluationSummaryCard.cshtml" model="evaluationSummary" />
         </li>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -33,7 +33,7 @@
 
     <h2 class="nhsuk-heading-m">Usage stats</h2>
 
-    <div class="js-only-block">
+    <div id="activity-graph" class="js-only-block">
       <partial name="_ActivityGraph.cshtml" />
     </div>
     <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -36,6 +36,9 @@
     <div id="activity-graph" class="js-only-block">
       <partial name="_ActivityGraph.cshtml" />
     </div>
+    <div id="activity-graph-data-error" class="js-only-block" hidden>
+      Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart.
+    </div>
     <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />
 
     <a class="nhsuk-button nhsuk-u-margin-top-6"
@@ -51,7 +54,8 @@
     <p>Summary of evaluation responses collected from delegates on completion of learning activities.</p>
 
     <ul class="nhsuk-card-group">
-      @foreach (var evaluationSummary in Model.EvaluationSummaryBreakdown) {
+      @foreach (var evaluationSummary in Model.EvaluationSummaryBreakdown)
+      {
         <li class="nhsuk-card-group__item">
           <partial name="_EvaluationSummaryCard.cshtml" model="evaluationSummary" />
         </li>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_ActivityGraphDataPointError.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_ActivityGraphDataPointError.cshtml
@@ -1,4 +1,0 @@
-﻿<div class="nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
-  <span class="nhsuk-u-visually-hidden">Information: </span>
-  <p>Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart.</p>
-</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_ActivityGraphDataPointError.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_ActivityGraphDataPointError.cshtml
@@ -1,0 +1,4 @@
+﻿<div class="nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
+  <span class="nhsuk-u-visually-hidden">Information: </span>
+  <p>Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart.</p>
+</div>


### PR DESCRIPTION
…cted for the reports graph

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-587

### Description
Limit the number of allowed data points on the reports activity graph to 17 (this was the max I think reasonably fits at all page widths).
Display a message instead when the graph is not displayed.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/140084438-b456c01e-5b9b-4d7a-94f7-52b872421100.png)
![image](https://user-images.githubusercontent.com/59561751/140084480-3bbef763-1072-4c68-885c-3b969fe4f05c.png)
![image](https://user-images.githubusercontent.com/59561751/140084505-06217cb4-02a1-4288-8b23-4455a7ae905a.png)
Mobile graph with 17 data points
![image](https://user-images.githubusercontent.com/59561751/140084646-7a0787af-de37-4cc1-9fcb-5bb26a63dd67.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
