### PR TITLE
DLSV2-413 Adds sign-off declined status and alters model and data ser…

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
@@ -11,7 +11,8 @@
         public string? SupervisorRoleTitle { get; set; }
         public DateTime StartedDate { get; set; }
         public DateTime LastAccessed { get; set; }
-        public DateTime? SignedOff { get; set; }
+        public DateTime? SignedOffDate { get; set; }
+        public bool SignedOff { get; set; }
         public DateTime? CompleteByDate { get; set; }
         public int LaunchCount { get; set; }
         public DateTime? CompletedDate { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -68,6 +68,16 @@ WHERE (cas.SupervisorDelegateId = sd.ID) AND (ca.RemovedDate IS NULL)) AS Candid
              JobGroups AS jg RIGHT OUTER JOIN
              Candidates AS c ON jg.JobGroupID = c.JobGroupID ON ct.CentreID = c.CentreID ON sd.CandidateID = c.CandidateID ";
         private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate";
+        private const string signedOffFields = @"(SELECT TOP (1) casv.Verified
+FROM CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
+             CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
+WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
+ORDER BY casv.Requested DESC) AS SignedOffDate,
+(SELECT TOP(1) casv.SignedOff
+FROM   CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
+             CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
+WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
+ORDER BY casv.Requested DESC) AS SignedOff,";
         public SupervisorService(IDbConnection connection, ILogger<SupervisorService> logger)
         {
             this.connection = connection;
@@ -223,7 +233,7 @@ WHERE (cas.SupervisorDelegateId = sd.ID) AND (ca.RemovedDate IS NULL)) AS Candid
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-                (SELECT MAX(Verified) FROM CandidateAssessmentSupervisorVerifications WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NOT NULL) AND (SignedOff = 1)) AS SignedOff,
+                {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
 FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
 WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
@@ -244,7 +254,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-                (SELECT MAX(Verified) FROM CandidateAssessmentSupervisorVerifications WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NOT NULL) AND (SignedOff = 1)) AS SignedOff,
+                {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
                     FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
@@ -258,11 +268,11 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
         public DelegateSelfAssessment GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId)
         {
             return connection.Query<DelegateSelfAssessment>(
-               @"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, ca.StartedDate, COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate,
+               @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, ca.StartedDate, COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate,
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-                (SELECT MAX(Verified) FROM CandidateAssessmentSupervisorVerifications WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NOT NULL) AND (SignedOff = 1)) AS SignedOff,
+                {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
                     FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
@@ -279,7 +289,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-                (SELECT MAX(Verified) FROM CandidateAssessmentSupervisorVerifications WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NOT NULL) AND (SignedOff = 1)) AS SignedOff,
+                {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
                     FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
@@ -307,11 +317,11 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
         public DelegateSelfAssessment GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId)
         {
             return connection.Query<DelegateSelfAssessment>(
-                @"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup,
+                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup,
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-                (SELECT MAX(Verified) FROM CandidateAssessmentSupervisorVerifications WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NOT NULL) AND (SignedOff = 1)) AS SignedOff,
+               {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
                     FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_ProfileAssessmentStatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_ProfileAssessmentStatusTag.cshtml
@@ -15,7 +15,7 @@ else if (Model.CompletedDate != null)
 }
 else if (Model.SignOffRequested > 0)
 {
-  <strong class="nhsuk-tag nhsuk-tag--red status-tag">
+  <strong class="nhsuk-tag nhsuk-tag--pink status-tag">
     Sign-off requested
   </strong>
 }
@@ -25,11 +25,21 @@ else if (Model.ResultsVerificationRequests > 0)
     Results to verify
   </strong>
 }
-else if (Model.SignedOff != null)
+else if (Model.SignedOffDate != null)
 {
-  <strong class="nhsuk-tag nhsuk-tag--green status-tag">
-    Signed off
-  </strong>
+  if (Model.SignedOff)
+  {
+    <strong class="nhsuk-tag nhsuk-tag--green status-tag">
+      Signed off
+    </strong>
+  }
+  else
+  {
+    <strong class="nhsuk-tag nhsuk-tag--red status-tag">
+      Sign off declined
+    </strong>
+  }
+
 }
 else
 {


### PR DESCRIPTION
…vice to support

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-413

### Description

- Alters data service to load most recent of all verifications (not just current supervisor) and tweaks model to include SignedOffDate and SignedOff (status) bool.
- Alters service to load these values, using a string constant to make sure the same SQL is used throughout service calls.
- Uses these values to display an accurate "Signed off" or "Sign-off declined" status tag for self assessment in Supervisor delegate self assessments view.
