### PR TITLE
DLSV2-415 Prevent SelfAssessment result duplicate entries

### DIFF
--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -345,15 +345,29 @@ LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
                             AND CAQ.AssessmentQuestionID = @assessmentQuestionId
                     )
                     BEGIN
-                        INSERT INTO SelfAssessmentResults
-                          ([CandidateID]
-                          ,[SelfAssessmentID]
-                          ,[CompetencyID]
-                          ,[AssessmentQuestionID]
-                          ,[Result]
-                          ,[DateTime]
-                          ,[SupportingComments])
-                    VALUES(@candidateId, @selfAssessmentId, @competencyId, @assessmentQuestionId, @result, GETUTCDATE(), @supportingComments)
+                        DECLARE @existentResultId int = (
+	                        SELECT TOP 1 ID FROM SelfAssessmentResults
+	                        WHERE [CandidateID] = @candidateId
+		                        AND [SelfAssessmentID] = @selfAssessmentId
+		                        AND [CompetencyID] = @competencyId
+		                        AND [AssessmentQuestionID] = @assessmentQuestionId
+                                AND [Result] = @result
+	                        ORDER BY DateTime DESC)
+                        IF (@existentResultId IS NOT NULL)
+	                        UPDATE SelfAssessmentResults
+	                        SET [DateTime] = GETUTCDATE(),
+		                        [SupportingComments] = @supportingComments
+	                        WHERE ID = @existentResultId
+                        ELSE
+                            INSERT INTO SelfAssessmentResults
+                              ([CandidateID]
+                              ,[SelfAssessmentID]
+                              ,[CompetencyID]
+                              ,[AssessmentQuestionID]
+                              ,[Result]
+                              ,[DateTime]
+                              ,[SupportingComments])
+                            VALUES(@candidateId, @selfAssessmentId, @competencyId, @assessmentQuestionId, @result, GETUTCDATE(), @supportingComments)
                     END",
                 new { competencyId, selfAssessmentId, candidateId, assessmentQuestionId, result, supportingComments }
             );

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -345,28 +345,31 @@ LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
                             AND CAQ.AssessmentQuestionID = @assessmentQuestionId
                     )
                     BEGIN
-                        DECLARE @existentResultId int = (
-	                        SELECT TOP 1 ID FROM SelfAssessmentResults
-	                        WHERE [CandidateID] = @candidateId
-		                        AND [SelfAssessmentID] = @selfAssessmentId
-		                        AND [CompetencyID] = @competencyId
-		                        AND [AssessmentQuestionID] = @assessmentQuestionId
-                                AND [Result] = @result
-	                        ORDER BY DateTime DESC)
-                        IF (@existentResultId IS NOT NULL)
+                        DECLARE @existentResultId INT
+                        DECLARE @existentResult INT
+
+                        SELECT TOP 1 @existentResultId = ID, @existentResult = [Result]
+                        FROM SelfAssessmentResults
+                        WHERE [CandidateID] = @candidateId
+	                        AND [SelfAssessmentID] = @selfAssessmentId
+	                        AND [CompetencyID] = @competencyId
+	                        AND [AssessmentQuestionID] = @assessmentQuestionId
+                        ORDER BY DateTime DESC
+
+                        IF (@existentResultId IS NOT NULL AND @existentResult = @result)
 	                        UPDATE SelfAssessmentResults
 	                        SET [DateTime] = GETUTCDATE(),
 		                        [SupportingComments] = @supportingComments
 	                        WHERE ID = @existentResultId
                         ELSE
                             INSERT INTO SelfAssessmentResults
-                              ([CandidateID]
-                              ,[SelfAssessmentID]
-                              ,[CompetencyID]
-                              ,[AssessmentQuestionID]
-                              ,[Result]
-                              ,[DateTime]
-                              ,[SupportingComments])
+                                ([CandidateID]
+                                ,[SelfAssessmentID]
+                                ,[CompetencyID]
+                                ,[AssessmentQuestionID]
+                                ,[Result]
+                                ,[DateTime]
+                                ,[SupportingComments])
                             VALUES(@candidateId, @selfAssessmentId, @competencyId, @assessmentQuestionId, @result, GETUTCDATE(), @supportingComments)
                     END",
                 new { competencyId, selfAssessmentId, candidateId, assessmentQuestionId, result, supportingComments }


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-415

### Description
1. If a SelfAssessmentResult exists for the same candidate, assessment, result, competency and question, then update it with the new comment and dateTime. 
2. If it doesn't exist, insert a new one. 
3. If there are already not one but multiple results for the same candidate, assessment, result, competency and question, then update only the most recent.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/143022472-ccf0da6d-0e6a-496f-9fcf-845fef5327bf.png)

-----
### Developer checks

For a given candidate, assessment, competency and question, I have:
- [ ] Changed the result and checked that is creating new record in table SelfAssessmentResults
- [ ] Changed the comment and checked that is updating most recent version in table SelfAssessmentResults
- [ ] Submitted multiple questions in the same form for checking combinations of the above cases
