### PR TITLE
Heedls 691 search all delegates candidate number

### DIFF
--- a/DigitalLearningSolutions.Data/Models/BaseSearchableItem.cs
+++ b/DigitalLearningSolutions.Data/Models/BaseSearchableItem.cs
@@ -13,5 +13,7 @@
         protected string? SearchableNameOverrideForFuzzySharp;
 
         public abstract string SearchableName { get; set; }
+
+        public virtual string?[] SearchableContent => new[] { SearchableName };
     }
 }

--- a/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
@@ -19,6 +19,8 @@
         public bool HasBeenPromptedForPrn { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
 
+        public override string[] SearchableContent => new []{ SearchableName, CandidateNumber };
+
         public override UserReference ToUserReference()
         {
             return new UserReference(Id, UserType.DelegateUser);

--- a/DigitalLearningSolutions.Web.Tests/Helpers/GenericSearchHelperTests/AllDelegatesSearchTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/GenericSearchHelperTests/AllDelegatesSearchTests.cs
@@ -1,0 +1,46 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Helpers.GenericSearchHelperTests
+{
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.Helpers;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class AllDelegatesSearchTests
+    {
+        private DelegateUser[] delegateUsers = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            delegateUsers = new[]
+            {
+                UserTestHelper.GetDefaultDelegateUser(10, firstName: "Mark", lastName: "Jones", candidateNumber: "MJ10"),
+                UserTestHelper.GetDefaultDelegateUser(12, firstName: "Ethan", lastName: "Jones", candidateNumber: "EJ12"),
+                UserTestHelper.GetDefaultDelegateUser(14, firstName: "Emily", lastName: "Harper", candidateNumber: "EH14"),
+                UserTestHelper.GetDefaultDelegateUser(144, firstName: "Andrew", lastName: "Harper", candidateNumber: "AH144"),
+                UserTestHelper.GetDefaultDelegateUser(200, firstName: "Mark", lastName: "Lowe", candidateNumber: "ML200"),
+                UserTestHelper.GetDefaultDelegateUser(202, firstName: "Sandra", lastName: "Halos", candidateNumber: "SH202"),
+            };
+        }
+
+        [TestCase("Mark", new[] { 10, 200 })]
+        [TestCase("MJ1", new[] { 10 })]
+        [TestCase("J1", new[] { 10, 12 })]
+        [TestCase("Harper H14", new[] { 14, 144 })]
+        [TestCase("lo", new[] { 200, 202 })]
+        public void DelegateUsers_should_be_filtered_on_name_and_candidateNumber_correctly(
+            string searchString,
+            int[] expectedIds
+        )
+        {
+            // When
+            var result = GenericSearchHelper.SearchItems(delegateUsers, searchString);
+            var filteredIds = result.Select(delegateUser => delegateUser.Id);
+
+            // Then
+            filteredIds.Should().Equal(expectedIds);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Helpers/GenericSearchHelperTests/CoursesSearchTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/GenericSearchHelperTests/CoursesSearchTests.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
+﻿namespace DigitalLearningSolutions.Web.Tests.Helpers.GenericSearchHelperTests
 {
     using System.Linq;
     using DigitalLearningSolutions.Data.Models;
@@ -7,9 +7,9 @@
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using FluentAssertions;
     using NUnit.Framework;
-    using SelfAssessmentHelper = DigitalLearningSolutions.Data.Tests.TestHelpers.SelfAssessmentHelper;
+    using SelfAssessmentHelper = Data.Tests.TestHelpers.SelfAssessmentHelper;
 
-    public class GenericSearchHelperTests
+    public class CoursesSearchTests
     {
         private AvailableCourse[] availableCourses = null!;
         private CompletedCourse[] completedCourses = null!;

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/Support/FaqsPageViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/Support/FaqsPageViewModelTests.cs
@@ -9,7 +9,7 @@
     using FluentAssertions;
     using NUnit.Framework;
 
-    public class FaqsViewModelTests
+    public class FaqsPageViewModelTests
     {
         private readonly IEnumerable<Faq> allFaqs = new List<Faq>
         {

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/Support/SearchableFaqTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/Support/SearchableFaqTests.cs
@@ -17,8 +17,7 @@
             var searchableFaq = new SearchableFaq(faq);
 
             // Then
-            const string expectedSearchableFaqAnswer = " p Helpful content  p ";
-            searchableFaq.SearchableFaqAnswer.Should().Be(expectedSearchableFaqAnswer);
+            searchableFaq.SearchableFaqAnswer.Should().Be(" p Helpful content  p ");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/Support/SearchableFaqTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/Support/SearchableFaqTests.cs
@@ -5,21 +5,20 @@
     using FluentAssertions;
     using NUnit.Framework;
 
-    public class FaqViewModelTests
+    public class SearchableFaqTests
     {
         [Test]
-        public void FaqViewModelTests_returns_model_with_cleaned_searchName()
+        public void SearchableFaq_returns_model_with_cleaned_SearchableFaqAnswer()
         {
             // Given
             var faq = FaqTestHelper.GetDefaultFaq();
-            var expectedSearchableName = "A common question?  p Helpful content  p ";
+            var expectedSearchableFaqAnswer = " p Helpful content  p ";
 
             // When
-            var faqViewModel = new SearchableFaq(faq);
+            var searchableFaq = new SearchableFaq(faq);
 
             // Then
-            faqViewModel.Should().NotBeNull();
-            faqViewModel.SearchableName.Should().Be(expectedSearchableName);
+            searchableFaq.SearchableFaqAnswer.Should().Be(expectedSearchableFaqAnswer);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/Support/SearchableFaqTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/Support/SearchableFaqTests.cs
@@ -11,13 +11,13 @@
         public void SearchableFaq_returns_model_with_cleaned_SearchableFaqAnswer()
         {
             // Given
-            var faq = FaqTestHelper.GetDefaultFaq();
-            var expectedSearchableFaqAnswer = " p Helpful content  p ";
+            var faq = FaqTestHelper.GetDefaultFaq(aHtml: "<p>Helpful content.<p>");
 
             // When
             var searchableFaq = new SearchableFaq(faq);
 
             // Then
+            const string expectedSearchableFaqAnswer = " p Helpful content  p ";
             searchableFaq.SearchableFaqAnswer.Should().Be(expectedSearchableFaqAnswer);
         }
     }

--- a/DigitalLearningSolutions.Web/Helpers/GenericSearchHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/GenericSearchHelper.cs
@@ -73,7 +73,7 @@
             var results = Process.ExtractAll(
                 (T)query,
                 items,
-                item => item.SearchableName.ToLower(),
+                item => string.Join(" ", item.SearchableContent.Where(s => s != null)).ToLower(),
                 ratioScorer,
                 matchCutOffScore
             );

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/allDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/allDelegates.ts
@@ -1,4 +1,9 @@
 import { SearchSortFilterAndPaginate } from '../searchSortFilterAndPaginate/searchSortFilterAndPaginate';
 
 // eslint-disable-next-line no-new
-new SearchSortFilterAndPaginate('TrackingSystem/Delegates/All/AllDelegateItems', true, true, true, 'DelegateFilter');
+new SearchSortFilterAndPaginate('TrackingSystem/Delegates/All/AllDelegateItems',
+  true,
+  true,
+  true,
+  'DelegateFilter',
+  ['title', 'candidate-number']);

--- a/DigitalLearningSolutions.Web/ViewModels/Support/Faqs/SearchableFaq.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Support/Faqs/SearchableFaq.cs
@@ -32,9 +32,12 @@
 
         public override string SearchableName
         {
-            get => SearchableNameOverrideForFuzzySharp ??
-                   $"{QText} {DisplayStringHelper.ReplaceNonAlphaNumericSpaceChars(AHtml, " ")}";
+            get => SearchableNameOverrideForFuzzySharp ?? QText;
             set => SearchableNameOverrideForFuzzySharp = value;
         }
+
+        public string SearchableFaqAnswer => DisplayStringHelper.ReplaceNonAlphaNumericSpaceChars(AHtml, " ")!;
+
+        public override string?[] SearchableContent => new [] { SearchableName, SearchableFaqAnswer };
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
@@ -7,7 +7,7 @@
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text" id="@Model.DelegateInfo.Id-name">
-        <span class="searchable-element-title" name="name">@Model.DelegateInfo.Name</span> (@Model.DelegateInfo.CandidateNumber)
+        <span class="searchable-element-title" name="name">@Model.DelegateInfo.Name</span> <span class="searchable-element-candidate-number">(@Model.DelegateInfo.CandidateNumber)</span>
       </span>
     </summary>
 


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-691](https://softwiretech.atlassian.net/browse/HEEDLS-691)

### Description
Add the ability to search all delegates by their candidate number as well as their name.
This adds the ability to search across multiple properties on a model.
A slight refactor of the first version of this concept which affects support FAQs.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
