### PR TITLE
Heedls 595 course delegates unlock course

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -53,7 +53,8 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             "xxxx",
             "xxxxxx",
             "",
-            101
+            101,
+            false
         );
 
         private SqlConnection connection = null!;

--- a/DigitalLearningSolutions.Data.Tests/DataServices/ProgressDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ProgressDataServiceTests.cs
@@ -14,8 +14,8 @@
     {
         private SqlConnection connection = null!;
         private ProgressDataService progressDataService = null!;
-        private TutorialContentTestHelper tutorialContentTestHelper = null!;
         private ProgressTestHelper progressTestHelper = null!;
+        private TutorialContentTestHelper tutorialContentTestHelper = null!;
 
         [SetUp]
         public void SetUp()
@@ -240,6 +240,30 @@
 
                 // Then
                 result.Should().BeNull();
+            }
+            finally
+            {
+                transaction.Dispose();
+            }
+        }
+
+        [Test]
+        public void UnlockCourseProgress_updates_progress_record()
+        {
+            // Given
+            const int progressId = 280244;
+            var statusBeforeUnlock = progressTestHelper.GetCourseProgressLockedStatusByProgressId(progressId);
+
+            using var transaction = new TransactionScope();
+            try
+            {
+                // When
+                progressDataService.UnlockProgress(progressId);
+                var statusAfterUnlocked = progressTestHelper.GetCourseProgressLockedStatusByProgressId(progressId);
+
+                // Then
+                statusBeforeUnlock.Should().BeTrue();
+                statusAfterUnlocked.Should().BeFalse();
             }
             finally
             {

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/ProgressTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/ProgressTestHelper.cs
@@ -33,7 +33,7 @@
                 Completed = completed,
                 RemovedDate = removedDate,
                 SupervisorAdminId = supervisorAdminId,
-                CompleteByDate = completeByDate
+                CompleteByDate = completeByDate,
             };
         }
 
@@ -44,6 +44,16 @@
                     FROM aspProgress
                     WHERE aspProgressId = @aspProgressId",
                 new { aspProgressId }
+            ).Single();
+        }
+
+        public bool GetCourseProgressLockedStatusByProgressId(int progressId)
+        {
+            return connection.Query<bool>(
+                @"SELECT PLLocked 
+                    FROM Progress
+                    WHERE ProgressId = @ProgressId",
+                new { progressId }
             ).Single();
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -126,6 +126,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                 pr.Answer1,
                 pr.Answer2,
                 pr.Answer3,
+                pr.PLLocked as IsProgressLocked,
                 ca.CandidateID AS DelegateId,
                 ca.FirstName AS DelegateFirstName,
                 ca.LastName AS DelegateLastName,

--- a/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
@@ -50,6 +50,7 @@
                         p.CompleteByDate AS CompleteBy,
                         p.RemovedDate,
                         p.Completed,
+                        p.CustomisationId,
                         {allAttemptsQuery},
                         {attemptsPassedQuery}
                     FROM Candidates AS c

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -25,7 +25,7 @@
         void CreateNewAspProgress(int tutorialId, int progressId);
         void InsertNewAspProgressRecordsForTutorialIfNoneExist(int tutorialId, int customisationId);
         void ClearAspProgressVerificationRequest(int progressId);
-        void UnlockProgress(int progressId, int delegateId);
+        void UnlockProgress(int progressId);
     }
 
     public class ProgressDataService : IProgressDataService
@@ -163,14 +163,13 @@
             );
         }
 
-        public void UnlockProgress(int progressId, int delegateId)
+        public void UnlockProgress(int progressId)
         {
             connection.Execute(
                 @"UPDATE Progress SET
                         PLLocked = 0
-                    WHERE ProgressID = @progressId
-                        AND CandidateID = @delegateId",
-                new { progressId, delegateId }
+                    WHERE ProgressID = @progressId",
+                new { progressId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -25,6 +25,7 @@
         void CreateNewAspProgress(int tutorialId, int progressId);
         void InsertNewAspProgressRecordsForTutorialIfNoneExist(int tutorialId, int customisationId);
         void ClearAspProgressVerificationRequest(int progressId);
+        void UnlockProgress(int progressId, int delegateId);
     }
 
     public class ProgressDataService : IProgressDataService
@@ -159,6 +160,17 @@
                         SupervisorVerificationRequested = NULL
                     WHERE ProgressID = @progressId",
                 new { progressId }
+            );
+        }
+
+        public void UnlockProgress(int progressId, int delegateId)
+        {
+            connection.Execute(
+                @"UPDATE Progress SET
+                        PLLocked = 0
+                    WHERE ProgressID = @progressId
+                        AND CandidateID = @delegateId",
+                new { progressId, delegateId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegate.cs
@@ -19,6 +19,7 @@
         public DateTime? Completed { get; set; }
         public int AllAttempts { get; set; }
         public int AttemptsPassed { get; set; }
+        public int CustomisationId { get; set; }
 
         public string FullName => (string.IsNullOrEmpty(FirstName) ? "" : $"{FirstName} ") + LastName;
 

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -39,7 +39,8 @@
             string? delegateFirstName,
             string delegateLastName,
             string? delegateEmail,
-            int delegateCentreId
+            int delegateCentreId,
+            bool isProgressLocked
         )
         {
             ProgressId = progressId;
@@ -75,6 +76,7 @@
             DelegateLastName = delegateLastName;
             DelegateEmail = delegateEmail;
             DelegateCentreId = delegateCentreId;
+            IsProgressLocked = isProgressLocked;
         }
 
         public int ProgressId { get; set; }
@@ -108,5 +110,6 @@
         public string DelegateLastName { get; set; }
         public string? DelegateEmail { get; set; }
         public int DelegateCentreId { get; set; }
+        public bool IsProgressLocked { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Data/Services/ProgressService.cs
@@ -8,7 +8,7 @@
     {
         void UpdateSupervisor(int progressId, int? newSupervisorId);
 
-        void UnlockProgress(int progressId, int delegateId);
+        void UnlockProgress(int progressId);
     }
 
     public class ProgressService : IProgressService
@@ -51,9 +51,9 @@
             transaction.Complete();
         }
 
-        public void UnlockProgress(int progressId, int delegateId)
+        public void UnlockProgress(int progressId)
         {
-            progressDataService.UnlockProgress(progressId, delegateId);
+            progressDataService.UnlockProgress(progressId);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Data/Services/ProgressService.cs
@@ -7,6 +7,8 @@
     public interface IProgressService
     {
         void UpdateSupervisor(int progressId, int? newSupervisorId);
+
+        void UnlockProgress(int progressId, int delegateId);
     }
 
     public class ProgressService : IProgressService
@@ -47,6 +49,11 @@
             progressDataService.ClearAspProgressVerificationRequest(progressId);
 
             transaction.Complete();
+        }
+
+        public void UnlockProgress(int progressId, int delegateId)
+        {
+            progressDataService.UnlockProgress(progressId, delegateId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
@@ -14,6 +14,7 @@
     {
         private ICourseService courseService = null!;
         private DelegateProgressController delegateProgressController = null!;
+        private INotificationService notificationService = null;
         private IProgressService progressService = null!;
         private IUserService userService = null!;
 
@@ -30,13 +31,32 @@
             }
         }
 
+        private static IEnumerable<TestCaseData> UnlockCourseProgressData
+        {
+            get
+            {
+                yield return new TestCaseData(DelegateProgressAccessRoute.CourseDelegates, "CourseDelegates", "Index")
+                    .SetName("UnlockCourseProgress_redirects_to_course_delegates_progress");
+                yield return
+                    new TestCaseData(DelegateProgressAccessRoute.ViewDelegate, "ViewDelegate", "Index").SetName(
+                        "UnlockCourseProgress_redirects_to_view_delegate"
+                    );
+            }
+        }
+
         [SetUp]
         public void Setup()
         {
             courseService = A.Fake<ICourseService>();
             userService = A.Fake<IUserService>();
             progressService = A.Fake<IProgressService>();
-            delegateProgressController = new DelegateProgressController(courseService, userService, progressService)
+            notificationService = A.Fake<INotificationService>();
+            delegateProgressController = new DelegateProgressController(
+                    courseService,
+                    userService,
+                    progressService,
+                    notificationService
+                )
                 .WithDefaultContext()
                 .WithMockUser(true);
         }
@@ -62,6 +82,41 @@
             var result = delegateProgressController.EditSupervisor(formData, progressId, accessedVia);
 
             // Then
+            result.Should().BeRedirectToActionResult().WithControllerName(expectedController)
+                .WithActionName(expectedAction);
+        }
+
+        [Test]
+        [TestCaseSource(
+            typeof(DelegateProgressControllerTests),
+            nameof(UnlockCourseProgressData)
+        )]
+        public void UnlockCourseProgress_redirects_to_correct_action_and_unlocks_progress_and_sends_notification(
+            DelegateProgressAccessRoute accessedVia,
+            string expectedController,
+            string expectedAction
+        )
+        {
+            // Given
+            const int progressId = 1;
+            const int delegateId = 1;
+            const int customisationId = 1;
+
+            A.CallTo(() => progressService.UnlockProgress(progressId)).DoesNothing();
+            A.CallTo(() => notificationService.SendUnlockRequest(progressId)).DoesNothing();
+
+            // When
+            var result = delegateProgressController.UnlockProgress(
+                progressId,
+                customisationId,
+                delegateId,
+                accessedVia
+            );
+
+            // Then
+            A.CallTo(() => progressService.UnlockProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => notificationService.SendUnlockRequest(progressId)).MustHaveHappened();
+
             result.Should().BeRedirectToActionResult().WithControllerName(expectedController)
                 .WithActionName(expectedAction);
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -22,18 +22,21 @@
     public class DelegateProgressController : Controller
     {
         private readonly ICourseService courseService;
+        private readonly INotificationService notificationService;
         private readonly IProgressService progressService;
         private readonly IUserService userService;
 
         public DelegateProgressController(
             ICourseService courseService,
             IUserService userService,
-            IProgressService progressService
+            IProgressService progressService,
+            INotificationService notificationService
         )
         {
             this.courseService = courseService;
             this.userService = userService;
             this.progressService = progressService;
+            this.notificationService = notificationService;
         }
 
         public IActionResult Index(int progressId, DelegateProgressAccessRoute accessedVia)
@@ -92,18 +95,21 @@
             return RedirectToAction("Index", "ViewDelegate", new { formData.DelegateId });
         }
 
-        [HttpPost]
-        [Route("/UnlockProgress/{delegateId:int}")]
+        [HttpGet]
+        [Route("UnlockProgress")]
         public IActionResult UnlockProgress(
             int progressId,
+            int customisationId,
             int delegateId,
-            DelegateProgressAccessRoute accessedVia)
+            DelegateProgressAccessRoute accessedVia
+        )
         {
-            progressService.UnlockProgress(progressId, delegateId);
+            progressService.UnlockProgress(progressId);
+            notificationService.SendUnlockRequest(progressId);
 
             if (accessedVia.Equals(DelegateProgressAccessRoute.CourseDelegates))
             {
-                return RedirectToAction("Index", new { progressId, accessedVia });
+                return RedirectToAction("Index", "CourseDelegates", new { customisationId });
             }
 
             return RedirectToAction("Index", "ViewDelegate", new { delegateId });

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -91,5 +91,22 @@
 
             return RedirectToAction("Index", "ViewDelegate", new { formData.DelegateId });
         }
+
+        [HttpPost]
+        [Route("/UnlockProgress/{delegateId:int}")]
+        public IActionResult UnlockProgress(
+            int progressId,
+            int delegateId,
+            DelegateProgressAccessRoute accessedVia)
+        {
+            progressService.UnlockProgress(progressId, delegateId);
+
+            if (accessedVia.Equals(DelegateProgressAccessRoute.CourseDelegates))
+            {
+                return RedirectToAction("Index", new { progressId, accessedVia });
+            }
+
+            return RedirectToAction("Index", "ViewDelegate", new { delegateId });
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SearchableCourseDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SearchableCourseDelegateViewModel.cs
@@ -19,6 +19,7 @@
             CompleteBy = courseDelegate.CompleteBy?.ToString(DateHelper.StandardDateAndTimeFormat);
             Completed = courseDelegate.Completed?.ToString(DateHelper.StandardDateAndTimeFormat);
             RemovedDate = courseDelegate.RemovedDate?.ToString(DateHelper.StandardDateAndTimeFormat);
+            CustomisationId = courseDelegate.CustomisationId;
             PassRate = courseDelegate.PassRate;
             Tags = FilterableTagHelper.GetCurrentTagsForCourseDelegate(courseDelegate);
         }
@@ -35,5 +36,6 @@
         public string? Completed { get; set; }
         public string? RemovedDate { get; set; }
         public double PassRate { get; set; }
+        public int CustomisationId { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/DelegateCourseInfoViewModel.cs
@@ -21,6 +21,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.ViewD
             CompleteBy = info.CompleteBy?.ToString(DateHelper.StandardDateFormat);
             Completed = info.Completed?.ToString(DateHelper.StandardDateFormat);
             Evaluated = info.Evaluated?.ToString(DateHelper.StandardDateFormat);
+            IsProgressLocked = info.IsProgressLocked;
             EnrolmentMethod = info.EnrolmentMethodId switch
             {
                 1 => "Self enrolled",
@@ -64,6 +65,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.ViewD
         public int TotalAttempts { get; set; }
         public int AttemptsPassed { get; set; }
         public double PassRate { get; set; }
+        public bool IsProgressLocked { get; set; }
 
         public string? Supervisor
         {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -64,6 +64,14 @@
             @Model.PassRate%
           </dd>
         </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+            Progress locked
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+            @(Model.Locked? "Yes": "No")
+          </dd>
+        </div>
       </dl>
 
       <a class="nhsuk-button expander-card__button"
@@ -74,17 +82,17 @@
          asp-route-accessedVia="@DelegateProgressAccessRoute.CourseDelegates">
         View progress
       </a>
-      @*@if (Model.Locked) {*@
+      @if (Model.Locked) {
         <a class="nhsuk-button nhsuk-button--secondary expander-card__button"
            role="button"
            asp-controller="DelegateProgress"
            asp-action="UnlockProgress"
            asp-route-progressId="@Model.ProgressId"
-           asp-route-delegateId="@Model.DelegateId"
+           asp-route-customisationId="@Model.CustomisationId"
            asp-route-accessedVia="@DelegateProgressAccessRoute.CourseDelegates">
           Unlock progress
         </a>
-      @*}*@
+      }
       @if (Model.RemovedDate == null) {
         <a class="nhsuk-button delete-button expander-card__button" role="button">
           Remove from course

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -74,11 +74,17 @@
          asp-route-accessedVia="@DelegateProgressAccessRoute.CourseDelegates">
         View progress
       </a>
-      @if (Model.Locked) {
-        <a class="nhsuk-button nhsuk-button--secondary expander-card__button" role="button">
+      @*@if (Model.Locked) {*@
+        <a class="nhsuk-button nhsuk-button--secondary expander-card__button"
+           role="button"
+           asp-controller="DelegateProgress"
+           asp-action="UnlockProgress"
+           asp-route-progressId="@Model.ProgressId"
+           asp-route-delegateId="@Model.DelegateId"
+           asp-route-accessedVia="@DelegateProgressAccessRoute.CourseDelegates">
           Unlock progress
         </a>
-      }
+      @*}*@
       @if (Model.RemovedDate == null) {
         <a class="nhsuk-button delete-button expander-card__button" role="button">
           Remove from course

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
@@ -105,6 +105,15 @@
           <dd class="nhsuk-summary-list__actions"></dd>
         </div>
 
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+            Progress locked
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+            @(Model.IsProgressLocked ? "Yes" : "No")
+          </dd>
+        </div>
+
         @if (Model.IsAssessed) {
           <div class="nhsuk-summary-list__row details-list-with-button__row">
             <dt class="nhsuk-summary-list__key">
@@ -150,13 +159,24 @@
         View progress
       </a>
       <a class="nhsuk-button nhsuk-button--secondary" role="button">See learning log</a>
-      <a
-        class="nhsuk-button delete-button"
-        role="button"
-        asp-controller="ViewDelegate"
-        asp-action="ConfirmRemoveFromCourse"
-        asp-route-delegateId="@Model.DelegateId"
-        asp-route-customisationId="@Model.CustomisationId">
+
+      @if (Model.IsProgressLocked) {
+        <a class="nhsuk-button nhsuk-button--secondary"
+           role="button"
+           asp-controller="DelegateProgress"
+           asp-route-progressId="@Model.ProgressId"
+           asp-route-delegateId="@Model.DelegateId"
+           asp-action="UnlockProgress"
+           asp-route-accessedVia="@DelegateProgressAccessRoute.ViewDelegate">
+          Unlock progress
+        </a>
+      }
+      <a class="nhsuk-button delete-button"
+         role="button"
+         asp-controller="ViewDelegate"
+         asp-action="ConfirmRemoveFromCourse"
+         asp-route-delegateId="@Model.DelegateId"
+         asp-route-customisationId="@Model.CustomisationId">
         Remove
       </a>
     </div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-595

### Description
1. Added new action method in DelegateProgressConroller to unlock the course progress
2. When "Unlock progress" is clicked, it will update PLLocked to 0 and refresh the page
3. The "Unlock progress" button is available in different two pages - Course course card available in Course delegates page and View Delegate> Manage delegate 

### Screenshots
![image](https://user-images.githubusercontent.com/90783892/143400898-5b37b972-cad5-46e6-996b-4bcfadacb7c2.png)
![image](https://user-images.githubusercontent.com/90783892/143401067-00891aa9-0336-489f-b0a2-bd9d4f6f9f21.png)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
