### PR TITLE
HEEDLS-671 - disable resource retrieval when signposting disabled

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
@@ -145,6 +145,24 @@
         }
 
         [Test]
+        public async Task GetIncompleteActionPlanResources_returns_empty_list_if_signposting_is_disabled()
+        {
+            // Given
+            const int delegateId = 1;
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("false");
+
+            // When
+            var result = await actionPlanService.GetIncompleteActionPlanResources(delegateId);
+
+            // Then
+            result.Should().BeEmpty();
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(A<int>._))
+                .MustNotHaveHappened();
+            A.CallTo(() => learningHubApiClient.GetBulkResourcesByReferenceIds(A<IEnumerable<int>>._))
+                .MustNotHaveHappened();
+        }
+
+        [Test]
         public async Task GetIncompleteActionPlanResources_returns_empty_list_if_no_incomplete_learning_log_items_found()
         {
             // Given

--- a/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
@@ -150,7 +150,6 @@
         {
             // Given
             const int delegateId = 1;
-            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("true");
             var invalidLearningLogItems = Builder<LearningLogItem>.CreateListOfSize(3)
                 .All().With(i => i.CompletedDate = null).And(i => i.ArchivedDate = null)
                 .And(i => i.LearningHubResourceReferenceId = 1)
@@ -175,7 +174,6 @@
         {
             // Given
             const int delegateId = 1;
-            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("true");
             var learningLogIds = new List<int> { 4, 5, 6, 7, 8 };
             var learningResourceIds = new List<int> { 15, 21, 33, 48, 51 };
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(5).All()

--- a/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
@@ -145,25 +145,8 @@
         }
 
         [Test]
-        public async Task GetIncompleteActionPlanResources_returns_empty_list_if_signposting_is_disabled()
-        {
-            // Given
-            const int delegateId = 1;
-            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("false");
-
-            // When
-            var result = await actionPlanService.GetIncompleteActionPlanResources(delegateId);
-
-            // Then
-            result.Should().BeEmpty();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(A<int>._))
-                .MustNotHaveHappened();
-            A.CallTo(() => learningHubApiClient.GetBulkResourcesByReferenceIds(A<IEnumerable<int>>._))
-                .MustNotHaveHappened();
-        }
-
-        [Test]
-        public async Task GetIncompleteActionPlanResources_returns_empty_list_if_no_incomplete_learning_log_items_found()
+        public async Task
+            GetIncompleteActionPlanResources_returns_empty_list_if_no_incomplete_learning_log_items_found()
         {
             // Given
             const int delegateId = 1;
@@ -399,7 +382,8 @@
         }
 
         [Test]
-        public void VerifyDelegateCanAccessActionPlanResource_returns_false_if_LearningLogItem_is_for_different_delegate()
+        public void
+            VerifyDelegateCanAccessActionPlanResource_returns_false_if_LearningLogItem_is_for_different_delegate()
         {
             // Given
             A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("true");

--- a/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
@@ -102,11 +102,6 @@
 
         public async Task<IEnumerable<ActionPlanResource>> GetIncompleteActionPlanResources(int delegateId)
         {
-            if (!config.IsSignpostingUsed())
-            {
-                return new List<ActionPlanResource>();
-            }
-
             var incompleteLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId)
                 .Where(
                     i => i.CompletedDate == null && i.ArchivedDate == null && i.LearningHubResourceReferenceId != null
@@ -171,7 +166,8 @@
 
             var actionPlanResource = learningLogItemsDataService.GetLearningLogItem(learningLogItemId);
 
-            if (!(actionPlanResource is { ArchivedDate: null }) || actionPlanResource.LearningHubResourceReferenceId == null)
+            if (!(actionPlanResource is { ArchivedDate: null }) ||
+                actionPlanResource.LearningHubResourceReferenceId == null)
             {
                 return null;
             }

--- a/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
@@ -102,6 +102,11 @@
 
         public async Task<IEnumerable<ActionPlanResource>> GetIncompleteActionPlanResources(int delegateId)
         {
+            if (!config.IsSignpostingUsed())
+            {
+                return new List<ActionPlanResource>();
+            }
+
             var incompleteLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId)
                 .Where(
                     i => i.CompletedDate == null && i.ArchivedDate == null && i.LearningHubResourceReferenceId != null

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -1,10 +1,14 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Helpers;
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.LearningResources;
+    using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current;
     using FakeItEasy;
@@ -35,8 +39,10 @@
             var bannerText = "bannerText";
             A.CallTo(() => courseDataService.GetCurrentCourses(CandidateId)).Returns(currentCourses);
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(CandidateId)).Returns(selfAssessments);
-            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).Returns(actionPlanResources);
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId))
+                .Returns(actionPlanResources);
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("true");
 
             // When
             var result = await controller.Current();
@@ -54,6 +60,62 @@
             );
             result.Should().BeViewResult()
                 .Model.Should().BeEquivalentTo(expectedModel);
+        }
+
+        [Test]
+        public async Task Current_action_should_not_fetch_ActionPlanResources_if_signposting_disabled()
+        {
+            // Given
+            GivenCurrentActivitesAreEmptyLists();
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("false");
+
+            // When
+            await controller.Current();
+
+            // Then
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task Current_action_should_fetch_ActionPlanResources_if_signposting_enabled()
+        {
+            // Given
+            GivenCurrentActivitesAreEmptyLists();
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("false");
+
+            // When
+            await controller.Current();
+
+            // Then
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task AllCurrentItems_action_should_not_fetch_ActionPlanResources_if_signposting_disabled()
+        {
+            // Given
+            GivenCurrentActivitesAreEmptyLists();
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("false");
+
+            // When
+            await controller.AllCurrentItems();
+
+            // Then
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task AllCurrentItems_action_should_fetch_ActionPlanResources_if_signposting_enabled()
+        {
+            // Given
+            GivenCurrentActivitesAreEmptyLists();
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("false");
+
+            // When
+            await controller.AllCurrentItems();
+
+            // Then
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).MustNotHaveHappened();
         }
 
         [Test]
@@ -292,6 +354,7 @@
             // Given
             const string bannerText = "Banner text";
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);
+            A.CallTo(() => config[ConfigHelper.UseSignposting]).Returns("true");
 
             // When
             var currentViewModel = await CurrentCourseHelper.CurrentPageViewModelFromController(controller);
@@ -333,6 +396,16 @@
             result.Should().BeRedirectResult().WithUrl(resourceLink);
             A.CallTo(() => actionPlanService.GetLearningResourceLinkAndUpdateLastAccessedDate(learningLogItemId, 11))
                 .MustHaveHappenedOnceExactly();
+        }
+
+        private void GivenCurrentActivitesAreEmptyLists()
+        {
+            A.CallTo(() => courseDataService.GetCurrentCourses(A<int>._)).Returns(new List<CurrentCourse>());
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(A<int>._))
+                .Returns(new List<CurrentSelfAssessment>());
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(A<int>._))
+                .Returns(new List<ActionPlanResource>());
+            A.CallTo(() => centresDataService.GetBannerText(A<int>._)).Returns("bannerText");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -1,9 +1,12 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.LearningPortalController
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Helpers;
+    using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
@@ -29,7 +32,7 @@
             var bannerText = GetBannerText();
             var selfAssessments =
                 selfAssessmentService.GetSelfAssessmentsForCandidate(delegateId);
-            var learningResources = await actionPlanService.GetIncompleteActionPlanResources(delegateId);
+            var learningResources = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
             var model = new CurrentPageViewModel(
                 currentCourses,
                 searchString,
@@ -49,7 +52,7 @@
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var selfAssessment =
                 selfAssessmentService.GetSelfAssessmentsForCandidate(delegateId);
-            var learningResources = await actionPlanService.GetIncompleteActionPlanResources(delegateId);
+            var learningResources = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);
             return View("Current/AllCurrentItems", model);
         }
@@ -188,6 +191,15 @@
         {
             actionPlanService.RemoveActionPlanResource(learningLogItemId, User.GetCandidateIdKnownNotNull());
             return RedirectToAction("Current");
+        }
+
+        private async Task<IEnumerable<ActionPlanResource>> GetIncompleteActionPlanResourcesIfSignpostingEnabled(
+            int delegateId
+        )
+        {
+            return config.IsSignpostingUsed()
+                ? await actionPlanService.GetIncompleteActionPlanResources(delegateId)
+                : new List<ActionPlanResource>();
         }
     }
 }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-671

### Description
In 671 I mistakenly removed a Signposting config check from a method that it should not have been removed from. This MR adds the check back.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
