### PR TITLE
HEEDLS-565 Fix Sorting by name on Course Delegates page and parameter order

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
@@ -110,8 +110,8 @@
                 customisationId,
                 centreId,
                 sortBy,
-                sortDirection,
-                filterBy
+                filterBy,
+                sortDirection
             );
 
             const string fileName = "Digital Learning Solutions Course Delegates.xlsx";

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
@@ -30,6 +30,7 @@ export function getSortValue(
   sortBy: string,
 ): string | number | Date {
   switch (sortBy) {
+    case 'FullNameForSearchingSorting':
     case 'SearchableName':
     case 'FullName':
     case 'Name':


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-565

### Description
Fix the broken course delegate name Javascript sorting caused by previous refactoring, and incorrect parameter order causing exception when trying to load the page.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
