### PR TITLE
Heedls 763 filter by course admin fields

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.DataServices
 {
+    using System.Collections.Generic;
     using System.Linq;
     using System.Transactions;
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FluentAssertions;
     using FluentAssertions.Execution;
@@ -131,6 +133,40 @@
             finally
             {
                 transaction.Dispose();
+            }
+        }
+
+        [Test]
+        public void GetDelegateAnswersForCourseAdminFields_returns_expected_results()
+        {
+            // Given
+            const int customisationId = 319;
+            const int centreId = 101;
+            var expectedResult = new List<DelegateCourseAdminFieldAnswers>
+            {
+                new DelegateCourseAdminFieldAnswers
+                {
+                    Answer1 = "s",
+                    Answer2 = "sss",
+                    Answer3 = "",
+                },
+                new DelegateCourseAdminFieldAnswers
+                {
+                    Answer1 = "uyuy",
+                    Answer2 = "hhjkh",
+                    Answer3 = "",
+                }
+            };
+
+            // When
+            var result = courseAdminFieldsDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId)
+                .ToList();
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().HaveCount(2);
+                result.Should().BeEquivalentTo(expectedResult);
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -933,5 +933,30 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
                 transaction.Dispose();
             }
         }
+
+        [Test]
+        public void GetDelegateAnswersForCourseAdminFields_returns_expected_results()
+        {
+            // Given
+            const int customisationId = 1379;
+            const int centreId = 101;
+            var expectedResult = new DelegateCourseAdminFieldAnswers
+            {
+                DelegateId = 1,
+                Answer1 = null,
+                Answer2 = null,
+                Answer3 = null,
+            };
+
+            // When
+            var result = courseDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId).ToList();
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().HaveCount(7);
+                result.Should().ContainEquivalentOf(expectedResult);
+            }
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -947,6 +947,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
                 Answer2 = null,
                 Answer3 = null,
             };
+            var expectedDelegateIds = new[] { 1, 33220, 66, 11, 32096, 23194, 59585 };
 
             // When
             var result = courseDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId).ToList();
@@ -956,6 +957,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             {
                 result.Should().HaveCount(7);
                 result.Should().ContainEquivalentOf(expectedResult);
+                result.Select(x => x.DelegateId).Should().BeEquivalentTo(expectedDelegateIds);
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -933,32 +933,5 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
                 transaction.Dispose();
             }
         }
-
-        [Test]
-        public void GetDelegateAnswersForCourseAdminFields_returns_expected_results()
-        {
-            // Given
-            const int customisationId = 1379;
-            const int centreId = 101;
-            var expectedResult = new DelegateCourseAdminFieldAnswers
-            {
-                DelegateId = 1,
-                Answer1 = null,
-                Answer2 = null,
-                Answer3 = null,
-            };
-            var expectedDelegateIds = new[] { 1, 33220, 66, 11, 32096, 23194, 59585 };
-
-            // When
-            var result = courseDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId).ToList();
-
-            // Then
-            using (new AssertionScope())
-            {
-                result.Should().HaveCount(7);
-                result.Should().ContainEquivalentOf(expectedResult);
-                result.Select(x => x.DelegateId).Should().BeEquivalentTo(expectedDelegateIds);
-            }
-        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
@@ -16,14 +16,16 @@
     {
         private ICourseAdminFieldsDataService courseAdminFieldsDataService = null!;
         private ICourseAdminFieldsService courseAdminFieldsService = null!;
+        private ICourseDataService courseDataService = null!;
         private ILogger<CourseAdminFieldsService> logger = null!;
 
         [SetUp]
         public void Setup()
         {
             courseAdminFieldsDataService = A.Fake<ICourseAdminFieldsDataService>();
+            courseDataService = A.Fake<ICourseDataService>();
             logger = A.Fake<ILogger<CourseAdminFieldsService>>();
-            courseAdminFieldsService = new CourseAdminFieldsService(courseAdminFieldsDataService, logger);
+            courseAdminFieldsService = new CourseAdminFieldsService(courseAdminFieldsDataService, courseDataService, logger);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
@@ -18,18 +18,15 @@
     {
         private ICourseAdminFieldsDataService courseAdminFieldsDataService = null!;
         private ICourseAdminFieldsService courseAdminFieldsService = null!;
-        private ICourseDataService courseDataService = null!;
         private ILogger<CourseAdminFieldsService> logger = null!;
 
         [SetUp]
         public void Setup()
         {
             courseAdminFieldsDataService = A.Fake<ICourseAdminFieldsDataService>();
-            courseDataService = A.Fake<ICourseDataService>();
             logger = A.Fake<ILogger<CourseAdminFieldsService>>();
             courseAdminFieldsService = new CourseAdminFieldsService(
                 courseAdminFieldsDataService,
-                courseDataService,
                 logger
             );
         }
@@ -208,7 +205,13 @@
             var result = courseAdminFieldsService.GetCustomPromptsWithAnswerCountsForCourse(customisationId, centreId);
 
             // Then
-            result.Should().BeEmpty();
+            using (new AssertionScope())
+            {
+                result.Should().BeEmpty();
+                A.CallTo(
+                    () => courseAdminFieldsDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId)
+                ).MustNotHaveHappened();
+            }
         }
 
         [Test]
@@ -234,7 +237,9 @@
                 .TheRest()
                 .With(a => a.Answer1 = null)
                 .Build();
-            A.CallTo(() => courseDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId))
+            A.CallTo(
+                    () => courseAdminFieldsDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId)
+                )
                 .Returns(delegateAnswers);
 
             // When
@@ -282,7 +287,9 @@
                 .TheRest()
                 .With(a => a.Answer1 = null)
                 .Build();
-            A.CallTo(() => courseDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId))
+            A.CallTo(
+                    () => courseAdminFieldsDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId)
+                )
                 .Returns(delegateAnswers);
 
             // When

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
@@ -246,10 +246,12 @@
             {
                 result.Should().HaveCount(1);
                 result.First().ResponseCounts.Should()
-                    .ContainEquivalentOf(new ResponseCounts("not blank", numberOfDelegatesWithAnswer));
-                result.First().ResponseCounts.Should()
-                    .ContainEquivalentOf(
-                        new ResponseCounts("blank", totalDelegatesCount - numberOfDelegatesWithAnswer)
+                    .BeEquivalentTo(
+                        new List<ResponseCount>
+                        {
+                            new ResponseCount("blank", totalDelegatesCount - numberOfDelegatesWithAnswer),
+                            new ResponseCount("not blank", numberOfDelegatesWithAnswer),
+                        }
                     );
             }
         }
@@ -292,15 +294,16 @@
             {
                 result.Should().HaveCount(1);
                 result.First().ResponseCounts.Should()
-                    .ContainEquivalentOf(new ResponseCounts("Answer", numberOfDelegatesWithAnswer));
-                result.First().ResponseCounts.Should()
-                    .ContainEquivalentOf(new ResponseCounts("Test", numberOfDelegatesWithTest));
-                result.First().ResponseCounts.Should()
-                    .ContainEquivalentOf(
-                        new ResponseCounts(
-                            "blank",
-                            totalDelegatesCount - numberOfDelegatesWithAnswer - numberOfDelegatesWithTest
-                        )
+                    .BeEquivalentTo(
+                        new List<ResponseCount>
+                        {
+                            new ResponseCount("Test", numberOfDelegatesWithTest),
+                            new ResponseCount("Answer", numberOfDelegatesWithAnswer),
+                            new ResponseCount(
+                                "blank",
+                                totalDelegatesCount - numberOfDelegatesWithAnswer - numberOfDelegatesWithTest
+                            ),
+                        }
                     );
             }
         }

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -63,7 +63,7 @@
             var expectedIdOrder = new List<int> { 1, 2 };
 
             // When
-            var resultIdOrder = courseService.GetCentreSpecificCourseStatistics(CentreId, AdminCategoryId)
+            var resultIdOrder = courseService.GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(CentreId, AdminCategoryId)
                 .Select(r => r.CustomisationId).ToList();
 
             // Then

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -57,13 +57,15 @@
         }
 
         [Test]
-        public void GetCentreSpecificCourseStatistics_should_only_return_course_statistics_for_centre()
+        public void
+            GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts_should_only_return_course_statistics_for_centre()
         {
             // Given
             var expectedIdOrder = new List<int> { 1, 2 };
 
             // When
-            var resultIdOrder = courseService.GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(CentreId, AdminCategoryId)
+            var resultIdOrder = courseService
+                .GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(CentreId, AdminCategoryId)
                 .Select(r => r.CustomisationId).ToList();
 
             // Then
@@ -347,7 +349,8 @@
         }
 
         [Test]
-        public void VerifyAdminUserCanViewCourse_should_return_true_when_course_is_at_centre_and_all_centres_without_application()
+        public void
+            VerifyAdminUserCanViewCourse_should_return_true_when_course_is_at_centre_and_all_centres_without_application()
         {
             // Given
             var validationDetails = new CourseValidationDetails

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -4,6 +4,7 @@
     using System.Data;
     using System.Linq;
     using Dapper;
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public interface ICourseAdminFieldsDataService
@@ -26,6 +27,11 @@
         int GetAnswerCountForCourseAdminField(int customisationId, int promptNumber);
 
         void DeleteAllAnswersForCourseAdminField(int customisationId, int promptNumber);
+
+        IEnumerable<DelegateCourseAdminFieldAnswers> GetDelegateAnswersForCourseAdminFields(
+            int customisationId,
+            int centreId
+        );
     }
 
     public class CourseAdminFieldsDataService : ICourseAdminFieldsDataService
@@ -137,6 +143,26 @@
                         SET Answer{promptNumber} = NULL
                         WHERE CustomisationID = @customisationId",
                 new { customisationId }
+            );
+        }
+
+        public IEnumerable<DelegateCourseAdminFieldAnswers> GetDelegateAnswersForCourseAdminFields(
+            int customisationId,
+            int centreId
+        )
+        {
+            return connection.Query<DelegateCourseAdminFieldAnswers>(
+                @"SELECT
+                        c.CandidateID AS DelegateId,
+                        p.Answer1 AS Answer1,
+                        p.Answer2 AS Answer2,
+                        p.Answer3 AS Answer3
+                    FROM Candidates AS c
+                    INNER JOIN Progress AS p ON p.CandidateID = c.CandidateID
+                    WHERE c.CentreID = @centreId
+                        AND p.CustomisationID = @customisationId
+                        AND RemovedDate IS NULL",
+                new { customisationId, centreId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -742,7 +742,6 @@ namespace DigitalLearningSolutions.Data.DataServices
                         p.Answer3 AS CourseAnswer3
                     FROM Candidates AS c
                     INNER JOIN Progress AS p ON p.CandidateID = c.CandidateID
-                    INNER JOIN Customisations cu ON cu.CustomisationID = p.CustomisationID
                     WHERE c.CentreID = @centreId
                         AND p.CustomisationID = @customisationId
                         AND RemovedDate IS NULL",

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -78,6 +78,11 @@ namespace DigitalLearningSolutions.Data.DataServices
         public CourseValidationDetails? GetCourseValidationDetails(int customisationId, int centreId);
 
         int CreateNewCentreCourse(Customisation customisation);
+
+        IEnumerable<DelegateCourseAdminFieldAnswers> GetDelegateAnswersForCourseAdminFields(
+            int customisationId,
+            int centreId
+        );
     }
 
     public class CourseDataService : ICourseDataService
@@ -304,7 +309,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                         cu.HideInLearnerPortal,
                         cc.CategoryName,
                         ct.CourseTopic,
-                        cu.LearningTimeMins AS LearningMinutes
+                        cu.LearningTimeMins AS LearningMinutes,
+                        cu.IsAssessed
                     FROM dbo.Customisations AS cu
                     INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = cu.ApplicationID
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = ca.ApplicationID
@@ -721,6 +727,27 @@ namespace DigitalLearningSolutions.Data.DataServices
             );
 
             return customisationId;
+        }
+
+        public IEnumerable<DelegateCourseAdminFieldAnswers> GetDelegateAnswersForCourseAdminFields(
+            int customisationId,
+            int centreId
+        )
+        {
+            return connection.Query<DelegateCourseAdminFieldAnswers>(
+                @"SELECT
+                        c.CandidateID AS DelegateId,
+                        p.Answer1 AS CourseAnswer1,
+                        p.Answer2 AS CourseAnswer2,
+                        p.Answer3 AS CourseAnswer3
+                    FROM Candidates AS c
+                    INNER JOIN Progress AS p ON p.CandidateID = c.CandidateID
+                    INNER JOIN Customisations cu ON cu.CustomisationID = p.CustomisationID
+                    WHERE c.CentreID = @centreId
+                        AND p.CustomisationID = @customisationId
+                        AND RemovedDate IS NULL",
+                new { customisationId, centreId }
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -78,11 +78,6 @@ namespace DigitalLearningSolutions.Data.DataServices
         public CourseValidationDetails? GetCourseValidationDetails(int customisationId, int centreId);
 
         int CreateNewCentreCourse(Customisation customisation);
-
-        IEnumerable<DelegateCourseAdminFieldAnswers> GetDelegateAnswersForCourseAdminFields(
-            int customisationId,
-            int centreId
-        );
     }
 
     public class CourseDataService : ICourseDataService
@@ -727,26 +722,6 @@ namespace DigitalLearningSolutions.Data.DataServices
             );
 
             return customisationId;
-        }
-
-        public IEnumerable<DelegateCourseAdminFieldAnswers> GetDelegateAnswersForCourseAdminFields(
-            int customisationId,
-            int centreId
-        )
-        {
-            return connection.Query<DelegateCourseAdminFieldAnswers>(
-                @"SELECT
-                        c.CandidateID AS DelegateId,
-                        p.Answer1 AS CourseAnswer1,
-                        p.Answer2 AS CourseAnswer2,
-                        p.Answer3 AS CourseAnswer3
-                    FROM Candidates AS c
-                    INNER JOIN Progress AS p ON p.CandidateID = c.CandidateID
-                    WHERE c.CentreID = @centreId
-                        AND p.CustomisationID = @customisationId
-                        AND RemovedDate IS NULL",
-                new { customisationId, centreId }
-            );
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Helpers/CustomPromptHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/CustomPromptHelper.cs
@@ -25,7 +25,7 @@
             return prompt != null ? new CustomPromptWithAnswer(promptNumber, prompt, options, mandatory, answer) : null;
         }
 
-        public static CustomPromptWithResponseCounts? PopulateCustomPromptWithResponseCounts(
+        public static CustomPromptWithResponseCounts? GetBaseCustomPromptWithResponseCountsModel(
             int promptNumber,
             string? prompt,
             string? options,

--- a/DigitalLearningSolutions.Data/Helpers/CustomPromptHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/CustomPromptHelper.cs
@@ -24,5 +24,15 @@
         {
             return prompt != null ? new CustomPromptWithAnswer(promptNumber, prompt, options, mandatory, answer) : null;
         }
+
+        public static CustomPromptWithResponseCounts? PopulateCustomPromptWithResponseCounts(
+            int promptNumber,
+            string? prompt,
+            string? options,
+            bool mandatory
+        )
+        {
+            return prompt != null ? new CustomPromptWithResponseCounts(promptNumber, prompt, options, mandatory) : null;
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseStatistics.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseStatistics.cs
@@ -14,6 +14,7 @@
         public string CategoryName { get; set; }
         public string CourseTopic { get; set; }
         public string LearningMinutes { get; set; }
+        public bool IsAssessed { get; set; }
 
         public double PassRate => AllAttempts == 0 ? 0 : Math.Round(100 * AttemptsPassed / (double)AllAttempts);
     }

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Data.Models.Courses
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+
+    public class CourseStatisticsWithAdminFieldResponseCounts : CourseStatistics
+    {
+        public CourseStatisticsWithAdminFieldResponseCounts(){}
+
+        public CourseStatisticsWithAdminFieldResponseCounts(
+            CourseStatistics courseStatistics,
+            IEnumerable<CustomPromptWithResponseCounts> adminFieldsWithResponses
+        )
+        {
+            AdminFieldsWithResponses = adminFieldsWithResponses;
+            AllCentres = courseStatistics.AllCentres;
+            DelegateCount = courseStatistics.DelegateCount;
+            CompletedCount = courseStatistics.CompletedCount;
+            AllAttempts = courseStatistics.AllAttempts;
+            AttemptsPassed = courseStatistics.AttemptsPassed;
+            HideInLearnerPortal = courseStatistics.HideInLearnerPortal;
+            CategoryName = courseStatistics.CategoryName;
+            CourseTopic = courseStatistics.CourseTopic;
+            LearningMinutes = courseStatistics.LearningMinutes;
+            IsAssessed = courseStatistics.IsAssessed;
+            CustomisationId = courseStatistics.CustomisationId;
+            CentreId = courseStatistics.CentreId;
+            ApplicationId = courseStatistics.ApplicationId;
+            Active = courseStatistics.Active;
+            CustomisationName = courseStatistics.CustomisationName;
+            ApplicationName = courseStatistics.ApplicationName;
+        }
+
+        public IEnumerable<CustomPromptWithResponseCounts> AdminFieldsWithResponses { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.Courses
 {
     using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public class CourseStatisticsWithAdminFieldResponseCounts : CourseStatistics
@@ -32,5 +33,7 @@
         }
 
         public IEnumerable<CustomPromptWithResponseCounts> AdminFieldsWithResponses { get; set; }
+
+        public bool HasAdminFields => AdminFieldsWithResponses.Any();
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseAdminFieldAnswers.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseAdminFieldAnswers.cs
@@ -1,0 +1,16 @@
+﻿namespace DigitalLearningSolutions.Data.Models.Courses
+{
+    public class DelegateCourseAdminFieldAnswers
+    {
+        public int DelegateId { get; set; }
+
+        public string? Answer1 { get; set; }
+
+        public string? Answer2 { get; set; }
+
+        public string? Answer3 { get; set; }
+
+        public string?[] AdminFieldAnswers =>
+            new[] { Answer1, Answer2, Answer3 };
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseAdminFieldAnswers.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseAdminFieldAnswers.cs
@@ -2,8 +2,6 @@
 {
     public class DelegateCourseAdminFieldAnswers
     {
-        public int DelegateId { get; set; }
-
         public string? Answer1 { get; set; }
 
         public string? Answer2 { get; set; }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPromptWithResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPromptWithResponseCounts.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
+{
+    using System.Collections.Generic;
+
+    public class CustomPromptWithResponseCounts : CustomPrompt
+    {
+        public CustomPromptWithResponseCounts(int customPromptNumber, string text, string? options, bool mandatory) :
+            base(customPromptNumber, text, options, mandatory) { }
+
+        public IEnumerable<ResponseCounts> ResponseCounts { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPromptWithResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPromptWithResponseCounts.cs
@@ -7,6 +7,6 @@
         public CustomPromptWithResponseCounts(int customPromptNumber, string text, string? options, bool mandatory) :
             base(customPromptNumber, text, options, mandatory) { }
 
-        public IEnumerable<ResponseCounts> ResponseCounts { get; set; }
+        public IEnumerable<ResponseCount> ResponseCounts { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/ResponseCount.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/ResponseCount.cs
@@ -1,8 +1,8 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
 {
-    public class ResponseCounts
+    public class ResponseCount
     {
-        public ResponseCounts(string response, int count)
+        public ResponseCount(string response, int count)
         {
             Response = response;
             Count = count;

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/ResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/ResponseCounts.cs
@@ -1,0 +1,15 @@
+﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
+{
+    public class ResponseCounts
+    {
+        public ResponseCounts(string response, int count)
+        {
+            Response = response;
+            Count = count;
+        }
+
+        public string Response { get; set; }
+
+        public int Count { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
@@ -41,18 +41,15 @@
     public class CourseAdminFieldsService : ICourseAdminFieldsService
     {
         private readonly ICourseAdminFieldsDataService courseAdminFieldsDataService;
-        private readonly ICourseDataService courseDataService;
         private readonly ILogger<CourseAdminFieldsService> logger;
 
         public CourseAdminFieldsService(
             ICourseAdminFieldsDataService courseAdminFieldsDataService,
-            ICourseDataService courseDataService,
             ILogger<CourseAdminFieldsService> logger
         )
         {
             this.courseAdminFieldsDataService = courseAdminFieldsDataService;
             this.logger = logger;
-            this.courseDataService = courseDataService;
         }
 
         public CourseAdminFields GetCustomPromptsForCourse(
@@ -146,9 +143,15 @@
         )
         {
             var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId);
-            var adminFields = PopulateCustomPromptWithResponseCountsListFromCourseCustomPromptsResult(result);
+            var adminFields = GetBaseCustomPromptWithResponseCountsModelsFromCourseCustomPromptsResult(result);
 
-            var allAnswers = courseDataService.GetDelegateAnswersForCourseAdminFields(customisationId, centreId)
+            if (!adminFields.Any())
+            {
+                return adminFields;
+            }
+
+            var allAnswers = courseAdminFieldsDataService
+                .GetDelegateAnswersForCourseAdminFields(customisationId, centreId)
                 .ToList();
 
             foreach (var adminField in adminFields)
@@ -316,9 +319,10 @@
             return list;
         }
 
-        private static List<CustomPromptWithResponseCounts> PopulateCustomPromptWithResponseCountsListFromCourseCustomPromptsResult(
-            CourseAdminFieldsResult? result
-        )
+        private static List<CustomPromptWithResponseCounts>
+            GetBaseCustomPromptWithResponseCountsModelsFromCourseCustomPromptsResult(
+                CourseAdminFieldsResult? result
+            )
         {
             var list = new List<CustomPromptWithResponseCounts>();
 
@@ -327,7 +331,7 @@
                 return list;
             }
 
-            var prompt1 = CustomPromptHelper.PopulateCustomPromptWithResponseCounts(
+            var prompt1 = CustomPromptHelper.GetBaseCustomPromptWithResponseCountsModel(
                 1,
                 result.CustomField1Prompt,
                 result.CustomField1Options,
@@ -338,7 +342,7 @@
                 list.Add(prompt1);
             }
 
-            var prompt2 = CustomPromptHelper.PopulateCustomPromptWithResponseCounts(
+            var prompt2 = CustomPromptHelper.GetBaseCustomPromptWithResponseCountsModel(
                 2,
                 result.CustomField2Prompt,
                 result.CustomField2Options,
@@ -349,7 +353,7 @@
                 list.Add(prompt2);
             }
 
-            var prompt3 = CustomPromptHelper.PopulateCustomPromptWithResponseCounts(
+            var prompt3 = CustomPromptHelper.GetBaseCustomPromptWithResponseCountsModel(
                 3,
                 result.CustomField3Prompt,
                 result.CustomField3Options,

--- a/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
@@ -145,9 +145,6 @@
             int centreId
         )
         {
-            const string blank = "blank";
-            const string notBlank = "not blank";
-
             var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId);
             var adminFields = PopulateCustomPromptWithResponseCountsListFromCourseCustomPromptsResult(result);
 
@@ -156,25 +153,26 @@
 
             foreach (var adminField in adminFields)
             {
-                adminField.ResponseCounts = GetResponseCountsForPrompt(adminField, allAnswers, notBlank, blank);
+                adminField.ResponseCounts = GetResponseCountsForPrompt(adminField, allAnswers);
             }
 
             return adminFields;
         }
 
-        private static IEnumerable<ResponseCounts> GetResponseCountsForPrompt(
+        private static IEnumerable<ResponseCount> GetResponseCountsForPrompt(
             CustomPrompt customPrompt,
-            IReadOnlyCollection<DelegateCourseAdminFieldAnswers> allAnswers,
-            string notBlank,
-            string blank
+            IReadOnlyCollection<DelegateCourseAdminFieldAnswers> allAnswers
         )
         {
-            var responseCounts = new List<ResponseCounts>();
+            const string blank = "blank";
+            const string notBlank = "not blank";
+
+            var responseCounts = new List<ResponseCount>();
             if (customPrompt.Options.Any())
             {
                 responseCounts.AddRange(
                     customPrompt.Options.Select(
-                        x => new ResponseCounts(
+                        x => new ResponseCount(
                             x,
                             allAnswers.Count(a => a.AdminFieldAnswers[customPrompt.CustomPromptNumber - 1] == x)
                         )
@@ -184,7 +182,7 @@
             else
             {
                 responseCounts.Add(
-                    new ResponseCounts(
+                    new ResponseCount(
                         notBlank,
                         allAnswers.Count(
                             a => !string.IsNullOrEmpty(a.AdminFieldAnswers[customPrompt.CustomPromptNumber - 1])
@@ -194,7 +192,7 @@
             }
 
             responseCounts.Add(
-                new ResponseCounts(
+                new ResponseCount(
                     blank,
                     allAnswers.Count(
                         a => string.IsNullOrEmpty(a.AdminFieldAnswers[customPrompt.CustomPromptNumber - 1])

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -10,7 +10,11 @@
     {
         public IEnumerable<CourseStatistics> GetTopCourseStatistics(int centreId, int? categoryId);
 
-        public IEnumerable<CourseStatistics> GetCentreSpecificCourseStatistics(int centreId, int? categoryId);
+        public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>
+            GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(
+                int centreId,
+                int? categoryId
+            );
 
         public bool DelegateHasCurrentProgress(int delegateId, int customisationId);
 
@@ -112,10 +116,19 @@
             return allCourses.Where(c => c.Active).OrderByDescending(c => c.InProgressCount);
         }
 
-        public IEnumerable<CourseStatistics> GetCentreSpecificCourseStatistics(int centreId, int? categoryId)
+        public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>
+            GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(
+                int centreId,
+                int? categoryId
+            )
         {
             var allCourses = courseDataService.GetCourseStatisticsAtCentreFilteredByCategory(centreId, categoryId);
-            return allCourses.Where(c => c.CentreId == centreId);
+            return allCourses.Where(c => c.CentreId == centreId).Select(
+                c => new CourseStatisticsWithAdminFieldResponseCounts(
+                    c,
+                    courseAdminFieldsService.GetCustomPromptsWithAnswerCountsForCourse(c.CustomisationId, centreId)
+                )
+            );
         }
 
         public IEnumerable<DelegateCourseDetails> GetAllCoursesInCategoryForDelegate(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/CourseSetupControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/CourseSetupControllerTests.cs
@@ -55,9 +55,9 @@
             new Category { CategoryName = "Category 2" },
         };
 
-        private readonly List<CourseStatistics> courses = new List<CourseStatistics>
+        private readonly List<CourseStatisticsWithAdminFieldResponseCounts> courses = new List<CourseStatisticsWithAdminFieldResponseCounts>
         {
-            new CourseStatistics
+            new CourseStatisticsWithAdminFieldResponseCounts
             {
                 ApplicationName = "Course",
                 CustomisationName = "Customisation",
@@ -97,7 +97,7 @@
             sectionService = A.Fake<ISectionService>();
             courseTopicsService = A.Fake<ICourseTopicsService>();
 
-            A.CallTo(() => courseService.GetCentreSpecificCourseStatistics(A<int>._, A<int>._)).Returns(courses);
+            A.CallTo(() => courseService.GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(A<int>._, A<int>._)).Returns(courses);
             A.CallTo(() => courseCategoryDataService.GetCategoriesForCentreAndCentrallyManagedCourses(A<int>._))
                 .Returns(categories);
             A.CallTo(() => courseTopicsDataService.GetCourseTopicsAvailableAtCentre(A<int>._)).Returns(topics);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseSetupViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseSetupViewModelTests.cs
@@ -11,23 +11,23 @@
 
     public class CourseSetupViewModelTests
     {
-        private readonly IEnumerable<CourseStatistics> courses = new List<CourseStatistics>
+        private readonly IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> courses = new List<CourseStatisticsWithAdminFieldResponseCounts>
         {
-            new CourseStatistics { ApplicationName = "A" },
-            new CourseStatistics { ApplicationName = "B" },
-            new CourseStatistics { ApplicationName = "C" },
-            new CourseStatistics { ApplicationName = "D" },
-            new CourseStatistics { ApplicationName = "E" },
-            new CourseStatistics { ApplicationName = "F" },
-            new CourseStatistics { ApplicationName = "G" },
-            new CourseStatistics { ApplicationName = "H" },
-            new CourseStatistics { ApplicationName = "I" },
-            new CourseStatistics { ApplicationName = "J" },
-            new CourseStatistics { ApplicationName = "K" },
-            new CourseStatistics { ApplicationName = "L" },
-            new CourseStatistics { ApplicationName = "M" },
-            new CourseStatistics { ApplicationName = "N" },
-            new CourseStatistics { ApplicationName = "O" }
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "A" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "B" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "C" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "D" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "E" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "F" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "G" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "H" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "I" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "J" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "K" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "L" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "M" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "N" },
+            new CourseStatisticsWithAdminFieldResponseCounts { ApplicationName = "O" }
         };
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
@@ -90,6 +90,26 @@
             }
         );
 
+        private readonly FilterViewModel expectedHasAdminFieldsFilterViewModel = new FilterViewModel(
+            "HasAdminFields",
+            "Admin fields",
+            new[]
+            {
+                new FilterOptionViewModel(
+                    "Has admin fields",
+                    "HasAdminFields" + FilteringHelper.Separator + "HasAdminFields" + FilteringHelper.Separator +
+                    "true",
+                    FilterStatus.Default
+                ),
+                new FilterOptionViewModel(
+                    "Doesn't have admin fields",
+                    "HasAdminFields" + FilteringHelper.Separator + "HasAdminFields" + FilteringHelper.Separator +
+                    "false",
+                    FilterStatus.Default
+                )
+            }
+        );
+
         private readonly List<string> filterableCategories = new List<string> { "Category 1", "Category 2" };
 
         private readonly List<string> filterableTopics = new List<string> { "Topic 1", "Topic 2" };
@@ -108,7 +128,8 @@
                     expectedCategoriesFilterViewModel,
                     expectedTopicsFilterViewModel,
                     expectedStatusFilterViewModel,
-                    expectedVisibilityFilterViewModel
+                    expectedVisibilityFilterViewModel,
+                    expectedHasAdminFieldsFilterViewModel
                 }
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -80,7 +80,7 @@
             var centreId = User.GetCentreId();
             var categoryId = User.GetAdminCourseCategoryFilter();
             var centreCourses =
-                courseService.GetCentreSpecificCourseStatistics(centreId, categoryId);
+                courseService.GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(centreId, categoryId);
             var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId)
                 .Select(c => c.CategoryName);
             var topics = courseTopicsDataService.GetCourseTopicsAvailableAtCentre(centreId).Select(c => c.CourseTopic);
@@ -108,7 +108,7 @@
             var centreId = User.GetCentreId();
             var categoryId = User.GetAdminCourseCategoryFilter();
             var centreCourses =
-                courseService.GetCentreSpecificCourseStatistics(centreId, categoryId);
+                courseService.GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(centreId, categoryId);
             var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId)
                 .Select(c => c.CategoryName);
             var topics = courseTopicsDataService.GetCourseTopicsAvailableAtCentre(centreId).Select(c => c.CourseTopic);

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -49,7 +49,7 @@
                 nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields),
                 "true"
             ),
-            FilterStatus.Warning
+            FilterStatus.Default
         );
 
         public static readonly FilterOptionViewModel DoesNotHaveAdminFields = new FilterOptionViewModel(
@@ -59,7 +59,7 @@
                 nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields),
                 "false"
             ),
-            FilterStatus.Success
+            FilterStatus.Default
         );
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -37,4 +37,29 @@
             FilterStatus.Success
         );
     }
+
+    public static class CourseHasAdminFieldsFilterOptions
+    {
+        private const string Group = "HasAdminFields";
+
+        public static readonly FilterOptionViewModel HasAdminFields = new FilterOptionViewModel(
+            "Has admin fields",
+            FilteringHelper.BuildFilterValueString(
+                Group,
+                nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields),
+                "true"
+            ),
+            FilterStatus.Warning
+        );
+
+        public static readonly FilterOptionViewModel DoesNotHaveAdminFields = new FilterOptionViewModel(
+            "Doesn't have admin fields",
+            FilteringHelper.BuildFilterValueString(
+                Group,
+                nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields),
+                "false"
+            ),
+            FilterStatus.Success
+        );
+    }
 }

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
@@ -2,3 +2,7 @@
 @import "../shared/cardWithButtons";
 @import "../shared/searchableElements/searchableElements";
 @import "../shared/headingButtons.scss";
+
+.admin-field-count {
+    width: 10%;
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AllCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AllCourseStatisticsViewModel.cs
@@ -9,7 +9,7 @@
     public class AllCourseStatisticsViewModel : BaseJavaScriptFilterableViewModel
     {
         public AllCourseStatisticsViewModel(
-            IEnumerable<CourseStatistics> courses,
+            IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> courses,
             IEnumerable<string> categories,
             IEnumerable<string> topics
         )

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseSetupViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseSetupViewModel.cs
@@ -9,7 +9,7 @@
     public class CourseSetupViewModel : BaseSearchablePageViewModel
     {
         public CourseSetupViewModel(
-            IEnumerable<CourseStatistics> courses,
+            IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> courses,
             IEnumerable<string> categories,
             IEnumerable<string> topics,
             string? searchString,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptions.cs
@@ -13,13 +13,19 @@
         private static readonly IEnumerable<FilterOptionViewModel> CourseStatusOptions = new[]
         {
             CourseStatusFilterOptions.IsActive,
-            CourseStatusFilterOptions.IsInactive
+            CourseStatusFilterOptions.IsInactive,
         };
 
         private static readonly IEnumerable<FilterOptionViewModel> CourseVisibilityOptions = new[]
         {
             CourseVisibilityFilterOptions.IsHiddenInLearningPortal,
-            CourseVisibilityFilterOptions.IsNotHiddenInLearningPortal
+            CourseVisibilityFilterOptions.IsNotHiddenInLearningPortal,
+        };
+
+        private static readonly IEnumerable<FilterOptionViewModel> CourseHasAdminFieldOptions = new[]
+        {
+            CourseHasAdminFieldsFilterOptions.HasAdminFields,
+            CourseHasAdminFieldsFilterOptions.DoesNotHaveAdminFields,
         };
 
         public static IEnumerable<FilterViewModel> GetFilterOptions(
@@ -40,7 +46,16 @@
                     GetTopicOptions(topics)
                 ),
                 new FilterViewModel(nameof(CourseStatistics.Active), "Status", CourseStatusOptions),
-                new FilterViewModel(nameof(CourseStatistics.HideInLearnerPortal), "Visibility", CourseVisibilityOptions)
+                new FilterViewModel(
+                    nameof(CourseStatistics.HideInLearnerPortal),
+                    "Visibility",
+                    CourseVisibilityOptions
+                ),
+                new FilterViewModel(
+                    nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields),
+                    "Admin fields",
+                    CourseHasAdminFieldOptions
+                ),
             };
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Web.Helpers;
@@ -33,6 +34,7 @@
         public bool Assessed { get; set; }
 
         public IEnumerable<CustomPromptWithResponseCounts> AdminFieldWithResponseCounts { get; set; }
+        public bool HasAdminFields => AdminFieldWithResponseCounts.Any();
 
         public string CategoryFilter => nameof(CourseStatistics.CategoryName) + FilteringHelper.Separator +
                                         nameof(CourseStatistics.CategoryName) +
@@ -41,6 +43,11 @@
         public string TopicFilter => nameof(CourseStatistics.CourseTopic) + FilteringHelper.Separator +
                                      nameof(CourseStatistics.CourseTopic) +
                                      FilteringHelper.Separator + CourseTopic;
+
+        public string HasAdminFieldsFilter => nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields) +
+                                              FilteringHelper.Separator +
+                                              nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields) +
+                                              FilteringHelper.Separator + HasAdminFields.ToString().ToLowerInvariant();
 
         public string EmailHref => GenerateEmailHref();
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -1,13 +1,15 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 {
     using System;
+    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public class SearchableCourseStatisticsViewModel : BaseFilterableViewModel
     {
-        public SearchableCourseStatisticsViewModel(CourseStatistics courseStatistics)
+        public SearchableCourseStatisticsViewModel(CourseStatisticsWithAdminFieldResponseCounts courseStatistics)
         {
             CustomisationId = courseStatistics.CustomisationId;
             DelegateCount = courseStatistics.DelegateCount;
@@ -17,6 +19,8 @@
             CourseTopic = courseStatistics.CourseTopic;
             LearningMinutes = courseStatistics.LearningMinutes;
             Tags = FilterableTagHelper.GetCurrentTagsForCourseStatistics(courseStatistics);
+            Assessed = courseStatistics.IsAssessed;
+            AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
         }
 
         public int CustomisationId { get; set; }
@@ -26,6 +30,9 @@
         public string CategoryName { get; set; }
         public string CourseTopic { get; set; }
         public string LearningMinutes { get; set; }
+        public bool Assessed { get; set; }
+
+        public IEnumerable<CustomPromptWithResponseCounts> AdminFieldWithResponseCounts { get; set; }
 
         public string CategoryFilter => nameof(CourseStatistics.CategoryName) + FilteringHelper.Separator +
                                         nameof(CourseStatistics.CategoryName) +

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -14,7 +14,7 @@
 
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
-      <input type="hidden" asp-for="HasAdminFields" data-filter-value="@Model.HasAdminFieldsFilter"/>
+      <input type="hidden" data-filter-value="@Model.HasAdminFieldsFilter"/>
       @if (Model.HasAdminFields) {
         <partial name="_CentreCourseCardAdminFields" model="@Model" />
       }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -14,7 +14,8 @@
 
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
-      @if (Model.AdminFieldWithResponseCounts.Any()) {
+      <input type="hidden" asp-for="HasAdminFields" data-filter-value="@Model.HasAdminFieldsFilter"/>
+      @if (Model.HasAdminFields) {
         <partial name="_CentreCourseCardAdminFields" model="@Model" />
       }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -12,53 +12,11 @@
     <div class="nhsuk-details__text">
       <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
 
-      <dl class="nhsuk-summary-list">
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Category
-          </dt>
-          <dd class="nhsuk-summary-list__value" data-filter-value="@Model.CategoryFilter">
-            @Model.CategoryName
-          </dd>
-        </div>
+      <partial name="_CentreCourseCardDetails" model="@Model" />
 
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Topic
-          </dt>
-          <dd class="nhsuk-summary-list__value" data-filter-value="@Model.TopicFilter">
-            @Model.CourseTopic
-          </dd>
-        </div>
-
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Learning minutes
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            @Model.LearningMinutes
-          </dd>
-        </div>
-
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Total delegates
-          </dt>
-          <dd class="nhsuk-summary-list__value" name="delegate-count">
-            @Model.DelegateCount
-          </dd>
-        </div>
-
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            In progress
-          </dt>
-          <dd class="nhsuk-summary-list__value" name="in-progress-count">
-            @Model.InProgressCount
-          </dd>
-        </div>
-
-      </dl>
+      @if (Model.AdminFieldWithResponseCounts.Any()) {
+        <partial name="_CentreCourseCardAdminFields" model="@Model" />
+      }
 
       <p class="nhsuk-u-margin-bottom-0">Want to share the course?</p>
       <a href="@Model.EmailHref">Generate email</a>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
@@ -1,0 +1,19 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
+@model SearchableCourseStatisticsViewModel
+
+<b>Admin fields and response summary</b>
+
+@foreach (var prompt in Model.AdminFieldWithResponseCounts) {
+  <dl class="nhsuk-summary-list">
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        @prompt.CustomPromptText
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @foreach (var responseCount in prompt.ResponseCounts) {
+          <p>@responseCount.Response @responseCount.Count</p>
+        }
+      </dd>
+    </div>
+  </dl>
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
@@ -6,7 +6,7 @@
 @foreach (var prompt in Model.AdminFieldWithResponseCounts) {
   <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
+      <dt class="nhsuk-summary-list__key nhsuk-u-font-weight-normal">
         @prompt.CustomPromptText
       </dt>
       <dd class="nhsuk-summary-list__value">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
@@ -10,9 +10,18 @@
         @prompt.CustomPromptText
       </dt>
       <dd class="nhsuk-summary-list__value">
-        @foreach (var responseCount in prompt.ResponseCounts) {
-          <p>@responseCount.Response @responseCount.Count</p>
-        }
+        <dl class="nhsuk-summary-list">
+          @foreach (var responseCount in prompt.ResponseCounts) {
+            <div class="nhsuk-summary-list__row basic-summary-list__row">
+              <dt class="nhsuk-summary-list__key nhsuk-u-font-weight-normal">
+                @responseCount.Response
+              </dt>
+              <dd class="nhsuk-summary-list__value admin-field-count">
+                @responseCount.Count
+              </dd>
+            </div>
+          }
+        </dl>
       </dd>
     </div>
   </dl>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardAdminFields.cshtml
@@ -3,8 +3,8 @@
 
 <b>Admin fields and response summary</b>
 
-@foreach (var prompt in Model.AdminFieldWithResponseCounts) {
-  <dl class="nhsuk-summary-list">
+<dl class="nhsuk-summary-list">
+  @foreach (var prompt in Model.AdminFieldWithResponseCounts) {
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key nhsuk-u-font-weight-normal">
         @prompt.CustomPromptText
@@ -24,5 +24,5 @@
         </dl>
       </dd>
     </div>
-  </dl>
-}
+  }
+</dl>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCardDetails.cshtml
@@ -1,0 +1,56 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
+@model SearchableCourseStatisticsViewModel
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Category
+    </dt>
+    <dd class="nhsuk-summary-list__value" data-filter-value="@Model.CategoryFilter">
+      @Model.CategoryName
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Topic
+    </dt>
+    <dd class="nhsuk-summary-list__value" data-filter-value="@Model.TopicFilter">
+      @Model.CourseTopic
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Assessed
+    </dt>
+    <partial name="_SummaryBooleanField" model="Model.Assessed" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Learning minutes
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.LearningMinutes
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Total delegates
+    </dt>
+    <dd class="nhsuk-summary-list__value" name="delegate-count">
+      @Model.DelegateCount
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      In progress
+    </dt>
+    <dd class="nhsuk-summary-list__value" name="in-progress-count">
+      @Model.InProgressCount
+    </dd>
+  </div>
+</dl>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-763

### Description
Added admin fields and answer counts for them to the course cards in Course Setup. Add Has Admin Fields to the filters.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/152978015-effe1d7d-30d3-430a-adea-6f85658cb6ca.png)
![image](https://user-images.githubusercontent.com/59561751/152978129-40f1aa2b-37f7-4c44-98b2-dd319b25bcac.png)
![image](https://user-images.githubusercontent.com/59561751/152978391-f7e60829-8c28-424a-9414-10c6abde1d1c.png)
![image](https://user-images.githubusercontent.com/59561751/152978447-9a72f48b-addf-49f4-a550-3bca54f7298c.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
