### PR TITLE
DLSV2-468 Fixes error with adding framework default question

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -926,7 +926,7 @@ WHERE (fc.Id = @frameworkCompetencyId)",
             {
                 numberOfAffectedRows = connection.Execute(
                     @"INSERT INTO CompetencyAssessmentQuestions (CompetencyID, AssessmentQuestionID, Ordering)
-                        SELECT CompetencyID, @assessmentQuestionId AS AssessmentQuestionID, COALESCE
+                        SELECT DISTINCT CompetencyID, @assessmentQuestionId AS AssessmentQuestionID, COALESCE
                              ((SELECT        MAX(Ordering)
                                  FROM            [CompetencyAssessmentQuestions]
                                  WHERE        ([CompetencyId] = fc.CompetencyID)), 0)+1 AS Ordering


### PR DESCRIPTION
### JIRA link
[DLSV2-468](https://hee-dls.atlassian.net/browse/DLSV2-468)

### Description
Fixes error with adding framework default question where the framework contains multiple FrameworkCompetencies with the same CompetencyID. This is achieved by selecting **DISTINCT** CompetencyID in the insert query. The query already ignores any competencies that already have the assessment question associated so the initial suspicions about the cause of the error were a red herring.