### PR TITLE
HEEDLS-661 Hide diagnostics on course setup

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseDetails/CourseOptionsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseDetails/CourseOptionsViewModel.cs
@@ -11,6 +11,7 @@
             DiagnosticObjectiveSelection = courseDetails.DiagObjSelect;
             HideInLearningPortal = courseDetails.HideInLearnerPortal;
             CustomisationId = courseDetails.CustomisationId;
+            ShowDiagnosticObjectiveSelection = courseDetails.DiagAssess;
         }
 
         public int CustomisationId { get; set; }
@@ -18,5 +19,6 @@
         public bool AllowSelfEnrolment { get; set; }
         public bool DiagnosticObjectiveSelection { get; set; }
         public bool HideInLearningPortal { get; set; }
+        public bool ShowDiagnosticObjectiveSelection { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseOptionsExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/ManageCourse/_CourseOptionsExpandable.cshtml
@@ -11,42 +11,44 @@
   <div class="nhsuk-details__text">
     <dl class="nhsuk-summary-list details-list-with-button">
       <div class="nhsuk-summary-list__row details-list-with-button__row">
-      <dt class="nhsuk-summary-list__key">
-        Active
-      </dt>
-      <partial name="_SummaryBooleanField" model="Model.Active" />
-  </div>
+        <dt class="nhsuk-summary-list__key">
+          Active
+        </dt>
+        <partial name="_SummaryBooleanField" model="Model.Active" />
+      </div>
 
-  <div class="nhsuk-summary-list__row details-list-with-button__row">
-    <dt class="nhsuk-summary-list__key">
-      Allow self-enrolment
-    </dt>
-    <partial name="_SummaryBooleanField" model="Model.AllowSelfEnrolment" />
-  </div>
+      <div class="nhsuk-summary-list__row details-list-with-button__row">
+        <dt class="nhsuk-summary-list__key">
+          Allow self-enrolment
+        </dt>
+        <partial name="_SummaryBooleanField" model="Model.AllowSelfEnrolment" />
+      </div>
 
-  <div class="nhsuk-summary-list__row details-list-with-button__row">
-    <dt class="nhsuk-summary-list__key">
-      Hide in Learning Portal
-    </dt>
-    <partial name="_SummaryBooleanField" model="Model.HideInLearningPortal" />
-  </div>
+      <div class="nhsuk-summary-list__row details-list-with-button__row">
+        <dt class="nhsuk-summary-list__key">
+          Hide in Learning Portal
+        </dt>
+        <partial name="_SummaryBooleanField" model="Model.HideInLearningPortal" />
+      </div>
 
-  <div class="nhsuk-summary-list__row details-list-with-button__row">
-    <dt class="nhsuk-summary-list__key">
-      Allow diagnostic objective selection
-    </dt>
-    <partial name="_SummaryBooleanField" model="Model.DiagnosticObjectiveSelection" />
-  </div>
-  </dl>
+      @if (Model.ShowDiagnosticObjectiveSelection) {
+        <div class="nhsuk-summary-list__row details-list-with-button__row">
+          <dt class="nhsuk-summary-list__key">
+            Allow diagnostic objective selection
+          </dt>
+          <partial name="_SummaryBooleanField" model="Model.DiagnosticObjectiveSelection" />
+        </div>
+      }
+    </dl>
 
-  <a class="nhsuk-button nhsuk-u-margin-right-2"
-     role="button"
-     aria-label="Edit course options"
-     asp-controller="ManageCourse"
-     asp-action="EditCourseOptions"
-     asp-route-customisationId="@Model.CustomisationId">
-    Edit
-  </a>
+    <a class="nhsuk-button nhsuk-u-margin-right-2"
+       role="button"
+       aria-label="Edit course options"
+       asp-controller="ManageCourse"
+       asp-action="EditCourseOptions"
+       asp-route-customisationId="@Model.CustomisationId">
+      Edit
+    </a>
 
   </div>
 </details>


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-661](https://softwiretech.atlassian.net/browse/HEEDLS-661)

### Description
Hide diagnostic checkbox within course options, under course setup when the underlying application diagnostics is set to false.

### Screenshots
Diagnostic checkbox is hidden when required:
![image](https://user-images.githubusercontent.com/18046982/144199260-1dac2ff5-6208-4187-9413-3848d47f08a1.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
