### PR TITLE
DLSV2-503 Adds Beta label to Framework Service sub-applications

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -296,3 +296,18 @@ nav, .nhsuk-header__navigation, #header-navigation {
   overflow: hidden;
   white-space: nowrap;
 }
+.nhsuk-header__link--service {
+  @include mq($from: large-desktop) {
+    align-items:unset;
+  }
+}
+.header-beta {
+  color: #c8e4ff;
+  font-family: FrutigerLTW01-55Roman, Arial, sans-serif;
+  margin-left: 2px;
+  text-transform: uppercase;
+
+  &.header-beta--dark {
+    color: $color_nhsuk-dark-pink;
+  }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -53,6 +53,7 @@
         </div>
         <div class="nhsuk-header__transactional-service-name">
           <span class="nhsuk-header__transactional-service-name--link">@ViewData["SelfAssessmentTitle"]</span>
+          <sup class="header-beta">Beta</sup>
         </div>
       </div>
     </header>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -66,8 +66,12 @@
             <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
           </svg>
 
-          <span class="nhsuk-header__service-name">@(ViewData[LayoutViewDataKeys.HeaderPrefix] ?? "Digital Learning Solutions ")@(headerExtension)</span>
-        </a>
+                        <span class="nhsuk-header__service-name">@(ViewData[LayoutViewDataKeys.HeaderPrefix] ?? "Digital Learning Solutions ")@(headerExtension)</span>
+                        @if(ViewData[LayoutViewDataKeys.Application].ToString() == "Framework Service" | ViewData[LayoutViewDataKeys.Application].ToString() == "Supervise")
+                        {
+                            <sup class="header-beta header-beta--dark">Beta</sup>
+                        }
+                    </a>
       </div>
 
       @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true) {


### PR DESCRIPTION
### JIRA link
DLSV2-503

### Description
To meet GDS assessment requirements, we need to mark all parts of the Frameworks Service as Beta. This change adds a beta label to the header in the layout pages. There is a light (standard) and dark styling class to give a high contrast label for both white and blue background headers.