### PR TITLE
HEEDLS-761 - screen reader pagination announcement fixes

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -65,7 +65,7 @@ export class SearchSortFilterAndPaginate {
           );
           this.updateSearchableElementLinks(searchableData);
         }
-        this.searchSortAndPaginate(searchableData);
+        this.searchSortAndPaginate(searchableData, false);
       });
   }
 
@@ -97,7 +97,7 @@ export class SearchSortFilterAndPaginate {
     SearchSortFilterAndPaginate.scrollToTop();
   }
 
-  private searchSortAndPaginate(searchableData: ISearchableData): void {
+  private searchSortAndPaginate(searchableData: ISearchableData, updateResultCount = true): void {
     const searchedElements = this.searchEnabled
       ? search(searchableData.searchableElements)
       : searchableData.searchableElements;
@@ -107,9 +107,11 @@ export class SearchSortFilterAndPaginate {
     const sortedElements = sortSearchableElements(filteredElements);
 
     const sortedUniqueElements = _.uniqBy(sortedElements, 'parentIndex');
-    const resultCount = sortedUniqueElements.length;
-    SearchSortFilterAndPaginate
-      .updateResultCount(resultCount);
+
+    if (updateResultCount) {
+      const resultCount = sortedUniqueElements.length;
+      SearchSortFilterAndPaginate.updateResultCount(resultCount);
+    }
 
     const paginatedElements = this.paginationEnabled
       ? paginateResults(sortedUniqueElements, this.page)

--- a/DigitalLearningSolutions.Web/Views/Shared/PaginatedPage/_PaginationNav.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/PaginatedPage/_PaginationNav.cshtml
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="page-indicator-container">
-      <span aria-live="polite" aria-atomic="true">
+      <span role="alert">
         <span class="nhsuk-u-visually-hidden">page </span>
         <span id="page-indicator">@Model.Page of @Model.TotalPages</span>
       </span>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-761

### Description
Tackled the comments in the ticket so that the page number is announced when loading the page, and the matching result count is not read out twice. This does impact how things are announced in other circumstances, which I have detailed on comments at the relevant changes. Do let me know if we think any of these side effects should be avoided.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
