### PR TITLE
Heedls 687 self registration prn

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
@@ -466,5 +466,23 @@
             var updatedUser = userDataService.GetDelegateUserById(2)!;
             updatedUser.HasDismissedLhLoginWarning.Should().BeTrue();
         }
+
+        [Test]
+        public void UpdateDelegateProfessionalRegistrationNumber_sets_ProfessionalRegistrationNumber()
+        {
+            // Given
+            const int delegateId = 2;
+            const string prn = "PRN123";
+
+            using var transaction = new TransactionScope();
+
+            // When
+            userDataService.UpdateDelegateProfessionalRegistrationNumber(delegateId, prn, true);
+
+            // Then
+            var updatedUser = userDataService.GetDelegateUserById(delegateId)!;
+            updatedUser.ProfessionalRegistrationNumber.Should().Be(prn);
+            updatedUser.HasBeenPromptedForPrn.Should().BeTrue();
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
@@ -101,7 +101,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                         )
                 )
                 .MustHaveHappened();
-            Assert.That(approved);
+            approved.Should().BeTrue();
         }
 
         [Test]
@@ -410,7 +410,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                         )
                 )
                 .MustHaveHappenedOnceExactly();
-            Assert.That(approved);
+            approved.Should().BeTrue();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
@@ -407,7 +407,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                             A<int>._,
                             prn,
                             true
-                            )
+                        )
                 )
                 .MustHaveHappenedOnceExactly();
             Assert.That(approved);

--- a/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
@@ -89,7 +89,8 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var (_, approved) = registrationService.RegisterDelegate(
                 model,
                 clientIp,
-                false
+                false,
+                null
             );
 
             // Then
@@ -110,7 +111,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
 
             // When
-            registrationService.RegisterDelegate(model, "::1", false);
+            registrationService.RegisterDelegate(model, "::1", false, null);
 
             // Then
             A.CallTo(
@@ -129,7 +130,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
 
             // When
-            registrationService.RegisterDelegate(model, "987.654.321.100", false);
+            registrationService.RegisterDelegate(model, "987.654.321.100", false, null);
 
             // Then
             A.CallTo(
@@ -148,7 +149,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
 
             // When
-            registrationService.RegisterDelegate(model, string.Empty, false);
+            registrationService.RegisterDelegate(model, string.Empty, false, null);
 
             // Then
             A.CallTo(
@@ -173,7 +174,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
 
             // When
-            registrationService.RegisterDelegate(model, string.Empty, true);
+            registrationService.RegisterDelegate(model, string.Empty, true, null);
 
             // Then
             A.CallTo(
@@ -198,7 +199,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
 
             // When
-            registrationService.RegisterDelegate(model, "123.456.789.100", false);
+            registrationService.RegisterDelegate(model, "123.456.789.100", false, null);
 
             // Then
             A.CallTo(
@@ -214,7 +215,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
 
             // When
-            registrationService.RegisterDelegate(model, string.Empty, false);
+            registrationService.RegisterDelegate(model, string.Empty, false, null);
 
             // Then
             A.CallTo(
@@ -234,7 +235,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
 
             // When
             var candidateNumber =
-                registrationService.RegisterDelegate(model, string.Empty, false)
+                registrationService.RegisterDelegate(model, string.Empty, false, null)
                     .candidateNumber;
 
             // Then
@@ -257,7 +258,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 .Returns(new DelegateUser { Id = 777 });
 
             // When
-            registrationService.RegisterDelegate(model, string.Empty, false, 999);
+            registrationService.RegisterDelegate(model, string.Empty, false, null, 999);
 
             // Then
             A.CallTo(
@@ -282,6 +283,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 model,
                 string.Empty,
                 false,
+                null,
                 matchingSupervisorDelegateId
             );
 
@@ -304,7 +306,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             GivenNoPendingSupervisorDelegateRecordsForEmail();
 
             // When
-            registrationService.RegisterDelegate(model, string.Empty, false, 999);
+            registrationService.RegisterDelegate(model, string.Empty, false, null, 999);
 
             // Then
             A.CallTo(
@@ -331,6 +333,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 model,
                 string.Empty,
                 false,
+                null,
                 supervisorDelegateId
             );
 
@@ -339,7 +342,8 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 .MustHaveHappened();
             A.CallTo(
                 () => frameworkNotificationService.SendSupervisorDelegateAcceptance(
-                    A<int>.That.Matches(id => id != supervisorDelegateId), A<int>._
+                    A<int>.That.Matches(id => id != supervisorDelegateId),
+                    A<int>._
                 )
             ).MustNotHaveHappened();
         }
@@ -352,7 +356,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => registrationDataService.RegisterDelegate(model)).Returns("-1");
 
             // When
-            Action act = () => registrationService.RegisterDelegate(model, string.Empty, false);
+            Action act = () => registrationService.RegisterDelegate(model, string.Empty, false, null);
 
             // Then
             act.Should().Throw<DelegateCreationFailedException>();
@@ -366,7 +370,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => registrationDataService.RegisterDelegate(model)).Returns("-1");
 
             // When
-            Action act = () => registrationService.RegisterDelegate(model, string.Empty, false);
+            Action act = () => registrationService.RegisterDelegate(model, string.Empty, false, null);
 
             // Then
             act.Should().Throw<DelegateCreationFailedException>();
@@ -378,6 +382,35 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 () =>
                     passwordDataService.SetPasswordByCandidateNumber(A<string>._, A<string>._)
             ).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void Registering_delegate_calls_data_service_to_set_prn()
+        {
+            // Given
+            const string clientIp = ApprovedIpPrefix + ".100";
+            const string prn = "PRN";
+            var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
+
+            // When
+            var (_, approved) = registrationService.RegisterDelegate(
+                model,
+                clientIp,
+                false,
+                prn
+            );
+
+            // Then
+            A.CallTo(
+                    () =>
+                        userDataService.UpdateDelegateProfessionalRegistrationNumber(
+                            A<int>._,
+                            prn,
+                            true
+                            )
+                )
+                .MustHaveHappenedOnceExactly();
+            Assert.That(approved);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -198,7 +198,8 @@
             byte[]? profileImage,
             string? professionalRegNumber,
             bool hasBeenPromptedForPrn,
-            int[] ids)
+            int[] ids
+        )
         {
             connection.Execute(
                 @"UPDATE Candidates
@@ -354,19 +355,19 @@
             connection.Execute(
                 @"UPDATE Candidates
                     SET
-				        FirstName = @firstName,
-				        LastName = @lastName,
-				        JobGroupID = @jobGroupId,
-				        Active = @active,
-				        Answer1 = @answer1,
-				        Answer2 = @answer2,
-				        Answer3 = @answer3,
-				        Answer4 = @answer4,
-				        Answer5 = @answer5,
-				        Answer6 = @answer6,
-				        AliasID = @aliasId,
-				        EmailAddress = @emailAddress
-		            WHERE CandidateID = @delegateId",
+                        FirstName = @firstName,
+                        LastName = @lastName,
+                        JobGroupID = @jobGroupId,
+                        Active = @active,
+                        Answer1 = @answer1,
+                        Answer2 = @answer2,
+                        Answer3 = @answer3,
+                        Answer4 = @answer4,
+                        Answer5 = @answer5,
+                        Answer6 = @answer6,
+                        AliasID = @aliasId,
+                        EmailAddress = @emailAddress
+                    WHERE CandidateID = @delegateId",
                 new
                 {
                     delegateId,
@@ -467,6 +468,22 @@
                     SET LearningHubAuthId = @learningHubAuthId
                     WHERE CandidateID = @delegateId",
                 new { delegateId, learningHubAuthId }
+            );
+        }
+
+        public void UpdateDelegateProfessionalRegistrationNumber(
+            int delegateId,
+            string? professionalRegistrationNumber,
+            bool hasBeenPromptedForPrn
+        )
+        {
+            connection.Execute(
+                @"UPDATE Candidates
+                    SET
+                        ProfessionalRegistrationNumber = @professionalRegistrationNumber,
+                        HasBeenPromptedForPrn = @hasBeenPromptedForPrn
+                    WHERE CandidateID = @delegateId",
+                new { delegateId, professionalRegistrationNumber, hasBeenPromptedForPrn }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -56,7 +56,8 @@
             byte[]? profileImage,
             string? professionalRegNumber,
             bool hasBeenPromptedForPrn,
-            int[] ids);
+            int[] ids
+        );
 
         void UpdateDelegate(
             int delegateId,
@@ -116,8 +117,14 @@
         int? GetDelegateUserLearningHubAuthId(int delegateId);
 
         void SetDelegateUserLearningHubAuthId(int delegateId, int learningHubAuthId);
-        
+
         void UpdateDelegateLhLoginWarningDismissalStatus(int delegateId, bool status);
+
+        void UpdateDelegateProfessionalRegistrationNumber(
+            int delegateId,
+            string? professionalRegistrationNumber,
+            bool hasBeenPromptedForPrn
+        );
     }
 
     public partial class UserDataService : IUserDataService

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
@@ -30,6 +30,7 @@
             Driver.SelectDropdownItemValue("Answer1", "Principal Relationship Manager");
             Driver.FillTextInput("Answer2", "A Person");
             Driver.SelectDropdownItemValue("JobGroup", "1");
+            Driver.SelectRadioOptionById("HasProfessionalRegistrationNumber_No");
             Driver.SubmitForm();
 
             var passwordResult = new AxeBuilder(Driver).Analyze();

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/TestHelpers/DriverHelper.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/TestHelpers/DriverHelper.cs
@@ -52,5 +52,11 @@
             var selectPromptForm = driver.FindElement(By.TagName("form"));
             selectPromptForm.Submit();
         }
+
+        public static void SelectRadioOptionById(this IWebDriver driver, string radioId)
+        {
+            var radioInput = driver.FindElement(By.Id(radioId));
+            radioInput.Click();
+        }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterControllerTests.cs
@@ -78,7 +78,7 @@
                 FirstName = "Test",
                 LastName = "User",
                 Centre = duplicateUser.CentreId,
-                Email = duplicateUser.EmailAddress
+                Email = duplicateUser.EmailAddress,
             };
             A.CallTo(() => userService.IsDelegateEmailValidForCentre(model.Email!, model.Centre.Value))
                 .Returns(false);
@@ -103,7 +103,7 @@
                 FirstName = "Test",
                 LastName = "User",
                 Centre = duplicateUser.CentreId + 1,
-                Email = duplicateUser.EmailAddress
+                Email = duplicateUser.EmailAddress,
             };
             A.CallTo(() => userService.IsDelegateEmailValidForCentre(model.Email!, model.Centre.Value))
                 .Returns(true);
@@ -176,6 +176,7 @@
                         A<DelegateRegistrationModel>._,
                         A<string>._,
                         A<bool>._,
+                        A<string?>._,
                         A<int>._
                     )
                 )
@@ -214,6 +215,7 @@
                             ),
                             IpAddress,
                             false,
+                            null,
                             SupervisorDelegateId
                         )
                 )
@@ -239,6 +241,7 @@
                             A<DelegateRegistrationModel>._,
                             IpAddress,
                             false,
+                            null,
                             SupervisorDelegateId
                         )
                 )
@@ -264,6 +267,7 @@
                             A<DelegateRegistrationModel>._,
                             IpAddress,
                             false,
+                            null,
                             SupervisorDelegateId
                         )
                 )
@@ -289,6 +293,7 @@
                             A<DelegateRegistrationModel>._,
                             IpAddress,
                             false,
+                            null,
                             SupervisorDelegateId
                         )
                 )
@@ -307,6 +312,7 @@
                         A<DelegateRegistrationModel>._,
                         A<string>._,
                         A<bool>._,
+                        A<string?>._,
                         A<int>._
                     )
                 )
@@ -335,6 +341,7 @@
                         A<DelegateRegistrationModel>._,
                         A<string>._,
                         A<bool>._,
+                        A<string?>._,
                         A<int>._
                     )
                 )

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -164,6 +164,12 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
                 ModelState
             );
 
+            ProfessionalRegistrationNumberHelper.ValidateProfessionalRegistrationNumber(
+                ModelState,
+                model.HasProfessionalRegistrationNumber,
+                model.ProfessionalRegistrationNumber
+            );
+
             if (!ModelState.IsValid)
             {
                 PopulateLearnerInformationExtraFields(model, data);
@@ -243,6 +249,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
                         RegistrationMappingHelper.MapSelfRegistrationToDelegateRegistrationModel(data),
                         userIp,
                         refactoredTrackingSystemEnabled,
+                        data.ProfessionalRegistrationNumber,
                         data.SupervisorDelegateId
                     );
 

--- a/DigitalLearningSolutions.Web/Models/DelegateRegistrationData.cs
+++ b/DigitalLearningSolutions.Web/Models/DelegateRegistrationData.cs
@@ -34,7 +34,7 @@
             Answer4 = model.Answer4;
             Answer5 = model.Answer5;
             Answer6 = model.Answer6;
-            ProfessionalRegistrationNumber = model.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = model.HasProfessionalRegistrationNumber == true ? model.ProfessionalRegistrationNumber : null;
             HasProfessionalRegistrationNumber = model.HasProfessionalRegistrationNumber;
         }
 

--- a/DigitalLearningSolutions.Web/Models/DelegateRegistrationData.cs
+++ b/DigitalLearningSolutions.Web/Models/DelegateRegistrationData.cs
@@ -22,6 +22,8 @@
         public string? Answer4 { get; set; }
         public string? Answer5 { get; set; }
         public string? Answer6 { get; set; }
+        public string? ProfessionalRegistrationNumber { get; set; }
+        public bool? HasProfessionalRegistrationNumber { get; set; }
 
         public override void SetLearnerInformation(LearnerInformationViewModel model)
         {
@@ -32,6 +34,8 @@
             Answer4 = model.Answer4;
             Answer5 = model.Answer5;
             Answer6 = model.Answer6;
+            ProfessionalRegistrationNumber = model.ProfessionalRegistrationNumber;
+            HasProfessionalRegistrationNumber = model.HasProfessionalRegistrationNumber;
         }
 
         public void ClearCustomPromptAnswers()

--- a/DigitalLearningSolutions.Web/ViewModels/Common/IEditProfessionalRegistrationNumbers.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/IEditProfessionalRegistrationNumbers.cs
@@ -1,0 +1,9 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common
+{
+    public interface IEditProfessionalRegistrationNumbers
+    {
+        public string? ProfessionalRegistrationNumber { get; set; }
+
+        public bool? HasProfessionalRegistrationNumber { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsFormData.cs
@@ -9,7 +9,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
     using DigitalLearningSolutions.Web.ViewModels.Common;
     using Microsoft.AspNetCore.Http;
 
-    public class MyAccountEditDetailsFormData : EditDetailsFormData, IValidatableObject
+    public class MyAccountEditDetailsFormData : EditDetailsFormData, IEditProfessionalRegistrationNumbers, IValidatableObject
     {
         public MyAccountEditDetailsFormData() { }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Register/LearnerInformationViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/LearnerInformationViewModel.cs
@@ -6,7 +6,7 @@
     using DigitalLearningSolutions.Web.ViewModels.Common;
     using Microsoft.AspNetCore.Mvc.Rendering;
 
-    public class LearnerInformationViewModel
+    public class LearnerInformationViewModel : IEditProfessionalRegistrationNumbers
     {
         public LearnerInformationViewModel() { }
 
@@ -23,6 +23,8 @@
             Answer4 = data.Answer4;
             Answer5 = data.Answer5;
             Answer6 = data.Answer6;
+            ProfessionalRegistrationNumber = data.ProfessionalRegistrationNumber;
+            HasProfessionalRegistrationNumber = data.HasProfessionalRegistrationNumber;
         }
 
         [Required(ErrorMessage = "Select a job group")]
@@ -43,5 +45,7 @@
         public IEnumerable<EditCustomFieldViewModel> CustomFields { get; set; } = new List<EditCustomFieldViewModel>();
 
         public IEnumerable<SelectListItem> JobGroupOptions { get; set; } = new List<SelectListItem>();
+        public string? ProfessionalRegistrationNumber { get; set; }
+        public bool? HasProfessionalRegistrationNumber { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Register/SummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/SummaryViewModel.cs
@@ -19,6 +19,8 @@
         public SummaryViewModel(DelegateRegistrationData data) : this((RegistrationData)data)
         {
             IsCentreSpecificRegistration = data.IsCentreSpecificRegistration;
+            ProfessionalRegistrationNumber = data.ProfessionalRegistrationNumber ?? "Not professionally registered";
+            HasProfessionalRegistrationNumber = data.HasProfessionalRegistrationNumber;
         }
 
         public string? FirstName { get; set; }
@@ -29,6 +31,8 @@
         public bool Terms { get; set; }
         public IEnumerable<CustomFieldViewModel> CustomFields { get; set; } = new List<CustomFieldViewModel>();
         public bool IsCentreSpecificRegistration { get; set; }
+        public string? ProfessionalRegistrationNumber { get; set; }
+        public bool? HasProfessionalRegistrationNumber { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {

--- a/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
@@ -9,52 +9,43 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred) {
-      <vc:error-summary order-of-property-names="@(new[] {
-                                                   nameof(Model.JobGroup),
-                                                   nameof(Model.Answer1),
-                                                   nameof(Model.Answer2),
-                                                   nameof(Model.Answer3),
-                                                   nameof(Model.Answer4),
-                                                   nameof(Model.Answer5),
-                                                   nameof(Model.Answer6)
-                                                 })" />
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.JobGroup), nameof(Model.Answer1), nameof(Model.Answer2), nameof(Model.Answer3), nameof(Model.Answer4), nameof(Model.Answer5), nameof(Model.Answer6) })" />
     }
 
     <h1 class="nhsuk-heading-xl">Learner information</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="LearnerInformation">
 
-      <vc:select-list
-        asp-for="JobGroup"
-        label="Job Group"
-        value="@Model.JobGroup?.ToString()"
-        hint-text=""
-        deselectable="false"
-        css-class="nhsuk-u-width-one-half"
-        default-option="Select a job group"
-        select-list-options="@Model.JobGroupOptions" />
+      <vc:select-list asp-for="JobGroup"
+                      label="Job Group"
+                      value="@Model.JobGroup?.ToString()"
+                      hint-text=""
+                      deselectable="false"
+                      css-class="nhsuk-u-width-one-half"
+                      default-option="Select a job group"
+                      select-list-options="@Model.JobGroupOptions" />
+
+      <partial name="_EditRegistrationNumber" model="@Model" />
 
       @foreach (var customField in Model.CustomFields) {
         if (customField.Options.Any()) {
-          <vc:select-list
-            asp-for="@("Answer" + customField.CustomFieldId)"
-            label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
-            value="@customField.Answer"
-            hint-text=""
-            deselectable="@(!customField.Mandatory)"
-            css-class="nhsuk-u-width-one-half"
-            default-option="Select a @customField.CustomPrompt.ToLower()"
-            select-list-options="@customField.Options" />
+          <vc:select-list asp-for="@("Answer" + customField.CustomFieldId)"
+                          label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
+                          value="@customField.Answer"
+                          hint-text=""
+                          deselectable="@(!customField.Mandatory)"
+                          css-class="nhsuk-u-width-one-half"
+                          default-option="Select a @customField.CustomPrompt.ToLower()"
+                          select-list-options="@customField.Options" />
         } else {
-          <vc:text-input
-            asp-for="@("Answer" + customField.CustomFieldId)"
-            label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
-            populate-with-current-value="true"
-            type="text"
-            spell-check="false"
-            hint-text=""
-            autocomplete=""
-            css-class="nhsuk-u-width-one-half" />
+          <vc:text-input asp-for="@("Answer" + customField.CustomFieldId)"
+                         label="@(customField.CustomPrompt + (customField.Mandatory ? "" : " (optional)"))"
+                         populate-with-current-value="true"
+                         type="text"
+                         spell-check="false"
+                         hint-text=""
+                         autocomplete=""
+                         css-class="nhsuk-u-width-one-half" />
         }
       }
 

--- a/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
@@ -11,7 +11,14 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred) {
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.JobGroup), nameof(Model.Answer1), nameof(Model.Answer2), nameof(Model.Answer3), nameof(Model.Answer4), nameof(Model.Answer5), nameof(Model.Answer6) })" />
+      <vc:error-summary order-of-property-names="@(new[] {
+                                                   nameof(Model.JobGroup),
+                                                   nameof(Model.Answer1),
+                                                   nameof(Model.Answer2),
+                                                   nameof(Model.Answer3),
+                                                   nameof(Model.Answer4),
+                                                   nameof(Model.Answer5),
+                                                   nameof(Model.Answer6) })" />
     }
 
     <h1 class="nhsuk-heading-xl">Learner information</h1>

--- a/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/LearnerInformation.cshtml
@@ -6,6 +6,8 @@
   ViewData["Title"] = errorHasOccurred ? "Error: Register - Learner information" : "Register - Learner information";
 }
 
+<link rel="stylesheet" href="@Url.Content("~/css/shared/formElements.css")" asp-append-version="true">
+
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred) {

--- a/DigitalLearningSolutions.Web/Views/Register/Summary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Summary.cshtml
@@ -83,6 +83,17 @@
           </a>
         </dd>
       </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Professional registration number
+        </dt>
+        <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
+        <dd class="nhsuk-summary-list__actions">
+          <a asp-action="LearnerInformation">
+            Change<span class="nhsuk-u-visually-hidden"> professional registration number</span>
+          </a>
+        </dd>
+      </div>
       @foreach (var customField in Model.CustomFields) {
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Common
+@using DigitalLearningSolutions.Web.ViewModels.Register
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 
 @model IEditProfessionalRegistrationNumbers
@@ -11,6 +12,8 @@
   var optionYesSelected = Model.HasProfessionalRegistrationNumber == true;
   var optionNoSelected = Model.HasProfessionalRegistrationNumber == false;
   const string professionalRegConditionalId = "professional-reg-conditional-Id";
+
+  var isRegisterJourney = Model is LearnerInformationViewModel;
 }
 
 <div class="nhsuk-form-group @(hasPrnErrorHasOccurred ? " nhsuk-form-group--error" : "" )">
@@ -22,6 +25,7 @@
       </div>
       <div class="nhsuk-hint nhsuk-u-margin-bottom-0" id="professional-registration-hint">
         You should have a professional registration number if you are a health professional registered with a professional body such as the NMC, GMC or GDC.
+        @(isRegisterJourney ? "If you don't have it to hand, you can provide it later by visiting My account / Edit details." : "")
       </div>
     </legend>
 

--- a/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
@@ -1,7 +1,7 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.MyAccount
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 
-@model MyAccountEditDetailsViewModel
+@model IEditProfessionalRegistrationNumbers
 
 @{
   var hasPrnErrorHasOccurred =
@@ -13,7 +13,7 @@
   const string professionalRegConditionalId = "professional-reg-conditional-Id";
 }
 
-<div class="nhsuk-form-group @(hasPrnErrorHasOccurred ? "nhsuk-form-group--error" : "")">
+<div class="nhsuk-form-group @(hasPrnErrorHasOccurred ? " nhsuk-form-group--error" : "" )">
   <fieldset class="nhsuk-fieldset" aria-describedby="professional-registration-hint">
 
     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
@@ -26,9 +26,9 @@
     </legend>
 
     @if (hasPrnErrorHasOccurred) {
-      <span class="nhsuk-error-message" id="no-selection-error">
-        <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState[nameof(Model.HasProfessionalRegistrationNumber)].Errors[0].ErrorMessage
-      </span>
+    <span class="nhsuk-error-message" id="no-selection-error">
+      <span class="nhsuk-u-visually-hidden">Error:</span> @ViewData.ModelState[nameof(Model.HasProfessionalRegistrationNumber)].Errors[0].ErrorMessage
+    </span>
     }
 
     <div class="nhsuk-radios nhsuk-radios--conditional">
@@ -38,7 +38,7 @@
                id="HasProfessionalRegistrationNumber_No"
                type="radio"
                value="false"
-               @(optionNoSelected ? "checked" : "") />
+               @(optionNoSelected ? "checked" : "" ) />
         <label class="nhsuk-label nhsuk-radios__label" for="HasProfessionalRegistrationNumber_No">
           No
         </label>
@@ -51,14 +51,13 @@
                type="radio"
                value="true"
                aria-controls="@professionalRegConditionalId"
-               @(optionYesSelected ? "checked" : "") />
+               @(optionYesSelected ? "checked" : "" ) />
         <label class="nhsuk-label nhsuk-radios__label" for="HasProfessionalRegistrationNumber_Yes">
           Yes
         </label>
       </div>
-      <div
-        class="nhsuk-radios__conditional @(optionYesSelected ? " " : " nhsuk-radios__conditional--hidden") @(professionalRegNumberErrorHasOccurred ? "form-group-wrapper--error" : "")"
-        id="@professionalRegConditionalId">
+      <div class="nhsuk-radios__conditional @(optionYesSelected ? " " : " nhsuk-radios__conditional--hidden") @(professionalRegNumberErrorHasOccurred ? "form-group-wrapper--error" : "" )"
+           id="@professionalRegConditionalId">
         <vc:text-input asp-for="@nameof(Model.ProfessionalRegistrationNumber)"
                        label="Professional Registration Number"
                        populate-with-current-value="true"


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-687

### Description
Added the PRN fields to the Learner Information page of the delegate self registration journey by moving the partial created for the My Account Edit Details page to a shared location and using that. 
Added an entry for this new value in the Summary view
Updated the service logic to make a call to save the provided value rather than updating the register candidate stored procedure.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/150798703-e7a372f2-6b56-4357-ab84-9750feba7099.png)
![image](https://user-images.githubusercontent.com/59561751/150798793-992ee931-a721-4e5e-8584-e50d27bd61d2.png)
![image](https://user-images.githubusercontent.com/59561751/150798821-848425d1-e55e-4506-bfdf-85f1b9750c74.png)
![image](https://user-images.githubusercontent.com/59561751/150798841-ab175f32-c6c3-4364-9818-39995a464ad1.png)
![image](https://user-images.githubusercontent.com/59561751/150798918-d0f1ca34-1040-4256-9a9f-656211d390b3.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
