### PR TITLE
DLSV2-418 Consolidate the two JS select-all methods into one TS file

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Scripts\checkboxGroup.ts" />
+    <None Remove="Scripts\checkboxes.ts" />
     <None Remove="Scripts\common.ts" />
     <None Remove="Scripts\frameworks\branding.ts" />
     <None Remove="Scripts\helpers\constants.ts" />
@@ -78,7 +78,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <TypeScriptCompile Include="Scripts\checkboxGroup.ts" />
+    <TypeScriptCompile Include="Scripts\checkboxes.ts" />
     <TypeScriptCompile Include="Scripts\common.ts" />
     <TypeScriptCompile Include="Scripts\checkboxGroup.ts" />
     <TypeScriptCompile Include="Scripts\frameworks\branding.ts" />

--- a/DigitalLearningSolutions.Web/Scripts/checkboxes.ts
+++ b/DigitalLearningSolutions.Web/Scripts/checkboxes.ts
@@ -1,11 +1,11 @@
-class CheckboxGroup {
-  public static setUpSelectAndDeselectButtons(): void {
+class Checkboxes {
+  public static setUpSelectAndDeselectInGroupButtons(): void {
     const selectAllButtons = document.querySelectorAll('.select-all') as NodeListOf<HTMLAnchorElement>;
     selectAllButtons.forEach((button) => {
       button.addEventListener('click',
         () => {
           const group = button.getAttribute('data-group') as string;
-          this.selectAll(group);
+          this.selectAllInGroup(group);
         });
     });
 
@@ -14,12 +14,12 @@ class CheckboxGroup {
       button.addEventListener('click',
         () => {
           const group = button.getAttribute('data-group') as string;
-          this.deselectAll(group);
+          this.deselectAllinGroup(group);
         });
     });
   }
 
-  static selectAll(group: string): void {
+  static selectAllInGroup(group: string): void {
     const allCheckboxes = document.querySelectorAll('.select-all-checkbox') as NodeListOf<HTMLInputElement>;
     allCheckboxes.forEach((checkbox) => {
       if (checkbox.getAttribute('data-group') === group) {
@@ -28,7 +28,7 @@ class CheckboxGroup {
     });
   }
 
-  static deselectAll(group: string): void {
+  static deselectAllinGroup(group: string): void {
     const allCheckboxes = document.querySelectorAll('.select-all-checkbox') as NodeListOf<HTMLInputElement>;
     allCheckboxes.forEach((checkbox) => {
       if (checkbox.getAttribute('data-group') === group) {
@@ -36,6 +36,20 @@ class CheckboxGroup {
       }
     });
   }
+
+  static selectAll(selectorClass: string): void {
+    const allCheckboxes = document.querySelectorAll(selectorClass) as NodeListOf<HTMLInputElement>;
+    allCheckboxes.forEach((checkbox) => {
+      if (!checkbox.checked) checkbox.click();
+    });
+  }
+
+  static deselectAll(selectorClass: string): void {
+    const allCheckboxes = document.querySelectorAll(selectorClass) as NodeListOf<HTMLInputElement>;
+    allCheckboxes.forEach((checkbox) => {
+      if (checkbox.checked) checkbox.click();
+    });
+  }
 }
 
-export default CheckboxGroup;
+export default Checkboxes;

--- a/DigitalLearningSolutions.Web/Scripts/common.ts
+++ b/DigitalLearningSolutions.Web/Scripts/common.ts
@@ -23,17 +23,3 @@ export function sendBrowserAgnosticEvent <T extends HTMLElement>(
 
   return event;
 }
-
-export function selectAll(selectorClass: string): void {
-  const allCheckboxes = document.querySelectorAll(selectorClass) as NodeListOf<HTMLInputElement>;
-  allCheckboxes.forEach((checkbox) => {
-    if (!checkbox.checked) checkbox.click();
-  });
-}
-
-export function deselectAll(selectorClass: string): void {
-  const allCheckboxes = document.querySelectorAll(selectorClass) as NodeListOf<HTMLInputElement>;
-  allCheckboxes.forEach((checkbox) => {
-    if (checkbox.checked) checkbox.click();
-  });
-}

--- a/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
@@ -1,4 +1,4 @@
-import * as CheckboxGroup from '../checkboxGroup';
+import * as Checkboxes from '../checkboxes';
 
 function onSliderUpdate(inputElement: HTMLInputElement) {
   const selectedRatio = parseInt(inputElement.value, 10) / parseInt(inputElement.max, 10);
@@ -16,4 +16,4 @@ inputs.forEach((e) => {
   e.addEventListener('change', () => onSliderUpdate(e));
 });
 
-CheckboxGroup.default.setUpSelectAndDeselectButtons();
+Checkboxes.default.setUpSelectAndDeselectInGroupButtons();

--- a/DigitalLearningSolutions.Web/Scripts/learningPortal/verificationPickResults.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningPortal/verificationPickResults.ts
@@ -1,3 +1,3 @@
-import * as CheckboxGroup from '../checkboxGroup';
+import * as Checkboxes from '../checkboxes';
 
-CheckboxGroup.default.setUpSelectAndDeselectButtons();
+Checkboxes.default.setUpSelectAndDeselectInGroupButtons();

--- a/DigitalLearningSolutions.Web/Scripts/supervisor/verifyMultipleResults.ts
+++ b/DigitalLearningSolutions.Web/Scripts/supervisor/verifyMultipleResults.ts
@@ -1,3 +1,3 @@
-import * as CheckboxGroup from '../checkboxGroup';
+import * as Checkboxes from '../checkboxes';
 
-CheckboxGroup.default.setUpSelectAndDeselectButtons();
+Checkboxes.default.setUpSelectAndDeselectInGroupButtons();

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/editCourseContent.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/editCourseContent.ts
@@ -1,4 +1,4 @@
-import { selectAll, deselectAll } from '../common';
+import * as Checkboxes from '../checkboxes';
 
 function setUpSelectAllButtons() {
   const submits = Array.from(
@@ -9,7 +9,7 @@ function setUpSelectAllButtons() {
     element.addEventListener('click', (e) => {
       e.preventDefault();
       const checkboxSelectorClass = `.${element.value.replace('select-all', 'checkbox')}`;
-      selectAll(checkboxSelectorClass);
+      Checkboxes.default.selectAll(checkboxSelectorClass);
     });
   });
 }
@@ -23,7 +23,7 @@ function setUpDeselectAllButtons() {
     element.addEventListener('click', (e) => {
       e.preventDefault();
       const checkboxSelectorClass = `.${element.value.replace('deselect-all', 'checkbox')}`;
-      deselectAll(checkboxSelectorClass);
+      Checkboxes.default.deselectAll(checkboxSelectorClass);
     });
   });
 }

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/emailDelegates.ts
@@ -1,5 +1,5 @@
 import { SearchSortFilterAndPaginate } from '../searchSortFilterAndPaginate/searchSortFilterAndPaginate';
-import { selectAll, deselectAll } from '../common';
+import * as Checkboxes from '../checkboxes';
 
 const selectedElements = document.querySelectorAll('.delegate-checkbox:checked') as NodeListOf<HTMLInputElement>;
 const selectedIds = Array.from(selectedElements).map((el) => el.value);
@@ -25,13 +25,13 @@ function setUpSelectAndDeselectButtons(): void {
 
   selectAllButton.addEventListener('click',
     () => {
-      selectAll(checkboxSelector);
+      Checkboxes.default.selectAll(checkboxSelector);
       alertResultCount();
     });
 
   deselectAllButton.addEventListener('click',
     () => {
-      deselectAll(checkboxSelector);
+      Checkboxes.default.deselectAll(checkboxSelector);
       alertResultCount();
     });
 }


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-418

### Description
Move the code for selecting and deselecting checkboxes into a common location: checkboxes.ts.

-----
### Developer checks

Class Checkboxes in checkboxes.ts provides two ways for selecting and deselecting checkboxes: by group or by selector (e.g. a css class). 

Checks:

Check that the right method is being invoked when using the library. If it's passing a class, should be using selectAll and deselectAll. If it's a group, should use selectAllInGroup, deselectAllinGroup. 

There are some special cases like emailDelegates.ts. Originally it was importing two methods from common.ts and selecting by class name. When emailDelegates.ts calls setUpSelectAndDeselectButtons(), that is a local implementation, not the one originally in common which was not being imported here. So this call doesn't need to be renamed.