### PR TITLE
HEEDLS-541 fix start date validation

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/ActivityServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActivityServiceTests.cs
@@ -468,6 +468,21 @@
             dateRange!.Value.endDate.Should().Be(DateTime.Parse(endDateString));
         }
 
+        [Test]
+        public void GetActivityStartDateForCentre_strips_time_from_database_value()
+        {
+            // given
+            var dateWithTime = DateTime.Parse("2020/12/12 12:40:40");
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(A<int>._))
+                .Returns(dateWithTime);
+
+            // when
+            var result = activityService.GetActivityStartDateForCentre(1);
+
+            // then
+            result.Should().Be(dateWithTime.Date);
+        }
+
         private void GivenActivityDataServiceReturnsDataInExampleSheet()
         {
             var activityResult = new List<ActivityLog>

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -19,7 +19,7 @@
         private ICourseDataService courseDataService = null!;
         private CourseService courseService = null!;
         private IProgressDataService progressDataService = null!;
-
+        
         [SetUp]
         public void Setup()
         {

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -19,7 +19,7 @@
         private ICourseDataService courseDataService = null!;
         private CourseService courseService = null!;
         private IProgressDataService progressDataService = null!;
-        
+
         [SetUp]
         public void Setup()
         {

--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -20,7 +20,7 @@
 
         ReportsFilterOptions GetFilterOptions(int centreId, int? courseCategoryId);
 
-        DateTime GetStartOfActivityForCentre(int centreId);
+        DateTime GetActivityStartDateForCentre(int centreId);
 
         byte[] GetActivityDataFileForCentre(int centreId, ActivityFilterData filterData);
 
@@ -115,9 +115,9 @@
             return new ReportsFilterOptions(jobGroups, courseCategories, courses);
         }
 
-        public DateTime GetStartOfActivityForCentre(int centreId)
+        public DateTime GetActivityStartDateForCentre(int centreId)
         {
-            return activityDataService.GetStartOfActivityForCentre(centreId);
+            return activityDataService.GetStartOfActivityForCentre(centreId).Date;
         }
 
         public byte[] GetActivityDataFileForCentre(int centreId, ActivityFilterData filterData)
@@ -193,7 +193,7 @@
         )
         {
             var startDateInvalid = !DateTime.TryParse(startDateString, out var startDate);
-            if (startDateInvalid || startDate < GetStartOfActivityForCentre(centreId))
+            if (startDateInvalid || startDate < GetActivityStartDateForCentre(centreId))
             {
                 return null;
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -99,7 +99,7 @@
 
             var filterOptions = GetDropdownValues(centreId, adminUser);
 
-            var dataStartDate = activityService.GetStartOfActivityForCentre(centreId);
+            var dataStartDate = activityService.GetActivityStartDateForCentre(centreId);
 
             var model = new EditFiltersViewModel(
                 filterData,
@@ -121,7 +121,7 @@
                 var adminUser = userDataService.GetAdminUserById(adminId)!;
                 var filterOptions = GetDropdownValues(centreId, adminUser);
                 model.SetUpDropdowns(filterOptions, adminUser.CategoryId);
-                model.DataStart = activityService.GetStartOfActivityForCentre(centreId);
+                model.DataStart = activityService.GetActivityStartDateForCentre(centreId);
                 return View(model);
             }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
@@ -29,6 +29,7 @@
 
     <h1 class="nhsuk-heading-xl">Edit report filters</h1>
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditFilters">
+      <input type="hidden" name="dataStart" value="@Model.DataStart" />
 
       <vc:select-list asp-for="@nameof(Model.JobGroupId)"
                       label="Choose job group filter"


### PR DESCRIPTION
### JIRA link
[_HEEDLS-541_](https://softwiretech.atlassian.net/browse/HEEDLS-541)

### Description
The start date is now stored in a hidden field in the view model so passed properly back on POST. The time component is also discarded when read from DB to avoid issues with picking the first day of data.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
