### PR TITLE
DLSV2-431 Tweak to allow html in sign-off declarations

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
@@ -44,9 +44,9 @@
       </nhs-form-group>
       <nhs-form-group nhs-validation-for="StatementChecked">
         <div class="nhsuk-checkboxes__item">
-          <input class="nhsuk-checkboxes__input" id="cb-verify" name="StatementChecked" asp-for="StatementChecked" type="checkbox">
+          <input class="nhsuk-checkboxes__input" id="cb-sign-off" name="StatementChecked" asp-for="StatementChecked" type="checkbox">
           <label class="nhsuk-label nhsuk-checkboxes__label" for="cb-sign-off">
-            @(Model.SelfAssessment.SignOffRequestorStatement == null ? "I confirm that this profile self-assessment accurately captures my current capability in the areas assessed." : Model.SelfAssessment.SignOffRequestorStatement)
+            @Html.Raw((Model.SelfAssessment.SignOffRequestorStatement == null ? "I confirm that this profile self-assessment accurately captures my current capability in the areas assessed." : Model.SelfAssessment.SignOffRequestorStatement))
           </label>
         </div>
       </nhs-form-group>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
@@ -154,7 +154,7 @@
               Sign-off profile self-assessment
             </label>
             <div class="nhsuk-hint nhsuk-checkboxes__hint" id="cb-verify-item-hint">
-              @(Model.SelfAssessmentResultSummary.SignOffSupervisorStatement == null ? $"I confirm that this profile self-assessment accurately captures {Model.SupervisorDelegate.FirstName} {Model.SupervisorDelegate.LastName}'s current capability in the areas assessed." : Model.SelfAssessmentResultSummary.SignOffSupervisorStatement)
+              @Html.Raw((Model.SelfAssessmentResultSummary.SignOffSupervisorStatement == null ? $"I confirm that this profile self-assessment accurately captures {Model.SupervisorDelegate.FirstName} {Model.SupervisorDelegate.LastName}'s current capability in the areas assessed." : Model.SelfAssessmentResultSummary.SignOffSupervisorStatement))
             </div>
           </div>
         </nhs-form-group>


### PR DESCRIPTION
### JIRA link
[DLSV2-431](https://hee-dls.atlassian.net/browse/DLSV2-431)

### Description
Tiny tweak to allow html markup in sign-off label (delegate sign-off request) and hint text (supervisor sign-off)
