### PR TITLE
DLSV2-477 Learning Hub api to populate EditCompetencyLearningResources view

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Frameworks/CompetencyResourceAssessmentQuestionParameter.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/CompetencyResourceAssessmentQuestionParameter.cs
@@ -7,6 +7,7 @@ namespace DigitalLearningSolutions.Data.Models.Frameworks
     public class CompetencyResourceAssessmentQuestionParameter
     {
         public int? AssessmentQuestionId { get; set; }
+        public int ResourceRefId { get; set; }
         public int CompetencyLearningResourceId { get; set; }
         public int MinResultMatch { get; set; }
         public int MaxResultMatch { get; set; }
@@ -14,6 +15,8 @@ namespace DigitalLearningSolutions.Data.Models.Frameworks
         public int? RelevanceAssessmentQuestionId { get; set; }
         public bool CompareToRoleRequirements { get; set; }
         public string OriginalResourceName { get; set; }
+        public string OriginalResourceType { get; set; }
+        public decimal OriginalRating { get; set; }
         public string Question { get; set; }
         public string CompareResultTo { get; set; }
         public AssessmentQuestion AssessmentQuestion { get; set; }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1667,7 +1667,8 @@ WHERE (RPC.AdminID = @adminId) AND (RPR.ReviewComplete IS NULL) AND (RPR.Archive
         public IEnumerable<CompetencyResourceAssessmentQuestionParameter> GetSignpostingResourceParametersByFrameworkAndCompetencyId(int frameworkId, int competencyId)
         {
             return connection.Query<CompetencyResourceAssessmentQuestionParameter>(
-                $@"SELECT clr.ID AS CompetencyLearningResourceID, lrr.OriginalResourceName, p.Essential, q.Question, p.MinResultMatch, p.MaxResultMatch, 
+                $@"SELECT clr.ID AS CompetencyLearningResourceID, lrr.ResourceRefID AS ResourceRefId, lrr.OriginalResourceName, lrr.OriginalResourceType,
+                    p.Essential, q.Question, p.MinResultMatch, p.MaxResultMatch, lrr.OriginalRating,
                     CASE 
 	                    WHEN p.CompareToRoleRequirements = 1 THEN 'Role requirements'  
 	                    WHEN p.RelevanceAssessmentQuestionID IS NOT NULL THEN raq.Question

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -336,13 +336,14 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             };
             var learningHubApiReferences = GetBulkResourcesByReferenceIds(model, parameters);
             var learningHubApiResourcesByRefId = learningHubApiReferences?.ResourceReferences?.ToDictionary(k => k.RefId, v => v);
-            model.CompetencyResourceLinks = (from p in parameters
+            model.CompetencyResourceLinks = (
+                from p in parameters
                 let resource = !model.LearningHubApiError && learningHubApiResourcesByRefId.Keys.Contains(p.ResourceRefId) ? learningHubApiResourcesByRefId[p.ResourceRefId] : null
                 select new SignpostingCardViewModel()
                 {
                     AssessmentQuestionId = p.AssessmentQuestionId,
                     CompetencyLearningResourceId = p.CompetencyLearningResourceId,
-                    Name = p.OriginalResourceName,
+                    Name = resource?.Title ?? p.OriginalResourceName,
                     AssessmentQuestion = p.Question,
                     MinimumResultMatch = p.MinResultMatch,
                     MaximumResultMatch = p.MaxResultMatch,
@@ -354,8 +355,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     ResourceType = resource?.ResourceType ?? p.OriginalResourceType,
                     Rating = resource?.Rating ?? p.OriginalRating,
                     UnmatchedResource = learningHubApiReferences?.UnmatchedResourceReferenceIds?.Contains(p.ResourceRefId) ?? false
-                }
-            ).ToList();
+                }).ToList();
             return model;
         }
 

--- a/DigitalLearningSolutions.Web/Models/SessionCompetencyLearningResourceSignpostingParameter.cs
+++ b/DigitalLearningSolutions.Web/Models/SessionCompetencyLearningResourceSignpostingParameter.cs
@@ -9,7 +9,7 @@ namespace DigitalLearningSolutions.Web.Models
     public class SessionCompetencyLearningResourceSignpostingParameter
     {
         public Guid Id { get; set; }
-        public LearningResourceReference LearningResourceReference { get; set; }
+        public string ResourceName { get; set; }
         public List<AssessmentQuestion> Questions { get; set; }
         public AssessmentQuestion SelectedQuestion { get; set; }
         public int SelectedQuestionRoleRequirements { get; set; }
@@ -25,11 +25,11 @@ namespace DigitalLearningSolutions.Web.Models
         public SessionCompetencyLearningResourceSignpostingParameter()
         {
         }
-        public SessionCompetencyLearningResourceSignpostingParameter(string cookieName, IRequestCookieCollection requestCookies, IResponseCookies responseCookies, FrameworkCompetency frameworkCompetency, LearningResourceReference resource, List<AssessmentQuestion> questions, AssessmentQuestion selectedQuestion, CompareAssessmentQuestionType selectedCompareQuestionType, CompetencyResourceAssessmentQuestionParameter assessmentQuestionParameter)
+        public SessionCompetencyLearningResourceSignpostingParameter(string cookieName, IRequestCookieCollection requestCookies, IResponseCookies responseCookies, FrameworkCompetency frameworkCompetency, string resourceName, List<AssessmentQuestion> questions, AssessmentQuestion selectedQuestion, CompareAssessmentQuestionType selectedCompareQuestionType, CompetencyResourceAssessmentQuestionParameter assessmentQuestionParameter)
         {
             var options = new CookieOptions { Expires = DateTimeOffset.UtcNow.AddDays(30) };
             FrameworkCompetency = frameworkCompetency;
-            LearningResourceReference = resource;
+            ResourceName = resourceName;
             Questions = questions;
             AssessmentQuestionParameter = assessmentQuestionParameter;
             SelectedQuestion = selectedQuestion;

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/SignpostingCardViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/SignpostingCardViewModel.cs
@@ -5,11 +5,16 @@
         public int? AssessmentQuestionId { get; set; }
         public int? CompetencyLearningResourceId { get; set; }
         public string Name { get; set; }
+        public string Description { get; set; }
+        public string Catalogue { get; set; }
+        public string ResourceType { get; set; }
+        public decimal Rating { get; set; }
         public string AssessmentQuestion { get; set; }
         public int MinimumResultMatch { get; set; }
         public int MaximumResultMatch { get; set; }
         public string CompareResultTo { get; set; }
         public bool Essential { get; set; }
         public bool ParameterHasNotBeenSet { get; set; }
+        public bool UnmatchedResource { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/EditCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/EditCompetencyLearningResources.cshtml
@@ -54,7 +54,7 @@ else
   <p>No learning resources have been added to this competency.</p>
 }
 <div class="nhsuk-u-margin-top-5">
-  <a class="nhsuk-button nhsuk-u-margin-bottom-4" href="@Url.Content($"~/Frameworks/{@Model.FrameworkId}/Competency/{@Model.FrameworkCompetencyId}/CompetencyGroup/{@Model.FrameworkCompetencyGroupId}/Signposting/AddResource")">
+  <a class="nhsuk-button nhsuk-u-margin-bottom-4" @(Model.LearningHubApiError ? "disabled" : String.Empty) href="@Url.Content($"~/Frameworks/{@Model.FrameworkId}/Competency/{@Model.FrameworkCompetencyId}/CompetencyGroup/{@Model.FrameworkCompetencyGroupId}/Signposting/AddResource")">
     Add resource
   </a>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/EditCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/EditCompetencyLearningResources.cshtml
@@ -27,6 +27,21 @@
   </p>
 </div>
 <h2>Competency Resource Links</h2>
+@if (Model.LearningHubApiError)
+{
+  <div class="nhsuk-warning-callout">
+    <h3 class="nhsuk-warning-callout__label">
+      <span role="text">
+        <span class="nhsuk-u-visually-hidden">Learning Hub API Unavailable</span>
+        Learning Hub API Unavailable
+      </span>
+    </h3>
+    <p>
+      The Learning Hub cannot currently be reached. The information shown below may not be up-to-date.
+      You will not be able to add resources while the Learning Hub is unavailable.
+    </p>
+  </div>
+}
 @if (Model.CompetencyResourceLinks.Any())
 {
   foreach (var link in Model.CompetencyResourceLinks)
@@ -34,7 +49,7 @@
     <partial name="_SignpostingCard.cshtml" model="link" view-data="@(new ViewDataDictionary(ViewData) {{"parent", Model}})" />
   }
 }
-else if (!Model.CompetencyResourceLinks.Any())
+else
 {
   <p>No learning resources have been added to this competency.</p>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingCard.cshtml
@@ -7,7 +7,7 @@
 <details class="nhsuk-details nhsuk-expander  nhsuk-u-margin-bottom-3">
   <summary class="nhsuk-details__summary">
     <span class="nhsuk-details__summary-text">
-      @Model.Name @(!String.IsNullOrEmpty(Model.Catalogue) ? $"[{Model.Catalogue}]" : "")
+      @Model.Name @(!String.IsNullOrEmpty(Model.Catalogue) ? $"({Model.Catalogue})" : "")
     </span>
   </summary>
   <div class="nhsuk-card__content nhsuk-u-padding-bottom-3 nhsuk-u-padding-top-0">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingCard.cshtml
@@ -1,86 +1,108 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks
+@using DigitalLearningSolutions.Web.Helpers;
 @model SignpostingCardViewModel
 @{
-    var parent = (CompetencyResourceSignpostingViewModel)ViewData["parent"];
+  var parent = (CompetencyResourceSignpostingViewModel)ViewData["parent"];
 }
 <details class="nhsuk-details nhsuk-expander  nhsuk-u-margin-bottom-3">
   <summary class="nhsuk-details__summary">
     <span class="nhsuk-details__summary-text">
-      @Model.Name
+      @Model.Name @(!String.IsNullOrEmpty(Model.Catalogue) ? $"[{Model.Catalogue}]" : "")
     </span>
   </summary>
   <div class="nhsuk-card__content nhsuk-u-padding-bottom-3 nhsuk-u-padding-top-0">
-  <div class="nhsuk-u-margin-bottom-4">
-    @if (Model.Essential)
+    @if (Model.UnmatchedResource)
     {
-      <div class="nhsuk-tag filter-tag nhsuk-u-margin-right-1">Essential</div>
+      <div class="nhsuk-grid-row nhsuk-details__text nhsuk-u-clear">
+        <div class="nhsuk-inset-text">
+          <span class="nhsuk-u-visually-hidden">Information: </span>
+          <p>
+            This resource has been removed from the Learning Hub. Please remove it from competency signposting and consider replacing it.
+          </p>
+        </div>
+      </div>
+    }
+    <div class="nhsuk-u-margin-bottom-4">
+      @if (Model.Essential)
+      {
+        <div class="nhsuk-tag filter-tag nhsuk-u-margin-right-1">Essential</div>
+      }
+      else
+      {
+        <div class="nhsuk-tag nhsuk-tag--blue filter-tag nhsuk-u-margin-right-1">Recommended</div>
+      }
+      @if (!String.IsNullOrEmpty(Model.ResourceType))
+      {
+          <strong class="nhsuk-tag nhsuk-tag--@(SignpostingHelper.DisplayTagColour(Model.ResourceType))">@Model.ResourceType</strong>
+      }
+      @*<div class="nhsuk-tag nhsuk-tag--grey centre-role-tag nhsuk-u-margin-right-1">Digital Learn</div> <!--Hidden for now-->*@
+    </div>
+    @if (!String.IsNullOrEmpty(Model.Description))
+    {
+      <p>@SignpostingHelper.DisplayText(Model.Description)</p>
+    }
+    <h5 class="mnhsuk-u-margin-bottom-2">Rated @Model.Rating/5</h5>
+    @if (Model.ParameterHasNotBeenSet)
+    {
+      <h5>This resource has no signposting parameters set.</h5>
     }
     else
     {
-      <div class="nhsuk-tag nhsuk-tag--blue filter-tag nhsuk-u-margin-right-1">Recommended</div>
-    }
-    @*<div class="nhsuk-tag nhsuk-tag--grey centre-role-tag nhsuk-u-margin-right-1">Digital Learn</div> <!--Hidden for now-->*@
-  </div>
-  @if(Model.ParameterHasNotBeenSet)
-  {
-    <h5>This resource has no signposting parameters set.</h5>
-  }
-  else
-  {
-    <h4 class="nhsuk-u-margin-bottom-2">Signposting Parameters</h4>
-    <dl class="nhsuk-summary-list">
-      @if(!String.IsNullOrEmpty(Model.AssessmentQuestion))
-      {
-        <div class="nhsuk-summary-list__row">
+      <h4 class="nhsuk-u-margin-bottom-2">Signposting Parameters</h4>
+      <dl class="nhsuk-summary-list">
+
+          <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
             Assessment Question
           </dt>
           <dd class="nhsuk-summary-list__value">
             @Model.AssessmentQuestion
           </dd>
-        </div>
+      </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Minimum result match
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          @Model.MinimumResultMatch
+        </dd>
+      </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Maximum result match
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          @Model.MaximumResultMatch
+        </dd>
+      </div>
+      @if (!String.IsNullOrEmpty(Model.CompareResultTo))
+      {
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
-            Minimum result match
+            Compare result to
           </dt>
           <dd class="nhsuk-summary-list__value">
-            @Model.MinimumResultMatch
-          </dd>
-        </div>
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Maximum result match
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            @Model.MaximumResultMatch
+            @Model.CompareResultTo
           </dd>
         </div>
       }
-      <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          Compare result to
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          @Model.CompareResultTo
-        </dd>
+      </dl>
+    }
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-full">
+        <a class="nhsuk-button small-edit-button nhsuk-u-margin-right-1"
+           asp-action="StartSignpostingParametersSession"
+           asp-route-frameworkId="@parent.FrameworkId"
+           asp-route-frameworkCompetencyId="@parent.FrameworkCompetencyId"
+           asp-route-frameworkCompetencyGroupId="@parent.FrameworkCompetencyGroupId"
+           asp-route-competencyLearningResourceId="@Model.CompetencyLearningResourceId">@(Model.ParameterHasNotBeenSet ? "Add" : "Manage") parameters</a>
+        <a class="nhsuk-button nhsuk-button--secondary small-edit-button nhsuk-u-margin-right-1" asp-action="ViewResource" asp-route-SignpostingCardId="Model.Id">View resource</a>
+        <a class="nhsuk-button nhsuk-button--secondary delete-button small-edit-button nhsuk-u-margin-right-1"
+           asp-action="RemoveResourceLink"
+           asp-route-frameworkId="@parent.FrameworkId"
+           asp-route-frameworkCompetencyId="@parent.FrameworkCompetencyId"
+           asp-route-frameworkCompetencyGroupId="@parent.FrameworkCompetencyGroupId"
+           asp-route-competencyLearningResourceId="@Model.CompetencyLearningResourceId">Remove resource link</a>
       </div>
-    </dl>
-  }
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <a class="nhsuk-button small-edit-button nhsuk-u-margin-right-1"
-          asp-action="StartSignpostingParametersSession"
-          asp-route-frameworkId="@parent.FrameworkId"
-          asp-route-frameworkCompetencyId="@parent.FrameworkCompetencyId"
-          asp-route-frameworkCompetencyGroupId="@parent.FrameworkCompetencyGroupId"
-          asp-route-competencyLearningResourceId="@Model.CompetencyLearningResourceId">@(Model.ParameterHasNotBeenSet ? "Add" : "Manage") parameters</a>
-      <a class="nhsuk-button nhsuk-button--secondary small-edit-button nhsuk-u-margin-right-1" asp-action="ViewResource" asp-route-SignpostingCardId="Model.Id">View resource</a>
-      <a class="nhsuk-button nhsuk-button--secondary delete-button small-edit-button nhsuk-u-margin-right-1"
-         asp-action="RemoveResourceLink"
-          asp-route-frameworkId="@parent.FrameworkId"
-          asp-route-frameworkCompetencyId="@parent.FrameworkCompetencyId"
-          asp-route-frameworkCompetencyGroupId="@parent.FrameworkCompetencyGroupId"
-         asp-route-competencyLearningResourceId="@Model.CompetencyLearningResourceId">Remove resource link</a>
     </div>
-  </div>
-</details>
+  </details>


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-477

### Description
When listing competency resources, also call learning hub api to ensure it has up-to-date information in the database about the resource. If the api is unavailable, use database information. 

Other related data like e.g. parameters are always stored in database, so api is used to override some resource fields likely to change as name or description.

### Screenshots
Switch application, go to Frameworks, Framework Structure and click on "Manage resource signposting".

#### Competency resource links with and without parameter
![image](https://user-images.githubusercontent.com/94055251/151164214-30b9839f-4586-4d5f-a410-a8b50f9ec9ec.png)

#### Learning Hub api is unavailable 
![image](https://user-images.githubusercontent.com/94055251/151164425-f4890a8d-1873-45cd-9a7d-09dda8be49b7.png)

#### Unmatched resource warning
![image](https://user-images.githubusercontent.com/94055251/151166824-ef158fa2-83f4-49a5-8525-563525ad92aa.png)

-----
### Developer checks
- Checked that Learning Hub api "is unavailable" warning message is in place when no internet connection.
- Checked that data retrieved in Swagger overrides database data for resources.
- Checked that unmatched resource is in place: add a record in LearningResourceReferences for ResourceRefID number 66666 that is unmatched in Swagger when calling bulk method
- Checked that Add Resource button is disabled when Learning Hub api is unavailable.