### PR TITLE
HEEDLS-712 - Modify the PK on CompetencyAssessmentQuestionRoleRequire…

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey.cs
@@ -18,8 +18,9 @@
         {
             Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
                 .FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable()
-                .PrimaryKey().Identity();
+            Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable().Identity();
+            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202201111021)]
+    public class ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey: Migration
+    {
+        public override void Up()
+        {
+            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Delete.Column("ID").FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
+        }
+
+        public override void Down()
+        {
+            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable()
+                .PrimaryKey().Identity();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements.cs
@@ -1,0 +1,30 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202201120821)]
+    public class ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements: Migration
+    {
+        public override void Up()
+        {
+            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable().Identity();
+            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
+            Create.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
+                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
+        }
+
+        public override void Down()
+        {
+            Delete.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
+                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Delete.Column("ID").FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -645,10 +645,10 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
                  FROM    SelfAssessmentResults AS sar2
                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
-WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
-             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
-             (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
-             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL)) AS UngradedCount,
+WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL) OR
+             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL) OR
+             (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL) OR
+             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL)) AS UngradedCount,
                  (SELECT COUNT(sas1.CompetencyID) AS NotMeetingCount
 FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              SelfAssessmentResults AS sar1 ON SelfAssessmentResultSupervisorVerifications.SelfAssessmentResultId = sar1.ID LEFT OUTER JOIN

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -645,10 +645,10 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
                  FROM    SelfAssessmentResults AS sar2
                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
-WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL) OR
-             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL) OR
-             (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL) OR
-             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.SelfAssessmentID IS NULL)) AS UngradedCount,
+WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
+             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
+             (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
+             (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL)) AS UngradedCount,
                  (SELECT COUNT(sas1.CompetencyID) AS NotMeetingCount
 FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              SelfAssessmentResults AS sar1 ON SelfAssessmentResultSupervisorVerifications.SelfAssessmentResultId = sar1.ID LEFT OUTER JOIN


### PR DESCRIPTION
…ments to be a compound key

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-712

### Description
The CompetencyAssessmentQuestionRoleRequirements table should only have one record for each SelfAssessmentID/CompetencyID combination, but the table did not actually enforce this. As advised by Kevin, I have removed the previous PK on the ID column, and the column itself, and replaced it with a compound PK on SelfAssessmentID and CompetencyID.

I have also made code changes where the ID was used and confirmed the method in question functions appropriately.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
