### PR TITLE
DLSV2-422 Only show RAG colour of self-assessment result when the result has been verified if supervisor verification of results is switched on for the self assessment

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -9,6 +9,7 @@
         public DateTime? SubmittedDate { get; set; }
         public bool IsSupervised { get; set; }
         public bool IsSupervisorResultsReviewed { get; set; }
+        public bool SupervisorSelfAssessmentReview { get; set; }
         public string? Vocabulary { get; set; }
         public string? VerificationRoleName { get; set; }
         public string? SignOffRoleName { get; set; }

--- a/DigitalLearningSolutions.Data/Models/SessionData/SelfAssessments/SessionRequestVerification.cs
+++ b/DigitalLearningSolutions.Data/Models/SessionData/SelfAssessments/SessionRequestVerification.cs
@@ -15,5 +15,6 @@
         public string Vocabulary { get; set; }
         public int CandidateAssessmentSupervisorId { get; set; }
         public List<int>? ResultIds { get; set; }
+        public bool SupervisorSelfAssessmentReview { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -230,6 +230,7 @@
 							 SA.DescriptionLabel,
                              SA.IncludesSignposting,
                              SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
+                             SA.SupervisorSelfAssessmentReview,
                              COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
                              COUNT(C.ID)         AS NumberOfCompetencies,
                              CA.StartedDate,

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -185,7 +185,7 @@
                 NumberOfOptionalCompetencies = optionalCompetencies.Count(),
                 SupervisorSignOffs = supervisorSignOffs
             };
-            
+            ViewBag.SupervisorSelfAssessmentReview = assessment.SupervisorSelfAssessmentReview;
             return View("SelfAssessments/SelfAssessmentOverview", model);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -487,6 +487,7 @@
             sessionRequestVerification.SelfAssessmentID = selfAssessmentId;
             sessionRequestVerification.Vocabulary = selfAssessment.Vocabulary;
             sessionRequestVerification.SelfAssessmentName = selfAssessment.Name;
+            sessionRequestVerification.SupervisorSelfAssessmentReview = selfAssessment.SupervisorSelfAssessmentReview;
             TempData.Set(sessionRequestVerification);
             return RedirectToAction("VerificationPickSupervisor", new { selfAssessmentId });
         }
@@ -503,6 +504,7 @@
                 Supervisors = supervisors,
                 CandidateAssessmentSupervisorId = sessionRequestVerification.CandidateAssessmentSupervisorId
             };
+            ViewBag.SupervisorSelfAssessmentReview = sessionRequestVerification.SupervisorSelfAssessmentReview;
             return View("SelfAssessments/VerificationPickSupervisor", model);
         }
         [HttpPost]
@@ -516,6 +518,7 @@
                 var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(User.GetCandidateIdKnownNotNull(), sessionRequestVerification.SelfAssessmentID);
                 model.SelfAssessment = selfAssessment;
                 model.Supervisors = selfAssessmentService.GetResultReviewSupervisorsForSelfAssessmentId(sessionRequestVerification.SelfAssessmentID, User.GetCandidateIdKnownNotNull()).ToList(); ;
+                ViewBag.SupervisorSelfAssessmentReview = sessionRequestVerification?.SupervisorSelfAssessmentReview;
                 return View("SelfAssessments/VerificationPickSupervisor", model);
             }
             sessionRequestVerification.CandidateAssessmentSupervisorId = model.CandidateAssessmentSupervisorId;
@@ -536,20 +539,22 @@
                 CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup),
                 ResultIds = sessionRequestVerification.ResultIds
             };
+            ViewBag.SupervisorSelfAssessmentReview = sessionRequestVerification?.SupervisorSelfAssessmentReview;
             return View("SelfAssessments/VerificationPickResults", model);
         }
         [HttpPost]
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Verification/Results")]
         public IActionResult VerificationPickResults(VerificationPickResultsViewModel model, int selfAssessmentId)
         {
+            SessionRequestVerification sessionRequestVerification = TempData.Peek<SessionRequestVerification>();
             if (model.ResultIds == null)
             {
                 var competencies = PopulateCompetencyLevelDescriptors(selfAssessmentService.GetCandidateAssessmentResultsToVerifyById(selfAssessmentId, User.GetCandidateIdKnownNotNull()).ToList());
                 model.CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup);
                 ModelState.AddModelError(nameof(model.ResultIds), "Please choose at least one result to verify.");
+                ViewBag.SupervisorSelfAssessmentReview = sessionRequestVerification?.SupervisorSelfAssessmentReview;
                 return View("SelfAssessments/VerificationPickResults", model);
             }
-            SessionRequestVerification sessionRequestVerification = TempData.Peek<SessionRequestVerification>();
             sessionRequestVerification.ResultIds = model.ResultIds;
             TempData.Set(sessionRequestVerification);
             return RedirectToAction("VerificationSummary", new { sessionRequestVerification.SelfAssessmentID });

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -145,6 +145,7 @@
             {
                 model.SupervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(delegateSelfAssessment.SelfAssessmentID, (int)superviseDelegate.CandidateID);
             }
+            ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
             return View("ReviewSelfAssessment", model);
         }
 
@@ -187,6 +188,7 @@
                 SupervisorComments = assessmentQuestion.SupervisorComments,
                 SignedOff = assessmentQuestion.SignedOff != null ? (bool)assessmentQuestion.SignedOff : false
             };
+            ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
             return View("ReviewCompetencySelfAsessment", model);
         }
         [HttpPost]

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
@@ -7,12 +7,13 @@
 }
 else
 {
-  bool isVerifiedAndSignedOff = (bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true;
-  string tagColour = (Model.ResultRAG == 0 || !isVerifiedAndSignedOff) ? "white"
+  bool isVerifiedOrVerificationNotRequired = (bool?)ViewBag.SupervisorSelfAssessmentReview == false | (Model.Verified.HasValue && Model.SignedOff == true);
+  string tagColour = (Model.ResultRAG == 0 || !isVerifiedOrVerificationNotRequired) ? "white"
     : Model.ResultRAG == 1 ? "red"
     : Model.ResultRAG == 2 ? "yellow"
     : "green";
-  string hiddenTagText = Model.ResultRAG == 0 ? "role expectations not specified"
+  string hiddenTagText = !isVerifiedOrVerificationNotRequired ? "not yet verified"
+    : Model.ResultRAG == 0 ? "role expectations not specified"
     : Model.ResultRAG == 1 ? "not meeting role expectations"
     : Model.ResultRAG == 2 ? "partially meeting role expectations"
     : "fully meeting role expectations";

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
@@ -7,7 +7,7 @@
 }
 else
 {
-  @if (Model.LevelDescriptors != null && (ViewBag.SupervisorSelfAssessmentReview == null || ((bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true)))
+  @if (Model.LevelDescriptors != null && (bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true)
   {
     foreach (var levelDescriptor in Model.LevelDescriptors)
     {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
@@ -7,7 +7,7 @@
 }
 else
 {
-  @if (Model.LevelDescriptors != null)
+  @if (Model.LevelDescriptors != null && (ViewBag.SupervisorSelfAssessmentReview == null || ((bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true)))
   {
     foreach (var levelDescriptor in Model.LevelDescriptors)
     {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
@@ -8,7 +8,7 @@
 else
 {
   bool isVerifiedAndSignedOff = (bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true;
-  string tagColour = (Model.ResultRAG == 0 || isVerifiedAndSignedOff) ? "white"
+  string tagColour = (Model.ResultRAG == 0 || !isVerifiedAndSignedOff) ? "white"
     : Model.ResultRAG == 1 ? "red"
     : Model.ResultRAG == 2 ? "yellow"
     : "green";

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionResponse.cshtml
@@ -7,14 +7,24 @@
 }
 else
 {
-  @if (Model.LevelDescriptors != null && (bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true)
+  bool isVerifiedAndSignedOff = (bool?)ViewBag.SupervisorSelfAssessmentReview == true && Model.Verified.HasValue && Model.SignedOff == true;
+  string tagColour = (Model.ResultRAG == 0 || isVerifiedAndSignedOff) ? "white"
+    : Model.ResultRAG == 1 ? "red"
+    : Model.ResultRAG == 2 ? "yellow"
+    : "green";
+  string hiddenTagText = Model.ResultRAG == 0 ? "role expectations not specified"
+    : Model.ResultRAG == 1 ? "not meeting role expectations"
+    : Model.ResultRAG == 2 ? "partially meeting role expectations"
+    : "fully meeting role expectations";
+
+  @if (Model.LevelDescriptors != null)
   {
     foreach (var levelDescriptor in Model.LevelDescriptors)
     {
       if (levelDescriptor.LevelValue == Model.Result)
       {
-<span class="nhsuk-tag nhsuk-tag--@(Model.ResultRAG == 0 ? "white" : Model.ResultRAG == 1 ? "red" : Model.ResultRAG == 2 ? "yellow" : "green"  )">
-  @levelDescriptor.LevelLabel  <span class="nhsuk-u-visually-hidden">(@(Model.ResultRAG == 0 ? "role expectations not specified" : Model.ResultRAG == 1 ? "not meeting role expectations" : Model.ResultRAG == 2 ? "partially meeting role expectations" : "fully meeting role expectations"  ))</span>
+<span class="nhsuk-tag nhsuk-tag--@(tagColour)">
+  @levelDescriptor.LevelLabel  <span class="nhsuk-u-visually-hidden">(@(hiddenTagText))</span>
 </span>
         break;
       }
@@ -22,8 +32,8 @@ else
   }
   else
   {
-<span class="nhsuk-tag nhsuk-tag--@(Model.ResultRAG == 0 ? "white" : Model.ResultRAG == 1 ? "red" : Model.ResultRAG == 2 ? "yellow" : "green"  )">
-  @Model.Result/@Model.MaxValue <span class="nhsuk-u-visually-hidden">(@(Model.ResultRAG == 0 ? "role expectations not specified" : Model.ResultRAG == 1 ? "(not meeting role expectations" : Model.ResultRAG == 2 ? " partially meeting role expectations" : "fully meeting role expectations"  ))</span>
+<span class="nhsuk-tag nhsuk-tag--@(tagColour)">
+  @Model.Result/@Model.MaxValue <span class="nhsuk-u-visually-hidden">(@(hiddenTagText))</span>
 </span>
   }
 }


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-422

### Description
Passing SupervisorSelfAssessmentReview to shared partial view _AssessmentQuestionResponse.cshtml from controllers returning views ReviewSelfAssessment, ReviewCompetencySelfAssessment, SelfAssessmentOverview and VerificationPickSupervisor. Then display SupervisorSelfAssessmentReview Rag coloured LevelRAG (levelDescriptor.LevelLabel) on that view if SupervisorSelfAssessmentReview is true, SelfAssessmentResultSupervisorVerifications is Verified and SignedOff. Otherwise display coloured Result/MaxValue.

-----
### Developer checks
Review verified and signed off self assessment for non-slider questions (AssessmentQuestionInputTypeID <> 2). 

- Check that LevelRAG label is visible when SupervisorSelfAssessmentReview is true on table SelfAssessments.
- Check that if any of the above conditions are not met, coloured Result/MaxValue is shown.
