### PR TITLE
DLSV2-469 Store additional fields in LearningResourceReferences

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Data;
-    using Dapper;
+    using Dapper;    
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
 
@@ -13,7 +13,7 @@
         IEnumerable<CompetencyLearningResource> GetCompetencyLearningResourcesByCompetencyId(int competencyId);
 
         IEnumerable<CompetencyResourceAssessmentQuestionParameter> GetCompetencyResourceAssessmentQuestionParameters(IEnumerable<int> competencyLearningResourceIds);
-        int AddCompetencyLearningResource(int resourceRefID, string originalResourceName, int competencyID, int adminId);
+        int AddCompetencyLearningResource(int resourceRefID, string originalResourceName, string description, string resourceType, string link, string catalogue, decimal rating, int competencyID, int adminId);
     }
 
     public class CompetencyLearningResourcesDataService : ICompetencyLearningResourcesDataService
@@ -52,14 +52,32 @@
             );
         }
 
-        public int AddCompetencyLearningResource(int resourceRefID, string originalResourceName, int competencyID, int adminId)
+        public int AddCompetencyLearningResource(int resourceRefID, string resourceName, string description, string resourceType, string link, string catalogue, decimal rating, int competencyID, int adminId)
         {
             return connection.ExecuteScalar<int>(
                 @$" DECLARE @learningResourceReferenceID int
                     IF NOT EXISTS(SELECT * FROM LearningResourceReferences WHERE @resourceRefID = resourceRefID)
                         BEGIN
-                            INSERT INTO LearningResourceReferences(ResourceRefID, OriginalResourceName, AdminID, Added)
-                            VALUES(@resourceRefID, @originalResourceName, @adminID, GETDATE())
+                            INSERT INTO LearningResourceReferences(
+                                ResourceRefID,
+                                OriginalResourceName,
+                                OriginalDescription,
+                                OriginalResourceType,
+                                ResourceLink,
+                                OriginalCatalogueName,
+                                OriginalRating,
+                                AdminID,
+                                Added)
+                            VALUES(
+                                @resourceRefID,
+                                @resourceName,
+                                @description,
+                                @resourceType,
+                                @link,
+                                @catalogue,
+                                @rating,
+                                @adminID,
+                                GETDATE())
                             SELECT @learningResourceReferenceID = SCOPE_IDENTITY()
                         END
                     ELSE
@@ -71,7 +89,18 @@
                     INSERT INTO CompetencyLearningResources(CompetencyID, LearningResourceReferenceID, AdminID)
                            VALUES (@competencyID, @learningResourceReferenceID, @adminID)
                     SELECT SCOPE_IDENTITY() AS CompetencyLearningResourceId",
-                new { resourceRefID, originalResourceName, competencyID, adminId }
+                new
+                {
+                    resourceRefID,
+                    resourceName,
+                    description,
+                    resourceType,
+                    link,
+                    catalogue,
+                    rating,
+                    competencyID,
+                    adminId
+                }
             );
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -13,6 +13,7 @@ using DigitalLearningSolutions.Web.Extensions;
 using DigitalLearningSolutions.Data.Models.Frameworks;
 using DigitalLearningSolutions.Web.Models.Enums;
 using DigitalLearningSolutions.Web.Models;
+using DigitalLearningSolutions.Web.Helpers;
 
 namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
 {
@@ -65,7 +66,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         public IActionResult ConfirmAddCompetencyLearningResourceSummary(CompetencyResourceSummaryViewModel model)
         {
             var frameworkCompetency = frameworkService.GetFrameworkCompetencyById(model.FrameworkCompetencyId.Value);
-            int competencyLearningResourceId = competencyLearningResourcesDataService.AddCompetencyLearningResource(model.ReferenceId, model.ResourceName, frameworkCompetency.CompetencyID, GetAdminId());
+            string plainTextDescription = SignpostingHelper.DisplayText(model.Description);
+            int competencyLearningResourceId = competencyLearningResourcesDataService.AddCompetencyLearningResource(model.ReferenceId, model.ResourceName, plainTextDescription, model.ResourceType, model.Link, model.Catalogue, model.Rating.Value, frameworkCompetency.CompetencyID, GetAdminId());
             return RedirectToAction("StartSignpostingParametersSession", "Frameworks", new { model.FrameworkId, model.FrameworkCompetencyId, model.FrameworkCompetencyGroupId, competencyLearningResourceId });
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
@@ -8,12 +8,48 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
 {
     public class CompetencyResourceSummaryViewModel : BaseSignpostingViewModel
     {
-        public int ReferenceId { get; set; }
+        private string _Link;
+        private string _Catalog;
+        private int _ReferenceId;
+        public int ReferenceId
+        {
+            get
+            {
+                return Resource?.References?.FirstOrDefault()?.RefId ?? _ReferenceId;
+            }
+            set
+            {
+                _ReferenceId = value;
+            }
+        }
 
         public string ResourceName => Resource?.Title ?? String.Empty;
         public string ResourceType => Resource?.ResourceType ?? String.Empty;
         public string Description => Resource?.Description ?? String.Empty;
-        public string Catalogue { get; set; }
+        public string Link
+        {
+            get
+            {
+                return Resource?.References?.FirstOrDefault()?.Link ?? _Link;
+            }
+            set
+            {
+                _Link = value;
+            }
+        }
+        public string Catalogue
+        {
+            get
+            {
+                return Resource?.References?.FirstOrDefault()?.Catalogue?.Name ?? _Catalog;
+            }
+            set
+            {
+                _Catalog = value;
+            }
+        }
+        public string SelectedCatalogue { get; set; }
+        public decimal? Rating { get; set; }
         public string NameOfCompetency { get; set; }
         public string SearchText { get; set; }
         public ResourceMetadata Resource { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
@@ -42,7 +42,7 @@
     </div>
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">Catalogue</dt>
-    <dd class="nhsuk-summary-list__value">@Model.Catalogue</dd>
+    <dd class="nhsuk-summary-list__value">@Model.SelectedCatalogue</dd>
     </div>
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">Description</dt>
@@ -74,6 +74,9 @@
   @Html.HiddenFor(m => m.Resource.Title)
   @Html.HiddenFor(m => m.Resource.ResourceType)
   @Html.HiddenFor(m => m.Resource.Description)
+  @Html.HiddenFor(m => m.Link)
+  @Html.HiddenFor(m => m.Catalogue)
+  @Html.HiddenFor(m => m.Rating)
 </form>
 <div class="nhsuk-back-link nhsuk-u-margin-left-1">
   <a class="nhsuk-back-link__link" asp-action="SearchLearningResources"

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -1,6 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks;
 @using DigitalLearningSolutions.Web.Helpers;
-@using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
 @model CompetencyResourceSummaryViewModel
 
 @{
@@ -22,46 +21,46 @@
     <div class="nhsuk-u-margin-left-1 nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3">
       @Html.Raw(SignpostingHelper.DisplayText(Model.Description))
     </div>
-    @if (Model.Resource.References.Count() > 0)
+    @if (!String.IsNullOrEmpty(Model.Catalogue))
     {
-      <div class="nhsuk-u-font-weight-bold nhsuk-u-margin-left-1 nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2">
-        Catalogues
-      </div>
-      @foreach (var reference in Model.Resource.References)
-      {
-        if (reference.Catalogue != null)
-        {
-          <form method="post" role="search" asp-controller="Frameworks">
-            <div class="nhsuk-card__content nhsuk-u-margin-1 nhsuk-u-padding-0">
-              <dl class="nhsuk-summary-list">
-                <div class="nhsuk-summary-list__row">
-                  <dt class="nhsuk-summary-list__key">
-                    @reference.Catalogue.Name
-                  </dt>
-                  <dd class="nhsuk-summary-list__value">
-                    <button class="nhsuk-button nhsuk-button--secondary small-edit-button">
-                      Preview
-                    </button>
-                    <button class="nhsuk-button small-edit-button" asp-action="AddCompetencyLearningResourceSummary">
-                      Select
-                    </button>
-                  </dd>
-                </div>
-              </dl>
+      <form method="post" role="search" asp-controller="Frameworks">
+        <div class="nhsuk-card__content nhsuk-u-margin-1 nhsuk-u-padding-0">
+          <dl class="nhsuk-summary-list">
+            <div class="nhsuk-summary-list__row">
+              <dt class="nhsuk-summary-list__key">
+                Catalogue
+              </dt>
+              <dd class="nhsuk-summary-list__value">
+                @Model.Catalogue
+              </dd>
             </div>
-            @Html.HiddenFor(m => m.FrameworkId)
-            @Html.HiddenFor(m => m.FrameworkCompetencyGroupId)
-            @Html.HiddenFor(m => m.FrameworkCompetencyId)
-            @Html.Hidden("ReferenceId", reference.RefId)
-            @Html.Hidden("Resource.Title", Model.Resource?.Title)
-            @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
-            @Html.Hidden("Catalogue", reference.Catalogue.Name)
-            @Html.HiddenFor(m => m.Resource.Description)
-            @Html.Hidden("NameOfCompetency", parent.NameOfCompetency)
-            @Html.Hidden("SearchText", parent.SearchText)
-          </form>
-        }
-      }
+            <div class="nhsuk-summary-list__row">
+              <dt class="nhsuk-summary-list__key"></dt>
+              <dd class="nhsuk-summary-list__value">
+                <button class="nhsuk-button nhsuk-button--secondary small-edit-button">
+                  Preview
+                </button>
+                <button class="nhsuk-button small-edit-button" asp-action="AddCompetencyLearningResourceSummary">
+                  Select
+                </button>
+              </dd>
+            </div>
+          </dl>
+        </div>
+        @Html.HiddenFor(m => m.FrameworkId)
+        @Html.HiddenFor(m => m.FrameworkCompetencyGroupId)
+        @Html.HiddenFor(m => m.FrameworkCompetencyId)
+        @Html.Hidden("ReferenceId", Model.ReferenceId)
+        @Html.Hidden("Resource.Title", Model.Resource?.Title)
+        @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
+        @Html.Hidden("SelectedCatalogue", Model.Catalogue)
+        @Html.HiddenFor(m => m.Resource.Description)
+        @Html.Hidden("NameOfCompetency", parent.NameOfCompetency)
+        @Html.Hidden("SearchText", parent.SearchText)
+        @Html.HiddenFor(m => m.Link)
+        @Html.HiddenFor(m => m.Catalogue)
+        @Html.Hidden("Rating", Model.Resource?.Rating ?? 0)
+      </form>
     }
   </div>
 </details>


### PR DESCRIPTION
Store description, link, catalogue, resource type and rating to LearningResourceReferences when inserting a record.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-469

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/150791631-ce86cb2a-7b18-4cd5-99f4-6e17438f80fa.png)

-----
### Developer checks

In Frameworks, Framework Structure
- Manage resource signposting
- Add resource
- Search for "test"
- Select one resource

Check that:
- Parameters can be created after adding a learning resource reference.
- The application does not attempt insert duplicates in LearningResourceReferences.
- The foreign key on table CompetencyLearningResources is correctly set for existing a newly created LearningResourceReferences.
- Html markup returned by LH api is not being inserted into LearningResourceReferences original description.