### PR TITLE
DLSV2-411 Add "Manage competency resource signposting" link to compet…

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Frameworks/FrameworkCompetency.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/FrameworkCompetency.cs
@@ -11,5 +11,6 @@
         public string? Description { get; set; }
         public int Ordering { get; set; }
         public int AssessmentQuestions { get; set; }
+        public int CompetencyLearningResourcesCount { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -554,6 +554,7 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
         {
             var result = connection.Query<FrameworkCompetencyGroup, FrameworkCompetency, FrameworkCompetencyGroup>(
                 @"SELECT fcg.ID, fcg.CompetencyGroupID, cg.Name, fcg.Ordering, fc.ID, c.ID AS CompetencyID, c.Name, c.Description, fc.Ordering, COUNT(caq.AssessmentQuestionID) AS AssessmentQuestions
+                    ,(SELECT COUNT(*) FROM CompetencyLearningResources clr WHERE clr.CompetencyID = c.ID) AS CompetencyLearningResourcesCount
                     FROM   FrameworkCompetencyGroups AS fcg INNER JOIN
                       CompetencyGroups AS cg ON fcg.CompetencyGroupID = cg.ID LEFT OUTER JOIN
                        FrameworkCompetencies AS fc ON fcg.ID = fc.FrameworkCompetencyGroupID LEFT OUTER JOIN

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CompetencyCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CompetencyCard.cshtml
@@ -24,6 +24,13 @@
         <a asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-frameworkCompetencyId="@Model.FrameworkCompetency.Id">
           Manage assessment questions (@(Model.FrameworkCompetency.AssessmentQuestions == 0 ? "None" : Model.FrameworkCompetency.AssessmentQuestions.ToString()) assigned)
         </a>
+        <br />
+        <a asp-controller="ManageResources" asp-action="EditCompetencyLearningResources"
+           asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])"
+           asp-route-frameworkCompetencyGrouypId="@(Model.FrameworkCompetencyGroupId)"
+           asp-route-frameworkCompetencyId="@(Model.FrameworkCompetency.CompetencyID)" >
+          Manage resource signposting (@(Model.FrameworkCompetency.CompetencyLearningResourcesCount == 0 ? "No" : Model.FrameworkCompetency.CompetencyLearningResourcesCount.ToString()) resources)
+        </a>
       }
       else
       {

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CompetencyCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CompetencyCard.cshtml
@@ -27,7 +27,7 @@
         <br />
         <a asp-controller="ManageResources" asp-action="EditCompetencyLearningResources"
            asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])"
-           asp-route-frameworkCompetencyGrouypId="@(Model.FrameworkCompetencyGroupId)"
+           asp-route-frameworkCompetencyGroupId="@(Model.FrameworkCompetencyGroupId)"
            asp-route-frameworkCompetencyId="@(Model.FrameworkCompetency.CompetencyID)" >
           Manage resource signposting (@(Model.FrameworkCompetency.CompetencyLearningResourcesCount == 0 ? "No" : Model.FrameworkCompetency.CompetencyLearningResourcesCount.ToString()) resources)
         </a>


### PR DESCRIPTION
…ency card.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-411

### Description
Added a link in Frameworks/Structure/Digital Capability Framework for managing learning resources (_CompetencyCard.cshtml).

### Screenshots

![image](https://user-images.githubusercontent.com/94055251/143255461-e928a08e-4c69-4a66-91fb-af2d798a905f.png)

-----
### Developer checks

I have inserted a number of records into table CompetencyLearningResources for testing purposes.
```
INSERT INTO [dbo].[CompetencyLearningResources] ([CompetencyID],[AdminID]) VALUES (1,1)
INSERT INTO [dbo].[CompetencyLearningResources] ([CompetencyID],[AdminID]) VALUES (2,1)
INSERT INTO [dbo].[CompetencyLearningResources] ([CompetencyID],[AdminID]) VALUES (2,1)
INSERT INTO [dbo].[CompetencyLearningResources] ([CompetencyID],[AdminID]) VALUES (3,1)
```
Checked that this is consistent with the resource counts shown on partial view _CompetencyCard.cshtml

1. Clicked on to Switch application
2. Frameworks
3. Manage My Frameworks
4. View/Edit
5. Expand one capability group.

As you hover over the resource links, competency ids can be seen on target url.