### PR TITLE
extend data service test timing to 500ms

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -258,7 +258,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
 
                 // Then
                 progressFields.Item1.Should().Be((int)RemovalMethod.NotRemoved);
-                progressFields.Item2.Should().BeCloseTo(removedDate);
+                progressFields.Item2.Should().BeCloseTo(removedDate, 500);
             }
             finally
             {


### PR DESCRIPTION
### JIRA link
[_HEEDLS-501_](https://softwiretech.atlassian.net/browse/HEEDLS-501)

### Description
Quick extension of the time to 500ms to make sure it passes even when run singly. 0.5s time difference should have no practical significance for the way the system is actually used.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
