### PR TITLE
HEEDLS-623 Add search function to delegate groups

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelTests.cs
@@ -76,7 +76,7 @@
         }
 
         [Test]
-        public void DelegateGroupsViewModel_filters_should_be_set()
+        public void DelegateGroupsViewModel_filters_and_search_string_should_be_set()
         {
             // Given
             var admins = new[]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelTests.cs
@@ -37,6 +37,7 @@
             var model = new DelegateGroupsViewModel(
                 groups.ToList(),
                 new List<CustomPrompt>(),
+                null!,
                 nameof(Group.SearchableName),
                 BaseSearchablePageViewModel.Ascending,
                 null,
@@ -57,6 +58,7 @@
             var model = new DelegateGroupsViewModel(
                 groups.ToList(),
                 new List<CustomPrompt>(),
+                null!,
                 nameof(Group.SearchableName),
                 BaseSearchablePageViewModel.Ascending,
                 null,
@@ -101,6 +103,7 @@
             var model = new DelegateGroupsViewModel(
                 groups.ToList(),
                 new List<CustomPrompt>(),
+                "My search string",
                 nameof(Group.SearchableName),
                 BaseSearchablePageViewModel.Ascending,
                 null,
@@ -110,6 +113,7 @@
             // Then
             model.Filters.Should().BeEquivalentTo(expectedFilters);
             model.DelegateGroups.First().Name.Should().BeEquivalentTo("K");
+            model.SearchString.Should().Be("My search string");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelTests.cs
@@ -103,7 +103,7 @@
             var model = new DelegateGroupsViewModel(
                 groups.ToList(),
                 new List<CustomPrompt>(),
-                "My search string",
+                "K",
                 nameof(Group.SearchableName),
                 BaseSearchablePageViewModel.Ascending,
                 null,
@@ -113,7 +113,7 @@
             // Then
             model.Filters.Should().BeEquivalentTo(expectedFilters);
             model.DelegateGroups.First().Name.Should().BeEquivalentTo("K");
-            model.SearchString.Should().Be("My search string");
+            model.SearchString.Should().Be("K");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -45,6 +45,7 @@
 
         [Route("{page=1:int}")]
         public IActionResult Index(
+            string? searchString = null,
             string? sortBy = null,
             string sortDirection = BaseSearchablePageViewModel.Ascending,
             string? filterBy = null,
@@ -70,6 +71,7 @@
             var model = new DelegateGroupsViewModel(
                 groups,
                 GetRegistrationPromptsWithSetOptions(centreId),
+                searchString,
                 sortBy,
                 sortDirection,
                 filterBy,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModel.cs
@@ -12,18 +12,20 @@
         public DelegateGroupsViewModel(
             List<Group> groups,
             IEnumerable<CustomPrompt> registrationPrompts,
+            string searchString,
             string sortBy,
             string sortDirection,
             string? filterBy,
             int page
-        ) : base(null, page, true, sortBy, sortDirection, filterBy)
+        ) : base(searchString, page, true, sortBy, sortDirection, filterBy)
         {
             var sortedItems = GenericSortingHelper.SortAllItems(
                 groups.AsQueryable(),
                 sortBy,
                 sortDirection
             );
-            var filteredItems = FilteringHelper.FilterItems(sortedItems.AsQueryable(), filterBy).ToList();
+            var searchedItems = GenericSearchHelper.SearchItems(sortedItems, SearchString);
+            var filteredItems = FilteringHelper.FilterItems(searchedItems.AsQueryable(), filterBy).ToList();
             MatchingSearchResults = filteredItems.Count;
             SetTotalPages();
             var paginatedItems = GetItemsOnCurrentPage(filteredItems);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/Index.cshtml
@@ -32,7 +32,7 @@
       </div>
     </div>
 
-    <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSortAndFilter" model="Model" />
+    <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
 
     @if (Model.NoDataFound) {
       <p class="nhsuk-u-margin-top-4" role="alert">


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-623](https://softwiretech.atlassian.net/browse/HEEDLS-623)

### Description
Add search by group label field to delegate groups page.
(Includes a non-Javascript version)

### Screenshots
**Desktop**
![image](https://user-images.githubusercontent.com/18046982/141008754-c4e7d46b-bb11-47df-ad4d-65372e6fdd27.png)

**Desktop - No JS version**
![image](https://user-images.githubusercontent.com/18046982/141008805-69785141-a660-440f-945b-f7c68e307d73.png)

**Tablet**
![image](https://user-images.githubusercontent.com/18046982/141008833-6abbdd67-dbd1-45e2-b06c-fa3e47ba5935.png)

**Mobile**
![image](https://user-images.githubusercontent.com/18046982/141008867-93aa1a3c-5dc7-477a-b9d9-c9647c166e01.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
