### PR TITLE
HEEDLS-747 - change padding and margin on deleted resource cards

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/CompletedActionPlanResourceCard/_CompletedActionPlanResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/CompletedActionPlanResourceCard/_CompletedActionPlanResourceCard.cshtml
@@ -3,7 +3,7 @@
 
 <div class="searchable-element nhsuk-panel" id="@Model.Id-card-lhr">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
-    <summary class="nhsuk-details__summary nhsuk-u-padding-top-0 nhsuk-u-padding-left-0">
+    <summary class="nhsuk-details__summary nhsuk-u-padding-top-0 nhsuk-u-padding-left-0 @(Model.AbsentInLearningHub ? "nhsuk-u-padding-bottom-0" : null)">
       <span class="nhsuk-details__summary-text searchable-element-title"
             id="@Model.Id-name-lhr"
             name="name"
@@ -12,7 +12,7 @@
         @Model.Name
       </span>
     </summary>
-    <div class="nhsuk-details__text">
+    <div class="nhsuk-details__text @(Model.AbsentInLearningHub ? "nhsuk-u-margin-top-4" : null)">
       <div class="nhsuk-grid-row">
         <partial name="Shared/_TagRow" model="@Model" />
       </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/_CurrentLearningResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/_CurrentLearningResourceCard.cshtml
@@ -3,7 +3,7 @@
 
 <div class="searchable-element nhsuk-panel @Model.DateStyle()" id="@Model.Id-lhr-card">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
-    <summary class="nhsuk-details__summary nhsuk-u-padding-top-0 nhsuk-u-padding-left-0">
+    <summary class="nhsuk-details__summary nhsuk-u-padding-top-0 nhsuk-u-padding-left-0 @(Model.AbsentInLearningHub ? "nhsuk-u-padding-bottom-0" : null)">
       <span class="nhsuk-u-visually-hidden">@Model.DueByDescription()</span>
       <span class="nhsuk-details__summary-text searchable-element-title"
             id="@Model.Id-name-lhr"
@@ -14,7 +14,7 @@
         @Model.Name
       </span>
     </summary>
-    <div class="nhsuk-details__text nhsuk-u-padding-left-0">
+    <div class="nhsuk-details__text nhsuk-u-padding-left-0 @(Model.AbsentInLearningHub ? "nhsuk-u-margin-top-4" : null)">
       <div class="nhsuk-u-padding-left-3">
         <div class="nhsuk-grid-row">
           <partial name="Shared/_TagRow" model="@Model" />


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-747

### Description
Small adjustments to the margins and padding so closed resource cards for deleted resources have reduced space.

### Screenshots
![Deleted resource margin fixing collapsed](https://user-images.githubusercontent.com/80777689/151830893-cf5869a0-6b5d-47e4-be76-afef15433fa0.PNG)

![Deleted resource margin fixing](https://user-images.githubusercontent.com/80777689/151830899-547f683a-e6f8-4f26-9717-885ea8c2e2a6.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
