### PR TITLE
DLSV2-469 Handle multiple catalogues for each resource

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -76,7 +76,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         {
             var frameworkCompetency = frameworkService.GetFrameworkCompetencyById(model.FrameworkCompetencyId.Value);
             string plainTextDescription = SignpostingHelper.DisplayText(model.Description);
-            int competencyLearningResourceId = competencyLearningResourcesDataService.AddCompetencyLearningResource(model.ReferenceId, model.ResourceName, plainTextDescription, model.ResourceType, model.Link, model.Catalogue, model.Rating.Value, frameworkCompetency.CompetencyID, GetAdminId());
+            int competencyLearningResourceId = competencyLearningResourcesDataService.AddCompetencyLearningResource(model.ReferenceId, model.ResourceName, plainTextDescription, model.ResourceType, model.Link, model.SelectedCatalogue, model.Rating.Value, frameworkCompetency.CompetencyID, GetAdminId());
             return RedirectToAction("StartSignpostingParametersSession", "Frameworks", new { model.FrameworkId, model.FrameworkCompetencyId, model.FrameworkCompetencyGroupId, competencyLearningResourceId });
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
@@ -37,15 +37,11 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
                 _Link = value;
             }
         }
-        public string Catalogue
+        public string[] Catalogues
         {
             get
             {
-                return Resource?.References?.FirstOrDefault()?.Catalogue?.Name ?? _Catalog;
-            }
-            set
-            {
-                _Catalog = value;
+                return Resource?.References?.Select(r => r.Catalogue.Name).ToArray() ?? new string[0];
             }
         }
         public string SelectedCatalogue { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
@@ -75,7 +75,7 @@
   @Html.HiddenFor(m => m.Resource.ResourceType)
   @Html.HiddenFor(m => m.Resource.Description)
   @Html.HiddenFor(m => m.Link)
-  @Html.HiddenFor(m => m.Catalogue)
+  @Html.HiddenFor(m => m.SelectedCatalogue)
   @Html.HiddenFor(m => m.Rating)
 </form>
 <div class="nhsuk-back-link nhsuk-u-margin-left-1">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -21,30 +21,30 @@
     <div class="nhsuk-u-margin-left-1 nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3">
       @Html.Raw(SignpostingHelper.DisplayText(Model.Description))
     </div>
-    @if (!String.IsNullOrEmpty(Model.Catalogue))
+    @if (Model.Catalogues.Count() > 0)
     {
+      <div class="nhsuk-u-font-weight-bold nhsuk-u-margin-left-1 nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2">
+        Catalogues
+      </div>
       <form method="post" role="search" asp-controller="Frameworks">
         <div class="nhsuk-card__content nhsuk-u-margin-1 nhsuk-u-padding-0">
           <dl class="nhsuk-summary-list">
-            <div class="nhsuk-summary-list__row">
-              <dt class="nhsuk-summary-list__key">
-                Catalogue
-              </dt>
-              <dd class="nhsuk-summary-list__value">
-                @Model.Catalogue
-              </dd>
-            </div>
-            <div class="nhsuk-summary-list__row">
-              <dt class="nhsuk-summary-list__key"></dt>
-              <dd class="nhsuk-summary-list__value">
-                <button class="nhsuk-button nhsuk-button--secondary small-edit-button">
-                  Preview
-                </button>
-                <button class="nhsuk-button small-edit-button" asp-action="AddCompetencyLearningResourceSummary">
-                  Select
-                </button>
-              </dd>
-            </div>
+            @foreach(var catalogue in Model.Catalogues)
+            {
+              <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key nhsuk-u-width-two-thirds">
+                  @catalogue
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                  <button class="nhsuk-button nhsuk-button--secondary small-edit-button">
+                    Preview
+                  </button>
+                  <button class="nhsuk-button small-edit-button" asp-action="AddCompetencyLearningResourceSummary" asp-route-SelectedCatalogue="@catalogue">
+                    Select
+                  </button>
+                </dd>
+              </div>
+            }
           </dl>
         </div>
         @Html.HiddenFor(m => m.FrameworkId)
@@ -53,12 +53,10 @@
         @Html.Hidden("ReferenceId", Model.ReferenceId)
         @Html.Hidden("Resource.Title", Model.Resource?.Title)
         @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
-        @Html.Hidden("SelectedCatalogue", Model.Catalogue)
         @Html.HiddenFor(m => m.Resource.Description)
         @Html.Hidden("NameOfCompetency", parent.NameOfCompetency)
         @Html.Hidden("SearchText", parent.SearchText)
         @Html.HiddenFor(m => m.Link)
-        @Html.HiddenFor(m => m.Catalogue)
         @Html.Hidden("Rating", Model.Resource?.Rating ?? 0)
       </form>
     }


### PR DESCRIPTION
Allow to handle multiple catalogues for each resource on Learning Hub resource search page.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-469

### Description
Rolled back a previous change on this branch that assumes there's only one catalogue for each Learning Hub resource. This could not be the case for some searches.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/152788051-23ee0d1f-ea6f-4dab-a5c2-c3f7d42ab482.png)

-----
### Developer checks
From Switch application/Frameworks/Manage my frameworks/Manage signposting/"Add resource" button:
1. Search for "covid".
2. Expand third result that contains multiple catalogues.
3. Select the last one and confirm.
4. Repeat for first one and confirm.
5. Check in the database table LearningResourceReferences that OriginalCatalogueName updated correctly.

Note: the resource would be added if it's not already in the table.