### PR TITLE
Develop/features/dlsv2 421 required competency assessment questions in self assessment overview

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202111291243_AddRequiredToCompetencyAssessmentQuestionsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111291243_AddRequiredToCompetencyAssessmentQuestionsTable.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202111291243)]
+    public class AddRequiredToCompetencyAssessmentQuestionsTable : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("CompetencyAssessmentQuestions").AddColumn("Required").AsBoolean().NotNullable().WithDefaultValue(true);
+        }
+
+        public override void Down()
+        {
+            Delete.Column("Required").FromTable("CompetencyAssessmentQuestions");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
@@ -22,6 +22,7 @@
         public int? SelfAssessmentResultSupervisorVerificationId { get; set; }
         public DateTime? Requested { get; set; }
         public DateTime? Verified { get; set; }
+        public bool Required { get; set; }
         public string? SupervisorComments { get; set; }
         public bool? SignedOff { get; set; }
         public bool? UserIsVerifier { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -129,6 +129,7 @@
                                                   DENSE_RANK() OVER (ORDER BY SAS.Ordering) as RowNo,
                                                   C.Name AS Name,
                                                   C.Description AS Description,
+                                                  CAQ.Required,
                                                   CG.Name       AS CompetencyGroup,
                                                   CG.ID AS CompetencyGroupID,
                                                   COALESCE((SELECT TOP(1) FrameworkConfig FROM Frameworks F INNER JOIN FrameworkCompetencies AS FC ON FC.FrameworkID = F.ID WHERE FC.CompetencyID = C.ID), 'Capability') AS Vocabulary,

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
@@ -18,24 +18,24 @@
         {
             return FrameworkVocabularyHelper.VocabularyPlural(SelfAssessment.Vocabulary);
         }
-        public bool AllQuestionsVerified()
+        public bool AllQuestionsVerifiedOrNotRequired()
         {
-            bool allVerified = true;
+            bool allVerifiedOrNotRequired = true;
             foreach (var competencyGroup in CompetencyGroups)
             {
                 foreach (var competency in competencyGroup)
                 {
                     foreach (var assessmentQuestion in competency.AssessmentQuestions)
                     {
-                        if (assessmentQuestion.Result == null || assessmentQuestion.Verified == null )
+                        if ((assessmentQuestion.Result == null || assessmentQuestion.Verified == null) && assessmentQuestion.Required)
                         {
-                            allVerified = false;
+                            allVerifiedOrNotRequired = false;
                             break;
                         }
-            }
+                    }
                 }
             }
-            return allVerified;
+            return allVerifiedOrNotRequired;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -75,7 +75,7 @@
 <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
   <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
   <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
-    @if (Model.AllQuestionsVerified())
+    @if (Model.AllQuestionsVerifiedOrNotRequired())
     {
       @if (!Model.SupervisorSignOffs.Any())
       {


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-421

### Description
Created migration for adding Required field to database table CompetencyAssessmentQuestions. Modified the logics to show and hide "Request [role] sign-off" button on view **SelfAssessmentOverview.cshtml**. Now it only checks for a verified result when the assessment question is Required.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/143913450-70ea7a8e-9257-4fa5-a972-f51acd666078.png)

-----
### Developer checks
Navigate to Learning portal / Launch self assessment / View capabilities. Check that even when some assessment questions are not verified, the button "Request [role] sign-off" can be seen when these questions are not required.
