### PR TITLE
HEEDLS-520 FAQ search - reverse cutoff score change

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/Support/Faqs/FaqsPageViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Support/Faqs/FaqsPageViewModel.cs
@@ -9,11 +9,11 @@
 
     public class FaqsPageViewModel : BaseSearchablePageViewModel, ISupportViewModel
     {
-        // A MatchCutOffScore of 60 is being used here rather than the default 80.
+        // A MatchCutOffScore of 65 is being used here rather than the default 80.
         // The default Fuzzy Search configuration does not reliably bring back expected FAQs.
         // Through trial and error a combination of the PartialTokenSetScorer ratio scorer
         // and this cut off score bring back reliable results comparable to the JS search.
-        private const int MatchCutOffScore = 60;
+        private const int MatchCutOffScore = 65;
         private const string FaqSortBy = "Weighting,FaqId";
 
         public FaqsPageViewModel(
@@ -29,7 +29,7 @@
             DlsSubApplication = dlsSubApplication;
             CurrentSystemBaseUrl = currentSystemBaseUrl;
 
-            var searchedItems = GenericSearchHelper.SearchItemsUsingTokeniseScorer(faqs, SearchString, MatchCutOffScore, true).ToList();
+            var searchedItems = GenericSearchHelper.SearchItemsUsingTokeniseScorer(faqs, SearchString, MatchCutOffScore).ToList();
             var faqsToShow = SortFilterAndPaginate(searchedItems);
             Faqs = faqsToShow.Select(f => new SearchableFaqViewModel(DlsSubApplication, f));
         }


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-520](https://softwiretech.atlassian.net/browse/HEEDLS-520)

### Description
Reverse the previous change made to the cutoff score for searching FAQs with FuzzySharp.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
