### PR TITLE
HEEDLS-767 - apply signposting featuregates to relevant endpoints

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Signposting/SignpostingControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Signposting/SignpostingControllerTests.cs
@@ -4,7 +4,7 @@
     using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
-    using DigitalLearningSolutions.Web.Controllers;
+    using DigitalLearningSolutions.Web.Controllers.Signposting;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
     using DigitalLearningSolutions.Web.ViewModels.Signposting;
     using FakeItEasy;

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -15,6 +15,7 @@
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using Microsoft.FeatureManagement.Mvc;
 
     public partial class LearningPortalController
     {
@@ -164,6 +165,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
         [ServiceFilter(typeof(VerifyDelegateCanAccessActionPlanResource))]
         [Route("/LearningPortal/Current/ActionPlan/{learningLogItemId:int}/MarkAsComplete")]
@@ -187,6 +189,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
         [ServiceFilter(typeof(VerifyDelegateCanAccessActionPlanResource))]
         [Route("/LearningPortal/Current/ActionPlan/{learningLogItemId:int}/MarkAsComplete")]
@@ -208,6 +211,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
         [ServiceFilter(typeof(VerifyDelegateCanAccessActionPlanResource))]
         [Route("/LearningPortal/Current/ActionPlan/{learningLogItemId:int}/CompleteBy")]
@@ -233,6 +237,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
         [ServiceFilter(typeof(VerifyDelegateCanAccessActionPlanResource))]
         [Route("/LearningPortal/Current/ActionPlan/{learningLogItemId:int}/CompleteBy")]
@@ -256,6 +261,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
         [ServiceFilter(typeof(VerifyDelegateCanAccessActionPlanResource))]
         [Route("/LearningPortal/Current/ActionPlan/{learningLogItemId:int}/Remove")]
@@ -279,6 +285,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [ServiceFilter(typeof(VerifyDelegateCanAccessActionPlanResource))]
         [Route("/LearningPortal/Current/ActionPlan/{learningLogItemId:int}/Remove")]
         public IActionResult RemoveResourceFromActionPlanPost(int learningLogItemId)

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
@@ -97,6 +97,7 @@
             return View("AllRecommendedLearningItems", model);
         }
 
+        [FeatureGate(FeatureFlags.UseSignposting)]
         [Route(
             "/LearningPortal/SelfAssessment/{selfAssessmentId:int}/AddResourceToActionPlan/{resourceReferenceId:int}"
         )]

--- a/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Controllers
+﻿namespace DigitalLearningSolutions.Web.Controllers.Signposting
 {
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Services;
@@ -8,10 +8,12 @@
     using DigitalLearningSolutions.Web.ViewModels.Signposting;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.FeatureManagement.Mvc;
 
     [Authorize(Policy = CustomPolicies.UserOnly)]
+    [FeatureGate(FeatureFlags.UseSignposting)]
     [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
-    [Route("Signposting")]
+    [Route("Signposting/LaunchLearningResource/{resourceReferenceId:int}")]
     public class SignpostingController : Controller
     {
         private readonly IActionPlanService actionPlanService;
@@ -30,7 +32,6 @@
         }
 
         [HttpGet]
-        [Route("LaunchLearningResource/{resourceReferenceId:int}")]
         public async Task<IActionResult> LaunchLearningResource(int resourceReferenceId)
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
@@ -63,7 +64,6 @@
         }
 
         [HttpPost]
-        [Route("LaunchLearningResource/{resourceReferenceId:int}")]
         public IActionResult LaunchLearningResource(int resourceReferenceId, LearningHubLoginWarningViewModel model)
         {
             if (model.LearningHubLoginWarningDismissed)


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-767

### Description
Applied the FeatureGate to any signposting endpoints that don't already have it (or some dynamic equivalent). This should be all of them, but if you can think of any others, do let me know.
Also moved the Signposting controller into the Signposting folder.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
