### PR TITLE
DLSV2-425 Tweaks request sign-off unavailable to wording

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -86,7 +86,7 @@
     }
     else
     {
-      <p class="nhsuk-body-l">All @Model.VocabPlural().ToLower() must be self-assessed and verified by your @Model.SelfAssessment.VerificationRoleName, before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.</p>
+      <p class="nhsuk-body-l">All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and verified, before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.</p>
     }
 
     </div>


### PR DESCRIPTION
### JIRA link
[DLSV2-425](https://hee-dls.atlassian.net/browse/DLSV2-425)

### Description
In self assessment overview, the wording of the statement provided explaining why Request sign-off is unavailable has been tweaked to indicate some competency assessment statements may be excluded.