### PR TITLE
DLSV2-470 Migration to add new fields to LearningResourceReferences

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202201071343_AddFieldsToLearningResourceReferences.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201071343_AddFieldsToLearningResourceReferences.cs
@@ -1,0 +1,23 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202201071343)]
+    public class AddFieldsToLearningResourceReferences : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("LearningResourceReferences")
+                .AddColumn("ResourceLink").AsString(256).Nullable()
+                .AddColumn("OriginalDescription").AsString(4000).Nullable()
+                .AddColumn("OriginalResourceType").AsString(128).Nullable()
+                .AddColumn("OriginalCatalogueName").AsString(128).Nullable();
+        }
+        public override void Down()
+        {
+            Delete.Column("ResourceLink").FromTable("LearningResourceReferences");
+            Delete.Column("OriginalDescription").FromTable("LearningResourceReferences");
+            Delete.Column("OriginalResourceType").FromTable("LearningResourceReferences");
+            Delete.Column("OriginalCatalogueName").FromTable("LearningResourceReferences");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[DLSV2-470](https://hee-dls.atlassian.net/browse/DLSV2-470)

### Description
Adds fields to LearningResourceReferences to store additional information retrieved from the Learning Hub API when storing learning resources. This information will be used as a fallback when the API is unavailable. [Another ticket](https://hee-dls.atlassian.net/browse/DLSV2-469) and PR will deal with the changes required to populate these fields during competency resource signposting.