### PR TITLE
DLSV2-480 Moves action buttons to a partial and repeats

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -2,7 +2,6 @@
 @using DigitalLearningSolutions.Data.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @using Microsoft.Extensions.Configuration
-@using DigitalLearningSolutions.Web.Helpers;
 @model SelfAssessmentOverviewViewModel
 
 @{
@@ -30,32 +29,7 @@
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
 <h1>@Model.SelfAssessment.Name - @Model.VocabPlural()</h1>
-@if (Model.NumberOfOptionalCompetencies > 0) {
-  <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
-     asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-     asp-route-vocabulary="@Model.VocabPlural()"
-     asp-action="ManageOptionalCompetencies"
-     role="button">
-    Manage optional @Model.VocabPlural().ToLower()
-  </a>
-}
-@if (Model.SelfAssessment.IsSupervised) {
-  <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
-     asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-     asp-action="StartRequestVerification"
-     role="button">
-    Request @Model.SelfAssessment.Vocabulary.ToLower() verification
-  </a>
-}
-<feature name="@(FeatureFlags.CandidateAssessmentExcelExport)">
-<a class="nhsuk-button nhsuk-button--secondary"
-   asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
-   asp-route-vocabulary="@Model.VocabPlural()"
-   asp-action="ExportCandidateAssessment"
-   role="button">
-  Export to Excel
-</a>
-</feature>
+<partial name="_OverviewActionButtons.cshtml" model=Model />
 @if (Model.CompetencyGroups.Any()) {
   foreach (var competencyGroup in Model.CompetencyGroups) {
     <div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
@@ -92,6 +66,7 @@
       }
     </div>
   }
+  <partial name="_OverviewActionButtons.cshtml" model=Model />
 }
 
 @if (Model.SelfAssessment.IncludesSignposting) {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
@@ -1,0 +1,29 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
+@using DigitalLearningSolutions.Web.Helpers;
+@model SelfAssessmentOverviewViewModel
+@if (Model.NumberOfOptionalCompetencies > 0) {
+  <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
+     asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+     asp-route-vocabulary="@Model.VocabPlural()"
+     asp-action="ManageOptionalCompetencies"
+     role="button">
+    Manage optional @Model.VocabPlural().ToLower()
+  </a>
+}
+@if (Model.SelfAssessment.IsSupervised) {
+  <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
+     asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+     asp-action="StartRequestVerification"
+     role="button">
+    Request @Model.SelfAssessment.Vocabulary.ToLower() verification
+  </a>
+}
+<feature name="@(FeatureFlags.CandidateAssessmentExcelExport)">
+<a class="nhsuk-button nhsuk-button--secondary"
+   asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
+   asp-route-vocabulary="@Model.VocabPlural()"
+   asp-action="ExportCandidateAssessment"
+   role="button">
+  Export to Excel
+</a>
+</feature>


### PR DESCRIPTION
### JIRA link
DLSV2-480

### Description
In response to a request from IV Passport testers, we have duplicated the action buttons (Manage optional competencies, Request verification, Export to Excel) below the list of competencies. This has been done by moving the buttons to a partial.