### PR TITLE
DLSV2-471 Migration to add OriginalRating field

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202201111458_LearningResourceReferencesOriginalRatingField.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201111458_LearningResourceReferencesOriginalRatingField.cs
@@ -11,7 +11,7 @@
         }
         public override void Down()
         {
-            Delete.Column("OriginalRating").FromTable("OriginalRating");
+            Delete.Column("OriginalRating").FromTable("LearningResourceReferences");
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202201111458_LearningResourceReferencesOriginalRatingField.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201111458_LearningResourceReferencesOriginalRatingField.cs
@@ -7,7 +7,7 @@
         public override void Up()
         {
             Alter.Table("LearningResourceReferences")
-                .AddColumn("OriginalRating").AsDecimal(2, 1).Nullable();
+                .AddColumn("OriginalRating").AsDecimal(2, 1).NotNullable().WithDefaultValue(0);
         }
         public override void Down()
         {

--- a/DigitalLearningSolutions.Data.Migrations/202201111458_LearningResourceReferencesOriginalRatingField.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201111458_LearningResourceReferencesOriginalRatingField.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202201111458)]
+    public class LearningResourceReferencesOriginalRatingField : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("LearningResourceReferences")
+                .AddColumn("OriginalRating").AsDecimal(2, 1).Nullable();
+        }
+        public override void Down()
+        {
+            Delete.Column("OriginalRating").FromTable("OriginalRating");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[DLSV2-471](https://hee-dls.atlassian.net/browse/DLSV2-471)

### Description
Migration to add OriginalRating field to LearningResourceReferences table. This will be populated when creating new LearningResourceReferences records and used as a fallback value if the Learning Bub API is unavailable.