### PR TITLE
HEEDLS-512 Reduce margin between title and group name

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/ConfirmDeleteGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/ConfirmDeleteGroup.cshtml
@@ -16,11 +16,11 @@
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Confirm), nameof(Model.DeleteEnrolments) })" />
     }
 
-    <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-8">Delete delegate group</h1>
+    <h1 class="nhsuk-heading-xl">Delete delegate group</h1>
   </div>
 </div>
 
-<div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row nhsuk-u-margin-bottom-8">
   <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l nhsuk-u-font-weight-bold">
     Group name:
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/ConfirmDeleteGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/ConfirmDeleteGroup.cshtml
@@ -20,7 +20,7 @@
   </div>
 </div>
 
-<div class="nhsuk-grid-row nhsuk-u-margin-bottom-8">
+<div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l nhsuk-u-font-weight-bold">
     Group name:
   </div>


### PR DESCRIPTION
…and increase margin between group name and body on delete group confirmation page

### JIRA link
[HEEDLS-512](https://softwiretech.atlassian.net/browse/HEEDLS-512)

### Description
Fixed the issue raised in testing where, on the delete group confirmation page, there was a large margin between the title and the group name and not much of one below the group name. I have increased the margin below the group name, but most of the margin below the title came from the `nhsuk-heading-xl` class which I don't want to remove or mess with, so that margin hasn't decreased by much. See the screenshots (and compare to the one on the ticket) for details.

### Screenshots
Desktop:
![image](https://user-images.githubusercontent.com/30173746/143479500-efeac71d-7bae-4fd0-8fe1-52a1edeb052b.png)
Tablet:
![image](https://user-images.githubusercontent.com/30173746/143479555-384521ff-787e-426a-bbb7-1df5805947f5.png)
Mobile:
![image](https://user-images.githubusercontent.com/30173746/143479593-55071311-0b18-4d2b-9ebc-42bcdb8b981e.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
