### PR TITLE
Develop/features/dlsv2 461 enforce role requirements

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202112200950_AddEnforceRoleRequirementsForSignOffFlag.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202112200950_AddEnforceRoleRequirementsForSignOffFlag.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202112200950)]
+    public class AddEnforceRoleRequirementsForSignOffFlag : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments").AddColumn("EnforceRoleRequirementsForSignOff").AsBoolean()
+                .WithDefaultValue(false);
+        }
+        public override void Down()
+        {
+            Delete.Column("EnforceRoleRequirementsForSignOff").FromTable("SelfAssessments");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -55,6 +55,7 @@
                         SA.IncludesSignposting,
                         SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                         SA.SupervisorSelfAssessmentReview,
+                        SA.EnforceRoleRequirementsForSignOff,
                         COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
                         COUNT(C.ID) AS NumberOfCompetencies,
                         CA.StartedDate,
@@ -106,7 +107,7 @@
                         SA.IncludesSignposting, SA.SignOffRequestorStatement, COALESCE(SA.Vocabulary, 'Capability'),
                         CA.StartedDate, CA.LastAccessed, CA.CompleteByDate, CA.UserBookmark, CA.UnprocessedUpdates,
                         CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders,
-                        SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview",
+                        SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview, SA.EnforceRoleRequirementsForSignOff",
                 new { candidateId, selfAssessmentId }
             );
         }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -14,5 +14,6 @@
         public string? VerificationRoleName { get; set; }
         public string? SignOffRoleName { get; set; }
         public string? SignOffRequestorStatement { get; set; }
+        public bool EnforceRoleRequirementsForSignOff { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
@@ -32,6 +32,13 @@
                             allVerifiedOrNotRequired = false;
                             break;
                         }
+
+                        if (SelfAssessment.EnforceRoleRequirementsForSignOff &&
+                            assessmentQuestion.ResultRAG == 1 | assessmentQuestion.ResultRAG == 2)
+                        {
+                            allVerifiedOrNotRequired = false;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### JIRA link
[DLSV2-461](https://hee-dls.atlassian.net/browse/DLSV2-461)

### Description
Adds SelfAssessment flag field “EnforceRoleRequirementsForSignOff” (default false).

When true, checks that all assessment questions are meeting their role requirements (if set in CompetencyAssessmentQuestionRoleRequirements) before allowing access to Request Sign Off.