### PR TITLE
Heedls 711 filter results outside range

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CompetencyLearningResourcesDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CompetencyLearningResourcesDataServiceTests.cs
@@ -78,7 +78,7 @@
 
                 testHelper.InsertLearningResourceReference(2, 2, adminId, "Resource 2");
                 testHelper.InsertCompetencyLearningResource(1, 1, 2, adminId);
-                testHelper.InsertCompetencyResourceAssessmentQuestionParameters(1, 1, true, 2, false);
+                testHelper.InsertCompetencyResourceAssessmentQuestionParameters(1, 1, true, 2, false, 1, 10);
                 var expectedItem = new CompetencyResourceAssessmentQuestionParameter
                 {
                     CompetencyLearningResourceId = 1,
@@ -86,6 +86,8 @@
                     Essential = true,
                     RelevanceAssessmentQuestionId = 2,
                     CompareToRoleRequirements = false,
+                    MinResultMatch = 1,
+                    MaxResultMatch = 10,
                 };
 
                 // When

--- a/DigitalLearningSolutions.Data.Tests/DigitalLearningSolutions.Data.Tests.csproj
+++ b/DigitalLearningSolutions.Data.Tests/DigitalLearningSolutions.Data.Tests.csproj
@@ -42,6 +42,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Folder Include="Extensions\" />
       <Folder Include="Services\TutorialContentDataServiceTests\" />
     </ItemGroup>
 

--- a/DigitalLearningSolutions.Data.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -12,12 +12,12 @@
         {
             // Given
             var list = new List<string?> { "1", "2", null, "3", null, "4" };
-            var expectedResult = new List<string?> { "1", "2", "3", "4" };
 
             // When
             var result = list.WhereNotNull();
 
             // Then
+            var expectedResult = new List<string> { "1", "2", "3", "4" };
             result.Should().BeEquivalentTo(expectedResult);
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -17,8 +17,7 @@
             var result = list.WhereNotNull();
 
             // Then
-            var expectedResult = new List<string> { "1", "2", "3", "4" };
-            result.Should().BeEquivalentTo(expectedResult);
+            result.Should().BeEquivalentTo(new List<string> { "1", "2", "3", "4" });
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,0 +1,24 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Extensions
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Extensions;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class EnumerableExtensionsTests
+    {
+        [Test]
+        public void WhereNotNull_filters_items_correctly()
+        {
+            // Given
+            var list = new List<string?> { "1", "2", null, "3", null, "4" };
+            var expectedResult = new List<string?> { "1", "2", "3", "4" };
+
+            // When
+            var result = list.WhereNotNull();
+
+            // Then
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
@@ -20,11 +20,13 @@
     {
         private const int SelfAssessmentId = 1;
         private const int CompetencyId = 2;
+        private const int SecondCompetencyId = 3;
         private const int LearningResourceReferenceId = 3;
         private const int LearningHubResourceReferenceId = 4;
         private const int DelegateId = 5;
         private const int LearningLogId = 6;
         private const int CompetencyLearningResourceId = 1;
+        private const int SecondCompetencyLearningResourceId = 2;
         private const int CompetencyAssessmentQuestionId = 1;
         private const int RelevanceAssessmentQuestionId = 2;
         private const string ResourceName = "Resource";
@@ -62,7 +64,7 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
                 .Returns(new List<LearningLogItem>());
@@ -86,7 +88,7 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(5).All()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId + 1)
@@ -113,7 +115,7 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var learningLogItem = Builder<LearningLogItem>.CreateNew()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
@@ -142,7 +144,7 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var learningLogItem = Builder<LearningLogItem>.CreateNew()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
@@ -171,7 +173,7 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(2)
                 .All()
@@ -212,7 +214,7 @@
                 () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(A<int>._)
             ).Returns(competencyLearningResources);
 
-            GivenLearningUpApiReturnsResources(0);
+            GivenLearningHubApiReturnsResources(0);
 
             // When
             await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId);
@@ -239,7 +241,7 @@
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
             GivenQuestionParametersAreReturned(essential, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, expectedScore);
 
@@ -259,9 +261,9 @@
         {
             // Given
             GivenResourceHasTwoCompetencies();
-            GivenLearningUpApiReturnsResources(0);
+            GivenLearningHubApiReturnsResources(0);
             GivenGetLearningLogItemsReturnsAnItem();
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var questionParameters = Builder<CompetencyResourceAssessmentQuestionParameter>
                 .CreateListOfSize(2)
@@ -295,10 +297,10 @@
         }
 
         [Test]
-        [TestCase(0, 175)]
-        [TestCase(1, 179)]
-        [TestCase(2.4, 184.6)]
-        [TestCase(5, 195)]
+        [TestCase(0, 0)]
+        [TestCase(1, 4)]
+        [TestCase(2.4, 9.6)]
+        [TestCase(5, 20)]
         public async Task
             GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_learning_hub_ratings_only(
                 decimal learningHubRating,
@@ -308,8 +310,7 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi(learningHubRating);
             GivenGetLearningLogItemsReturnsAnItem();
-            GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, expectedScore);
 
@@ -338,7 +339,7 @@
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
             GivenQuestionParametersAreReturned(true, true, 1, 10);
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var roleRequirement = Builder<CompetencyAssessmentQuestionRoleRequirement>.CreateNew()
                 .With(rr => rr.LevelRag = levelRag).Build();
@@ -382,7 +383,7 @@
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
             GivenNotComparingToRoleRequirements();
-            GivenSelfAssessmentHasResults(relevanceResult, confidenceResult);
+            GivenSelfAssessmentHasResultsForFirstCompetency(relevanceResult, confidenceResult);
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, expectedScore);
 
@@ -440,9 +441,9 @@
         {
             // Given
             GivenResourceHasTwoCompetencies();
-            GivenLearningUpApiReturnsResources(0);
+            GivenLearningHubApiReturnsResources(0);
             GivenGetLearningLogItemsReturnsAnItem();
-            GivenSelfAssessmentHasResults(5, 5);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
             var questionParameters = Builder<CompetencyResourceAssessmentQuestionParameter>
                 .CreateListOfSize(2)
@@ -454,7 +455,7 @@
                 .And(qp => qp.CompetencyLearningResourceId = CompetencyLearningResourceId)
                 .TheRest()
                 .With(qp => qp.Essential = false)
-                .And(qp => qp.CompetencyLearningResourceId = 2)
+                .And(qp => qp.CompetencyLearningResourceId = SecondCompetencyLearningResourceId)
                 .Build();
 
             A.CallTo(
@@ -493,7 +494,7 @@
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
             GivenQuestionParametersAreReturned(true, true, minScore, maxScore);
-            GivenSelfAssessmentHasResults(5, confidenceResult);
+            GivenSelfAssessmentHasResultsForFirstCompetency(5, confidenceResult);
 
             // When
             var result =
@@ -507,7 +508,7 @@
         private void GivenResourceForSelfAssessmentIsReturnedByLearningHubApi(decimal rating = 0)
         {
             GivenSingleCompetencyExistsForResource();
-            GivenLearningUpApiReturnsResources(rating);
+            GivenLearningHubApiReturnsResources(rating);
         }
 
         private void GivenSingleCompetencyExistsForResource()
@@ -532,7 +533,7 @@
         private void GivenResourceHasTwoCompetencies()
         {
             A.CallTo(() => selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(SelfAssessmentId))
-                .Returns(new[] { CompetencyId, 3 });
+                .Returns(new[] { CompetencyId, SecondCompetencyId });
 
             var competencyLearningResources = Builder<CompetencyLearningResource>.CreateListOfSize(2)
                 .All()
@@ -543,8 +544,8 @@
                 .With(clr => clr.Id = CompetencyLearningResourceId)
                 .And(clr => clr.CompetencyId = CompetencyId)
                 .TheRest()
-                .With(clr => clr.Id = 2)
-                .And(clr => clr.CompetencyId = 3)
+                .With(clr => clr.Id = SecondCompetencyLearningResourceId)
+                .And(clr => clr.CompetencyId = SecondCompetencyId)
                 .Build();
 
             A.CallTo(
@@ -552,7 +553,7 @@
             ).Returns(competencyLearningResources);
         }
 
-        private void GivenLearningUpApiReturnsResources(decimal rating)
+        private void GivenLearningHubApiReturnsResources(decimal rating)
         {
             var clientResponse = new BulkResourceReferences
             {
@@ -628,7 +629,7 @@
             ).Returns(questionParameters);
         }
 
-        private void GivenSelfAssessmentHasResults(int relevanceResult, int confidenceResult)
+        private void GivenSelfAssessmentHasResultsForFirstCompetency(int relevanceResult, int confidenceResult)
         {
             var assessmentResults = Builder<SelfAssessmentResult>.CreateListOfSize(2)
                 .All()

--- a/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
@@ -61,10 +61,13 @@
         {
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
+
             A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
                 .Returns(new List<LearningLogItem>());
 
-            var expectedResource = GetExpectedResource(false, false, null);
+            var expectedResource = GetExpectedResource(false, false, null, 175);
 
             // When
             var result =
@@ -82,6 +85,8 @@
         {
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(5).All()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId + 1)
@@ -89,7 +94,7 @@
             A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
                 .Returns(learningLogItems);
 
-            var expectedResource = GetExpectedResource(false, false, null);
+            var expectedResource = GetExpectedResource(false, false, null, 175);
 
             // When
             var result =
@@ -107,6 +112,8 @@
         {
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
             var learningLogItem = Builder<LearningLogItem>.CreateNew()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
@@ -116,7 +123,7 @@
             A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
                 .Returns(new List<LearningLogItem> { learningLogItem });
 
-            var expectedResource = GetExpectedResource(false, true, null);
+            var expectedResource = GetExpectedResource(false, true, null, 175);
 
             // When
             var result =
@@ -134,6 +141,8 @@
         {
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
             var learningLogItem = Builder<LearningLogItem>.CreateNew()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
@@ -143,7 +152,7 @@
             A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
                 .Returns(new List<LearningLogItem> { learningLogItem });
 
-            var expectedResource = GetExpectedResource(true, false, LearningLogId);
+            var expectedResource = GetExpectedResource(true, false, LearningLogId, 175);
 
             // When
             var result =
@@ -161,21 +170,23 @@
         {
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
-            var completeLearningLogItem = Builder<LearningLogItem>.CreateNew()
+            var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(2)
+                .All()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
-                .And(i => i.CompletedDate = DateTime.UtcNow)
                 .And(i => i.LearningLogItemId = LearningLogId)
-                .And(i => i.ArchivedDate = null).Build();
-            var incompleteLearningLogItem = Builder<LearningLogItem>.CreateNew()
-                .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
-                .And(i => i.CompletedDate = null)
-                .And(i => i.LearningLogItemId = LearningLogId)
-                .And(i => i.ArchivedDate = null).Build();
+                .And(i => i.ArchivedDate = null)
+                .TheFirst(1)
+                .With(i => i.CompletedDate = DateTime.UtcNow)
+                .TheRest()
+                .With(i => i.CompletedDate = null)
+                .Build();
             A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
-                .Returns(new List<LearningLogItem> { completeLearningLogItem, incompleteLearningLogItem });
+                .Returns(learningLogItems);
 
-            var expectedResource = GetExpectedResource(true, true, LearningLogId);
+            var expectedResource = GetExpectedResource(true, true, LearningLogId, 175);
 
             // When
             var result =
@@ -201,26 +212,7 @@
                 () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(A<int>._)
             ).Returns(competencyLearningResources);
 
-            var clientResponse = new BulkResourceReferences
-            {
-                ResourceReferences = new List<ResourceReferenceWithResourceDetails>
-                {
-                    new ResourceReferenceWithResourceDetails
-                    {
-                        ResourceId = 0,
-                        RefId = LearningHubResourceReferenceId,
-                        Title = ResourceName,
-                        Description = ResourceDescription,
-                        Catalogue = new Catalogue { Name = ResourceCatalogue },
-                        ResourceType = ResourceType,
-                        Rating = 0,
-                        Link = ResourceLink,
-                    },
-                },
-            };
-
-            A.CallTo(() => learningHubApiClient.GetBulkResourcesByReferenceIds(A<IEnumerable<int>>._))
-                .Returns(clientResponse);
+            GivenLearningUpApiReturnsResources(0);
 
             // When
             await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId);
@@ -235,12 +227,10 @@
         }
 
         [Test]
-        [TestCase(1, true, 100)]
-        [TestCase(1, false, 30)]
-        [TestCase(0, true, 0)]
+        [TestCase(true, 175)]
+        [TestCase(false, 105)]
         public async Task
-            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_essential_question_parameters_only(
-                int numberOfQuestionParameters,
+            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_essential_question_parameters(
                 bool essential,
                 decimal expectedScore
             )
@@ -248,19 +238,8 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
-
-            var questionParameters =
-                numberOfQuestionParameters == 0
-                    ? new List<CompetencyResourceAssessmentQuestionParameter>()
-                    : Builder<CompetencyResourceAssessmentQuestionParameter>
-                        .CreateListOfSize(numberOfQuestionParameters).All()
-                        .With(qp => qp.Essential = essential).Build();
-
-            A.CallTo(
-                () => competencyLearningResourcesDataService.GetCompetencyResourceAssessmentQuestionParameters(
-                    A<IEnumerable<int>>._
-                )
-            ).Returns(questionParameters);
+            GivenQuestionParametersAreReturned(essential, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, expectedScore);
 
@@ -276,17 +255,26 @@
 
         [Test]
         public async Task
-            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with__multiple_essential_question_parameters_of_different_value()
+            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_multiple_competencies_with_essential_question_parameters_of_different_value()
         {
             // Given
-            GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenResourceHasTwoCompetencies();
+            GivenLearningUpApiReturnsResources(0);
             GivenGetLearningLogItemsReturnsAnItem();
+            GivenSelfAssessmentHasResults(5, 5);
 
             var questionParameters = Builder<CompetencyResourceAssessmentQuestionParameter>
-                        .CreateListOfSize(5).TheFirst(2)
-                        .With(qp => qp.Essential = true)
-                        .TheRest()
-                        .With(qp => qp.Essential = false).Build();
+                .CreateListOfSize(2)
+                .All()
+                .With(qp => qp.MinResultMatch = 1)
+                .And(qp => qp.MaxResultMatch = 10)
+                .TheFirst(1)
+                .With(qp => qp.Essential = true)
+                .And(qp => qp.CompetencyLearningResourceId = CompetencyLearningResourceId)
+                .TheRest()
+                .With(qp => qp.Essential = false)
+                .And(qp => qp.CompetencyLearningResourceId = 2)
+                .Build();
 
             A.CallTo(
                 () => competencyLearningResourcesDataService.GetCompetencyResourceAssessmentQuestionParameters(
@@ -294,7 +282,7 @@
                 )
             ).Returns(questionParameters);
 
-            var expectedResource = GetExpectedResource(true, false, LearningLogId, 100);
+            var expectedResource = GetExpectedResource(true, false, LearningLogId, 175);
 
             // When
             var result =
@@ -307,10 +295,10 @@
         }
 
         [Test]
-        [TestCase(0, 0)]
-        [TestCase(1, 4)]
-        [TestCase(2.4, 9.6)]
-        [TestCase(5, 20)]
+        [TestCase(0, 175)]
+        [TestCase(1, 179)]
+        [TestCase(2.4, 184.6)]
+        [TestCase(5, 195)]
         public async Task
             GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_learning_hub_ratings_only(
                 decimal learningHubRating,
@@ -320,6 +308,8 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi(learningHubRating);
             GivenGetLearningLogItemsReturnsAnItem();
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, expectedScore);
 
@@ -347,16 +337,8 @@
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
-
-            var questionParameters = Builder<CompetencyResourceAssessmentQuestionParameter>
-                .CreateListOfSize(1).All()
-                .With(qp => qp.Essential = true)
-                .And(qp => qp.CompareToRoleRequirements = true).Build();
-            A.CallTo(
-                () => competencyLearningResourcesDataService.GetCompetencyResourceAssessmentQuestionParameters(
-                    A<IEnumerable<int>>._
-                )
-            ).Returns(questionParameters);
+            GivenQuestionParametersAreReturned(true, true, 1, 10);
+            GivenSelfAssessmentHasResults(5, 5);
 
             var roleRequirement = Builder<CompetencyAssessmentQuestionRoleRequirement>.CreateNew()
                 .With(rr => rr.LevelRag = levelRag).Build();
@@ -400,26 +382,7 @@
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
             GivenGetLearningLogItemsReturnsAnItem();
             GivenNotComparingToRoleRequirements();
-
-            var assessmentResults = Builder<SelfAssessmentResult>.CreateListOfSize(2)
-                .All()
-                .With(r => r.SelfAssessmentId = SelfAssessmentId)
-                .And(r => r.CandidateId = DelegateId)
-                .And(r => r.CompetencyId = CompetencyId)
-                .TheFirst(1)
-                .With(r => r.AssessmentQuestionId = CompetencyAssessmentQuestionId)
-                .And(r => r.Result = confidenceResult)
-                .TheRest()
-                .With(r => r.AssessmentQuestionId = RelevanceAssessmentQuestionId)
-                .And(r => r.Result = relevanceResult)
-                .Build();
-            A.CallTo(
-                () => selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-                    DelegateId,
-                    SelfAssessmentId,
-                    CompetencyId
-                )
-            ).Returns(assessmentResults);
+            GivenSelfAssessmentHasResults(relevanceResult, confidenceResult);
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, expectedScore);
 
@@ -441,7 +404,7 @@
 
         [Test]
         public async Task
-            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_missing_self_assessment_results()
+            GetRecommendedLearningForSelfAssessment_does_not_return_resources_relating_to_unanswered_optional_competencies()
         {
             // Given
             GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
@@ -456,7 +419,51 @@
                 )
             ).Returns(new List<SelfAssessmentResult>());
 
-            var expectedResource = GetExpectedResource(true, false, LearningLogId, 100);
+            // When
+            var result =
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                .ToList();
+
+            // Then
+            result.Should().BeEmpty();
+            A.CallTo(
+                () => selfAssessmentDataService.GetCompetencyAssessmentQuestionRoleRequirements(
+                    A<int>._,
+                    A<int>._
+                )
+            ).MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task
+            GetRecommendedLearningForSelfAssessment_does_return_resources_with_some_unanswered_optional_competencies()
+        {
+            // Given
+            GivenResourceHasTwoCompetencies();
+            GivenLearningUpApiReturnsResources(0);
+            GivenGetLearningLogItemsReturnsAnItem();
+            GivenSelfAssessmentHasResults(5, 5);
+
+            var questionParameters = Builder<CompetencyResourceAssessmentQuestionParameter>
+                .CreateListOfSize(2)
+                .All()
+                .With(qp => qp.MinResultMatch = 1)
+                .And(qp => qp.MaxResultMatch = 10)
+                .TheFirst(1)
+                .With(qp => qp.Essential = true)
+                .And(qp => qp.CompetencyLearningResourceId = CompetencyLearningResourceId)
+                .TheRest()
+                .With(qp => qp.Essential = false)
+                .And(qp => qp.CompetencyLearningResourceId = 2)
+                .Build();
+
+            A.CallTo(
+                () => competencyLearningResourcesDataService.GetCompetencyResourceAssessmentQuestionParameters(
+                    A<IEnumerable<int>>._
+                )
+            ).Returns(questionParameters);
+
+            var expectedResource = GetExpectedResource(true, false, LearningLogId, 175);
 
             // When
             var result =
@@ -466,15 +473,44 @@
             // Then
             result.Should().HaveCount(1);
             result.Single().Should().BeEquivalentTo(expectedResource);
-            A.CallTo(
-                () => selfAssessmentDataService.GetCompetencyAssessmentQuestionRoleRequirements(
-                    A<int>._,
-                    A<int>._
-                )
-            ).MustNotHaveHappened();
+        }
+
+        [Test]
+        [TestCase(1, 10, 5, 1)]
+        [TestCase(5, 10, 4, 0)]
+        [TestCase(1, 5, 6, 0)]
+        [TestCase(3, 7, 3, 1)]
+        [TestCase(3, 7, 7, 1)]
+        public async Task
+            GetRecommendedLearningForSelfAssessment_returns_expected_number_of_resources_for_answers_in_and_out_of_range(
+                int minScore,
+                int maxScore,
+                int confidenceResult,
+                int expectedResultCount
+            )
+        {
+            // Given
+            GivenResourceForSelfAssessmentIsReturnedByLearningHubApi();
+            GivenGetLearningLogItemsReturnsAnItem();
+            GivenQuestionParametersAreReturned(true, true, minScore, maxScore);
+            GivenSelfAssessmentHasResults(5, confidenceResult);
+
+            // When
+            var result =
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                .ToList();
+
+            // Then
+            result.Should().HaveCount(expectedResultCount);
         }
 
         private void GivenResourceForSelfAssessmentIsReturnedByLearningHubApi(decimal rating = 0)
+        {
+            GivenSingleCompetencyExistsForResource();
+            GivenLearningUpApiReturnsResources(rating);
+        }
+
+        private void GivenSingleCompetencyExistsForResource()
         {
             A.CallTo(() => selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(SelfAssessmentId))
                 .Returns(new[] { CompetencyId });
@@ -491,7 +527,33 @@
             A.CallTo(
                 () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(CompetencyId)
             ).Returns(new List<CompetencyLearningResource> { competencyLearningResource });
+        }
 
+        private void GivenResourceHasTwoCompetencies()
+        {
+            A.CallTo(() => selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(SelfAssessmentId))
+                .Returns(new[] { CompetencyId, 3 });
+
+            var competencyLearningResources = Builder<CompetencyLearningResource>.CreateListOfSize(2)
+                .All()
+                .With(clr => clr.LearningResourceReferenceId = LearningResourceReferenceId)
+                .And(clr => clr.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
+                .And(clr => clr.AdminId = 7)
+                .TheFirst(1)
+                .With(clr => clr.Id = CompetencyLearningResourceId)
+                .And(clr => clr.CompetencyId = CompetencyId)
+                .TheRest()
+                .With(clr => clr.Id = 2)
+                .And(clr => clr.CompetencyId = 3)
+                .Build();
+
+            A.CallTo(
+                () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(CompetencyId)
+            ).Returns(competencyLearningResources);
+        }
+
+        private void GivenLearningUpApiReturnsResources(decimal rating)
+        {
             var clientResponse = new BulkResourceReferences
             {
                 ResourceReferences = new List<ResourceReferenceWithResourceDetails>
@@ -531,13 +593,62 @@
                 .CreateListOfSize(1).All()
                 .With(qp => qp.Essential = true)
                 .And(qp => qp.CompareToRoleRequirements = false)
+                .And(qp => qp.CompetencyLearningResourceId = CompetencyLearningResourceId)
                 .And(qp => qp.AssessmentQuestionId = CompetencyAssessmentQuestionId)
-                .And(qp => qp.RelevanceAssessmentQuestionId = RelevanceAssessmentQuestionId).Build();
+                .And(qp => qp.RelevanceAssessmentQuestionId = RelevanceAssessmentQuestionId)
+                .And(qp => qp.MinResultMatch = 1)
+                .And(qp => qp.MaxResultMatch = 10)
+                .Build();
             A.CallTo(
                 () => competencyLearningResourcesDataService.GetCompetencyResourceAssessmentQuestionParameters(
                     A<IEnumerable<int>>._
                 )
             ).Returns(questionParameters);
+        }
+
+        private void GivenQuestionParametersAreReturned(
+            bool essential,
+            bool compareToRoleRequirements,
+            int minMatch,
+            int maxMatch
+        )
+        {
+            var questionParameters = Builder<CompetencyResourceAssessmentQuestionParameter>
+                .CreateListOfSize(1).All()
+                .With(qp => qp.Essential = essential)
+                .And(qp => qp.CompareToRoleRequirements = compareToRoleRequirements)
+                .And(qp => qp.MinResultMatch = minMatch)
+                .And(qp => qp.MaxResultMatch = maxMatch)
+                .And(qp => qp.CompetencyLearningResourceId = CompetencyLearningResourceId)
+                .Build();
+            A.CallTo(
+                () => competencyLearningResourcesDataService.GetCompetencyResourceAssessmentQuestionParameters(
+                    A<IEnumerable<int>>._
+                )
+            ).Returns(questionParameters);
+        }
+
+        private void GivenSelfAssessmentHasResults(int relevanceResult, int confidenceResult)
+        {
+            var assessmentResults = Builder<SelfAssessmentResult>.CreateListOfSize(2)
+                .All()
+                .With(r => r.SelfAssessmentId = SelfAssessmentId)
+                .And(r => r.CandidateId = DelegateId)
+                .And(r => r.CompetencyId = CompetencyId)
+                .TheFirst(1)
+                .With(r => r.AssessmentQuestionId = CompetencyAssessmentQuestionId)
+                .And(r => r.Result = confidenceResult)
+                .TheRest()
+                .With(r => r.AssessmentQuestionId = RelevanceAssessmentQuestionId)
+                .And(r => r.Result = relevanceResult)
+                .Build();
+            A.CallTo(
+                () => selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
+                    DelegateId,
+                    SelfAssessmentId,
+                    CompetencyId
+                )
+            ).Returns(assessmentResults);
         }
 
         private RecommendedResource GetExpectedResource(

--- a/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
@@ -302,7 +302,7 @@
         [TestCase(2.4, 9.6)]
         [TestCase(5, 20)]
         public async Task
-            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_learning_hub_ratings_only(
+            GetRecommendedLearningForSelfAssessment_returns_correct_recommendation_score_for_resource_with_learning_hub_ratings_and_no_question_parameters(
                 decimal learningHubRating,
                 decimal expectedScore
             )

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/CompetencyLearningResourcesTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/CompetencyLearningResourcesTestHelper.cs
@@ -47,14 +47,20 @@
             int assessmentQuestionId,
             bool essential,
             int? relevanceQuestionId,
-            bool compareToRoleRequirements
+            bool compareToRoleRequirements,
+            int minMatchResult,
+            int maxMatchResult
         )
         {
             connection.Execute(
                 @"INSERT INTO CompetencyResourceAssessmentQuestionParameters
                     (CompetencyLearningResourceId, AssessmentQuestionID, Essential, RelevanceAssessmentQuestionID, CompareToRoleRequirements, MinResultMatch, MaxResultMatch)
-                    VALUES (@competencyLearningResourceId, @assessmentQuestionId, @essential, @relevanceQuestionId, @compareToRoleRequirements, 0, 0)",
-                new { competencyLearningResourceId, assessmentQuestionId, essential, relevanceQuestionId, compareToRoleRequirements }
+                    VALUES (@competencyLearningResourceId, @assessmentQuestionId, @essential, @relevanceQuestionId, @compareToRoleRequirements, @minMatchResult, @maxMatchResult)",
+                new
+                {
+                    competencyLearningResourceId, assessmentQuestionId, essential, relevanceQuestionId,
+                    compareToRoleRequirements, minMatchResult, maxMatchResult,
+                }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
@@ -96,7 +96,9 @@
                         AssessmentQuestionID,
                         Essential,
                         RelevanceAssessmentQuestionID,
-                        CompareToRoleRequirements
+                        CompareToRoleRequirements,
+                        MinResultMatch,
+                        MaxResultMatch
                     FROM CompetencyResourceAssessmentQuestionParameters
                     WHERE CompetencyLearningResourceId IN @competencyLearningResourceIds",
                 new { competencyLearningResourceIds }

--- a/DigitalLearningSolutions.Data/Extensions/EnumerableExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Data.Extensions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> enumerable) where T : class
+        {
+            return enumerable.Where(e => e != null).Select(e => e!);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CompetencyResourceAssessmentQuestionParameter.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CompetencyResourceAssessmentQuestionParameter.cs
@@ -11,5 +11,9 @@
         public int? RelevanceAssessmentQuestionId { get; set; }
 
         public bool CompareToRoleRequirements { get; set; }
+
+        public int MinResultMatch { get; set; }
+
+        public int MaxResultMatch { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/RecommendedLearningService.cs
+++ b/DigitalLearningSolutions.Data/Services/RecommendedLearningService.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.ApiClients;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
@@ -77,7 +78,7 @@
                 )
             );
 
-            return recommendedResources.Where(r => r != null).Select(r => r!);
+            return recommendedResources.WhereNotNull();
         }
 
         private RecommendedResource? GetPopulatedRecommendedResource(


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-711

### Description
Filtering of resources where the delegate answer falls outside the range of results specified in CompetencyResourceAssessmentQuestionParameters. Refactored and added new unit tests to accommodate these changes.

### Screenshots
No visual changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
