### PR TITLE
HEEDLS-690 Fix 500 error if centre not set in registration

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -318,7 +318,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void ValidateEmailAddress(PersonalInformationViewModel model)
         {
-            if (model.Email == null)
+            if (model.Email == null || !model.Centre.HasValue)
             {
                 return;
             }


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-690](https://softwiretech.atlassian.net/browse/HEEDLS-690)

### Description
Added a check on the email validation to check that the centre id value is set as this value is required for the validation.

### Screenshots
Correct model validation now present when no centre is selected:
![image](https://user-images.githubusercontent.com/18046982/144028570-92ce4f8c-e233-4413-9817-e8e0888d953b.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
