### PR TITLE
DLSV2-454 competencies always show description

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202112170755_CompetenciesAlwaysShowDescription.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202112170755_CompetenciesAlwaysShowDescription.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202112170755)]
+    public class CompetenciesAlwaysShowDescription : Migration
+    {
+        public override void Down()
+        {
+            Alter.Table("Competencies").AddColumn("AlwaysShowDescription").AsBoolean().WithDefaultValue(false);
+        }
+
+        public override void Up()
+        {
+            Delete.Column("AlwaysShowDescription").FromTable("Competencies");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202112170755_CompetenciesAlwaysShowDescription.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202112170755_CompetenciesAlwaysShowDescription.cs
@@ -4,12 +4,12 @@
     [Migration(202112170755)]
     public class CompetenciesAlwaysShowDescription : Migration
     {
-        public override void Down()
+        public override void Up()
         {
             Alter.Table("Competencies").AddColumn("AlwaysShowDescription").AsBoolean().WithDefaultValue(false);
         }
 
-        public override void Up()
+        public override void Down()
         {
             Delete.Column("AlwaysShowDescription").FromTable("Competencies");
         }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -104,6 +104,7 @@
                 ELSE 0
             END AS HasDelegateNominatedRoles,
             SAS.Optional,
+            C.AlwaysShowDescription,
             AQ.ID AS Id,
             AQ.Question,
             AQ.MaxValueDescription,

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
@@ -13,6 +13,7 @@
         public int CompetencyGroupID { get; set; }
         public string? Vocabulary { get; set; }
         public bool Optional { get; set; }
+        public bool AlwaysShowDescription { get; set; }
         public bool IncludedInSelfAssessment { get; set; }
         public List<AssessmentQuestion> AssessmentQuestions { get; set; } = new List<AssessmentQuestion>();
     }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -26,7 +26,7 @@
   <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/pagination.css")" asp-append-version="true">
   <h1 class="competency-group-header nhsuk-u-font-size-32">@Model.Competency.CompetencyGroup</h1>
   <div class=" nhsuk-u-margin-top-8 nhsuk-u-margin-bottom-8">
-    @if (Model.Competency.Description != null && Model.Assessment.UseDescriptionExpanders)
+    @if (Model.Competency.Description != null && Model.Assessment.UseDescriptionExpanders && !Model.Competency.AlwaysShowDescription)
     {
       <details class="nhsuk-details">
         <summary class="nhsuk-details__summary">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -37,7 +37,7 @@
     <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
       <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
       @if (competency.AlwaysShowDescription) {
-    <p class="nhsuk-u-font-size-14 nhsuk-u-margin-top-2">@Html.Raw(competency.Description)</p>
+    <p class="nhsuk-u-margin-top-2">@Html.Raw(competency.Description)</p>
       }
     </td>
     <partial name="Shared/_AssessmentQuestionOverviewCells" model="competency.AssessmentQuestions.First()" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo } })" />

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -36,6 +36,9 @@
   <tr role="row" class="nhsuk-table__row first-row">
     <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
       <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
+      @if (competency.AlwaysShowDescription) {
+    <p class="nhsuk-u-font-size-14 nhsuk-u-margin-top-2">@Html.Raw(competency.Description)</p>
+      }
     </td>
     <partial name="Shared/_AssessmentQuestionOverviewCells" model="competency.AssessmentQuestions.First()" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo } })" />
     <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">


### PR DESCRIPTION
### JIRA link
DLSV2-454

### Description
Adds option to make competency description visible on the SelfAssessmentOverview table

This is decided per competency option, by a new flag “AlwaysShowDescription” on the competencies table.

We read the flag into the competency model and page ViewModel. If it is true, we display the competency description below the competency name on the SelfAssessmentOverview table and in the competency review screen.
