### PR TITLE
Heedls 608a implement on support page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Support/SupportTicketsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Support/SupportTicketsControllerTests.cs
@@ -26,96 +26,17 @@
         }
 
         [Test]
-        public async Task TrackingSystem_SupportTickets_page_should_be_shown_for_valid_claims()
+        public void Index_page_should_be_shown_by_index_method()
         {
             // Given
             var controller = new SupportTicketsController(featureManager, configuration)
-                .WithDefaultContext()
-                .WithMockUser(true, isCentreAdmin: true);
+                .WithDefaultContext();
 
             // When
-            var result = await controller.Index(DlsSubApplication.TrackingSystem);
+            var result = controller.Index(DlsSubApplication.TrackingSystem);
 
             // Then
             result.Should().BeViewResult().WithViewName("Index");
-        }
-
-        [Test]
-        public async Task Frameworks_SupportTickets_page_should_be_shown_for_valid_claims()
-        {
-            // Given
-            var controller = new SupportTicketsController(featureManager, configuration)
-                .WithDefaultContext()
-                .WithMockUser(true, isCentreAdmin: false, isFrameworkDeveloper: true);
-
-            // When
-            var result = await controller.Index(DlsSubApplication.Frameworks);
-
-            // Then
-            result.Should().BeViewResult().WithViewName("Index");
-        }
-
-        [Test]
-        public async Task Invalid_application_name_should_redirect_to_404_page()
-        {
-            // Given
-            var controller = new SupportTicketsController(featureManager, configuration)
-                .WithDefaultContext()
-                .WithMockUser(true, isCentreAdmin: true, isFrameworkDeveloper: true);
-
-            // When
-            var result = await controller.Index(DlsSubApplication.Supervisor);
-
-            // Then
-            result.Should().BeNotFoundResult();
-        }
-
-        [Test]
-        public async Task Home_page_should_be_shown_when_accessing_tracking_system_supportTickets_without_appropriate_claims()
-        {
-            // Given
-            var controller = new SupportTicketsController(featureManager, configuration)
-                .WithDefaultContext()
-                .WithMockUser(true, isCentreAdmin: false, isFrameworkDeveloper: true);
-
-            // When
-            var result = await controller.Index(DlsSubApplication.TrackingSystem);
-
-            // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("Home").WithActionName("Index");
-        }
-
-        [Test]
-        public async Task
-            Home_page_should_be_shown_when_accessing_tracking_system_with_refactored_tracking_system_disabled()
-        {
-            // Given
-            A.CallTo(() => featureManager.IsEnabledAsync(FeatureFlags.RefactoredTrackingSystem))
-                .Returns(false);
-            var controller = new SupportTicketsController(featureManager, configuration)
-                .WithDefaultContext()
-                .WithMockUser(true, isCentreAdmin: false, isFrameworkDeveloper: true);
-
-            // When
-            var result = await controller.Index(DlsSubApplication.TrackingSystem);
-
-            // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("Home").WithActionName("Index");
-        }
-
-        [Test]
-        public async Task Home_page_should_be_shown_when_accessing_frameworks_supportTickets_without_appropriate_claims()
-        {
-            // Given
-            var controller = new SupportTicketsController(featureManager, configuration)
-                .WithDefaultContext()
-                .WithMockUser(true, isCentreAdmin: true, isFrameworkDeveloper: false);
-
-            // When
-            var result = await controller.Index(DlsSubApplication.Frameworks);
-
-            // Then
-            result.Should().BeRedirectToActionResult().WithControllerName("Home").WithActionName("Index");
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Attributes/SetDlsSubApplicationAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/SetDlsSubApplicationAttribute.cs
@@ -40,8 +40,9 @@
             {
                 var dlsSubApplicationParameterName = context.ActionDescriptor.Parameters
                     .FirstOrDefault(x => x.ParameterType == typeof(DlsSubApplication))?.Name;
-                controller.ViewData[LayoutViewDataKeys.DlsSubApplication] =
-                    context.ActionArguments[dlsSubApplicationParameterName!];
+                controller.ViewData[LayoutViewDataKeys.DlsSubApplication] = context.ActionArguments.ContainsKey(dlsSubApplicationParameterName)
+                    ? context.ActionArguments[dlsSubApplicationParameterName]
+                    : null;
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Attributes/SetDlsSubApplicationAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/SetDlsSubApplicationAttribute.cs
@@ -8,8 +8,8 @@
     using Microsoft.AspNetCore.Mvc.Filters;
 
     /// <summary>
-    /// Sets a controller/action to be within the specified DlsSubApplication
-    /// or, if no DlsSubApplication is specified, attempts to read it from the action parameters
+    ///     Sets a controller/action to be within the specified DlsSubApplication
+    ///     or, if no DlsSubApplication is specified, attempts to read it from the action parameters
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class SetDlsSubApplicationAttribute : Attribute, IActionFilter
@@ -40,9 +40,10 @@
             {
                 var dlsSubApplicationParameterName = context.ActionDescriptor.Parameters
                     .FirstOrDefault(x => x.ParameterType == typeof(DlsSubApplication))?.Name;
-                controller.ViewData[LayoutViewDataKeys.DlsSubApplication] = context.ActionArguments.ContainsKey(dlsSubApplicationParameterName)
-                    ? context.ActionArguments[dlsSubApplicationParameterName]
-                    : null;
+                controller.ViewData[LayoutViewDataKeys.DlsSubApplication] =
+                    context.ActionArguments.ContainsKey(dlsSubApplicationParameterName)
+                        ? context.ActionArguments[dlsSubApplicationParameterName]
+                        : null;
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/Support/SupportTicketsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/SupportTicketsController.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ServiceFilter;
     using DigitalLearningSolutions.Web.ViewModels.Support;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,7 @@
     [Authorize(Policy = CustomPolicies.UserCentreAdminOrFrameworksAdmin)]
     [SetDlsSubApplication]
     [SetSelectedTab(nameof(NavMenuTab.Support))]
+    [TypeFilter(typeof(ValidateAllowedDlsSubApplication), Arguments = new object[] { new[] { nameof(DlsSubApplication.TrackingSystem), nameof(DlsSubApplication.Frameworks) } })]
     public class SupportTicketsController : Controller
     {
         private readonly IConfiguration configuration;
@@ -27,34 +29,14 @@
             this.configuration = configuration;
         }
 
-        public async Task<IActionResult> Index(DlsSubApplication dlsSubApplication)
+        public IActionResult Index(DlsSubApplication dlsSubApplication)
         {
-            if (!DlsSubApplication.TrackingSystem.Equals(dlsSubApplication) &&
-                !DlsSubApplication.Frameworks.Equals(dlsSubApplication))
-            {
-                return NotFound();
-            }
-
-            // TODO HEEDLS-608 If the user is centre admin but tracking system is off we need to show a 404
-            // TODO HEEDLS-608 name these something appropriate
-            var trackingSystemSupportEnabled =
-                DlsSubApplication.TrackingSystem.Equals(dlsSubApplication) &&
-                User.HasCentreAdminPermissions() &&
-                await featureManager.IsEnabledAsync(FeatureFlags.RefactoredTrackingSystem);
-            var frameworksSupportEnabled = DlsSubApplication.Frameworks.Equals(dlsSubApplication) &&
-                                           User.HasFrameworksAdminPermissions();
-
-            if (trackingSystemSupportEnabled || frameworksSupportEnabled)
-            {
-                var model = new SupportTicketsViewModel(
-                    dlsSubApplication,
-                    SupportPage.SupportTickets,
-                    configuration.GetCurrentSystemBaseUrl()
-                );
-                return View("Index", model);
-            }
-
-            return RedirectToAction("Index", "Home");
+            var model = new SupportTicketsViewModel(
+                dlsSubApplication,
+                SupportPage.SupportTickets,
+                configuration.GetCurrentSystemBaseUrl()
+            );
+            return View("Index", model);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/Support/SupportTicketsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/SupportTicketsController.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.Support
 {
-    using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Web.Attributes;
@@ -17,7 +16,11 @@
     [Authorize(Policy = CustomPolicies.UserCentreAdminOrFrameworksAdmin)]
     [SetDlsSubApplication]
     [SetSelectedTab(nameof(NavMenuTab.Support))]
-    [TypeFilter(typeof(ValidateAllowedDlsSubApplication), Arguments = new object[] { new[] { nameof(DlsSubApplication.TrackingSystem), nameof(DlsSubApplication.Frameworks) } })]
+    [TypeFilter(
+        typeof(ValidateAllowedDlsSubApplication),
+        Arguments = new object[]
+            { new[] { nameof(DlsSubApplication.TrackingSystem), nameof(DlsSubApplication.Frameworks) } }
+    )]
     public class SupportTicketsController : Controller
     {
         private readonly IConfiguration configuration;


### PR DESCRIPTION
### JIRA link
_[HEEDLS-608](https://softwiretech.atlassian.net/browse/HEEDLS-608)_

### Description
The SubApplication validation attribute has now been implemented on the Support Tickets controller, resolving the Support-specific test failures. The SetDlsSubApplication attribute has been modified to prevent it throwing when given an unfamiliar application.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
