### PR TITLE
HEEDLS-678 throw and log on too-short secret key

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/LearningHubSsoSecurityServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LearningHubSsoSecurityServiceTests.cs
@@ -43,11 +43,11 @@
             var now = DateTime.UtcNow;
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now);
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            var hash1 = helper.GenerateHash(stateString);
-            var hash2 = helper.GenerateHash(stateString);
+            var hash1 = service.GenerateHash(stateString);
+            var hash2 = service.GenerateHash(stateString);
 
             // Then
             hash1.Should().Be(hash2);
@@ -60,11 +60,11 @@
             var now = DateTime.UtcNow;
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now.AddSeconds(1));
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            var hash1 = helper.GenerateHash(stateString);
-            var hash2 = helper.GenerateHash(stateString);
+            var hash1 = service.GenerateHash(stateString);
+            var hash2 = service.GenerateHash(stateString);
 
             // Then
             hash1.Should().NotBe(hash2);
@@ -77,11 +77,11 @@
             var now = DateTime.UtcNow.Date;
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now.AddMilliseconds(999));
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            var hash1 = helper.GenerateHash(stateString);
-            var hash2 = helper.GenerateHash(stateString);
+            var hash1 = service.GenerateHash(stateString);
+            var hash2 = service.GenerateHash(stateString);
 
             // Then
             hash1.Should().Be(hash2);
@@ -95,11 +95,11 @@
             var stateString = "stateString";
             var differentStateString = "stateStrinh";
             var clockService = new BinaryClockService(now, now.AddSeconds(1));
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            var hash1 = helper.GenerateHash(stateString);
-            var hash2 = helper.GenerateHash(differentStateString);
+            var hash1 = service.GenerateHash(stateString);
+            var hash2 = service.GenerateHash(differentStateString);
 
             // Then
             hash1.Should().NotBe(hash2);
@@ -112,7 +112,7 @@
             var now = DateTime.UtcNow;
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now);
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             var alternateConfig = A.Fake<IConfiguration>();
 
@@ -124,7 +124,7 @@
             var helper2 = new LearningHubSsoSecurityService(clockService, alternateConfig, Logger);
 
             // When
-            var hash1 = helper.GenerateHash(stateString);
+            var hash1 = service.GenerateHash(stateString);
             var hash2 = helper2.GenerateHash(stateString);
 
             // Then
@@ -139,10 +139,10 @@
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now);
             A.CallTo(() => Config["LearningHubSSO:SecretKey"]).Returns("1234567");
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            Action action = () => helper.GenerateHash(stateString);
+            Action action = () => service.GenerateHash(stateString);
 
             // Then
             action.Should().Throw<CryptographicException>();
@@ -158,11 +158,11 @@
             var now = DateTime.UtcNow;
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now.AddSeconds(delay));
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            var hash = helper.GenerateHash(stateString);
-            var result = helper.VerifyHash(stateString, hash);
+            var hash = service.GenerateHash(stateString);
+            var result = service.VerifyHash(stateString, hash);
 
             // Then
             result.Should().BeTrue();
@@ -178,11 +178,11 @@
             var now = DateTime.UtcNow;
             var stateString = "stateString";
             var clockService = new BinaryClockService(now, now.AddSeconds(delay));
-            var helper = new LearningHubSsoSecurityService(clockService, Config, Logger);
+            var service = new LearningHubSsoSecurityService(clockService, Config, Logger);
 
             // When
-            var hash = helper.GenerateHash(stateString);
-            var result = helper.VerifyHash(stateString, hash);
+            var hash = service.GenerateHash(stateString);
+            var result = service.VerifyHash(stateString, hash);
 
             // Then
             result.Should().BeFalse();

--- a/DigitalLearningSolutions.Data/Services/LearningHubSsoSecurityService.cs
+++ b/DigitalLearningSolutions.Data/Services/LearningHubSsoSecurityService.cs
@@ -33,7 +33,7 @@
         public string GenerateHash(string state)
         {
             var secondsSinceEpoch = GetSecondsSinceEpoch();
-            var salt = GetSalt();
+            var salt = GetSecretKeyBytes();
 
             var encoder = new UTF8Encoding();
             var timedState = encoder.GetBytes(state + secondsSinceEpoch);
@@ -43,7 +43,7 @@
         public bool VerifyHash(string state, string hash)
         {
             var secondsSinceEpoch = GetSecondsSinceEpoch();
-            var salt = GetSalt();
+            var salt = GetSecretKeyBytes();
 
             var encoder = new UTF8Encoding();
             var toleranceInSec = config.GetLearningHubSsoHashTolerance();
@@ -61,18 +61,18 @@
             return false;
         }
 
-        private byte[] GetSalt()
+        private byte[] GetSecretKeyBytes()
         {
             var encoder = new UTF8Encoding();
-            var salt = encoder.GetBytes(config.GetLearningHubSsoSecretKey());
+            var secretKeyBytes = encoder.GetBytes(config.GetLearningHubSsoSecretKey());
 
-            if (salt.Length < 8)
+            if (secretKeyBytes.Length < 8)
             {
                 logger.LogError("Secret key invalid. The secret key must have a length of at least 8 characters.");
                 throw new CryptographicException();
             }
 
-            return salt;
+            return secretKeyBytes;
         }
 
         private string GetHash(byte[] input, byte[] salt)

--- a/DigitalLearningSolutions.Data/Services/LearningHubSsoSecurityService.cs
+++ b/DigitalLearningSolutions.Data/Services/LearningHubSsoSecurityService.cs
@@ -33,8 +33,9 @@
         public string GenerateHash(string state)
         {
             var secondsSinceEpoch = GetSecondsSinceEpoch();
+            var salt = GetSalt();
+
             var encoder = new UTF8Encoding();
-            var salt = GetSalt(encoder);
             var timedState = encoder.GetBytes(state + secondsSinceEpoch);
             return GetHash(timedState, salt);
         }
@@ -42,10 +43,10 @@
         public bool VerifyHash(string state, string hash)
         {
             var secondsSinceEpoch = GetSecondsSinceEpoch();
-            var encoder = new UTF8Encoding();
-            var salt = GetSalt(encoder);
-            var toleranceInSec = config.GetLearningHubSsoHashTolerance();
+            var salt = GetSalt();
 
+            var encoder = new UTF8Encoding();
+            var toleranceInSec = config.GetLearningHubSsoHashTolerance();
             for (var counter = 0; counter <= toleranceInSec * 2; counter++)
             {
                 var step = counter > toleranceInSec ? counter - toleranceInSec : -1 * counter;
@@ -60,13 +61,14 @@
             return false;
         }
 
-        private byte[] GetSalt(UTF8Encoding encoder)
+        private byte[] GetSalt()
         {
+            var encoder = new UTF8Encoding();
             var salt = encoder.GetBytes(config.GetLearningHubSsoSecretKey());
 
             if (salt.Length < 8)
             {
-                logger.LogError("Secret key invalid. The secret key must have a length of at least 8 bytes.");
+                logger.LogError("Secret key invalid. The secret key must have a length of at least 8 characters.");
                 throw new CryptographicException();
             }
 


### PR DESCRIPTION
### JIRA link
_[HEEDLS-XXXX](https://softwiretech.atlassian.net/browse/HEEDLS-678)_

### Description
Added handling for throwing and logging if the secret key is invalid.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
