### PR TITLE
HEEDLS-744 Fix learning resource warning bugs

### DIFF
--- a/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
@@ -153,9 +153,10 @@
         {
             var learningLogItem = learningLogItemsDataService.GetLearningLogItem(learningLogItemId)!;
 
-            var (resource, apiIsAccessible) = await learningHubResourceService.GetResourceByReferenceId(
-                learningLogItem.LearningHubResourceReferenceId!.Value
-            );
+            var (resource, apiIsAccessible) = await learningHubResourceService
+                .GetResourceByReferenceIdAndPopulateDeletedDetailsFromDatabase(
+                    learningLogItem.LearningHubResourceReferenceId!.Value
+                );
 
             return resource != null
                 ? (new ActionPlanResource(learningLogItem, resource), apiIsAccessible)

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -13,6 +13,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
         [Theory]
         [InlineData("/MyAccount", "My account")]
         [InlineData("/MyAccount/EditDetails", "Edit details")]
+        [InlineData("/Signposting/LaunchLearningResource/3", "View resource \"Test image resource\"")]
         [InlineData("/TrackingSystem/Centre/Administrators", "Centre administrators")]
         [InlineData("/TrackingSystem/Centre/Administrators/1/EditAdminRoles", "Edit administrator roles")]
         [InlineData(

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -13,7 +13,6 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
         [Theory]
         [InlineData("/MyAccount", "My account")]
         [InlineData("/MyAccount/EditDetails", "Edit details")]
-        [InlineData("/Signposting/LaunchLearningResource/3", "View resource \"Test image resource\"")]
         [InlineData("/TrackingSystem/Centre/Administrators", "Centre administrators")]
         [InlineData("/TrackingSystem/Centre/Administrators/1/EditAdminRoles", "Edit administrator roles")]
         [InlineData(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Signposting/SignpostingControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Signposting/SignpostingControllerTests.cs
@@ -84,7 +84,7 @@
             // Then
             result.Should().BeViewResult().WithViewName("LearningHubLoginWarning");
             A.CallTo(() => userService.DelegateUserLearningHubAccountIsLinked(A<int>._)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => learningHubResourceService.GetResourceByReferenceId(A<int>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => learningHubResourceService.GetResourceByReferenceIdAndPopulateDeletedDetailsFromDatabase(A<int>._)).MustHaveHappenedOnceExactly();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
@@ -45,9 +45,11 @@
             }
 
             var (resource, apiIsAccessible) =
-                await learningHubResourceService.GetResourceByReferenceId(resourceReferenceId);
+                await learningHubResourceService.GetResourceByReferenceIdAndPopulateDeletedDetailsFromDatabase(
+                    resourceReferenceId
+                );
 
-            if (resource == null)
+            if (resource == null || resource.AbsentInLearningHub)
             {
                 return NotFound();
             }

--- a/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
@@ -39,11 +39,6 @@
 
             var delegateUser = userService.GetDelegateUserById(delegateId);
 
-            if (delegateUser!.HasDismissedLhLoginWarning)
-            {
-                return RedirectToAction("ViewResource", "SignpostingSso", new { resourceReferenceId });
-            }
-
             var (resource, apiIsAccessible) =
                 await learningHubResourceService.GetResourceByReferenceIdAndPopulateDeletedDetailsFromDatabase(
                     resourceReferenceId
@@ -52,6 +47,11 @@
             if (resource == null || resource.AbsentInLearningHub)
             {
                 return NotFound();
+            }
+
+            if (delegateUser!.HasDismissedLhLoginWarning)
+            {
+                return RedirectToAction("ViewResource", "SignpostingSso", new { resourceReferenceId });
             }
 
             var learningHubAccountIsLinked = userService.DelegateUserLearningHubAccountIsLinked(delegateId);

--- a/DigitalLearningSolutions.Web/ViewComponents/LearningResourceWarningViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/LearningResourceWarningViewComponent.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class LearningResourceWarningViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(
+            string text,
+            string cssClass
+        )
+        {
+            var model = new InsetTextViewModel(text, string.IsNullOrEmpty(cssClass) ? null : cssClass);
+            return View(model);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -16,9 +16,8 @@
     }
 
     @if (!Model.ApiIsAccessible) {
-      <vc:inset-text
-        css-class="nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
-        text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"
+                                    text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
     }
 
     <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -26,9 +26,8 @@
     }
 
     @if (!Model.ApiIsAccessible) {
-      <vc:inset-text
-        css-class="nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
-        text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"
+                                    text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
     }
 
     @if (Model.NoDataFound) {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/MarkActionPlanResourceAsComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/MarkActionPlanResourceAsComplete.cshtml
@@ -20,14 +20,13 @@
     <h1 class="nhsuk-heading-xl word-break">Mark @Model.ResourceName as complete</h1>
 
     @if (Model.AbsentInLearningHub) {
-      <vc:inset-text css-class="nhsuk-u-margin-bottom-4"
-                     text="@LearningHubWarningTextHelper.ResourceHasBeenRemoved" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4"
+                                    text="@LearningHubWarningTextHelper.ResourceHasBeenRemoved" />
     }
 
     @if (!Model.ApiIsAccessible) {
-      <vc:inset-text
-        css-class="nhsuk-u-margin-bottom-4"
-        text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4"
+                                    text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
     }
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentActionPlanResourceConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/RemoveCurrentActionPlanResourceConfirmation.cshtml
@@ -13,14 +13,13 @@
     </h1>
 
     @if (Model.AbsentInLearningHub) {
-      <vc:inset-text css-class="nhsuk-u-margin-bottom-4"
-                     text="@LearningHubWarningTextHelper.ResourceHasBeenRemoved" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4"
+                                    text="@LearningHubWarningTextHelper.ResourceHasBeenRemoved" />
     }
 
     @if (!Model.ApiIsAccessible) {
-      <vc:inset-text
-        css-class="nhsuk-u-margin-bottom-4"
-        text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4"
+                                    text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
     }
 
     <p>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -28,9 +28,8 @@
     <h1 class="nhsuk-heading-xl word-break">Enter a complete by date for @Model.Name</h1>
 
     @if (Model.Type is LearningItemType.Resource && Model.ApiIsAccessible == false) {
-      <vc:inset-text
-        css-class="nhsuk-u-margin-bottom-4"
-        text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
+      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4"
+                                    text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
     }
 
     <form asp-action="@action"

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/RecommendedLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/RecommendedLearning.cshtml
@@ -29,9 +29,8 @@
 
     <div class="nhsuk-u-margin-bottom-4">
       @if (!Model.ApiIsAccessible) {
-        <vc:inset-text
-          css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
-          text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
+        <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
+                                      text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
       }
       <vc:inset-text
         css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/LearningResourceWarning/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/LearningResourceWarning/Default.cshtml
@@ -1,0 +1,11 @@
+﻿@using DigitalLearningSolutions.Data.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@using Microsoft.Extensions.Configuration
+@model InsetTextViewModel
+@inject IConfiguration configuration
+
+@if (configuration.IsSignpostingUsed()) {
+  <vc:inset-text
+    css-class="@Model.CssClass"
+    text="@Model.Text" />
+}

--- a/DigitalLearningSolutions.Web/Views/Signposting/LearningHubLoginWarning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Signposting/LearningHubLoginWarning.cshtml
@@ -14,9 +14,8 @@
 
     <div class="nhsuk-u-margin-bottom-4">
       @if (!Model.ApiIsAccessible) {
-        <vc:inset-text
-          css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
-          text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
+        <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
+                                      text="@LearningHubWarningTextHelper.ResourceNameMayBeOutOfDate" />
       }
 
       @if (!Model.LearningHubAccountLinked) {


### PR DESCRIPTION
### JIRA link
[_HEEDLS-744_](https://softwiretech.atlassian.net/browse/HEEDLS-744)

### Description
Made various fixes from issues from failed testing and from merge conflicts with HEEDLS-747:
- Adjusted spacing on warnings on Current and Completed pages so they look okay on tablet and mobile
- Added a config check so that the learning resource warnings will only be displayed is Signposting is used
- Fixed bugs in controllers so that when a resource is removed, the Mark as complete page and the Remove from action plan page will show a page with a warning, while the Set complete by date and Launch learning resource page will show NotFound.

### Screenshots
Spacing on warning: (identical for Completed activities page)
![localhost_5001_LearningPortal_Current (1)](https://user-images.githubusercontent.com/70278044/152345291-49c5bfa0-8f13-42c9-83ef-f053de6209ed.png)
![localhost_5001_LearningPortal_Current (2)](https://user-images.githubusercontent.com/70278044/152345302-0da530e0-512f-4e26-8b04-688225a40524.png)
![localhost_5001_LearningPortal_Current (3)](https://user-images.githubusercontent.com/70278044/152345308-083ba51f-55c2-449e-8e1e-e1a1cc2220d1.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
