### PR TITLE
DLSV2-427 Added mobile breadcrumb back links to Supervisor pages

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/AddMultipleSupervisorDelegates.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/AddMultipleSupervisorDelegates.cshtml
@@ -1,9 +1,9 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model AddMultipleSupervisorDelegatesViewModel;
 @{
-    var errorHasOccurred = !ViewData.ModelState.IsValid;
-    ViewData["Title"] = "Add Mutiple Staff";
-    ViewData["Application"] = "Supervisor";
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+  ViewData["Title"] = "Add Mutiple Staff";
+  ViewData["Application"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
@@ -20,21 +20,25 @@
     </div>
   </nav>
 }
-@if (errorHasOccurred)
-{
-  <vc:error-summary order-of-property-names="@new []{ nameof(AddMultipleSupervisorDelegatesViewModel.DelegateEmails) }" />
-}
-<h1>Add staff members to your team</h1>
-<form method="post" novalidate>
-  <vc:text-area asp-for="DelegateEmails"
-                label="User email addresses"
-                populate-with-current-value="false"
-                rows="8"
-                spell-check="false"
-                hint-text="Provide the work email address of each member of staff to add to your supervision list on a separate line."
-                css-class=""
-                character-count="null"/>
-  <button class="nhsuk-button" type="submit">
-    Submit
-  </button>
-</form>
+
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
+  </p>
+  @if (errorHasOccurred)
+  {
+    <vc:error-summary order-of-property-names="@new []{ nameof(AddMultipleSupervisorDelegatesViewModel.DelegateEmails) }" />
+  }
+  <h1>Add staff members to your team</h1>
+  <form method="post" novalidate>
+    <vc:text-area asp-for="DelegateEmails"
+                  label="User email addresses"
+                  populate-with-current-value="false"
+                  rows="8"
+                  spell-check="false"
+                  hint-text="Provide the work email address of each member of staff to add to your supervision list on a separate line."
+                  css-class=""
+                  character-count="null" />
+    <button class="nhsuk-button" type="submit">
+      Submit
+    </button>
+  </form>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/AddMultipleSupervisorDelegates.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/AddMultipleSupervisorDelegates.cshtml
@@ -18,12 +18,12 @@
         <li class="nhsuk-breadcrumb__item">Add Staff Members</li>
       </ol>
     </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
+    </p>
   </nav>
 }
 
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
-  </p>
   @if (errorHasOccurred)
   {
     <vc:error-summary order-of-property-names="@new []{ nameof(AddMultipleSupervisorDelegatesViewModel.DelegateEmails) }" />

--- a/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
@@ -18,12 +18,11 @@
         <li class="nhsuk-breadcrumb__item">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</li>
       </ol>
     </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">Back to My Staff</a>
+    </p>
   </nav>
 }
-
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">Back to My Staff</a>
-  </p>
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
@@ -20,24 +20,28 @@
     </div>
   </nav>
 }
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
-  </div>
-</details>
-@if (Model.DelegateSelfAssessments.Any())
-{
-  <partial name="Shared/_DelegateProfileAssessmentGrid" model="Model.DelegateSelfAssessments" />
-}
-else
-{
-  <p class="nhsuk-lede-text">You are not supervising any profile assessments for this member of staff, yet.</p>
-}
-<a class="nhsuk-button nhsuk-u-margin-top-4" asp-action="StartEnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-  Enrol on new assessment
-</a>
+
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">Back to My Staff</a>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+    </div>
+  </details>
+  @if (Model.DelegateSelfAssessments.Any())
+  {
+    <partial name="Shared/_DelegateProfileAssessmentGrid" model="Model.DelegateSelfAssessments" />
+  }
+  else
+  {
+    <p class="nhsuk-lede-text">You are not supervising any profile assessments for this member of staff, yet.</p>
+  }
+  <a class="nhsuk-button nhsuk-u-margin-top-4" asp-action="StartEnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+    Enrol on new assessment
+  </a>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
@@ -20,22 +20,24 @@
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
              asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
-          </li>
-          <li class="nhsuk-breadcrumb__item">
-            Enrol
-          </li>
-        </ol>
-      </div>
-    </nav>
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+          </a>
+        </li>
+        <li class="nhsuk-breadcrumb__item">
+          Enrol
+        </li>
+      </ol>
+    </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+         asp-action="DelegateProfileAssessments"
+         asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </a>
+    </p>
+  </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="DelegateProfileAssessments"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-  </a>
-  </p>
+
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
@@ -19,7 +19,8 @@
         <li class="nhsuk-breadcrumb__item">
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
           </li>
           <li class="nhsuk-breadcrumb__item">
             Enrol
@@ -28,77 +29,84 @@
       </div>
     </nav>
 }
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
-  </div>
-</details>
-<h2>Enrol on Profile Assessment</h2>
-<h3>Choose a role profile</h3>
-<form method="post">
-  <table class="nhsuk-table-responsive">
-    <thead role="rowgroup" class="nhsuk-table__head">
-      <tr role="row">
-        <th role="columnheader" class="" scope="col">
-          Profile name
-        </th>
-        <th role="columnheader" class="" scope="col">
-          Brand
-        </th>
-        <th role="columnheader" class="" scope="col">
-          Linked to role
-        </th>
-        <th role="columnheader" class="" scope="col">
-          Scope
-        </th>
-      </tr>
-    </thead>
-    <tbody class="nhsuk-table__body">
-      @foreach (var roleProfile in Model.RoleProfiles)
-      {
-        <tr role="row" class="nhsuk-table__row collaborator-row">
-          <td role="cell" class="nhsuk-table__cell">
-            <span class="nhsuk-table-responsive__heading">Profile name </span>
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input" id="role-profile-check-@roleProfile.ID" asp-for="SessionEnrolOnRoleProfile.SelfAssessmentID" name="SelfAssessmentID" type="radio" value="@roleProfile.ID">
-              <label class="nhsuk-label nhsuk-radios__label" for="role-profile-check-@roleProfile.ID">
-                @roleProfile.RoleProfileName
-              </label>
-            </div>
-          </td>
-          <td role="cell" class="nhsuk-table__cell">
-            <span class="nhsuk-table-responsive__heading">Brand </span>
-            @roleProfile.Brand
-          </td>
-          <td role="cell" class="nhsuk-table__cell">
-            <span class="nhsuk-table-responsive__heading">Linked to role </span>
-            @(roleProfile.NRPProfessionalGroup != null ? @roleProfile.NRPProfessionalGroup : "None/Generic")
-            @(roleProfile.NRPSubGroupID != null ? " / " + roleProfile.NRPSubGroup : "")
-            @(roleProfile.NRPRoleID != null ? " / " + roleProfile.NRPRole : "")
-          </td>
-          <td role="cell" class="nhsuk-table__cell">
-            <span class="nhsuk-table-responsive__heading">Scope </span>
-            @(roleProfile.National ? "National" : "Local")
-          </td>
-        </tr>
-      }
-
-    </tbody>
-  </table>
-  <button class="nhsuk-button nhsuk-u-margin-top-5" id="save-button" type="submit">Next</button>
-</form>
-<div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-controller="Supervisor"
-             asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="DelegateProfileAssessments"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
   </a>
-</div>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+    </div>
+  </details>
+  <h2>Enrol on Profile Assessment</h2>
+  <h3>Choose a role profile</h3>
+  <form method="post">
+    <table class="nhsuk-table-responsive">
+      <thead role="rowgroup" class="nhsuk-table__head">
+        <tr role="row">
+          <th role="columnheader" class="" scope="col">
+            Profile name
+          </th>
+          <th role="columnheader" class="" scope="col">
+            Brand
+          </th>
+          <th role="columnheader" class="" scope="col">
+            Linked to role
+          </th>
+          <th role="columnheader" class="" scope="col">
+            Scope
+          </th>
+        </tr>
+      </thead>
+      <tbody class="nhsuk-table__body">
+        @foreach (var roleProfile in Model.RoleProfiles)
+        {
+          <tr role="row" class="nhsuk-table__row collaborator-row">
+            <td role="cell" class="nhsuk-table__cell">
+              <span class="nhsuk-table-responsive__heading">Profile name </span>
+              <div class="nhsuk-radios__item">
+                <input class="nhsuk-radios__input" id="role-profile-check-@roleProfile.ID" asp-for="SessionEnrolOnRoleProfile.SelfAssessmentID" name="SelfAssessmentID" type="radio" value="@roleProfile.ID">
+                <label class="nhsuk-label nhsuk-radios__label" for="role-profile-check-@roleProfile.ID">
+                  @roleProfile.RoleProfileName
+                </label>
+              </div>
+            </td>
+            <td role="cell" class="nhsuk-table__cell">
+              <span class="nhsuk-table-responsive__heading">Brand </span>
+              @roleProfile.Brand
+            </td>
+            <td role="cell" class="nhsuk-table__cell">
+              <span class="nhsuk-table-responsive__heading">Linked to role </span>
+              @(roleProfile.NRPProfessionalGroup != null ? @roleProfile.NRPProfessionalGroup : "None/Generic")
+              @(roleProfile.NRPSubGroupID != null ? " / " + roleProfile.NRPSubGroup : "")
+              @(roleProfile.NRPRoleID != null ? " / " + roleProfile.NRPRole : "")
+            </td>
+            <td role="cell" class="nhsuk-table__cell">
+              <span class="nhsuk-table-responsive__heading">Scope </span>
+              @(roleProfile.National ? "National" : "Local")
+            </td>
+          </tr>
+        }
+
+      </tbody>
+    </table>
+    <button class="nhsuk-button nhsuk-u-margin-top-5" id="save-button" type="submit">Next</button>
+  </form>
+  <div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+      </svg>
+      Cancel
+    </a>
+  </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
@@ -20,22 +20,23 @@
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
              asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
-          </li>
-          <li class="nhsuk-breadcrumb__item">
-            Enrol
-          </li>
-        </ol>
-      </div>
-    </nav>
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+          </a>
+        </li>
+        <li class="nhsuk-breadcrumb__item">
+          Enrol
+        </li>
+      </ol>
+    </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+         asp-action="DelegateProfileAssessments"
+         asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </a>
+    </p>
+  </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="DelegateProfileAssessments"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-  </a>
-</p>
 @{
   var exampleDate = @DateTime.Today + TimeSpan.FromDays(7);
   string prefillDay;

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
@@ -19,7 +19,8 @@
         <li class="nhsuk-breadcrumb__item">
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
           </li>
           <li class="nhsuk-breadcrumb__item">
             Enrol
@@ -28,6 +29,13 @@
       </div>
     </nav>
 }
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="DelegateProfileAssessments"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+  </a>
+</p>
 @{
   var exampleDate = @DateTime.Today + TimeSpan.FromDays(7);
   string prefillDay;

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
@@ -26,15 +26,16 @@
           </li>
         </ol>
       </div>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="DelegateProfileAssessments"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+          Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+        </a>
+      </p>
     </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="DelegateProfileAssessments"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-  </a>
-  </p>
+
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
@@ -28,87 +28,94 @@
       </div>
     </nav>
 }
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
-  </div>
-</details>
-<h2>Enrolment Summary</h2>
-<dl class="nhsuk-summary-list">
-
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    Role profile
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    @Model.RoleProfile.RoleProfileName
-  </dd>
-
-  <dd class="nhsuk-summary-list__actions">
-
-    <a asp-action="EnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-      Change<span class="nhsuk-u-visually-hidden"> role profile</span>
-    </a>
-
-  </dd>
-
-  </div>
-
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    Complete by date
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    @(Model.CompleteByDate == null? "Not set" : Model.CompleteByDate.Value.ToShortDateString())
-  </dd>
-
-  <dd class="nhsuk-summary-list__actions">
-
-    <a asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-      Change<span class="nhsuk-u-visually-hidden"> complete by date</span>
-    </a>
-
-  </dd>
-
-  </div>
-
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    Supervisor role
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    @Model.SupervisorRoleName
-  </dd>
-
-  <dd class="nhsuk-summary-list__actions">
-    @if (Model.SupervisorRoleCount > 1)
-    {
-    <a asp-action="EnrolDelegateSupervisorRole" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-      Change<span class="nhsuk-u-visually-hidden"> supervisor role</span>
-    </a>
-    }
-    
-
-  </dd>
-
-  </div>
-
-</dl>
-<a class="nhsuk-button" asp-action="EnrolDelegateConfirm" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" asp-route-delegateId="@Model.SupervisorDelegateDetail.CandidateID.Value">
-  Confirm
-</a>
-<div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
      asp-action="DelegateProfileAssessments"
      asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
+    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
   </a>
-</div>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+    </div>
+  </details>
+  <h2>Enrolment Summary</h2>
+  <dl class="nhsuk-summary-list">
+
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Role profile
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.RoleProfile.RoleProfileName
+    </dd>
+
+    <dd class="nhsuk-summary-list__actions">
+
+      <a asp-action="EnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+        Change<span class="nhsuk-u-visually-hidden"> role profile</span>
+      </a>
+
+    </dd>
+
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Complete by date
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @(Model.CompleteByDate == null? "Not set" : Model.CompleteByDate.Value.ToShortDateString())
+    </dd>
+
+    <dd class="nhsuk-summary-list__actions">
+
+      <a asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+        Change<span class="nhsuk-u-visually-hidden"> complete by date</span>
+      </a>
+
+    </dd>
+
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Supervisor role
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.SupervisorRoleName
+    </dd>
+
+    <dd class="nhsuk-summary-list__actions">
+      @if (Model.SupervisorRoleCount > 1)
+      {
+        <a asp-action="EnrolDelegateSupervisorRole" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+          Change<span class="nhsuk-u-visually-hidden"> supervisor role</span>
+        </a>
+      }
+
+
+    </dd>
+
+    </div>
+
+  </dl>
+  <a class="nhsuk-button" asp-action="EnrolDelegateConfirm" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" asp-route-delegateId="@Model.SupervisorDelegateDetail.CandidateID.Value">
+    Confirm
+  </a>
+  <div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+      </svg>
+      Cancel
+    </a>
+  </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSupervisorRole.cshtml
@@ -20,23 +20,23 @@
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
              asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
           </a>
-          </li>
-          <li class="nhsuk-breadcrumb__item">
-            Enrol
-          </li>
-        </ol>
-      </div>
-    </nav>
+        </li>
+        <li class="nhsuk-breadcrumb__item">
+          Enrol
+        </li>
+      </ol>
+    </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+         asp-action="DelegateProfileAssessments"
+         asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </a>
+    </p>
+  </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="DelegateProfileAssessments"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-  </a>
-  </p>
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSupervisorRole.cshtml
@@ -19,7 +19,9 @@
         <li class="nhsuk-breadcrumb__item">
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+          </a>
           </li>
           <li class="nhsuk-breadcrumb__item">
             Enrol
@@ -28,61 +30,68 @@
       </div>
     </nav>
 }
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
-  </div>
-</details>
-<form method="post">
-  <div class="nhsuk-form-group">
-
-    <fieldset class="nhsuk-fieldset">
-      <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-        <h2 class="nhsuk-fieldset__heading">
-          Choose your supervisor role
-        </h2>
-      </legend>
-
-      <div class="nhsuk-radios">
-        @foreach (var role in Model.SelfAssessmentSupervisorRoles)
-        {
-        <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input" id="role-@role.ID" name="SelfAssessmentSupervisorRoleId" asp-for="SelfAssessmentSupervisorRoleId" type="radio" value="@role.ID">
-          <label class="nhsuk-label nhsuk-radios__label" for="role-@role.ID">
-            @role.RoleName
-          </label>
-          @if(role.RoleDescription != null)
-        {
-        <div class="nhsuk-hint nhsuk-radios__hint" id="role-@role.ID-hint">
-          @role.RoleDescription
-        </div>
-        }
-          
-        </div>
-        }
-
-      </div>
-    </fieldset>
-    <div class=" nhsuk-u-margin-top-5">
-      <a class="nhsuk-button nhsuk-button--secondary" asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-        Back
-      </a>
-      <button class="nhsuk-button" id="save-button" type="submit">Next</button>
-    </div>
-  </div>
-</form>
-<div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
      asp-action="DelegateProfileAssessments"
      asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
+    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
   </a>
-</div>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+    </div>
+  </details>
+  <form method="post">
+    <div class="nhsuk-form-group">
+
+      <fieldset class="nhsuk-fieldset">
+        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+          <h2 class="nhsuk-fieldset__heading">
+            Choose your supervisor role
+          </h2>
+        </legend>
+
+        <div class="nhsuk-radios">
+          @foreach (var role in Model.SelfAssessmentSupervisorRoles)
+          {
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="role-@role.ID" name="SelfAssessmentSupervisorRoleId" asp-for="SelfAssessmentSupervisorRoleId" type="radio" value="@role.ID">
+              <label class="nhsuk-label nhsuk-radios__label" for="role-@role.ID">
+                @role.RoleName
+              </label>
+              @if (role.RoleDescription != null)
+              {
+                <div class="nhsuk-hint nhsuk-radios__hint" id="role-@role.ID-hint">
+                  @role.RoleDescription
+                </div>
+              }
+
+            </div>
+          }
+
+        </div>
+      </fieldset>
+      <div class=" nhsuk-u-margin-top-5">
+        <a class="nhsuk-button nhsuk-button--secondary" asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+          Back
+        </a>
+        <button class="nhsuk-button" id="save-button" type="submit">Next</button>
+      </div>
+    </div>
+  </form>
+  <div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+      </svg>
+      Cancel
+    </a>
+  </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
@@ -20,6 +20,9 @@
     </div>
   </nav>
 }
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
+</p>
 <h1>My Staff</h1>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
@@ -18,11 +18,11 @@
         <li class="nhsuk-breadcrumb__item">My Staff</li>
       </ol>
     </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="Index">Back to Supervisor Dashboard</a>
+    </p>
   </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
-</p>
 <h1>My Staff</h1>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -1,9 +1,9 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model ReviewCompetencySelfAsessmentViewModel;
 @{
-    var errorHasOccurred = !ViewData.ModelState.IsValid;    
-    ViewData["Title"] = $"Review {Model.Competency.Vocabulary} Self Assessment";
-    ViewData["Application"] = "Supervisor";
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+  ViewData["Title"] = $"Review {Model.Competency.Vocabulary} Self Assessment";
+  ViewData["Application"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
@@ -26,72 +26,77 @@
                asp-action="ReviewDelegateSelfAssessment"
                asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
                asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
-              @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName )
+              @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
             </a>
           </li>
           <li class="nhsuk-breadcrumb__item">
-            @(Model.Competency.Name.Length > 35 ? Model.Competency.Name.Substring(0, 32) + "..." : Model.Competency.Name )
+            @(Model.Competency.Name.Length > 35 ? Model.Competency.Name.Substring(0,32) + "..." : Model.Competency.Name )
           </li>
         </ol>
       </div>
     </nav>
 }
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="ReviewDelegateSelfAssessment"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+     asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
+    Back to  @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+  </a>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegate" />
+    </div>
+  </details>
+  <h2>@Model.Competency.Vocabulary Self Assessment Result</h2>
+  <dl class="nhsuk-summary-list">
 
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegate" />
-  </div>
-</details>
-<h2>@Model.Competency.Vocabulary Self Assessment Result</h2>
-<dl class="nhsuk-summary-list">
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      @Model.Competency.Vocabulary
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.Competency.Name
+    </dd>
 
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    @Model.Competency.Vocabulary
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    @Model.Competency.Name
-  </dd>
-
-  </div>
-  @if (Model.Competency.Description != null)
+    </div>
+    @if (Model.Competency.Description != null)
   {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      @(string.IsNullOrWhiteSpace(Model.DelegateSelfAssessment.DescriptionLabel) ? "Description" :
-                           Model.DelegateSelfAssessment.DescriptionLabel)
+      Description
     </dt>
     <dd class="nhsuk-summary-list__value">
       @Html.Raw(Model.Competency.Description)
     </dd>
     </div>
   }
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    @(string.IsNullOrWhiteSpace(Model.DelegateSelfAssessment.QuestionLabel) ? "Question" :
-    Model.DelegateSelfAssessment.QuestionLabel) 
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    @Model.Competency.AssessmentQuestions.First().Question
-  </dd>
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Question
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.Competency.AssessmentQuestions.First().Question
+    </dd>
 
-  </div>
+    </div>
 
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    Learner response
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
-  </dd>
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Learner response
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
+    </dd>
 
-  </div>
-  @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
+    </div>
+    @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
   {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
@@ -103,7 +108,7 @@
 
     </div>
   }
-  @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
+    @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
   {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
@@ -114,22 +119,22 @@
     </dd>
     </div>
   }
-  <div class="nhsuk-summary-list__row">
-  <dt class="nhsuk-summary-list__key">
-    Status
-  </dt>
-  <dd class="nhsuk-summary-list__value">
-    <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
-  </dd>
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Status
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
+    </dd>
 
-  </div>
-</dl>
-@if (errorHasOccurred)
+    </div>
+  </dl>
+  @if (errorHasOccurred)
 {
   <vc:error-summary order-of-property-names="@new []{ nameof(ReviewCompetencySelfAsessmentViewModel) }" />
 }
 
-@if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Requested != null && ViewContext.RouteData.Values["viewMode"].ToString() == "Review" && (bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
+  @if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Requested != null && ViewContext.RouteData.Values["viewMode"].ToString() == "Review" && (bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
 {
   <div class="nhsuk-card">
     <div class="nhsuk-card__content">
@@ -143,30 +148,17 @@
           <input name="ResultSupervisorVerificationId" type="hidden" asp-for="ResultSupervisorVerificationId" />
           <nhs-form-group nhs-validation-for="SupervisorComments">
             <vc:text-area asp-for="SupervisorComments" character-count="null" label="Reviewer comments" rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
-            <span asp-validation-for="SupervisorComments" class="text-danger"></span>
           </nhs-form-group>
 
           <nhs-form-group nhs-validation-for="SignedOff">
-            <div class="nhsuk-radios nhsuk-radios--inline">
-              <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="rb-verify" name="SignedOff" required="required" type="radio" value="true">
-                <label class="nhsuk-label nhsuk-radios__label" for="rb-verify">
-                  Verify self-assessment response
-                </label>
-                <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
-                  I agree with @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName's self-assessment against this @Model.Competency.Vocabulary.ToLower()
-                </div>
+            <div class="nhsuk-checkboxes__item">
+              <input class="nhsuk-checkboxes__input" id="cb-verify" name="SignedOff" asp-for="SignedOff" type="checkbox">
+              <label class="nhsuk-label nhsuk-checkboxes__label" for="cb-sign-off">
+                Verify self-assessment response
+              </label>
+              <div class="nhsuk-hint nhsuk-checkboxes__hint" id="cb-verify-item-hint">
+                I agree with @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName's self-assessment against this @Model.Competency.Vocabulary.ToLower()
               </div>
-              <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="rb-reject" name="SignedOff" required="required" type="radio" value="false">
-                <label class="nhsuk-label nhsuk-radios__label" for="rb-reject">
-                  Reject self-assessment response
-                </label>
-                <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
-                  I disagree with @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName's self-assessment response against this @Model.Competency.Vocabulary.ToLower() for the reasons stated above
-                </div>
-              </div>
-              <span asp-validation-for="SignedOff" class="text-danger"></span>
             </div>
           </nhs-form-group>
         </fieldset>
@@ -182,49 +174,46 @@ else if (ViewContext.RouteData.Values["viewMode"].ToString() == "View" && Model.
   <h2>Review Outcome</h2>
   @if (Model.Competency.AssessmentQuestions.First().Verified == null)
   {
-    <p>Awaiting review by @((bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier? "you": "another supervisor") .</p>
+  <p>Awaiting review by @((bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier? "you": "another supervisor") .</p>
   }
   else
   {
 
-    <dl class="nhsuk-summary-list">
-      @if (Model.SupervisorComments != null)
+  <dl class="nhsuk-summary-list">
+    @if (Model.SupervisorComments != null)
       {
-        <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          Reviewer comments
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          @Html.Raw(Model.SupervisorComments)
-        </dd>
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Reviewer comments
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Html.Raw(Model.SupervisorComments)
+    </dd>
 
-        </div>
+    </div>
       }
 
-      <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Verified
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @if (Model.SignedOff)
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Verified
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @if (Model.SignedOff)
         {
-          <span class="nhsuk-tag nhsuk-tag--green">Yes</span>
+      <span class="nhsuk-tag nhsuk-tag--green">Yes</span>
         }
         else
         {
-          <span class="nhsuk-tag nhsuk-tag--red">No</span>
+      <span class="nhsuk-tag nhsuk-tag--red">No</span>
         }
-      </dd>
+    </dd>
 
-      </div>
-    </dl>
-    @if ((bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
-    {
-      <a class="nhsuk-button nhsuk-button--secondary" asp-action="ReviewCompetencySelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-viewMode="Review" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]" asp-route-resultId="@ViewContext.RouteData.Values["resultId"]">Update</a>
-    }
+    </div>
+  </dl>
+  @if((bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
+          {
+  <a class="nhsuk-button nhsuk-button--secondary" asp-action="ReviewCompetencySelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-viewMode="Review" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]" asp-route-resultId="@ViewContext.RouteData.Values["resultId"]">Update</a>
+          }
   }
 }
 
-@section scripts {
-  <script src="@Url.Content("~/js/supervisor/assessmentVerify.js")" asp-append-version="true"></script>
-}

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -34,16 +34,16 @@
           </li>
         </ol>
       </div>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="ReviewDelegateSelfAssessment"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+           asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
+          Back to  @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+        </a>
+      </p>
     </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="ReviewDelegateSelfAssessment"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-     asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
-    Back to  @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
-  </a>
-  </p>
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -1,8 +1,8 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model ReviewSelfAssessmentViewModel;
 @{
-    ViewData["Title"] = "Review Profile Assessment";
-    ViewData["Application"] = "Supervisor";
+  ViewData["Title"] = "Review Profile Assessment";
+  ViewData["Application"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
@@ -18,7 +18,8 @@
         <li class="nhsuk-breadcrumb__item">
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
           </li>
           <li class="nhsuk-breadcrumb__item">
             @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
@@ -27,89 +28,96 @@
       </div>
     </nav>
 }
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="DelegateProfileAssessments"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+  </a>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+    </div>
+  </details>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h2>@Model.DelegateSelfAssessment.RoleName</h2>
+    </div>
+    <div class="nhsuk-grid-column-one-third">
+      @if (Model.DelegateSelfAssessment.SignOffRequested > 0)
+      {
+        <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
+      }
+      @if (Model.DelegateSelfAssessment.ResultsVerificationRequests > 1)
+      {
+        <a role="button" asp-action="VerifyMultipleResults" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Verify multiple results</a>
+      }
+    </div>
   </div>
-</details>
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <h2>@Model.DelegateSelfAssessment.RoleName</h2>
-  </div>
-  <div class="nhsuk-grid-column-one-third">
-    @if (Model.DelegateSelfAssessment.SignOffRequested > 0)
-    {
-      <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
-    }
-    @if (Model.DelegateSelfAssessment.ResultsVerificationRequests > 1)
-    {
-      <a role="button" asp-action="VerifyMultipleResults" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Verify multiple results</a>
-    }
-  </div>
-</div>
 
-@if (Model.CompetencyGroups.Any())
-{
-  foreach (var competencyGroup in Model.CompetencyGroups)
+  @if (Model.CompetencyGroups.Any())
   {
-    <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
-      <caption class="nhsuk-table__caption"><h3>@competencyGroup.Key</h3></caption>
-      <thead role="rowgroup" class="nhsuk-table__head">
-        <tr role="row">
-          <th role="columnheader" class="" scope="col">
-            @competencyGroup.First().Vocabulary
-          </th>
-          <th role="columnheader" class="" scope="col">
-            @(string.IsNullOrWhiteSpace(Model.DelegateSelfAssessment.QuestionLabel) ? "Question" :
-                        Model.DelegateSelfAssessment.QuestionLabel)
-          </th>
-          <th role="columnheader" class="" scope="col">
-            Self-assessment
-          </th>
-          @if (Model.IsSupervisorResultsReviewed)
-          {
+    foreach (var competencyGroup in Model.CompetencyGroups)
+    {
+      <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
+        <caption class="nhsuk-table__caption"><h3>@competencyGroup.Key</h3></caption>
+        <thead role="rowgroup" class="nhsuk-table__head">
+          <tr role="row">
             <th role="columnheader" class="" scope="col">
-              Verification status
+              @competencyGroup.First().Vocabulary
             </th>
-          }
-          <th role="columnheader" class="" scope="col">
-            Actions
-          </th>
-        </tr>
-      </thead>
-      <tbody class="nhsuk-table__body">
-        @foreach (var competency in competencyGroup)
-        {
-          <tr role="row" class="nhsuk-table__row first-row">
-            <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
-              <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
-            </td>
-            <partial name="Shared/_AssessmentQuestionReviewCells"
-                     model="competency.AssessmentQuestions.First()"
-                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }})" />
+            <th role="columnheader" class="" scope="col">
+              @(string.IsNullOrWhiteSpace(Model.DelegateSelfAssessment.QuestionLabel) ? "Question" :
+                        Model.DelegateSelfAssessment.QuestionLabel)
+            </th>
+            <th role="columnheader" class="" scope="col">
+              Self-assessment
+            </th>
+            @if (Model.IsSupervisorResultsReviewed)
+            {
+              <th role="columnheader" class="" scope="col">
+                Verification status
+              </th>
+            }
+            <th role="columnheader" class="" scope="col">
+              Actions
+            </th>
           </tr>
-          @foreach (var question in competency.AssessmentQuestions.Skip(1))
+        </thead>
+        <tbody class="nhsuk-table__body">
+          @foreach (var competency in competencyGroup)
           {
-            <tr role="row" class="nhsuk-table__row">
+            <tr role="row" class="nhsuk-table__row first-row">
+              <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
+              </td>
               <partial name="Shared/_AssessmentQuestionReviewCells"
-                       model="question"
-                       view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }})"/>
+                       model="competency.AssessmentQuestions.First()"
+                       view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }})" />
             </tr>
+            @foreach (var question in competency.AssessmentQuestions.Skip(1))
+            {
+              <tr role="row" class="nhsuk-table__row">
+                <partial name="Shared/_AssessmentQuestionReviewCells"
+                         model="question"
+                         view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }})" />
+              </tr>
+            }
           }
-        }
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    }
   }
-}
-@if (Model.SupervisorSignOffs.Any())
-{
-<div class="nhsuk-u-margin-top-4">
-  <h3>Self Assessment Sign-off Status</h3>
-  <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
-</div>
-}
+  @if (Model.SupervisorSignOffs.Any())
+  {
+    <div class="nhsuk-u-margin-top-4">
+      <h3>Self Assessment Sign-off Status</h3>
+      <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
+    </div>
+  }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffHistory.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffHistory.cshtml
@@ -19,7 +19,10 @@
              asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
           </li>
           <li class="nhsuk-breadcrumb__item">
-            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+               asp-action="ReviewDelegateSelfAssessment"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
               @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
             </a>
           </li>
@@ -30,6 +33,15 @@
       </div>
     </nav>
 }
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="ReviewDelegateSelfAssessment"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+     asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+    Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
+      Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+  </a>
+</p>
 <partial name="Shared/_SignOffHistory" model="@Model.SupervisorSignOffs" />
 <div class="nhsuk-back-link">
   <a class="nhsuk-back-link__link" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffHistory.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffHistory.cshtml
@@ -31,17 +31,17 @@
           </li>
         </ol>
       </div>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="ReviewDelegateSelfAssessment"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+           asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+          Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
+      Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+        </a>
+      </p>
     </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="ReviewDelegateSelfAssessment"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-     asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-    Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
-      Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
-  </a>
-</p>
 <partial name="Shared/_SignOffHistory" model="@Model.SupervisorSignOffs" />
 <div class="nhsuk-back-link">
   <a class="nhsuk-back-link__link" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
@@ -36,6 +36,15 @@
       </div>
     </nav>
 }
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="ReviewDelegateSelfAssessment"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+     asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
+    Back to @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ?
+    Model.SelfAssessmentResultSummary.RoleName.Substring(0,32) + "..." : Model.SelfAssessmentResultSummary.RoleName )
+  </a>
+</p>
 <details class="nhsuk-details nhsuk-expander">
   <summary class="nhsuk-details__summary">
     <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
@@ -34,17 +34,17 @@
           </li>
         </ol>
       </div>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="ReviewDelegateSelfAssessment"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+           asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
+          Back to @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ?
+    Model.SelfAssessmentResultSummary.RoleName.Substring(0,32) + "..." : Model.SelfAssessmentResultSummary.RoleName )
+        </a>
+      </p>
     </nav>
 }
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="ReviewDelegateSelfAssessment"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-     asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
-    Back to @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ?
-    Model.SelfAssessmentResultSummary.RoleName.Substring(0,32) + "..." : Model.SelfAssessmentResultSummary.RoleName )
-  </a>
-</p>
 <details class="nhsuk-details nhsuk-expander">
   <summary class="nhsuk-details__summary">
     <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
@@ -20,31 +20,32 @@
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
              asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
-          </li>
-          <li class="nhsuk-breadcrumb__item">
-            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment"
-               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-               asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-              @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
-            </a>
-          </li>
-          <li>
-            Verify results
-          </li>
-        </ol>
-      </div>
-    </nav>
-}
-<p class="nhsuk-breadcrumb__back">
-  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-     asp-action="ReviewDelegateSelfAssessment"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-     asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-    Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+          </a>
+        </li>
+        <li class="nhsuk-breadcrumb__item">
+          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment"
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+             asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+            @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+          </a>
+        </li>
+        <li>
+          Verify results
+        </li>
+      </ol>
+    </div>
+    <p class="nhsuk-breadcrumb__back">
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+         asp-action="ReviewDelegateSelfAssessment"
+         asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+         asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+        Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
             Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
-  </a>
-  </p>
+      </a>
+    </p>
+  </nav>
+}
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
@@ -19,10 +19,13 @@
         <li class="nhsuk-breadcrumb__item">
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
              asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+          @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
           </li>
           <li class="nhsuk-breadcrumb__item">
-            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
               @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
             </a>
           </li>
@@ -33,75 +36,84 @@
       </div>
     </nav>
 }
-<details class="nhsuk-details nhsuk-expander">
-  <summary class="nhsuk-details__summary">
-    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-    </h1>
-  </summary>
-  <div class="nhsuk-details__text">
-    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
-  </div>
-</details>
-<h2>Verify Multiple Results for @Model.DelegateSelfAssessment.RoleName</h2>
-@if (Model.CompetencyGroups.Any())
+<p class="nhsuk-breadcrumb__back">
+  <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+     asp-action="ReviewDelegateSelfAssessment"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+     asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+    Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
+            Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+  </a>
+  </p>
+  <details class="nhsuk-details nhsuk-expander">
+    <summary class="nhsuk-details__summary">
+      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+      </h1>
+    </summary>
+    <div class="nhsuk-details__text">
+      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+    </div>
+  </details>
+  <h2>Verify Multiple Results for @Model.DelegateSelfAssessment.RoleName</h2>
+  @if (Model.CompetencyGroups.Any())
 {
   <h3>Tick each self assessment result that you wish to verify and then click Submit</h3>
   <form method="post">
     @foreach (var competencyGroup in Model.CompetencyGroups)
     {
       var vocabulary = competencyGroup.First().Vocabulary;
-      <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
-        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-          <span class="nhsuk-fieldset__heading">
-            @competencyGroup.Key
-          </span>
-        </legend>
-      </fieldset>
-      @if (competencyGroup.Count() > 1)
+    <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
+      <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+        <span class="nhsuk-fieldset__heading">
+          @competencyGroup.Key
+        </span>
+      </legend>
+    </fieldset>
+    @if (competencyGroup.Count() > 1)
       {
-        <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
-          <div class="nhsuk-grid-column-full">
-            <a class="nhsuk-button nhsuk-search__submit select-all-button select-all status-tag" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural(vocabulary).ToLower()</a>
-            <a class="nhsuk-button nhsuk-search__submit select-all-button deselect-all status-tag" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural(vocabulary).ToLower()</a>
-          </div>
-        </div>
+    <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
+      <div class="nhsuk-grid-column-full">
+        <a class="nhsuk-button nhsuk-search__submit select-all-button select-all status-tag" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural(vocabulary).ToLower()</a>
+        <a class="nhsuk-button nhsuk-search__submit select-all-button deselect-all status-tag" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural(vocabulary).ToLower()</a>
+      </div>
+    </div>
       }
-      <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
-        <thead role="rowgroup" class="nhsuk-table__head">
-          <tr role="row">
-            <th role="columnheader" class="" scope="col">
-              @vocabulary
-            </th>
-            <th role="columnheader" class="" scope="col">
-              Question
-            </th>
-            <th role="columnheader" class="" scope="col">
-              Response
-            </th>
-          </tr>
-        </thead>
-        <tbody class="nhsuk-table__body">
-          @foreach (var competency in competencyGroup)
+    <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
+      <thead role="rowgroup" class="nhsuk-table__head">
+        <tr role="row">
+          <th role="columnheader" class="" scope="col">
+            @vocabulary
+          </th>
+          <th role="columnheader" class="" scope="col">
+            Question
+          </th>
+          <th role="columnheader" class="" scope="col">
+            Response
+          </th>
+        </tr>
+      </thead>
+      <tbody class="nhsuk-table__body">
+        @foreach (var competency in competencyGroup)
           {
-            @foreach (var question in competency.AssessmentQuestions)
+        @foreach (var question in competency.AssessmentQuestions)
             {
-              <tr role="row" class="nhsuk-table__row">
-                <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                  <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
-                  <div class="nhsuk-checkboxes__item">
-                    <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.SelfAssessmentResultSupervisorVerificationId" name="resultChecked" type="checkbox" value="@question.SelfAssessmentResultSupervisorVerificationId">
-                    <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
-                      @competency.Name
-                    </label>
-                  </div>
-                </td>
-                <partial name="Shared/_AssessmentQuestionCells" model="question" />
-              </tr>
+        <tr role="row" class="nhsuk-table__row">
+          <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+            <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
+            <div class="nhsuk-checkboxes__item">
+              <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.SelfAssessmentResultSupervisorVerificationId" name="resultChecked" type="checkbox" value="@question.SelfAssessmentResultSupervisorVerificationId">
+              <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
+                @competency.Name
+              </label>
+            </div>
+          </td>
+          <partial name="Shared/_AssessmentQuestionCells" model="question" />
+        </tr>
             }
           }
-        </tbody>
-      </table>
+      </tbody>
+    </table>
     }
     <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
       <div class="nhsuk-grid-column-full">
@@ -119,6 +131,6 @@ else
   <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">Cancel</a>
 }
 
-@section scripts {
-  <script src="@Url.Content("~/js/Supervisor/verifyMultipleResults.js")" asp-append-version="true"></script>
-}
+  @section scripts {
+    <script src="@Url.Content("~/js/Supervisor/verifyMultipleResults.js")" asp-append-version="true"></script>
+  }


### PR DESCRIPTION
### JIRA link
[DLSV2-427](https://hee-dls.atlassian.net/browse/DLSV2-427)

### Description
Implements the previously missing backlinks to the breadcrumb navbar throughout the Supervisor interface for mobile layout fallback. These are a feature of the [NHS Design System Breadcrumb navigation](https://service-manual.nhs.uk/design-system/components/breadcrumbs) component.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/144253848-2c584b76-cff2-41b2-b623-178700f3deb3.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [y ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ y] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ y] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ y] Scanned over my own MR to ensure everything is as expected.
