### PR TITLE
DLSV2-484 Adds top link as view component and includes in view

### DIFF
--- a/DigitalLearningSolutions.Web/ViewComponents/TopLinkViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/TopLinkViewComponent.cs
@@ -1,0 +1,16 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class TopLinkViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(
+            string linkText,
+            string topElementId
+        )
+        {
+            return View(new TopLinkViewModel(linkText, topElementId));
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/TopLinkViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/TopLinkViewModel.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+{
+    public class TopLinkViewModel
+    {
+        public readonly string LinkText;
+        public readonly string TopElementId;
+        public TopLinkViewModel(string linkText, string topElementId)
+        {
+            LinkText = linkText;
+            TopElementId = topElementId;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/TopLink/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/TopLink/Default.cshtml
@@ -1,0 +1,10 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@model TopLinkViewModel
+
+<div class="nhsuk-back-link">
+  <a class="nhsuk-back-link__link" href="#@Model.TopElementId">
+    <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="24" width="24">
+  <path d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"/>
+</svg>
+    @Model.LinkText</a>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -113,6 +113,9 @@
           }
         </tbody>
       </table>
+      <div class="nhsuk-u-margin-top-4">
+      <vc:top-link top-element-id="maincontent" link-text="Top of page" />
+      </div>
     }
   }
   @if (Model.SupervisorSignOffs.Any())

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -113,9 +113,7 @@
           }
         </tbody>
       </table>
-      <div class="nhsuk-u-margin-top-4">
-      <vc:top-link top-element-id="maincontent" link-text="Top of page" />
-      </div>
+      
     }
   }
   @if (Model.SupervisorSignOffs.Any())
@@ -124,4 +122,10 @@
       <h3>Self Assessment Sign-off Status</h3>
       <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
     </div>
+  }
+  @if (Model.CompetencyGroups.Any())
+  {
+    <div class="nhsuk-u-margin-top-4">
+      <vc:top-link top-element-id="maincontent" link-text="Top of page" />
+      </div>
   }


### PR DESCRIPTION
### JIRA link
[DLSV2-484](https://hee-dls.atlassian.net/browse/DLSV2-484)

### Description
Adds a top of page link to the supervisor review self assessment view. Because this is likely to be required elsewhere, it has been implemented as a view component with two parameters - link text and id of top element.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/153025708-1d0e3b99-6c1d-4011-9fbe-f24c68c8f4d4.png)

