### PR TITLE
HEEDLS-685 show professional registration number on My Account page

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -31,7 +31,9 @@
             string? answer5 = null,
             string? answer6 = null,
             string? aliasId = null,
-            bool active = true
+            bool active = true,
+            bool hasBeenPromptedForPrn = false,
+            string? professionalRegistrationNumber = null
         )
         {
             dateRegistered ??= DateTime.Parse("2010-09-22 06:52:09.080");
@@ -58,7 +60,9 @@
                 Answer5 = answer5,
                 Answer6 = answer6,
                 AliasId = aliasId,
-                Active = active
+                Active = active,
+                HasBeenPromptedForPrn = hasBeenPromptedForPrn,
+                ProfessionalRegistrationNumber = professionalRegistrationNumber
             };
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -34,7 +34,9 @@
                         cd.Answer5,
                         cd.Answer6,
                         cd.JobGroupID,
-                        jg.JobGroupName
+                        jg.JobGroupName,
+                        cd.HasBeenPromptedForPrn,
+                        cd.ProfessionalRegistrationNumber
                     FROM Candidates AS cd
                     INNER JOIN Centres AS ct ON ct.CentreID = cd.CentreID
                     INNER JOIN JobGroups AS jg ON jg.JobGroupID = cd.JobGroupID
@@ -258,7 +260,7 @@
                     record.Answer6,
                     record.AliasId,
                     record.Approved,
-                    record.Email
+                    record.Email,
                 },
                 commandType: CommandType.StoredProcedure
             );
@@ -382,7 +384,7 @@
                     answer5,
                     answer6,
                     aliasId,
-                    emailAddress
+                    emailAddress,
                 }
             );
         }

--- a/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
@@ -16,6 +16,8 @@
         public string? Answer5 { get; set; }
         public string? Answer6 { get; set; }
         public string? AliasId { get; set; }
+        public bool HasBeenPromptedForPrn { get; set; }
+        public string? ProfessionalRegistrationNumber { get; set; }
 
         public override UserReference ToUserReference()
         {

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
@@ -138,14 +138,10 @@
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser(
                 hasBeenPromptedForPrn: false,
-                professionalRegistrationNumber: "123456"
+                professionalRegistrationNumber: null
             );
             var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
-                new List<CustomPromptWithAnswer>
-                {
-                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
-                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2),
-                }
+                new List<CustomPromptWithAnswer>{}
             );
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/MyAccount/MyAccountViewModelTests.cs
@@ -20,11 +20,17 @@
             var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
                 new List<CustomPromptWithAnswer>
                 {
-                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1)
-                });
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
+                }
+            );
 
             // When
-            var returnedModel = new MyAccountViewModel(adminUser, delegateUser, customPrompts, DlsSubApplication.Default);
+            var returnedModel = new MyAccountViewModel(
+                adminUser,
+                delegateUser,
+                customPrompts,
+                DlsSubApplication.Default
+            );
 
             // Then
             using (new AssertionScope())
@@ -71,8 +77,9 @@
             var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
                 new List<CustomPromptWithAnswer>
                 {
-                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1)
-                });
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
+                }
+            );
 
             // When
             var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts, DlsSubApplication.Default);
@@ -100,8 +107,9 @@
                 new List<CustomPromptWithAnswer>
                 {
                     CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
-                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2)
-                });
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2),
+                }
+            );
 
             // When
             var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts, DlsSubApplication.Default);
@@ -121,6 +129,84 @@
                     .BeEquivalentTo(customPrompts.CustomPrompts[1].CustomPromptText);
                 returnedModel.CustomFields[1].Answer.Should().BeEquivalentTo(delegateUser.Answer1);
                 returnedModel.CustomFields[1].Mandatory.Should().BeFalse();
+            }
+        }
+
+        [Test]
+        public void MyAccountViewModel_where_user_has_not_been_asked_for_prn_says_not_yet_provided()
+        {
+            // Given
+            var delegateUser = UserTestHelper.GetDefaultDelegateUser(
+                hasBeenPromptedForPrn: false,
+                professionalRegistrationNumber: "123456"
+            );
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
+                new List<CustomPromptWithAnswer>
+                {
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2),
+                }
+            );
+
+            // When
+            var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts, DlsSubApplication.Default);
+
+            // Then
+            using (new AssertionScope())
+            {
+                returnedModel.ProfessionalRegistrationNumber.Should().Be("Not yet provided");
+            }
+        }
+
+        [Test]
+        public void MyAccountViewModel_with_no_prn_should_show_not_registered()
+        {
+            // Given
+            var delegateUser = UserTestHelper.GetDefaultDelegateUser(
+                hasBeenPromptedForPrn: true,
+                professionalRegistrationNumber: null
+            );
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
+                new List<CustomPromptWithAnswer>
+                {
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2),
+                }
+            );
+
+            // When
+            var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts, DlsSubApplication.Default);
+
+            // Then
+            using (new AssertionScope())
+            {
+                returnedModel.ProfessionalRegistrationNumber.Should().Be("Not professionally registered");
+            }
+        }
+
+        [Test]
+        public void MyAccountViewModel_with_prn_displays_prn()
+        {
+            // Given
+            var delegateUser = UserTestHelper.GetDefaultDelegateUser(
+                hasBeenPromptedForPrn: true,
+                professionalRegistrationNumber: "12345678"
+            );
+            var customPrompts = CustomPromptsTestHelper.GetDefaultCentreCustomPromptsWithAnswers(
+                new List<CustomPromptWithAnswer>
+                {
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(1),
+                    CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(2),
+                }
+            );
+
+            // When
+            var returnedModel = new MyAccountViewModel(null, delegateUser, customPrompts, DlsSubApplication.Default);
+
+            // Then
+            using (new AssertionScope())
+            {
+                returnedModel.ProfessionalRegistrationNumber.Should().Be(delegateUser.ProfessionalRegistrationNumber);
             }
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
@@ -13,7 +14,8 @@
             AdminUser? adminUser,
             DelegateUser? delegateUser,
             CentreCustomPromptsWithAnswers? customPrompts,
-            DlsSubApplication dlsSubApplication)
+            DlsSubApplication dlsSubApplication
+        )
         {
             FirstName = adminUser?.FirstName ?? delegateUser?.FirstName;
             Surname = adminUser?.LastName ?? delegateUser?.LastName;
@@ -23,12 +25,24 @@
             DelegateNumber = delegateUser?.CandidateNumber;
             AliasId = delegateUser?.AliasId;
             JobGroup = delegateUser?.JobGroupName;
+            ProfessionalRegistrationNumber = delegateUser?.HasBeenPromptedForPrn == true
+                ? delegateUser.ProfessionalRegistrationNumber ?? "Not professionally registered"
+                : "Not yet provided";
+
+            Console.WriteLine(delegateUser);
 
             CustomFields = new List<CustomFieldViewModel>();
             if (customPrompts != null)
             {
-                CustomFields = customPrompts.CustomPrompts.Select(cp =>
-                        new CustomFieldViewModel(cp.CustomPromptNumber, cp.CustomPromptText, cp.Mandatory, cp.Answer))
+                CustomFields = customPrompts.CustomPrompts.Select(
+                        cp =>
+                            new CustomFieldViewModel(
+                                cp.CustomPromptNumber,
+                                cp.CustomPromptText,
+                                cp.Mandatory,
+                                cp.Answer
+                            )
+                    )
                     .ToList();
             }
 
@@ -50,6 +64,8 @@
         public byte[]? ProfilePicture { get; set; }
 
         public string? JobGroup { get; set; }
+
+        public string? ProfessionalRegistrationNumber { get; set; }
 
         public List<CustomFieldViewModel> CustomFields { get; set; }
 

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
@@ -28,8 +27,6 @@
             ProfessionalRegistrationNumber = delegateUser?.HasBeenPromptedForPrn == true
                 ? delegateUser.ProfessionalRegistrationNumber ?? "Not professionally registered"
                 : "Not yet provided";
-
-            Console.WriteLine(delegateUser);
 
             CustomFields = new List<CustomFieldViewModel>();
             if (customPrompts != null)

--- a/DigitalLearningSolutions.Web/Views/MyAccount/_MyDetailsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/_MyDetailsCard.cshtml
@@ -43,6 +43,13 @@
         }
 
         <div class="nhsuk-summary-list__row details-list-with-button__row">
+          <dt class="nhsuk-summary-list__key">
+            Professional Registration Number
+          </dt>
+          <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
+        </div>
+
+        <div class="nhsuk-summary-list__row details-list-with-button__row">
           <dt class="nhsuk-summary-list__key profile-picture__label">
             Profile picture (optional)
           </dt>


### PR DESCRIPTION
### JIRA link
_HEEDLS-685_(https://softwiretech.atlassian.net/jira/software/c/projects/HEEDLS/boards/671?modal=detail&selectedIssue=HEEDLS-685&assignee=6065c334b30f0d00704264d4)

### Description
Add the professional registration number to the my account page. 

- Shows "Not yet registered" if they have not yet been asked for their PRN. 
- "Not professionally registered" if they have been asked for their PRN but it is null
- And the professional registration number if they have been asked for and provided one

### Screenshots
![hee685 prn](https://user-images.githubusercontent.com/88332001/145064679-9a397f0b-260c-40e7-963a-644c7c8c55b9.png)
![hee685 not registered](https://user-images.githubusercontent.com/88332001/145064707-6a0c3e9e-8475-4c04-a49b-8ce7e4d00a34.png)
![hee685 not yet](https://user-images.githubusercontent.com/88332001/145064741-29567350-33e3-4690-9141-a8df40595a61.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
