### PR TITLE
Heedls 741 fix migrations for competency assessment question role requirements constraints

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey.cs
@@ -5,22 +5,25 @@
     [Migration(202201111021)]
     public class ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey: Migration
     {
+        // This migration is undone in 202201171115_UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements
+        // and does not need to be run again, so it has been commented out
+
         public override void Up()
         {
-            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Delete.Column("ID").FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
+            //Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Delete.Column("ID").FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
         }
 
         public override void Down()
         {
-            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable().Identity();
-            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
+            //Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable().Identity();
+            //Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements.cs
@@ -5,26 +5,29 @@
     [Migration(202201120821)]
     public class ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements: Migration
     {
+        // This migration is undone in 202201171115_UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements
+        // and does not need to be run again, so it has been commented out
+
         public override void Up()
         {
-            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable().Identity();
-            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
-            Create.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
-                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
+            //Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable().Identity();
+            //Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
+            //Create.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
+            //    .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
         }
 
         public override void Down()
         {
-            Delete.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
-                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Delete.Column("ID").FromTable("CompetencyAssessmentQuestionRoleRequirements");
-            Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
-                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
+            //Delete.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
+            //    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Delete.Column("ID").FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            //Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+            //    .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns("SelfAssessmentID", "CompetencyID");
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Migrations/202201171115_UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201171115_UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements.cs
@@ -11,13 +11,13 @@
                 "IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID"
             ).Exists())
             {
-                // This undoes the changes from 202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements
+                // This undoes the unwanted changes from 202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements
                 Delete.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
                     .FromTable("CompetencyAssessmentQuestionRoleRequirements");
             }
             else if (!Schema.Table("CompetencyAssessmentQuestionRoleRequirements").Column("ID").Exists())
             {
-                // This undoes the changes from 202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey
+                // This undoes the unwanted changes from 202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey
                 Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
                     .FromTable("CompetencyAssessmentQuestionRoleRequirements");
                 Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable()

--- a/DigitalLearningSolutions.Data.Migrations/202201171115_UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201171115_UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements.cs
@@ -1,0 +1,37 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202201171115)]
+    public class UndoPreviousConstraintMigrationsForCompetencyAssessmentQuestionRoleRequirements : Migration
+    {
+        public override void Up()
+        {
+            if (Schema.Table("CompetencyAssessmentQuestionRoleRequirements").Constraint(
+                "IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID"
+            ).Exists())
+            {
+                // This undoes the changes from 202201120821_ChangeUniqueConstraintsOnCompetencyAssessmentQuestionRoleRequirements
+                Delete.UniqueConstraint("IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID")
+                    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+            }
+            else if (!Schema.Table("CompetencyAssessmentQuestionRoleRequirements").Column("ID").Exists())
+            {
+                // This undoes the changes from 202201111021_ChangeCompetencyAssessmentQuestionRoleRequirementsPrimaryKey
+                Delete.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                    .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+                Alter.Table("CompetencyAssessmentQuestionRoleRequirements").AddColumn("ID").AsInt32().NotNullable()
+                    .Identity();
+                Create.PrimaryKey("PK_CompetencyAssessmentQuestionRoleRequirements")
+                    .OnTable("CompetencyAssessmentQuestionRoleRequirements").Column("ID");
+            }
+        }
+
+        public override void Down()
+        {
+            // The Up migration reverts the database to how it should be.
+            // Previous migrations that should not be run have been commented out.
+            // Thus this Down migration does not need to do anything.
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202201171130_AddUniqueConstraintToCompetencyAssessmentQuestionRoleRequirements.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202201171130_AddUniqueConstraintToCompetencyAssessmentQuestionRoleRequirements.cs
@@ -2,7 +2,7 @@
 {
     using FluentMigrator;
 
-    [Migration(202217011130)]
+    [Migration(202201171130)]
     public class AddUniqueConstraintToCompetencyAssessmentQuestionRoleRequirements : Migration
     {
         public override void Up()

--- a/DigitalLearningSolutions.Data.Migrations/202217011130_AddUniqueConstraintToCompetencyAssessmentQuestionRoleRequirements.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202217011130_AddUniqueConstraintToCompetencyAssessmentQuestionRoleRequirements.cs
@@ -1,0 +1,29 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202217011130)]
+    public class AddUniqueConstraintToCompetencyAssessmentQuestionRoleRequirements : Migration
+    {
+        public override void Up()
+        {
+            Create.UniqueConstraint(
+                    "IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID_AssessmentQuestionID_LevelValue"
+                )
+                .OnTable("CompetencyAssessmentQuestionRoleRequirements").Columns(
+                    "SelfAssessmentID",
+                    "CompetencyID",
+                    "AssessmentQuestionID",
+                    "LevelValue"
+                );
+        }
+
+        public override void Down()
+        {
+            Delete.UniqueConstraint(
+                    "IX_CompetencyAssessmentQuestionRoleRequirements_SelfAssessmentID_CompetencyID_AssessmentQuestionID_LevelValue"
+                )
+                .FromTable("CompetencyAssessmentQuestionRoleRequirements");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/SeleniumServerFactory.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/SeleniumServerFactory.cs
@@ -31,7 +31,11 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests
             RootUri = host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First();
 
             // Fake Server to satisfy the return type
-            return new TestServer(new WebHostBuilder().UseStartup<TStartup>().UseSerilog());
+            return new TestServer(new WebHostBuilder()
+                .UseStartup<TStartup>()
+                .UseSerilog()
+                .ConfigureAppConfiguration(configBuilder => { configBuilder.AddConfiguration(GetConfigForUiTests()); }
+                    ));
         }
 
         protected sealed override IWebHostBuilder CreateWebHostBuilder()


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-741

### Description
Created two new migrations, one to undo the previous constraint-introducing migrations (depending on the state the DB is in), and one to add the new unique constraint.
I also commented out the previous migrations to prevent them from causing more errors when migrating past them. The "Undo" migration takes this into account.
I also modified one of the automated test files, as the set up of a fake server was causing errors when it tried to migrate up as it didn't have a config file to take a connection string from. I suspect it could probably be made more efficient in future.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
