### PR TITLE
HEEDLS-761 - Made the Add to Action Plan method return the user to th…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
@@ -104,7 +104,7 @@
                 .Returns(false);
 
             // When
-            var result = await controller.AddResourceToActionPlan(SelfAssessmentId, resourceReferenceId);
+            var result = await controller.AddResourceToActionPlan(SelfAssessmentId, resourceReferenceId, 1);
 
             // Then
             result.Should().BeNotFoundResult();
@@ -113,7 +113,7 @@
         }
 
         [Test]
-        public async Task AddResourceToActionPlan_adds_resource_and_returns_redirect_when_resource_not_in_action_plan()
+        public async Task AddResourceToActionPlan_adds_resource_and_returns_redirect_with_correct_return_page_when_resource_not_in_action_plan()
         {
             // Given
             const int resourceReferenceId = 1;
@@ -121,13 +121,13 @@
                 .Returns(true);
 
             // When
-            var result = await controller.AddResourceToActionPlan(SelfAssessmentId, resourceReferenceId);
+            var result = await controller.AddResourceToActionPlan(SelfAssessmentId, resourceReferenceId, 3);
 
             // Then
             A.CallTo(() => actionPlanService.AddResourceToActionPlan(resourceReferenceId, DelegateId, SelfAssessmentId))
                 .MustHaveHappenedOnceExactly();
             result.Should().BeRedirectToActionResult().WithActionName("RecommendedLearning")
-                .WithRouteValue("selfAssessmentId", SelfAssessmentId);
+                .WithRouteValue("selfAssessmentId", SelfAssessmentId).WithRouteValue("page", 3);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningPortal/SearchableRecommendedResourceViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningPortal/SearchableRecommendedResourceViewModelTests.cs
@@ -21,7 +21,7 @@
             var recommendedResource = new RecommendedResource { RecommendationScore = recommendationScore };
 
             // When
-            var result = new SearchableRecommendedResourceViewModel(recommendedResource, 1);
+            var result = new SearchableRecommendedResourceViewModel(recommendedResource, 1, 1);
 
             // Then
             result.Rating.Should().BeEquivalentTo(expectedRating);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
@@ -101,7 +101,7 @@
         [Route(
             "/LearningPortal/SelfAssessment/{selfAssessmentId:int}/AddResourceToActionPlan/{resourceReferenceId:int}"
         )]
-        public async Task<IActionResult> AddResourceToActionPlan(int selfAssessmentId, int resourceReferenceId)
+        public async Task<IActionResult> AddResourceToActionPlan(int selfAssessmentId, int resourceReferenceId, int? returnPage)
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
 
@@ -126,7 +126,7 @@
                 return View("ResourceRemovedErrorPage", model);
             }
 
-            return RedirectToAction("RecommendedLearning", new { selfAssessmentId });
+            return RedirectToAction("RecommendedLearning", new { selfAssessmentId, page = returnPage });
         }
 
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Filtered/Dashboard")]

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/RecommendedLearning/AllRecommendedLearningItemsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/RecommendedLearning/AllRecommendedLearningItemsViewModel.cs
@@ -10,7 +10,7 @@
         {
             RecommendedResources =
                 resources.OrderByDescending(r => r.RecommendationScore).Select(
-                    r => new SearchableRecommendedResourceViewModel(r, selfAssessmentId)
+                    r => new SearchableRecommendedResourceViewModel(r, selfAssessmentId, 1)
                 );
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/RecommendedLearning/RecommendedLearningViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/RecommendedLearning/RecommendedLearningViewModel.cs
@@ -40,9 +40,10 @@
             MatchingSearchResults = sortedResources.Count;
             SetTotalPages();
             var paginatedItems = GetItemsOnCurrentPage(sortedResources);
+            var returnPage = string.IsNullOrWhiteSpace(searchString) ? page : 1;
 
             RecommendedResources =
-                paginatedItems.Select(r => new SearchableRecommendedResourceViewModel(r, selfAssessment.Id));
+                paginatedItems.Select(r => new SearchableRecommendedResourceViewModel(r, selfAssessment.Id, returnPage));
         }
 
         public SelfAssessment SelfAssessment { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/RecommendedLearning/SearchableRecommendedResourceViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/RecommendedLearning/SearchableRecommendedResourceViewModel.cs
@@ -4,7 +4,7 @@
 
     public class SearchableRecommendedResourceViewModel
     {
-        public SearchableRecommendedResourceViewModel(RecommendedResource recommendedResource, int selfAssessmentId)
+        public SearchableRecommendedResourceViewModel(RecommendedResource recommendedResource, int selfAssessmentId, int returnPage)
         {
             SelfAssessmentId = selfAssessmentId;
             LearningResourceReferenceId = recommendedResource.LearningResourceReferenceId;
@@ -18,6 +18,7 @@
             IsCompleted = recommendedResource.IsCompleted;
             LearningLogItemId = recommendedResource.LearningLogId;
             RecommendationScore = recommendedResource.RecommendationScore;
+            ReturnPage = returnPage;
         }
 
         public int SelfAssessmentId { get; set; }
@@ -43,6 +44,8 @@
         public int? LearningLogItemId { get; set; }
 
         public decimal RecommendationScore { get; set; }
+
+        public int ReturnPage { get; set; }
 
         public string Rating => RecommendationScore >= 100 ? "Essential" :
             RecommendationScore >= 40 ? "Recommended" : "Optional";

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/_SearchableRecommendedResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/_SearchableRecommendedResourceCard.cshtml
@@ -46,7 +46,8 @@
          asp-controller="RecommendedLearning"
          asp-action="AddResourceToActionPlan"
          asp-route-selfAssessmentId="@Model.SelfAssessmentId"
-         asp-route-resourceReferenceId="@Model.LearningResourceReferenceId">
+         asp-route-resourceReferenceId="@Model.LearningResourceReferenceId"
+         asp-route-returnPage="@Model.ReturnPage">
         Add to action plan
       </a>
     }


### PR DESCRIPTION
…e correct page if no search is specificed.

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-761

### Description
Minor code changes so that the user is returned to the page they are on when adding a recommended resource to the action plan. As with the implementation from 621, we return to the first page whenever search is enabled.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
