### PR TITLE
HEEDLS-689 - made group deletion SQL safer for progress removal and c…

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/GroupsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/GroupsDataServiceTests.cs
@@ -406,6 +406,32 @@
         }
 
         [Test]
+        public async Task
+            RemoveRelatedProgressRecordsForGroup_does_not_remove_progress_for_delegates_outside_specified_group()
+        {
+            using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            try
+            {
+                // Given
+                const int groupId = 5;
+                const bool deleteStartedEnrolment = true;
+                var removedDate = DateTime.UtcNow;
+
+                // When
+                groupsDataService.RemoveRelatedProgressRecordsForGroup(groupId, deleteStartedEnrolment, removedDate);
+
+                // Then
+                var progressWithNoGroup = await connection.GetProgressRemovedFields(284968);
+                progressWithNoGroup.Item1.Should().Be(0);
+                progressWithNoGroup.Item2.Should().BeNull();
+            }
+            finally
+            {
+                transaction.Dispose();
+            }
+        }
+
+        [Test]
         public async Task DeleteGroupDelegates_deletes_all_group_delegates()
         {
             using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);

--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -113,6 +113,22 @@
                             WHERE (ApplicationID = c.ApplicationID)
                                 AND (CentreID = @centreID) AND (Active = 1))";
 
+        private const string SelectIdsOfGroupProgressRecordsSuitableForRemoval =
+            @"SELECT ProgressID
+            FROM Progress AS P
+            INNER JOIN GroupCustomisations AS GC ON P.CustomisationID = GC.CustomisationID
+            INNER JOIN GroupDelegates AS GD ON GD.DelegateID = P.CandidateID AND GD.GroupID = GC.GroupID
+            WHERE P.Completed IS NULL
+            AND P.EnrollmentMethodID = 3
+            AND GC.GroupID = @groupId
+            AND P.RemovedDate IS NULL
+            AND (P.LoginCount = 0 OR @deleteStartedEnrolment = 1)
+            AND NOT EXISTS (SELECT * FROM GroupCustomisations AS GCInner
+                            INNER JOIN GroupDelegates AS GDInner ON GCInner.GroupID = GDInner.GroupID
+                            WHERE GCInner.CustomisationID = P.CustomisationID
+                            AND GDInner.DelegateID = P.CandidateID
+                            AND GCInner.GroupID != GC.GroupID)";
+
         private readonly IDbConnection connection;
 
         public GroupsDataService(IDbConnection connection)
@@ -297,8 +313,6 @@
             );
         }
 
-        // TODO: HEEDLS-689 see note on ticket regarding
-        // commonising duplicate SQL here and in method RemoveRelatedProgressRecordsForGroupCourse
         public void RemoveRelatedProgressRecordsForGroup(
             int groupId,
             int? delegateId,
@@ -307,31 +321,17 @@
         )
         {
             connection.Execute(
-                @"UPDATE Progress
+                $@"UPDATE Progress
                         SET
                             RemovedDate = @removedDate,
                             RemovalMethodID = 3
                         WHERE ProgressID IN
-                            (SELECT ProgressID
-                             FROM Progress AS P
-                             INNER JOIN GroupCustomisations AS GC ON P.CustomisationID = GC.CustomisationID
-                             WHERE P.Completed IS NULL
-                             AND P.EnrollmentMethodID = 3
-                             AND GC.GroupID = @groupId
-                             AND (P.CandidateID = @delegateId OR @delegateId IS NULL)
-                             AND P.RemovedDate IS NULL
-                             AND (P.LoginCount = 0 OR @deleteStartedEnrolment = 1)
-                             AND NOT EXISTS (SELECT * FROM GroupCustomisations AS GCInner
-                                                INNER JOIN GroupDelegates AS GD ON GCInner.GroupID = GD.GroupID
-                                                WHERE GCInner.CustomisationID = P.CustomisationID
-                                                AND GD.DelegateID = P.CandidateID
-                                                AND GCInner.GroupID != GC.GroupID))",
+                            ({SelectIdsOfGroupProgressRecordsSuitableForRemoval}
+                             AND (P.CandidateID = @delegateId OR @delegateId IS NULL))",
                 new { groupId, removedDate, deleteStartedEnrolment, delegateId }
             );
         }
 
-        // TODO: HEEDLS-689 see note on ticket regarding
-        // commonising duplicate SQL here and in method RemoveRelatedProgressRecordsForGroup
         public void RemoveRelatedProgressRecordsForGroupCourse(
             int groupId,
             int groupCustomisationId,
@@ -340,26 +340,13 @@
         )
         {
             connection.Execute(
-                @"UPDATE Progress
+                $@"UPDATE Progress
                         SET
                             RemovedDate = @timeOfRemoval,
                             RemovalMethodID = 3
                         WHERE ProgressID IN
-                            (SELECT ProgressID
-                             FROM Progress AS P
-                             INNER JOIN GroupCustomisations AS GC ON P.CustomisationID = GC.CustomisationID
-                             INNER JOIN GroupDelegates AS GD ON GD.DelegateID = P.CandidateID AND GD.GroupID = GC.GroupID
-                             WHERE P.Completed IS NULL
-                             AND P.EnrollmentMethodID = 3
-                             AND GC.GroupID = @groupId
-                             AND GC.GroupCustomisationID = @groupCustomisationId
-                             AND P.RemovedDate IS NULL
-                             AND (P.LoginCount = 0 OR @deleteStartedEnrolment = 1)
-                             AND NOT EXISTS (SELECT * FROM GroupCustomisations AS GCInner
-                                                INNER JOIN GroupDelegates AS GDInner ON GCInner.GroupID = GDInner.GroupID
-                                                WHERE GCInner.CustomisationID = P.CustomisationID
-                                                AND GDInner.DelegateID = P.CandidateID
-                                                AND GCInner.GroupID != GC.GroupID))",
+                            ({SelectIdsOfGroupProgressRecordsSuitableForRemoval}
+                             AND GC.GroupCustomisationID = @groupCustomisationId)",
                 new { groupId, timeOfRemoval, deleteStartedEnrolment, groupCustomisationId }
             );
         }
@@ -434,13 +421,12 @@
                     OUTPUT Inserted.GroupCustomisationId
                     VALUES
                         (@groupId, @customisationId, @completeWithinMonths, @addedByAdminUserId, @cohortLearners, @supervisorAdminID)",
-                new { groupId, customisationId, completeWithinMonths, addedByAdminUserId, cohortLearners, supervisorAdminId }
+                new
+                {
+                    groupId, customisationId, completeWithinMonths, addedByAdminUserId, cohortLearners,
+                    supervisorAdminId,
+                }
             );
-        }
-
-        public void RemoveRelatedProgressRecordsForGroupDelegate(int groupId, int delegateId, DateTime removedDate)
-        {
-            RemoveRelatedProgressRecordsForGroup(groupId, delegateId, false, removedDate);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -19,13 +19,6 @@
 
         string? GetGroupName(int groupId, int centreId);
 
-        void RemoveRelatedProgressRecordsForGroup(
-            int groupId,
-            int? delegateId,
-            bool removeStartedEnrolments,
-            DateTime removedDate
-        );
-
         int? GetGroupCentreId(int groupId);
 
         int? GetRelatedProgressIdForGroupDelegate(int groupId, int delegateId);
@@ -40,6 +33,13 @@
             int groupId,
             int groupCustomisationId,
             bool deleteStartedEnrolment,
+            DateTime removedDate
+        );
+
+        void RemoveRelatedProgressRecordsForGroup(
+            int groupId,
+            int? delegateId,
+            bool removeStartedEnrolments,
             DateTime removedDate
         );
 
@@ -272,11 +272,6 @@
             );
         }
 
-        public void RemoveRelatedProgressRecordsForGroup(int groupId, bool deleteStartedEnrolment, DateTime removedDate)
-        {
-            RemoveRelatedProgressRecordsForGroup(groupId, null, deleteStartedEnrolment, removedDate);
-        }
-
         public void DeleteGroupDelegates(int groupId)
         {
             connection.Execute(
@@ -311,6 +306,11 @@
                      WHERE GroupID = @groupId",
                 new { groupId }
             );
+        }
+
+        public void RemoveRelatedProgressRecordsForGroup(int groupId, bool deleteStartedEnrolment, DateTime removedDate)
+        {
+            RemoveRelatedProgressRecordsForGroup(groupId, null, deleteStartedEnrolment, removedDate);
         }
 
         public void RemoveRelatedProgressRecordsForGroup(


### PR DESCRIPTION
…leaned up related methods

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-500

### Description
Made one of the group progress removal methods more like the other by joining on group delegates to make sure that no non-group delegates are removed. Tidied up the code for progress removal methods to commonise the logic.

### Screenshots
N/A - all backend changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
