### PR TITLE
Develop/fixes/DLSV2-449 Enrol on self assessment none available profile assessments better

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -320,6 +320,22 @@
         public IActionResult EnrolSetRoleProfile(int supervisorDelegateId, int selfAssessmentID)
         {
             SessionEnrolOnRoleProfile sessionEnrolOnRoleProfile = TempData.Peek<SessionEnrolOnRoleProfile>();
+
+            if (selfAssessmentID < 1)
+            {
+                ModelState.AddModelError("selfAssessmentId", "You must select a self assessment");
+                TempData.Set(sessionEnrolOnRoleProfile);
+                var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminID(), 0);
+                var roleProfiles = supervisorService.GetAvailableRoleProfilesForDelegate((int)supervisorDelegate.CandidateID, GetCentreId());
+                var model = new EnrolDelegateOnProfileAssessmentViewModel()
+                {
+                    SessionEnrolOnRoleProfile = sessionEnrolOnRoleProfile,
+                    SupervisorDelegateDetail = supervisorDelegate,
+                    RoleProfiles = roleProfiles
+                };
+                return View("EnrolDelegateOnProfileAssessment", model);
+            }
+            
             sessionEnrolOnRoleProfile.SelfAssessmentID = selfAssessmentID;
             TempData.Set(sessionEnrolOnRoleProfile);
             return RedirectToAction("EnrolDelegateCompleteBy", "Supervisor", new { supervisorDelegateId = supervisorDelegateId });

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
@@ -37,7 +37,10 @@
     </p>
   </nav>
 }
-
+@if (errorHasOccurred)
+{
+  <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SessionEnrolOnRoleProfile.SelfAssessmentID) })" />
+}
 <details class="nhsuk-details nhsuk-expander">
   <summary class="nhsuk-details__summary">
     <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateOnProfileAssessment.cshtml
@@ -38,24 +38,26 @@
   </nav>
 }
 
-  <details class="nhsuk-details nhsuk-expander">
-    <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </h1>
-    </summary>
-    <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
-    </div>
-  </details>
-  <h2>Enrol on Profile Assessment</h2>
-  <h3>Choose a role profile</h3>
+<details class="nhsuk-details nhsuk-expander">
+  <summary class="nhsuk-details__summary">
+    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+      @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+    </h1>
+  </summary>
+  <div class="nhsuk-details__text">
+    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+  </div>
+</details>
+<h2>Enrol on Self Assessment</h2>
+@if (Model.RoleProfiles.Any())
+{
+  <h3>Choose a self assessment</h3>
   <form method="post">
     <table class="nhsuk-table-responsive">
       <thead role="rowgroup" class="nhsuk-table__head">
         <tr role="row">
           <th role="columnheader" class="" scope="col">
-            Profile name
+            Self assessment
           </th>
           <th role="columnheader" class="" scope="col">
             Brand
@@ -73,7 +75,7 @@
         {
           <tr role="row" class="nhsuk-table__row collaborator-row">
             <td role="cell" class="nhsuk-table__cell">
-              <span class="nhsuk-table-responsive__heading">Profile name </span>
+              <span class="nhsuk-table-responsive__heading">Self assessment </span>
               <div class="nhsuk-radios__item">
                 <input class="nhsuk-radios__input" id="role-profile-check-@roleProfile.ID" asp-for="SessionEnrolOnRoleProfile.SelfAssessmentID" name="SelfAssessmentID" type="radio" value="@roleProfile.ID">
                 <label class="nhsuk-label nhsuk-radios__label" for="role-profile-check-@roleProfile.ID">
@@ -102,13 +104,20 @@
     </table>
     <button class="nhsuk-button nhsuk-u-margin-top-5" id="save-button" type="submit">Next</button>
   </form>
-  <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
-       asp-action="DelegateProfileAssessments"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-      </svg>
-      Cancel
-    </a>
-  </div>
+}
+else
+{
+  <h3>No self assessments available</h3>
+  <p>No self assessments are available for enrolment for this member of staff.</p>
+}
+
+<div class="nhsuk-back-link">
+  <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+     asp-action="DelegateProfileAssessments"
+     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+    </svg>
+    Cancel
+  </a>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
@@ -51,7 +51,7 @@
 
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Role profile
+      Self Assessment
     </dt>
     <dd class="nhsuk-summary-list__value">
       @Model.RoleProfile.RoleProfileName


### PR DESCRIPTION
### JIRA link
[DLSV2-449](https://hee-dls.atlassian.net/browse/DLSV2-449)

### Description
- If there are no profile assessments in the ViewModel, we display a message saying “No profile assessments are available for enrolment for this member of staff.” and remove the “Next” button.
- Also replaced references to "profile assessment" with "self assessment" in enrol flow.
- Implements validation on choose self-assessment screen.
