### PR TITLE
HEEDLS-631 Add migration to reduce the GroupDescription column length

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202111081225_ReduceGroupsGroupDescriptionLength.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111081225_ReduceGroupsGroupDescriptionLength.cs
@@ -1,0 +1,19 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202111081225)]
+    public class ReduceGroupsGroupDescriptionLength : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql("UPDATE Groups SET GroupDescription = LEFT(GroupDescription, 1000)");
+            Alter.Table("Groups").AlterColumn("GroupDescription").AsString(1000).Nullable();
+        }
+
+        public override void Down()
+        {
+            Alter.Table("Groups").AlterColumn("GroupDescription").AsString(int.MaxValue).Nullable();
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-631

### Description
Migration to reduce the size of Groups.GroupDescription from nvarchar(max) to nvarchar(1000), truncating any values over this limit (there should hopefully still be none by the time this makes it live)

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
