### PR TITLE
HEEDLS-749 - Exclude removed competency learning resources

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CompetencyLearningResourcesDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CompetencyLearningResourcesDataServiceTests.cs
@@ -25,7 +25,7 @@
         }
 
         [Test]
-        public void GetCompetencyIdsByLearningHubResourceReference_returns_expected_ids_from_active_records_only()
+        public void GetCompetencyIdsLinkedToResource_returns_expected_ids_from_active_records_only()
         {
             using var transaction = new TransactionScope();
             try
@@ -36,7 +36,7 @@
                 testHelper.InsertCompetencyLearningResource(7, 7, 2, 7, DateTime.UtcNow, 7);
 
                 // When
-                var result = service.GetCompetencyIdsByLearningResourceReferenceId(2);
+                var result = service.GetCompetencyIdsLinkedToResource(2);
 
                 // Then
                 result.Should().BeEquivalentTo(expectedIds);

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CompetencyLearningResourcesDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CompetencyLearningResourcesDataServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.DataServices
 {
+    using System;
     using System.Linq;
     using System.Transactions;
     using DigitalLearningSolutions.Data.DataServices;
@@ -24,7 +25,7 @@
         }
 
         [Test]
-        public void GetCompetencyIdsByLearningHubResourceReference_returns_expected_ids()
+        public void GetCompetencyIdsByLearningHubResourceReference_returns_expected_ids_from_active_records_only()
         {
             using var transaction = new TransactionScope();
             try
@@ -32,6 +33,7 @@
                 // Given
                 var expectedIds = new[] { 1, 2, 3, 5, 6 };
                 InsertCompetencyLearningResources();
+                testHelper.InsertCompetencyLearningResource(7, 7, 2, 7, DateTime.UtcNow, 7);
 
                 // When
                 var result = service.GetCompetencyIdsByLearningResourceReferenceId(2);
@@ -46,12 +48,14 @@
         }
 
         [Test]
-        public void GetCompetencyLearningResourcesByCompetencyId_returns_expected_records()
+        public void GetActiveCompetencyLearningResourcesByCompetencyId_returns_expected_active_records()
         {
             using var transaction = new TransactionScope();
 
             // Given
             InsertCompetencyLearningResources();
+            testHelper.InsertCompetencyLearningResource(7, 1, 3, 7, DateTime.UtcNow, 7);
+
             var expectedItem = new CompetencyLearningResource
             {
                 Id = 1,
@@ -62,7 +66,7 @@
             };
 
             // When
-            var result = service.GetCompetencyLearningResourcesByCompetencyId(1).ToList();
+            var result = service.GetActiveCompetencyLearningResourcesByCompetencyId(1).ToList();
 
             // Then
             result.Should().HaveCount(1);

--- a/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
@@ -84,7 +84,7 @@
 
             var resourceCompetencies = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
             A.CallTo(
-                () => competencyLearningResourcesDataService.GetCompetencyIdsByLearningResourceReferenceId(
+                () => competencyLearningResourcesDataService.GetCompetencyIdsLinkedToResource(
                     learningResourceReferenceId
                 )
             ).Returns(resourceCompetencies);

--- a/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RecommendedLearningServiceTests.cs
@@ -211,7 +211,7 @@
                 .With(clr => clr.LearningHubResourceReferenceId = LearningHubResourceReferenceId)
                 .And(clr => clr.LearningResourceReferenceId = LearningResourceReferenceId).Build();
             A.CallTo(
-                () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(A<int>._)
+                () => competencyLearningResourcesDataService.GetActiveCompetencyLearningResourcesByCompetencyId(A<int>._)
             ).Returns(competencyLearningResources);
 
             GivenLearningHubApiReturnsResources(0);
@@ -526,7 +526,7 @@
             };
 
             A.CallTo(
-                () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(CompetencyId)
+                () => competencyLearningResourcesDataService.GetActiveCompetencyLearningResourcesByCompetencyId(CompetencyId)
             ).Returns(new List<CompetencyLearningResource> { competencyLearningResource });
         }
 
@@ -549,7 +549,7 @@
                 .Build();
 
             A.CallTo(
-                () => competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(CompetencyId)
+                () => competencyLearningResourcesDataService.GetActiveCompetencyLearningResourcesByCompetencyId(CompetencyId)
             ).Returns(competencyLearningResources);
         }
 

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/CompetencyLearningResourcesTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/CompetencyLearningResourcesTestHelper.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.TestHelpers
 {
+    using System;
     using Dapper;
     using Microsoft.Data.SqlClient;
 
@@ -28,17 +29,19 @@
             int id,
             int competencyId,
             int learningResourceReferenceId,
-            int adminId
+            int adminId,
+            DateTime? removedDate = null,
+            int? removedByAdminId = null
         )
         {
             return connection.QuerySingle<int>(
                 @"SET IDENTITY_INSERT dbo.CompetencyLearningResources ON
                     INSERT INTO CompetencyLearningResources
-                    (ID, CompetencyId, LearningResourceReferenceID, AdminId)
+                    (ID, CompetencyId, LearningResourceReferenceID, AdminId, RemovedDate, RemovedByAdminId)
                     OUTPUT Inserted.ID
-                    VALUES (@id, @competencyId, @learningResourceReferenceId, @adminId)
+                    VALUES (@id, @competencyId, @learningResourceReferenceId, @adminId, @removedDate, @removedByAdminId)
                     SET IDENTITY_INSERT dbo.CompetencyLearningResources OFF",
-                new { id, competencyId, learningResourceReferenceId, adminId }
+                new { id, competencyId, learningResourceReferenceId, adminId, removedDate, removedByAdminId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
@@ -10,7 +10,7 @@
     {
         IEnumerable<int> GetCompetencyIdsByLearningResourceReferenceId(int learningResourceReferenceId);
 
-        IEnumerable<CompetencyLearningResource> GetCompetencyLearningResourcesByCompetencyId(int competencyId);
+        IEnumerable<CompetencyLearningResource> GetActiveCompetencyLearningResourcesByCompetencyId(int competencyId);
 
         IEnumerable<CompetencyResourceAssessmentQuestionParameter> GetCompetencyResourceAssessmentQuestionParameters(IEnumerable<int> competencyLearningResourceIds);
         int AddCompetencyLearningResource(int resourceRefID, string originalResourceName, int competencyID, int adminId);
@@ -31,12 +31,12 @@
                 @"SELECT
                         CompetencyID
                     FROM CompetencyLearningResources
-                    WHERE LearningResourceReferenceID = @learningResourceReferenceId",
+                    WHERE LearningResourceReferenceID = @learningResourceReferenceId AND RemovedDate IS NULL",
                 new { learningResourceReferenceId }
             );
         }
 
-        public IEnumerable<CompetencyLearningResource> GetCompetencyLearningResourcesByCompetencyId(int competencyId)
+        public IEnumerable<CompetencyLearningResource> GetActiveCompetencyLearningResourcesByCompetencyId(int competencyId)
         {
             return connection.Query<CompetencyLearningResource>(
                 @"SELECT
@@ -47,7 +47,7 @@
                         lrr.ResourceRefID AS LearningHubResourceReferenceId
                     FROM CompetencyLearningResources AS clr
                     INNER JOIN LearningResourceReferences AS lrr ON lrr.ID = clr.LearningResourceReferenceID
-                    WHERE CompetencyID = @competencyId",
+                    WHERE CompetencyID = @competencyId AND clr.RemovedDate IS NULL",
                 new { competencyId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
@@ -8,7 +8,7 @@
 
     public interface ICompetencyLearningResourcesDataService
     {
-        IEnumerable<int> GetCompetencyIdsByLearningResourceReferenceId(int learningResourceReferenceId);
+        IEnumerable<int> GetCompetencyIdsLinkedToResource(int learningResourceReferenceId);
 
         IEnumerable<CompetencyLearningResource> GetActiveCompetencyLearningResourcesByCompetencyId(int competencyId);
 
@@ -25,7 +25,7 @@
             this.connection = connection;
         }
 
-        public IEnumerable<int> GetCompetencyIdsByLearningResourceReferenceId(int learningResourceReferenceId)
+        public IEnumerable<int> GetCompetencyIdsLinkedToResource(int learningResourceReferenceId)
         {
             return connection.Query<int>(
                 @"SELECT

--- a/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
@@ -70,7 +70,7 @@
                 learningResourceReferenceDataService.GetLearningHubResourceReferenceById(learningResourceReferenceId);
 
             var competenciesForResource =
-                competencyLearningResourcesDataService.GetCompetencyIdsByLearningResourceReferenceId(
+                competencyLearningResourcesDataService.GetCompetencyIdsLinkedToResource(
                     learningResourceReferenceId
                 );
 

--- a/DigitalLearningSolutions.Data/Services/RecommendedLearningService.cs
+++ b/DigitalLearningSolutions.Data/Services/RecommendedLearningService.cs
@@ -50,7 +50,7 @@
             foreach (var competencyId in competencyIds)
             {
                 var learningHubResourceReferencesForCompetency =
-                    competencyLearningResourcesDataService.GetCompetencyLearningResourcesByCompetencyId(
+                    competencyLearningResourcesDataService.GetActiveCompetencyLearningResourcesByCompetencyId(
                         competencyId
                     );
                 competencyLearningResources.AddRange(learningHubResourceReferencesForCompetency);


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-749

### Description
Prevented Removed CompetencyLearningResources from being used in the resource recommendation algorithm. Also prevented them from being extracted when adding a resource to learning log items.

### Screenshots
N/A - all backend

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
