### PR TITLE
HEEDLS-620 Add word-break to several h1 elements with dynamic content

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/Index.cshtml
@@ -16,7 +16,7 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
 
-    <h1 class="nhsuk-heading-xl">@Model.CourseName</h1>
+    <h1 class="nhsuk-heading-xl word-break">@Model.CourseName</h1>
 
     <div class="nhsuk-inset-text">
       <span class="nhsuk-u-visually-hidden">Information: </span>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/EditDescription.cshtml
@@ -15,7 +15,7 @@
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Description) })" />
     }
 
-    <h1 class="nhsuk-heading-xl">Edit description for @Model.GroupName group (optional)</h1>
+    <h1 class="nhsuk-heading-xl word-break">Edit description for @Model.GroupName group (optional)</h1>
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditDescription">
 
       <vc:text-area asp-for="@nameof(Model.Description)"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesRemove.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesRemove.cshtml
@@ -17,7 +17,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(Model.ConfirmRemovalFromGroup) }" />
     }
 
-    <h1 class="nhsuk-heading-xl">Are you sure you would like to remove @Model.DelegateName from this group?</h1>
+    <h1 class="nhsuk-heading-xl word-break">Are you sure you would like to remove @Model.DelegateName from this group?</h1>
   </div>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesRemove.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/GroupDelegatesRemove.cshtml
@@ -50,7 +50,7 @@
           <div class="nhsuk-checkboxes">
             <div class="nhsuk-checkboxes__item">
               <input class="nhsuk-checkboxes__input" asp-for="ConfirmRemovalFromGroup" />
-              <label class="nhsuk-label nhsuk-checkboxes__label" asp-for="ConfirmRemovalFromGroup">
+              <label class="nhsuk-label nhsuk-checkboxes__label word-break" asp-for="ConfirmRemovalFromGroup">
                 I am sure that I wish to remove @Model.DelegateName from this group.
               </label>
             </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditSupervisor.cshtml
@@ -31,7 +31,7 @@
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SupervisorId) })" />
     }
 
-    <h1 class="nhsuk-heading-xl">Edit supervisor for @Model.CourseName</h1>
+    <h1 class="nhsuk-heading-xl word-break">Edit supervisor for @Model.CourseName</h1>
 
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
@@ -14,7 +14,7 @@
     @if (errorHasOccurred) {
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Confirm) })" />
     }
-    <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-3">Remove delegate enrolment from @Model.CourseName</h1>
+    <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-3 word-break">Remove delegate enrolment from @Model.CourseName</h1>
     <h2 class="nhsuk-heading-l">Delegate: @Model.Name</h2>
     <div class="nhsuk-form-group">
       <form asp-action="ExecuteRemoveFromCourse" asp-route-delegateId="@Model.DelegateId" asp-route-customisationId="@Model.CustomisationId">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
@@ -15,7 +15,7 @@
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Confirm) })" />
     }
     <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-3 word-break">Remove delegate enrolment from @Model.CourseName</h1>
-    <h2 class="nhsuk-heading-l">Delegate: @Model.Name</h2>
+    <h2 class="nhsuk-heading-l word-break">Delegate: @Model.Name</h2>
     <div class="nhsuk-form-group">
       <form asp-action="ExecuteRemoveFromCourse" asp-route-delegateId="@Model.DelegateId" asp-route-customisationId="@Model.CustomisationId">
         <fieldset class="nhsuk-fieldset" aria-describedby="example-hint">
@@ -24,7 +24,7 @@
               <input type="hidden" name="name" value="@Model.Name" />
               <input type="hidden" name="courseName" value="@Model.CourseName" />
               <input class="nhsuk-checkboxes__input" id="confirm" name="confirm" type="checkbox" value="true" aria-describedby="confirm-item-hint">
-              <label class="nhsuk-label nhsuk-checkboxes__label" for="confirm">
+              <label class="nhsuk-label nhsuk-checkboxes__label word-break" for="confirm">
                 I am sure that I want to remove @Model.Name from the @Model.CourseName course.
               </label>
               <div class="nhsuk-hint nhsuk-checkboxes__hint" id="confirm-item-hint">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -17,7 +17,7 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-3">@Model.DelegateInfo.Name</h1>
+    <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-3 word-break">@Model.DelegateInfo.Name</h1>
   </div>
   @if (Model.DelegateInfo.IsActive) {
     <div class="nhsuk-grid-column-one-third view-delegate-top-button-group">


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-620

### Description
Adds the word-break css class to various elements to prevent long course, group or delegate names overflowing the layout

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/142436980-3a84d030-242a-4bf8-ad34-b59bbce7a064.png)
![image](https://user-images.githubusercontent.com/59561751/142437271-f3b42d25-102d-40ac-9be1-ecf358a527f1.png)
![image](https://user-images.githubusercontent.com/59561751/142437831-3616a418-ce94-4162-8e56-142ef4c2db23.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
