### PR TITLE
DLSV2-488 Ignore removed competency learning resources in manage resource signposting count

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -563,7 +563,7 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
         {
             var result = connection.Query<FrameworkCompetencyGroup, FrameworkCompetency, FrameworkCompetencyGroup>(
                 @"SELECT fcg.ID, fcg.CompetencyGroupID, cg.Name, fcg.Ordering, fc.ID, c.ID AS CompetencyID, c.Name, c.Description, fc.Ordering, COUNT(caq.AssessmentQuestionID) AS AssessmentQuestions
-                    ,(SELECT COUNT(*) FROM CompetencyLearningResources clr WHERE clr.CompetencyID = c.ID) AS CompetencyLearningResourcesCount
+                    ,(SELECT COUNT(*) FROM CompetencyLearningResources clr WHERE clr.CompetencyID = c.ID AND clr.RemovedDate IS NULL) AS CompetencyLearningResourcesCount
                     FROM   FrameworkCompetencyGroups AS fcg INNER JOIN
                       CompetencyGroups AS cg ON fcg.CompetencyGroupID = cg.ID LEFT OUTER JOIN
                        FrameworkCompetencies AS fc ON fcg.ID = fc.FrameworkCompetencyGroupID LEFT OUTER JOIN


### PR DESCRIPTION
Ignore removed competency learning resources in "Manage resource signposting" resource count.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-488

### Description
Added a filter in FrameworkService sql query to ignore competency learning resources that are soft deleted in table CompetencyLearningResources.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/151225006-e15261a1-7f30-4fd7-9b8e-04499c5d0fe7.png)

-----
### Developer checks
- Checked with hard deleted resources: delete a resource without parameters or logs.
- Checked with soft deleted resources: delete a resource with parameter.