### PR TITLE
Heedls add learning hub api key to jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,16 +46,18 @@ pipeline {
         }
         stage('Integration Tests') {
             environment {
-               DlsRefactor_ConnectionStrings__DefaultConnection = credentials('ci-db-connection-string')
-           }
+                DlsRefactor_ConnectionStrings__DefaultConnection = credentials('ci-db-connection-string')
+                DlsRefactor_LearningHubOpenAPIKey = credentials('ci-learning-hub-open-api-key')
+        }
             steps {
                 bat "dotnet test DigitalLearningSolutions.Web.IntegrationTests"
             }
         }
         stage('Automated UI Tests') {
             environment {
-               DlsRefactor_ConnectionStrings__DefaultConnection = credentials('ci-db-connection-string')
-           }
+                DlsRefactor_ConnectionStrings__DefaultConnection = credentials('ci-db-connection-string')
+                DlsRefactor_LearningHubOpenAPIKey = credentials('ci-learning-hub-open-api-key')
+            }
             steps {
                 bat "dotnet test DigitalLearningSolutions.Web.AutomatedUiTests"
             }
@@ -110,7 +112,7 @@ def sendSlackMessageToTeamChannel(message, color) {
 	sendSlackNotificationToChannel("#hee-notifications", message, color)
 }
 
-def sendSlackNotificationToChannel(channel, message, color) {	
+def sendSlackNotificationToChannel(channel, message, color) {
 	withCredentials([string(credentialsId: 'slack-token', variable: 'SLACKTOKEN')]) {
         slackSend teamDomain: "softwire",
             channel: channel,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     }
     environment {
         DlsRefactor_ConnectionStrings__UnitTestConnection = credentials('ci-db-connection-string')
+        DlsRefactor_LearningHubOpenAPIKey = credentials('ci-learning-hub-open-api-key')
     }
     parameters {
         booleanParam(name: 'DeployToUAT', defaultValue: false, description: 'Deploy changes to UAT after build? NB will not deploy to test if this is set')
@@ -47,7 +48,6 @@ pipeline {
         stage('Integration Tests') {
             environment {
                 DlsRefactor_ConnectionStrings__DefaultConnection = credentials('ci-db-connection-string')
-                DlsRefactor_LearningHubOpenAPIKey = credentials('ci-learning-hub-open-api-key')
         }
             steps {
                 bat "dotnet test DigitalLearningSolutions.Web.IntegrationTests"
@@ -56,7 +56,6 @@ pipeline {
         stage('Automated UI Tests') {
             environment {
                 DlsRefactor_ConnectionStrings__DefaultConnection = credentials('ci-db-connection-string')
-                DlsRefactor_LearningHubOpenAPIKey = credentials('ci-learning-hub-open-api-key')
             }
             steps {
                 bat "dotnet test DigitalLearningSolutions.Web.AutomatedUiTests"


### PR DESCRIPTION
### Description
Added line to Jenkinsfile to pull in LH API key from Jenkins credentials.

Also fixed some whitespace in the file.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [Swiki Secrets in Jenkins section](https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/19902234654/Secret+config+settings#Secrets-in-Jenkins)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
