### PR TITLE
Heedls 512 delete delegate group

### DIFF
--- a/DigitalLearningSolutions.Web/ViewComponents/SingleCheckboxViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/SingleCheckboxViewComponent.cs
@@ -14,7 +14,9 @@
             var model = ViewData.Model;
             var property = model.GetType().GetProperty(aspFor);
             var valueToSet = (bool)(property?.GetValue(model) ?? false);
-            var errorMessage = ViewData.ModelState[property?.Name]?.Errors[0]?.ErrorMessage;
+
+            var hasError = ViewData.ModelState[property?.Name]?.Errors?.Count > 0;
+            var errorMessage = hasError ? ViewData.ModelState[property?.Name]?.Errors[0].ErrorMessage : null;
 
             var viewModel = new CheckboxItemViewModel(
                 aspFor,

--- a/DigitalLearningSolutions.Web/ViewComponents/SingleCheckboxViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/SingleCheckboxViewComponent.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewComponents
 {
+    using System.Linq;
     using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
     using Microsoft.AspNetCore.Mvc;
 
@@ -14,9 +15,7 @@
             var model = ViewData.Model;
             var property = model.GetType().GetProperty(aspFor);
             var valueToSet = (bool)(property?.GetValue(model) ?? false);
-
-            var hasError = ViewData.ModelState[property?.Name]?.Errors?.Count > 0;
-            var errorMessage = hasError ? ViewData.ModelState[property?.Name]?.Errors[0].ErrorMessage : null;
+            var errorMessage = ViewData.ModelState[property?.Name]?.Errors?.FirstOrDefault()?.ErrorMessage;
 
             var viewModel = new CheckboxItemViewModel(
                 aspFor,

--- a/SQLScripts/20211103_SetUpDelegateGroupMember.sql
+++ b/SQLScripts/20211103_SetUpDelegateGroupMember.sql
@@ -1,0 +1,1 @@
+UPDATE GroupDelegates SET GroupID = 8 WHERE GroupDelegateID = 1389


### PR DESCRIPTION
### JIRA link
[HEEDLS-512](https://softwiretech.atlassian.net/browse/HEEDLS-512)

### Description
Got a 500 error when only checking the DeleteEnrolments checkbox on the delete group confirmation page. This was because we were trying to access index 0 of an empty list, I have added a check so that we skip that if the list is empty.
I also added the SQL script that sets up data for this ticket's tests.

### Screenshots
Nothing has changed visually since the last review.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
