### PR TITLE
DLSV2-451 Fixes competency preview comments prompt and hint

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1224,7 +1224,9 @@ WHERE (FrameworkID = @frameworkId)", new { frameworkId, assessmentQuestionId }
                                                   AQ.MaxValue,
                                                   AQ.AssessmentQuestionInputTypeID,
                                                   AQ.IncludeComments,
-                                                  AQ.MinValue AS Result
+                                                  AQ.MinValue AS Result,
+                                                  AQ.CommentsPrompt,
+                                                  AQ.CommentsHint
 												  FROM   Competencies AS C INNER JOIN
              FrameworkCompetencies AS FC ON C.ID = FC.CompetencyID INNER JOIN
              FrameworkCompetencyGroups AS FCG ON FC.FrameworkCompetencyGroupID = FCG.ID INNER JOIN


### PR DESCRIPTION
### JIRA link
[DLSV2-451](https://hee-dls.atlassian.net/browse/DLSV2-451)

### Description
Adds missing assessment question fields to dapper query to populate competency preview comments custom prompt and hint text.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/145361210-bee33eff-8b0a-43f3-8b80-1cd01bd8ca57.png)