### PR TITLE
HEEDLS-703 - Migration to add question comparison columns to Competen…

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202112091009_AddColumnsToCompetencyResourceAssessmentQuestionParameters.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202112091009_AddColumnsToCompetencyResourceAssessmentQuestionParameters.cs
@@ -20,7 +20,7 @@
                 )
                 .OnTable("CompetencyResourceAssessmentQuestionParameters");
             Delete.Column("RelevanceAssessmentQuestionID").FromTable("CompetencyResourceAssessmentQuestionParameters");
-            Delete.Column("CompareToRoleRequirements ").FromTable("CompetencyResourceAssessmentQuestionParameters");
+            Delete.Column("CompareToRoleRequirements").FromTable("CompetencyResourceAssessmentQuestionParameters");
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202112091009_AddColumnsToCompetencyResourceAssessmentQuestionParameters.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202112091009_AddColumnsToCompetencyResourceAssessmentQuestionParameters.cs
@@ -1,0 +1,26 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202112091009)]
+    public class AddColumnsToCompetencyResourceAssessmentQuestionParameters : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("CompetencyResourceAssessmentQuestionParameters")
+                .AddColumn("RelevanceAssessmentQuestionID").AsInt32().Nullable().WithDefaultValue(null)
+                .ForeignKey("AssessmentQuestions", "ID")
+                .AddColumn("CompareToRoleRequirements").AsBoolean().NotNullable().WithDefaultValue(false);
+        }
+
+        public override void Down()
+        {
+            Delete.ForeignKey(
+                    "FK_CompetencyResourceAssessmentQuestionParameters_RelevanceAssessmentQuestionID_AssessmentQuestions_ID"
+                )
+                .OnTable("CompetencyResourceAssessmentQuestionParameters");
+            Delete.Column("RelevanceAssessmentQuestionID").FromTable("CompetencyResourceAssessmentQuestionParameters");
+            Delete.Column("CompareToRoleRequirements ").FromTable("CompetencyResourceAssessmentQuestionParameters");
+        }
+    }
+}


### PR DESCRIPTION
…cyResourceAssessmentQuestionParameters

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-703

### Description
New migration adding two new columns to the ComptencyResourceAssessmentQuestionParameters that will be used in the Recommendation Score generation for learning resources.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/19875758087/Recommendation+Score
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
