### PR TITLE
HEEDLS-684 add prn and hasBeenPromptedForPrn to candidates table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202111241539_AddPrnToCandidateTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111241539_AddPrnToCandidateTable.cs
@@ -1,10 +1,10 @@
 namespace DigitalLearningSolutions.Data.Migrations
 {
     using FluentMigrator;
+
     [Migration(202111241539)]
-
-    public class AddPrnToCandidateTable: Migration {
-
+    public class AddPrnToCandidateTable : Migration
+    {
         public override void Up()
         {
             Alter.Table("Candidates")

--- a/DigitalLearningSolutions.Data.Migrations/202111241539_AddPrnToCandidateTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111241539_AddPrnToCandidateTable.cs
@@ -1,0 +1,22 @@
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202111241539)]
+
+    public class AddPrnToCandidateTable: Migration {
+
+        public override void Up()
+        {
+            Alter.Table("Candidates")
+                .AddColumn("HasBeenPromptedForPrn").AsBoolean().NotNullable().WithDefaultValue(false)
+                .AddColumn("ProfessionalRegistrationNumber").AsString(32).Nullable();
+        }
+
+        public override void Down()
+        {
+            Alter.Table("Candidates")
+                .AddColumn("HasBeenPromptedForPrn").AsBoolean().NotNullable().WithDefault(0)
+                .AddColumn("ProfessionalRegistrationNumber").AsString(32).Nullable();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202111241539_AddPrnToCandidateTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111241539_AddPrnToCandidateTable.cs
@@ -14,9 +14,8 @@ namespace DigitalLearningSolutions.Data.Migrations
 
         public override void Down()
         {
-            Alter.Table("Candidates")
-                .AddColumn("HasBeenPromptedForPrn").AsBoolean().NotNullable().WithDefault(0)
-                .AddColumn("ProfessionalRegistrationNumber").AsString(32).Nullable();
+            Delete.Column("HasBeenPromptedForPrn").FromTable("Candidates");
+            Delete.Column("ProfessionalRegistrationNumber").FromTable("Candidates");
         }
     }
 }


### PR DESCRIPTION
### JIRA link
_HEEDLS-684_

### Description
Add a migration to add ProfessionalRegistrationNumber and HasBeenPromptedForPrn to the candidates table

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
