### PR TITLE
Added new migration to increase length on self assessment tbl

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202111231427_IncreaseSelfassessmentSignOffRequestorStatementLength.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111231427_IncreaseSelfassessmentSignOffRequestorStatementLength.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202111231427)]
+    public class IncreaseSelfassessmentSignOffRequestorStatementLength : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments").AlterColumn("SignOffRequestorStatement").AsString(2000).Nullable();
+        }
+
+        public override void Down()
+        {
+            Alter.Table("SelfAssessments").AlterColumn("SignOffRequestorStatement").AsString(1000).Nullable();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202111231708_IncreaseSelfassessmentSignOffSupervisorStatementLength.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111231708_IncreaseSelfassessmentSignOffSupervisorStatementLength.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202111231708)]
+    public class IncreaseSelfassessmentSignOffSupervisorStatementLength : Migration
+    {
+        public override void Up()
+        {            
+            Alter.Table("SelfAssessments").AlterColumn("SignOffSupervisorStatement").AsString(2000).Nullable();
+        }
+
+        public override void Down()
+        {
+            Alter.Table("SelfAssessments").AlterColumn("SignOffSupervisorStatement").AsString(1000).Nullable();
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[DLSV2-424](https://hee-dls.atlassian.net/browse/DLSV2-424)

### Description
Added new migration to increase SignOffRequestorStatement and SignOffSupervisorStatement fields length from nvarchar(1000) to nvarchar(2000) on Selfassessment table

### Screenshots
![image](https://user-images.githubusercontent.com/8265687/143072708-4abe14d6-d58f-45df-81cb-cf8dfe332ead.png)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
