### PR TITLE
HEEDLS-679 Add LearningHubAuthId column to candidates

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202111261305_AddLearningHubAuthIdToCandidates.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202111261305_AddLearningHubAuthIdToCandidates.cs
@@ -1,0 +1,19 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202111261305)]
+    public class AddLearningHubAuthIdToCandidates : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("Candidates")
+                .AddColumn("LearningHubAuthId").AsInt32().Nullable();
+        }
+
+        public override void Down()
+        {
+            Delete.Column("LearningHubAuthId").FromTable("Candidates");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-679](https://softwiretech.atlassian.net/browse/HEEDLS-679)

### Description
Add a new LearningHubAuthId (int) column to the Candidates tables to store the LH Auth Id once DLS and LH accounts have been linked.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
