### PR TITLE
DLSV2-465 Removes duplicated heading within expander

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -2,10 +2,6 @@
 @model IGrouping<string, Competency>;
 
 <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
-  @if (!(bool)ViewData["linearNavigation"])
-  {
-    <caption class="nhsuk-table__caption"><h2>@Model.Key</h2></caption>
-  }
   <thead role="rowgroup" class="nhsuk-table__head">
     <tr role="row">
       <th role="columnheader" class="" scope="col">


### PR DESCRIPTION
### JIRA link
[DLSV2-465](https://hee-dls.atlassian.net/browse/DLSV2-465)

### Description
Removes duplicated heading within competency group expander on the overview page:
![image](https://user-images.githubusercontent.com/67740339/147764654-88bb3827-4a29-439b-93b6-1652e5ed5e68.png)
