### PR TITLE
DLSV2-409 Changes to Overview table My response and status columns

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -8,6 +8,7 @@
         public int LaunchCount { get; set; }
         public DateTime? SubmittedDate { get; set; }
         public bool IsSupervised { get; set; }
+        public bool IsSupervisorResultsReviewed { get; set; }
         public string? Vocabulary { get; set; }
         public string? VerificationRoleName { get; set; }
         public string? SignOffRoleName { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -197,6 +197,7 @@
                              SA.Name,
                              SA.Description,
                              SA.UseFilteredApi,
+                             SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                              COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
                              COUNT(C.ID)         AS NumberOfCompetencies,
                              CA.StartedDate,
@@ -213,7 +214,7 @@
                                INNER JOIN Competencies AS C
                                           ON SAS.CompetencyID = C.ID
                       WHERE CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
-                      GROUP BY CA.SelfAssessmentID, SA.Name, SA.Description, SA.UseFilteredApi, COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate, CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate",
+                      GROUP BY CA.SelfAssessmentID, SA.Name, SA.Description, SA.UseFilteredApi, SA.SupervisorResultsReview, COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate, CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate",
                 new { candidateId }
             );
         }
@@ -224,6 +225,7 @@
                              SA.Name,
                              SA.Description,
                              SA.UseFilteredApi,
+                             SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                              COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
                              COUNT(C.ID)         AS NumberOfCompetencies,
                              CA.StartedDate,
@@ -231,7 +233,8 @@
                              CA.CompleteByDate,
                              CA.UserBookmark,
                              CA.UnprocessedUpdates,
-                             CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders, SA.ManageOptionalCompetenciesPrompt, CAST(CASE WHEN SA.SupervisorSelfAssessmentReview = 1 OR SA.SupervisorResultsReview = 1 THEN 1 ELSE 0 END AS BIT) AS IsSupervised,
+                             CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders, SA.ManageOptionalCompetenciesPrompt,
+                                                  CAST(CASE WHEN SA.SupervisorSelfAssessmentReview = 1 OR SA.SupervisorResultsReview = 1 THEN 1 ELSE 0 END AS BIT) AS IsSupervised,
                                                   CASE WHEN (SELECT COUNT(*) FROM SelfAssessmentSupervisorRoles WHERE SelfAssessmentID = @selfAssessmentId AND AllowDelegateNomination = 1) > 0 THEN 1 ELSE 0 END AS HasDelegateNominatedRoles, COALESCE
                  ((SELECT TOP (1) RoleName
                   FROM    SelfAssessmentSupervisorRoles

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentDescriptionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentDescriptionViewModel.cs
@@ -14,6 +14,7 @@
         public readonly bool UnprocessedUpdates;
         public readonly bool LinearNavigation;
         public readonly bool IsSupervised;
+        public readonly bool IsSupervisorResultsReviewed;
         public readonly string? Vocabulary;
         public readonly string VocabPlural;
         public List<SelfAssessmentSupervisor> Supervisors { get; set; }
@@ -27,6 +28,7 @@
             UnprocessedUpdates = selfAssessment.UnprocessedUpdates;
             LinearNavigation = selfAssessment.LinearNavigation;
             IsSupervised = selfAssessment.IsSupervised;
+            IsSupervisorResultsReviewed = selfAssessment.IsSupervisorResultsReviewed;
             Supervisors = supervisors;
             Vocabulary = selfAssessment.Vocabulary;
             VocabPlural = FrameworkVocabularyHelper.VocabularyPlural(selfAssessment.Vocabulary);

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -44,7 +44,10 @@
                      view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
           }
 
-          <partial name="SelfAssessments/_OverviewTable" view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation } })" model="competencyGroup" />
+          <partial name="SelfAssessments/_OverviewTable" view-data="@(
+            new ViewDataDictionary(ViewData) {
+              { "linearNavigation", Model.SelfAssessment.LinearNavigation },
+              { "selfAssessment", Model.SelfAssessment } })" model="competencyGroup" />
 
         </div>
       </details>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -15,7 +15,7 @@
         Question
       </th>
       <th role="columnheader" class="" scope="col">
-        My response
+        Self-assessment
       </th>
       @if (((CurrentSelfAssessment)ViewData["selfAssessment"])?.IsSupervisorResultsReviewed ?? true)
       {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -1,7 +1,6 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
 @model IGrouping<string, Competency>;
 
-
 <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
   @if (!(bool)ViewData["linearNavigation"])
   {
@@ -18,9 +17,12 @@
       <th role="columnheader" class="" scope="col">
         My response
       </th>
-      <th role="columnheader" class="" scope="col">
-        Status
-      </th>
+      @if (((CurrentSelfAssessment)ViewData["selfAssessment"])?.IsSupervisorResultsReviewed ?? true)
+      {
+        <th role="columnheader" class="" scope="col">
+          Verification status
+        </th>
+      }
       <th role="columnheader" class="" scope="col">
         <span class="nhsuk-u-visually-hidden">Actions</span>
       </th>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionOverviewCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionOverviewCells.cshtml
@@ -7,10 +7,14 @@
     @Model.Question
 </td>
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-  <span class="nhsuk-table-responsive__heading">My response </span>
+  <span class="nhsuk-table-responsive__heading">Self-assessment </span>
   <partial name="../../Supervisor/Shared/_AssessmentQuestionResponse" model="Model" />
 </td>
-<td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+@if (((CurrentSelfAssessment)ViewData["selfAssessment"])?.IsSupervisorResultsReviewed ?? true)
+{
+  <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Questions </span>
   <partial name="Shared/_AssessmentQuestionStatusTag" model="Model" />
-</td>
+  </td>
+}
+

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionStatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionStatusTag.cshtml
@@ -2,43 +2,29 @@
 @model AssessmentQuestion
 <span class="status-tag">
 
-  @if (Model.SelfAssessmentResultSupervisorVerificationId == null)
+  @if (Model.SelfAssessmentResultSupervisorVerificationId != null)
   {
-
-    if (Model.Result != null)
+    if (Model.Verified != null)
     {
-      <span class="nhsuk-tag nhsuk-tag status-tag">
-        Self assessed
-      </span>
+      if ((bool)Model.SignedOff)
+      {
+        <span class="nhsuk-tag nhsuk-tag--green status-tag">
+          Verified
+        </span>
+      }
+      else
+      {
+        <span class="nhsuk-tag nhsuk-tag--red status-tag">
+          Rejected
+        </span>
+      }
     }
     else
     {
-      <span class="nhsuk-tag nhsuk-tag--grey status-tag">
-        Not started
-      </span>
-    }
-  }
-  else if (Model.Verified != null)
-  {
-    if ((bool)Model.SignedOff)
-    {
-      <span class="nhsuk-tag nhsuk-tag--green status-tag">
-        Verified
-      </span>
-    }
-    else
-    {
-      <span class="nhsuk-tag nhsuk-tag--red status-tag">
-        Rejected
-      </span>
-    }
-  }
-  else
-  {
-
       <span class="nhsuk-tag nhsuk-tag--yellow status-tag">
         Awaiting verification
       </span>
-  }
+    }
 
+  }
 </span>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
@@ -3,12 +3,11 @@
 
 @if (Model.Result == null)
 {
-  <span class="nhsuk-u-font-weight-bold status-tag">No response</span>
+  <span class="nhsuk-u-font-weight-bold status-tag"></span>
 }
 else
 {
   @if (Model.LevelDescriptors != null)
-
   {
     foreach (var levelDescriptor in Model.LevelDescriptors)
     {


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-409

### Description
The following tweaks are required to the Learning Portal / Self Assessment / Overview view:
- In the “My Response” column, remove the “No response” default status (leave blank instead).
- Relabel the “My response” column header “Self-assessment”
- In the “Status” column, remove the status tags “Not started” and “Self assessed” and leave the column blank when the criteria for these statuses are met.
- Hide the “Status” column if SelfAssessments.SupervisorResultsReview = 0 for the current self assessment. 
- Relabel the “Status” column “Verification status”

### Screenshots
How it should look after changes
![image](https://user-images.githubusercontent.com/94055251/141816925-c9023e26-acda-48e7-912a-e32494969e58.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)
For a given self assessment check that:
- [x] When SupervisorResultsReview is 0 in database table SelfAssessments, "verification status" remain hidden:
- [x] When SupervisorResultsReview is 1 in database table SelfAssessments, "verification status" column can be seen: