### PR TITLE
HEEDLS-701 Move LearningHubApiClient models into External folder

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
@@ -8,7 +8,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
     using DigitalLearningSolutions.Data.Helpers;
-    using DigitalLearningSolutions.Data.Models.LearningHubApiClient;
+    using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Services;
     using FakeItEasy;

--- a/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
+++ b/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
@@ -6,7 +6,7 @@
     using System.Net.Http;
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Helpers;
-    using DigitalLearningSolutions.Data.Models.LearningHubApiClient;
+    using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using Microsoft.Extensions.Configuration;
     using Newtonsoft.Json;
 

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/BulkResourceReferences.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/BulkResourceReferences.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Models.LearningHubApiClient
+﻿namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
 {
     using System.Collections.Generic;
 

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/Catalogue.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/Catalogue.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Models.LearningHubApiClient
+﻿namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
 {
     public class Catalogue
     {

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceMetadata.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceMetadata.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Models.LearningHubApiClient
+﻿namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
 {
     using System.Collections.Generic;
 

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceReference.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceReference.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Models.LearningHubApiClient
+﻿namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
 {
     public class ResourceReference
     {

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceReferenceWithResourceDetails.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceReferenceWithResourceDetails.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Models.LearningHubApiClient
+﻿namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
 {
     public class ResourceReferenceWithResourceDetails
     {

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceSearchResult.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/ResourceSearchResult.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Data.Models.LearningHubApiClient
+﻿namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
 {
     using System.Collections.Generic;
 

--- a/DigitalLearningSolutions.Data/Models/LearningResources/ActionPlanItem.cs
+++ b/DigitalLearningSolutions.Data/Models/LearningResources/ActionPlanItem.cs
@@ -1,7 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.LearningResources
 {
     using System;
-    using DigitalLearningSolutions.Data.Models.LearningHubApiClient;
+    using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
 
     public class ActionPlanItem : CurrentLearningItem
     {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-701

### Description
Moved the LearningHubApiClient models into the Models/External folder

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
