### PR TITLE
Adds brackets around parameterised IN lists

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
@@ -56,10 +56,9 @@
         public async Task SetPasswordForUsersAsync(IEnumerable<UserReference> users, string passwordHash)
         {
             var userRefs = users.ToList();
-
             await connection.ExecuteAsync(
-                @"UPDATE AdminUsers SET Password = @PasswordHash WHERE AdminID IN @AdminIds;
-                  UPDATE Candidates SET Password = @PasswordHash WHERE CandidateID IN @CandidateIds;",
+                @"UPDATE AdminUsers SET Password = @PasswordHash WHERE AdminID IN (@AdminIds);
+                  UPDATE Candidates SET Password = @PasswordHash WHERE CandidateID IN (@CandidateIds);",
                 new
                 {
                     PasswordHash = passwordHash,


### PR DESCRIPTION
### JIRA link
N/A

### Description
Fix to a bug with the My Account / Change Password update password query. This was previously throwing an error because the query uses parameterised lists of admin and candidate IDs but these were missing brackets in the SQL query text.
