### PR TITLE
Heedls 625 centre admins results per page

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_ItemsPerPageSelect.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_ItemsPerPageSelect.cshtml
@@ -25,7 +25,7 @@
               asp-items="Model.ItemsPerPageSelectListItems"
               aria-label="Items per page">
       </select>
-      <button class="non-js-only nhsuk-search__submit items-per-page-submit" type="submit">
+      <button class="non-js-only nhsuk-search__submit items-per-page-submit" type="submit" asp-route-page="1">
         Update
       </button>
     </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_ItemsPerPageSelect.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_ItemsPerPageSelect.cshtml
@@ -23,7 +23,7 @@
               id="items-per-page-select"
               asp-for="ItemsPerPage"
               asp-items="Model.ItemsPerPageSelectListItems"
-              aria-label="Sort by">
+              aria-label="Items per page">
       </select>
       <button class="non-js-only nhsuk-search__submit items-per-page-submit" type="submit">
         Update


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-625

### Description
Changed the aria label on the items per page dropdown and change the no JS behaviour to bring the user back to the first page in line with the JS behaviour.

This change affects all 3 pages with the custom items per page, Centre admins, Course Setup and All delegates.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
