### PR TITLE
Heedls 500 learning log test fixes

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
@@ -35,19 +35,19 @@ export function getSortValue(
     case 'Name':
       return getElementText(searchableElement, 'name').toLocaleLowerCase();
     case 'DateRegistered':
-      return parseDate(getElementText(searchableElement, 'registration-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'registration-date'));
     case 'StartedDate':
-      return parseDate(getElementText(searchableElement, 'started-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'started-date'));
     case 'Enrolled':
-      return parseDate(getElementText(searchableElement, 'enrolled-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'enrolled-date'));
     case 'LastAccessed':
-      return parseDate(getElementText(searchableElement, 'accessed-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'accessed-date'));
     case 'LastUpdated':
-      return parseDate(getElementText(searchableElement, 'last-updated-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'last-updated-date'));
     case 'CompleteByDate':
-      return parseDate(getElementText(searchableElement, 'complete-by-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'complete-by-date'));
     case 'Completed':
-      return parseDate(getElementText(searchableElement, 'completed-date'));
+      return parseDateAndTime(getElementText(searchableElement, 'completed-date'));
     case 'HasDiagnostic,DiagnosticScore':
       return parseInt(getElementText(searchableElement, 'diagnostic-score').split('/')[0] || '-1', 10);
     case 'IsAssessed,Passes':
@@ -89,11 +89,6 @@ function getElementText(searchableElement: ISearchableElement, elementName: stri
   return searchableElement.element.querySelector(`[data-name-for-sorting="${elementName}"]`)?.textContent?.trim()
     ?? searchableElement.element.querySelector(`[name="${elementName}"]`)?.textContent?.trim()
     ?? '';
-}
-
-function parseDate(dateString: string): Date {
-  const date = moment(dateString, 'DD/MM/YYYY').toDate();
-  return date.toString() === 'Invalid Date' ? new Date(0) : date;
 }
 
 function parseDateAndTime(dateString: string): Date {

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/sort.ts
@@ -75,7 +75,7 @@ export function getSortValue(
     case 'CandidateNumber':
       return getElementText(searchableElement, 'delegate-id').toLocaleLowerCase();
     case 'When':
-      return parseDate(getElementText(searchableElement, 'when'));
+      return parseDateAndTime(getElementText(searchableElement, 'when'));
     case 'LearningTime':
       return parseNonNegativeIntOrNotApplicable(getElementText(searchableElement, 'learning-time'));
     case 'AssessmentScore':
@@ -94,6 +94,11 @@ function getElementText(searchableElement: ISearchableElement, elementName: stri
 function parseDate(dateString: string): Date {
   const date = moment(dateString, 'DD/MM/YYYY').toDate();
   return date.toString() === 'Invalid Date' ? new Date(0) : date;
+}
+
+function parseDateAndTime(dateString: string): Date {
+  const dateAndTime = moment(dateString, 'DD/MM/YYYY hh:mm:ss').toDate();
+  return dateAndTime.toString() === 'Invalid Date' ? new Date(0) : dateAndTime;
 }
 
 function parseNonNegativeIntOrNotApplicable(value: string): number {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-500

### Description
Fixed the issue raised in test that JS sorting by When did not take the hours/minutes/seconds into account. I've replaced the old parseDate method with one that takes considers hours/minutes/seconds. I've double checked, and this does not break places where we only display the date without the time.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
