### PR TITLE
Heedls 564 set active filter as default

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -7,16 +7,22 @@
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates;
     using FakeItEasy;
+    using FizzWare.NBuilder;
+    using FluentAssertions;
     using FluentAssertions.AspNetCore.Mvc;
+    using FluentAssertions.Execution;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
     using NUnit.Framework;
 
     public class CourseDelegatesControllerTests
     {
         private const int UserCentreId = 3;
         private CourseDelegatesController controller = null!;
-        private ICourseDelegatesService courseDelegatesService = null!;
         private ICourseDelegatesDownloadFileService courseDelegatesDownloadFileService = null!;
+        private ICourseDelegatesService courseDelegatesService = null!;
 
         [SetUp]
         public void SetUp()
@@ -24,7 +30,8 @@
             courseDelegatesService = A.Fake<ICourseDelegatesService>();
             courseDelegatesDownloadFileService = A.Fake<ICourseDelegatesDownloadFileService>();
 
-            controller = new CourseDelegatesController(courseDelegatesService, courseDelegatesDownloadFileService).WithDefaultContext()
+            controller = new CourseDelegatesController(courseDelegatesService, courseDelegatesDownloadFileService)
+                .WithDefaultContext()
                 .WithMockUser(true, UserCentreId);
         }
 
@@ -55,6 +62,65 @@
 
             // Then
             result.Should().BeNotFoundResult();
+        }
+
+        [Test]
+        public void Index_should_default_to_Active_filter_and_return_active_course_delegates()
+        {
+            // Given
+            const int customisationId = 2;
+            var course = new Course { CustomisationId = customisationId, Active = true };
+            var courseDelegate = Builder<CourseDelegate>
+                .CreateListOfSize(2)
+                .TheFirst(1)
+                .With(c => c.Active = false)
+                .TheLast(1)
+                .With(c => c.Active = true)
+                .Build();
+            A.CallTo(
+                    () => courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(
+                        UserCentreId,
+                        null,
+                        customisationId
+                    )
+                )
+                .Returns(new CourseDelegatesData(customisationId, new List<Course> { course }, courseDelegate));
+
+            var httpRequest = A.Fake<HttpRequest>();
+            var httpResponse = A.Fake<HttpResponse>();
+            const string cookieName = "CourseDelegatesFilter";
+            const string cookieValue = "AccountStatus|Active|true";
+
+            var courseDelegatesController = new CourseDelegatesController(
+                    courseDelegatesService,
+                    courseDelegatesDownloadFileService
+                )
+                .WithMockHttpContext(httpRequest, cookieName, cookieValue, httpResponse)
+                .WithMockUser(true, UserCentreId)
+                .WithMockTempData();
+
+            A.CallTo(() => httpRequest.Cookies).Returns(A.Fake<IRequestCookieCollection>());
+
+            // When
+            var result = courseDelegatesController.Index(customisationId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.As<ViewResult>().Model.As<CourseDelegatesViewModel>().CourseDetails!.FilterBy.Should()
+                    .Be("AccountStatus|Active|true");
+                result.As<ViewResult>().Model.As<CourseDelegatesViewModel>().CourseDetails!.Delegates.Should()
+                    .HaveCount(1);
+
+                A.CallTo(
+                        () => courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(
+                            UserCentreId,
+                            null,
+                            customisationId
+                        )
+                    )
+                    .MustHaveHappened();
+            }
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Helpers.FilterOptions;
     using DigitalLearningSolutions.Web.Models.Enums;
     using DigitalLearningSolutions.Web.ServiceFilter;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
@@ -49,7 +50,8 @@
                 filterBy,
                 filterValue,
                 Request,
-                CourseDelegatesFilterCookieName
+                CourseDelegatesFilterCookieName,
+                CourseDelegateAccountStatusFilterOptions.Active.FilterValue
             );
 
             var centreId = User.GetCentreId();

--- a/DigitalLearningSolutions.Web/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/GenericSortingHelper.cs
@@ -163,9 +163,9 @@
             nameof(CourseDelegate.PassRate)
         );
 
-        public static readonly CourseDelegatesSortByOption CandidateNumber = new CourseDelegatesSortByOption(
+        public static readonly CourseDelegatesSortByOption DelegateId = new CourseDelegatesSortByOption(
             7,
-            nameof(CandidateNumber),
+            nameof(DelegateId),
             "Delegate ID",
             nameof(CourseDelegate.CandidateNumber)
         );

--- a/DigitalLearningSolutions.Web/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/GenericSortingHelper.cs
@@ -163,6 +163,13 @@
             nameof(CourseDelegate.PassRate)
         );
 
+        public static readonly CourseDelegatesSortByOption CandidateNumber = new CourseDelegatesSortByOption(
+            7,
+            nameof(CandidateNumber),
+            "Candidate number",
+            nameof(CourseDelegate.CandidateNumber)
+        );
+
         public readonly string DisplayText;
         public readonly string PropertyName;
 

--- a/DigitalLearningSolutions.Web/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/GenericSortingHelper.cs
@@ -166,7 +166,7 @@
         public static readonly CourseDelegatesSortByOption CandidateNumber = new CourseDelegatesSortByOption(
             7,
             nameof(CandidateNumber),
-            "Candidate number",
+            "Delegate ID",
             nameof(CourseDelegate.CandidateNumber)
         );
 

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
@@ -72,6 +72,8 @@ export function getSortValue(
       return parseInt(getElementText(searchableElement, 'faq-weighting'), 10);
     case 'FaqId':
       return parseInt(getElementText(searchableElement, 'faq-id'), 10);
+    case 'CandidateNumber':
+      return getElementText(searchableElement, 'candidate-number').toLocaleLowerCase();
     default:
       return '';
   }

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
@@ -73,7 +73,7 @@ export function getSortValue(
     case 'FaqId':
       return parseInt(getElementText(searchableElement, 'faq-id'), 10);
     case 'CandidateNumber':
-      return getElementText(searchableElement, 'candidate-number').toLocaleLowerCase();
+      return getElementText(searchableElement, 'delegate-id').toLocaleLowerCase();
     default:
       return '';
   }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -18,7 +18,7 @@
           <dt class="nhsuk-summary-list__key">
             Delegate ID
           </dt>
-          <dd class="nhsuk-summary-list__value"  data-name-for-sorting="candidate-number">
+          <dd class="nhsuk-summary-list__value"  data-name-for-sorting="delegate-id">
             @Model.CandidateNumber
           </dd>
         </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -18,7 +18,7 @@
           <dt class="nhsuk-summary-list__key">
             Delegate ID
           </dt>
-          <dd class="nhsuk-summary-list__value">
+          <dd class="nhsuk-summary-list__value"  data-name-for-sorting="candidate-number">
             @Model.CandidateNumber
           </dd>
         </div>


### PR DESCRIPTION
### JIRA link
[https://softwiretech.atlassian.net/browse/HEEDLS-564](https://softwiretech.atlassian.net/browse/HEEDLS-564)

### Description

- Set the "Active Status" filter to on and "true" by default
- Add sort by Delegate ID to the sorting options.

### Screenshots
![image](https://user-images.githubusercontent.com/18046982/152773181-ce80ab10-239c-4817-a3be-f72f9f77e16a.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
