### PR TITLE
DLSV2-428 Update supervisor interface to bring into line with DLSV2-409

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
@@ -21,5 +21,6 @@
         public string? RoleProfile { get; set; }
         public int SignOffRequested { get; set; }
         public int ResultsVerificationRequests { get; set; }
+        public bool IsSupervisorResultsReviewed { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -317,7 +317,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
         public DelegateSelfAssessment GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId)
         {
             return connection.Query<DelegateSelfAssessment>(
-                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup,
+                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup, sa.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -139,7 +139,8 @@
             {
                 SupervisorDelegateDetail = superviseDelegate,
                 DelegateSelfAssessment = delegateSelfAssessment,
-                CompetencyGroups = reviewedCompetencies.GroupBy(competency => competency.CompetencyGroup)
+                CompetencyGroups = reviewedCompetencies.GroupBy(competency => competency.CompetencyGroup),
+                IsSupervisorResultsReviewed = delegateSelfAssessment.IsSupervisorResultsReviewed
             };
             if (superviseDelegate.CandidateID != null)
             {

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
@@ -12,6 +12,7 @@
         public DelegateSelfAssessment DelegateSelfAssessment { get; set; }
         public IEnumerable<IGrouping<string, Competency>> CompetencyGroups { get; set; }
         public IEnumerable<SupervisorSignOff>? SupervisorSignOffs { get; set; }
+        public bool IsSupervisorResultsReviewed { get; set; }
 
         public string VocabPlural(string vocabulary)
         {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -68,11 +68,14 @@
             Question
           </th>
           <th role="columnheader" class="" scope="col">
-            Learner<br />Response
+            Self-assessment
           </th>
-          <th role="columnheader" class="" scope="col">
-            Status
-          </th>
+          @if (Model.IsSupervisorResultsReviewed)
+          {
+            <th role="columnheader" class="" scope="col">
+              Verification status
+            </th>
+          }
           <th role="columnheader" class="" scope="col">
             Actions
           </th>
@@ -85,12 +88,16 @@
             <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
               <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
             </td>
-            <partial name="Shared/_AssessmentQuestionReviewCells" model="competency.AssessmentQuestions.First()" />
+            <partial name="Shared/_AssessmentQuestionReviewCells"
+                     model="competency.AssessmentQuestions.First()"
+                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }})" />
           </tr>
           @foreach (var question in competency.AssessmentQuestions.Skip(1))
           {
             <tr role="row" class="nhsuk-table__row">
-              <partial name="Shared/_AssessmentQuestionReviewCells" model="question" />
+              <partial name="Shared/_AssessmentQuestionReviewCells"
+                       model="question"
+                       view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }})"/>
             </tr>
           }
         }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
@@ -3,9 +3,9 @@
 
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Questions </span>
-    @Model.Question
-  </td>
+  @Model.Question
+</td>
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-  <span class="nhsuk-table-responsive__heading">Learner response </span>
+  <span class="nhsuk-table-responsive__heading">Self-assessment </span>
   <partial name="Shared/_AssessmentQuestionResponse" model="Model" />
 </td>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionReviewCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionReviewCells.cshtml
@@ -1,12 +1,15 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
-@model AssessmentQuestion 
+@model AssessmentQuestion
 
 
 <partial name="Shared/_AssessmentQuestionCells" model="Model" />
-<td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-  <span class="nhsuk-table-responsive__heading">Questions </span>
-  <partial name="Shared/_AssessmentQuestionStatusTag" model="Model" />
-</td>
+@if ((bool)(ViewData["isSupervisorResultsReviewed"] ?? true))
+{
+  <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+    <span class="nhsuk-table-responsive__heading">Questions </span>
+    <partial name="Shared/_AssessmentQuestionStatusTag" model="Model" />
+  </td>
+}
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   @if (Model.ResultId != null)
   {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionStatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionStatusTag.cshtml
@@ -2,51 +2,38 @@
 @model AssessmentQuestion
 <span class="status-tag">
 
-  @if (Model.SelfAssessmentResultSupervisorVerificationId == null)
+  @if (Model.SelfAssessmentResultSupervisorVerificationId != null)
   {
-
-    if (Model.Result != null)
+    if (Model.Verified != null)
     {
-      <span class="nhsuk-tag nhsuk-tag status-tag">
-        In progress
-      </span>
+      if ((bool)Model.SignedOff)
+      {
+        <span class="nhsuk-tag nhsuk-tag--green status-tag">
+          Verified
+        </span>
+      }
+      else
+      {
+        <span class="nhsuk-tag nhsuk-tag--red status-tag">
+          Rejected
+        </span>
+      }
     }
     else
     {
-      <span class="nhsuk-tag nhsuk-tag--grey status-tag">
-        Not started
-      </span>
-    }
-  }
-  else if (Model.Verified != null)
-  {
-    if ((bool)Model.SignedOff)
-    {
-      <span class="nhsuk-tag nhsuk-tag--green status-tag">
-        Verified
-      </span>
-    }
-    else
-    {
-      <span class="nhsuk-tag nhsuk-tag--red status-tag">
-        Rejected
-      </span>
-    }
-  }
-  else
-  {
-    if ((bool)Model.UserIsVerifier)
-    {
-      <span class="nhsuk-tag nhsuk-tag--orange status-tag">
-        Verification requested
-      </span>
-    }
-    else
-    {
-      <span class="nhsuk-tag nhsuk-tag--yellow status-tag">
-        Pending verification
-      </span>
+      if ((bool)Model.UserIsVerifier)
+      {
+        <span class="nhsuk-tag nhsuk-tag--orange status-tag">
+          Verification requested
+        </span>
+      }
+      else
+      {
+        <span class="nhsuk-tag nhsuk-tag--yellow status-tag">
+          Pending verification
+        </span>
+      }
     }
   }
 
-</span>
+  </span>


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-428

### Description
Apply same changes requested in [DLSV2-409](https://hee-dls.atlassian.net/browse/DLSV2-409) to Supervisor / Review SelfAssessment.

### Screenshots
Verification status displaying blank rather than in progress or not started. Learner response renamed as Self-assessment and status renamed as verification status.

![image](https://user-images.githubusercontent.com/94055251/143608636-1661fdfb-3d93-48f7-9a22-0dc1811d139d.png)

-----
### Developer checks
Check that:

- Changes in LearningPortal/Self Assessment/Overview view are now available in **Supervisor/ReviewSelfAssessment** view.
- Change the value of SupervisorResultsReview in SelfAssessment database table and verify that the column "Verfication status" on the view is visible for True and hidden for False. 

