### PR TITLE
HEEDLS-444 Fix course name

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/ManageCourseControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/ManageCourseControllerTests.cs
@@ -430,7 +430,7 @@
             ).MustNotHaveHappened();
             result.Should().BeViewResult().ModelAs<EditCourseDetailsViewModel>();
             controller.ModelState["CustomisationName"].Errors[0].ErrorMessage.Should()
-                .BeEquivalentTo("A course with this name already exists, add on to the course name to make it unique");
+                .BeEquivalentTo("A course with no add on already exists");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/ManageCourseControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/ManageCourseControllerTests.cs
@@ -323,7 +323,7 @@
             A.CallTo(
                 () => courseService.UpdateCourseDetails(
                     1,
-                    "Name - v1",
+                    "Name",
                     "Password",
                     "hello@test.com",
                     false,
@@ -393,8 +393,44 @@
                 )
             ).MustNotHaveHappened();
             result.Should().BeViewResult().ModelAs<EditCourseDetailsViewModel>();
-            controller.ModelState["CustomisationNameSuffix"].Errors[0].ErrorMessage.Should()
+            controller.ModelState["CustomisationName"].Errors[0].ErrorMessage.Should()
                 .BeEquivalentTo("Course name must be unique, including any additions");
+        }
+
+        [Test]
+        public void
+            SaveCourseDetails_correctly_adds_model_error_if_application_already_exists_with_blank_customisation_name()
+        {
+            // Given
+            var model = GetEditCourseDetailsViewModel(customisationName: "");
+
+            A.CallTo(
+                () => courseService.DoesCourseNameExistAtCentre(
+                    A<int>._,
+                    A<string>._,
+                    A<int>._,
+                    A<int>._
+                )
+            ).Returns(true);
+
+            // When
+            var result = controller.SaveCourseDetails(1, model);
+
+            // Then
+            A.CallTo(
+                () => courseService.UpdateCourseDetails(
+                    A<int>._,
+                    A<string>._,
+                    A<string>._,
+                    A<string>._,
+                    A<bool>._,
+                    A<int>._,
+                    A<int>._
+                )
+            ).MustNotHaveHappened();
+            result.Should().BeViewResult().ModelAs<EditCourseDetailsViewModel>();
+            controller.ModelState["CustomisationName"].Errors[0].ErrorMessage.Should()
+                .BeEquivalentTo("A course with this name already exists, add on to the course name to make it unique");
         }
 
         [Test]
@@ -424,7 +460,7 @@
             A.CallTo(
                 () => courseService.UpdateCourseDetails(
                     1,
-                    "Name - v1",
+                    "Name",
                     null!,
                     null!,
                     true,
@@ -525,7 +561,6 @@
             int customisationId = 1,
             int applicationId = 1,
             string customisationName = "Name",
-            string customisationNameSuffix = "v1",
             bool passwordProtected = true,
             string password = "Password",
             bool receiveNotificationEmails = true,
@@ -541,7 +576,6 @@
             {
                 ApplicationId = applicationId,
                 CustomisationName = customisationName,
-                CustomisationNameSuffix = customisationNameSuffix,
                 PasswordProtected = passwordProtected,
                 Password = password,
                 ReceiveNotificationEmails = receiveNotificationEmails,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/ManageCourseControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/ManageCourseControllerTests.cs
@@ -306,13 +306,13 @@
 
             A.CallTo(
                 () => courseService.UpdateCourseDetails(
-                    A<int>._,
-                    A<string>._,
-                    A<string>._,
-                    A<string>._,
-                    A<bool>._,
-                    A<int>._,
-                    A<int>._
+                    1,
+                    "Name",
+                    "Password",
+                    "hello@test.com",
+                    false,
+                    75,
+                    90
                 )
             ).DoesNothing();
 
@@ -370,10 +370,10 @@
 
             A.CallTo(
                 () => courseService.DoesCourseNameExistAtCentre(
-                    A<int>._,
-                    A<string>._,
-                    A<int>._,
-                    A<int>._
+                    1,
+                    "Name",
+                    101,
+                    1
                 )
             ).Returns(true);
 
@@ -406,10 +406,10 @@
 
             A.CallTo(
                 () => courseService.DoesCourseNameExistAtCentre(
-                    A<int>._,
-                    A<string>._,
-                    A<int>._,
-                    A<int>._
+                    1,
+                    "",
+                    101,
+                    1
                 )
             ).Returns(true);
 
@@ -446,10 +446,10 @@
 
             A.CallTo(
                 () => courseService.DoesCourseNameExistAtCentre(
-                    A<int>._,
-                    A<string>._,
-                    A<int>._,
-                    A<int>._
+                    1,
+                    "Name",
+                    101,
+                    1
                 )
             ).Returns(false);
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
@@ -313,7 +313,7 @@
             {
                 ModelState.AddModelError(
                     nameof(EditCourseDetailsViewModel.CustomisationName),
-                    "A course with this name already exists, add on to the course name to make it unique"
+                    "A course with no add on already exists"
                 );
             }
             else if (customisationName.Length > 250)
@@ -323,7 +323,7 @@
                     "Course name must be 250 characters or fewer, including any additions"
                 );
             }
-            else if (customisationName != string.Empty && courseService.DoesCourseNameExistAtCentre(
+            else if (courseService.DoesCourseNameExistAtCentre(
                 customisationId,
                 customisationName,
                 centreId,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
@@ -304,32 +304,26 @@
             EditCourseDetailsFormData formData
         )
         {
-            if (customisationName == string.Empty)
+            if (customisationName == string.Empty && courseService.DoesCourseNameExistAtCentre(
+                customisationId,
+                customisationName,
+                centreId,
+                formData.ApplicationId
+            ))
             {
-                if (courseService.DoesCourseNameExistAtCentre(
-                    customisationId,
-                    "",
-                    centreId,
-                    formData.ApplicationId
-                ))
-                {
-                    ModelState.AddModelError(
-                        nameof(EditCourseDetailsViewModel.CustomisationName),
-                        "A course with this name already exists, add on to the course name to make it unique"
-                    );
-                }
-
-                return;
+                ModelState.AddModelError(
+                    nameof(EditCourseDetailsViewModel.CustomisationName),
+                    "A course with this name already exists, add on to the course name to make it unique"
+                );
             }
-
-            if (customisationName.Length > 250)
+            else if (customisationName.Length > 250)
             {
                 ModelState.AddModelError(
                     nameof(EditCourseDetailsViewModel.CustomisationName),
                     "Course name must be 250 characters or fewer, including any additions"
                 );
             }
-            else if (courseService.DoesCourseNameExistAtCentre(
+            else if (customisationName != string.Empty && courseService.DoesCourseNameExistAtCentre(
                 customisationId,
                 customisationName,
                 centreId,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/ManageCourseController.cs
@@ -202,9 +202,10 @@
         )
         {
             var centreId = User.GetCentreId();
-            var customisationNameSuffix =
-                formData.CustomisationNameSuffix == null ? "" : " - " + formData.CustomisationNameSuffix;
-            var customisationName = formData.CustomisationName + customisationNameSuffix;
+            var customisationName =
+                formData.CustomisationName == null || string.IsNullOrWhiteSpace(formData.CustomisationName)
+                    ? string.Empty
+                    : formData.CustomisationName;
 
             ValidateCustomisationName(customisationId, customisationName, centreId, formData);
             ValidatePassword(formData);
@@ -303,10 +304,28 @@
             EditCourseDetailsFormData formData
         )
         {
+            if (customisationName == string.Empty)
+            {
+                if (courseService.DoesCourseNameExistAtCentre(
+                    customisationId,
+                    "",
+                    centreId,
+                    formData.ApplicationId
+                ))
+                {
+                    ModelState.AddModelError(
+                        nameof(EditCourseDetailsViewModel.CustomisationName),
+                        "A course with this name already exists, add on to the course name to make it unique"
+                    );
+                }
+
+                return;
+            }
+
             if (customisationName.Length > 250)
             {
                 ModelState.AddModelError(
-                    nameof(EditCourseDetailsViewModel.CustomisationNameSuffix),
+                    nameof(EditCourseDetailsViewModel.CustomisationName),
                     "Course name must be 250 characters or fewer, including any additions"
                 );
             }
@@ -317,13 +336,9 @@
                 formData.ApplicationId
             ))
             {
-                var uniqueNameErrorMessage = string.IsNullOrWhiteSpace(formData.CustomisationNameSuffix)
-                    ? "A course with this name already exists, add on to the course name to make it unique"
-                    : "Course name must be unique, including any additions";
-
                 ModelState.AddModelError(
-                    nameof(EditCourseDetailsViewModel.CustomisationNameSuffix),
-                    uniqueNameErrorMessage
+                    nameof(EditCourseDetailsViewModel.CustomisationName),
+                    "Course name must be unique, including any additions"
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseDetails/EditCourseDetailsFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseDetails/EditCourseDetailsFormData.cs
@@ -12,8 +12,8 @@
         protected EditCourseDetailsFormData(EditCourseDetailsFormData formData)
         {
             ApplicationId = formData.ApplicationId;
+            ApplicationName = formData.ApplicationName;
             CustomisationName = formData.CustomisationName;
-            CustomisationNameSuffix = formData.CustomisationNameSuffix;
             PasswordProtected = formData.PasswordProtected;
             Password = formData.Password;
             ReceiveNotificationEmails = formData.ReceiveNotificationEmails;
@@ -28,8 +28,8 @@
         protected EditCourseDetailsFormData(CourseDetails courseDetails)
         {
             ApplicationId = courseDetails.ApplicationId;
-            CustomisationName = GetPartOfCustomisationName(courseDetails.CustomisationName, 0)!;
-            CustomisationNameSuffix = GetPartOfCustomisationName(courseDetails.CustomisationName, 1);
+            ApplicationName = courseDetails.ApplicationName;
+            CustomisationName = courseDetails.CustomisationName;
             PasswordProtected = !string.IsNullOrEmpty(courseDetails.Password);
             Password = courseDetails.Password;
             ReceiveNotificationEmails = !string.IsNullOrEmpty(courseDetails.NotificationEmails);
@@ -43,9 +43,9 @@
 
         public int ApplicationId { get; set; }
 
-        public string CustomisationName { get; set; }
+        public string ApplicationName { get; set; }
 
-        public string? CustomisationNameSuffix { get; set; }
+        public string? CustomisationName { get; set; }
 
         public bool PasswordProtected { get; set; }
 
@@ -72,15 +72,5 @@
 
         [WholeNumberWithinInclusiveRange(0, 100, "Enter a whole number from 0 to 100")]
         public string? DiagCompletionThreshold { get; set; }
-
-        private static string? GetPartOfCustomisationName(string customisationName, int index)
-        {
-            if (customisationName.Contains(" - "))
-            {
-                return customisationName.Split(" - ")[index];
-            }
-
-            return index == 0 ? customisationName : null;
-        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/EditCourseDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/EditCourseDetails.cshtml
@@ -20,7 +20,7 @@
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred) {
       <vc:error-summary order-of-property-names="@(new[] {
-                                                   nameof(Model.CustomisationNameSuffix),
+                                                   nameof(Model.CustomisationName),
                                                    nameof(Model.Password),
                                                    nameof(Model.NotificationEmails),
                                                    nameof(Model.TutCompletionThreshold),
@@ -37,22 +37,22 @@
           asp-route-customisationId="@Model.CustomisationId">
 
       <input type="hidden" asp-for="ApplicationId" />
-      <input type="hidden" asp-for="CustomisationName" />
+      <input type="hidden" asp-for="ApplicationName" />
       <input type="hidden" asp-for="PostLearningAssessment" />
       <input type="hidden" asp-for="DiagAssess" />
 
       <div class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
 
-        <div class="nhsuk-grid-column-one-quarter nhsuk-heading-s word-break">
+        <div class="nhsuk-grid-column-one-half nhsuk-heading-s word-break">
           <label class="nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">
             Course name
           </label>
           <div class="nhsuk-u-margin-top-1">
-            @Model.CustomisationName -
+            @Model.ApplicationName -
           </div>
         </div>
         <div class="nhsuk-grid-column-one-half nhsuk-u-margin-top-1">
-          <vc:text-input asp-for="@nameof(Model.CustomisationNameSuffix)"
+          <vc:text-input asp-for="@nameof(Model.CustomisationName)"
                          id="CustomisationNameSuffix"
                          label="Add on to course name (optional)"
                          populate-with-current-value="true"


### PR DESCRIPTION
### JIRA link
[_HEEDLS-444_](https://softwiretech.atlassian.net/browse/HEEDLS-444)

### Description
Sorted out some confusion I had about course names - the Application name is now displayed under course name, and the editable box edits the Customisation name as it should be.

### Screenshots
The only UI change is that I shifted the course name input box over because the Application names tend to be long, and usually split onto a second line with a smaller width to the column
![localhost_5001_TrackingSystem_CourseSetup_24224_Manage_CourseDetails (1)](https://user-images.githubusercontent.com/70278044/143213594-a87f2b26-8989-4604-88b7-e2decb685623.png)

This is the previous column width. I thought this looked a bit weird, but shout if you prefer it:
![localhost_5001_TrackingSystem_CourseSetup_24286_Manage_CourseDetails (1)](https://user-images.githubusercontent.com/70278044/143213614-5a96fcc4-0229-4e7d-a0f6-7918ffad6d55.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
