### PR TITLE
DLSV2-491 Rework Learning Hub resource search to reuse existing pagination

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -28,8 +28,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             return View("Developer/EditCompetencyLearningResources", model);
         }
 
-        [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/CompetencyGroup/{frameworkCompetencyGroupId}/Signposting/AddResource")]
-        public async Task<IActionResult> SearchLearningResourcesAsync(int frameworkId, int frameworkCompetencyId, int? frameworkCompetencyGroupId, string searchText, int page = 1)
+        [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/CompetencyGroup/{frameworkCompetencyGroupId}/Signposting/AddResource/{page=1:int}")]
+        public async Task<IActionResult> SearchLearningResourcesAsync(int frameworkId, int frameworkCompetencyId, int? frameworkCompetencyGroupId, string searchText, int page)
         {
             var model = new CompetencyResourceSignpostingViewModel(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId);
             if (frameworkCompetencyGroupId.HasValue)
@@ -39,7 +39,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             }
             if (searchText?.Trim().Length > 1)
             {
-                model.Page = page; 
+                model.Page = Math.Max(page, 1);
                 model.SearchText = searchText;
                 try
                 {

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/BasePaginatedViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/BasePaginatedViewModel.cs
@@ -19,11 +19,11 @@
             ItemsPerPage = itemsPerPage;
         }
 
-        public int Page { get; protected set; }
+        public virtual int Page { get; set; }
 
-        public int TotalPages { get; protected set; }
+        public virtual int TotalPages { get; set; }
 
-        public int ItemsPerPage { get; protected set; }
+        public int ItemsPerPage { get; set; }
 
         public IEnumerable<SelectListItem> ItemsPerPageSelectListItems =>
             SelectListHelper.MapOptionsToSelectListItems(ItemsPerPageOptions);

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/BaseSignpostingViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/BaseSignpostingViewModel.cs
@@ -1,18 +1,20 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
+﻿using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+
+namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
 {
-    public class BaseSignpostingViewModel
+    public class BaseSignpostingViewModel : BasePaginatedViewModel
     {
         public int FrameworkId { get; set; }
         public int? FrameworkCompetencyId { get; set; }
         public int? FrameworkCompetencyGroupId { get; set; }
-        public BaseSignpostingViewModel(int frameworkId, int? frameworkCompetencyId, int? frameworkCompetencyGroupId)
+        public BaseSignpostingViewModel(int frameworkId, int? frameworkCompetencyId, int? frameworkCompetencyGroupId, int page = 1, int itemsPerPage = DefaultItemsPerPage) : this(page, itemsPerPage)
         {
             FrameworkId = frameworkId;
             FrameworkCompetencyId = frameworkCompetencyId;
             FrameworkCompetencyGroupId = frameworkCompetencyGroupId;
         }
 
-        public BaseSignpostingViewModel()
+        public BaseSignpostingViewModel(int page = 1, int itemsPerPage = DefaultItemsPerPage) : base(page, itemsPerPage)
         {
 
         }

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSignpostingViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSignpostingViewModel.cs
@@ -12,9 +12,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
         public List<SignpostingCardViewModel> CompetencyResourceLinks { get; set; }
         public IEnumerable<SearchableCompetencyViewModel> Delegates { get; set; }
         public string SearchText { get; set; }
-        public int Page { get; set; }
+        public override int Page { get; set; }
         public bool LearningHubApiError { get; set; }
-        public int TotalPages
+        public override int TotalPages
         {
             get
             {
@@ -35,7 +35,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
             return new CompetencyResourceSignpostingViewModel(model.FrameworkId, model.FrameworkCompetencyId, model.FrameworkCompetencyGroupId);
         }
 
-        public CompetencyResourceSignpostingViewModel(int frameworkId, int? frameworkCompetencyId, int? frameworkCompetencyGroupId) : base(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId)
+        public CompetencyResourceSignpostingViewModel(int frameworkId, int? frameworkCompetencyId, int? frameworkCompetencyGroupId) : base(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId, 1, ItemsPerPage)
         {
             FrameworkId = frameworkId;
             FrameworkCompetencyId = frameworkCompetencyId;

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -37,7 +37,7 @@
       <div class="search-box-container" id="search">
         @Html.LabelFor(m => m.SearchText, "Search", new { @class = "nhsuk-u-visually-hidden", @for = "search-field" })
         @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
-        <button class="nhsuk-search__submit sort-submit" type="submit">
+        <button class="nhsuk-search__submit sort-submit" type="submit" asp-route-page="1">
           Search
         </button>
       </div>
@@ -59,9 +59,10 @@ else if (Model.SearchResult?.Results != null)
 }
 @if (Model.TotalPages > 1)
 {
-  <div class="nhsuk-u-margin-bottom-0">
-    <partial name="Developer/_SignpostingPaginationNav" model="Model" />
-  </div>
+  <form method="get">
+    <partial name="PaginatedPage/_PaginationNav" model="Model" />
+    @Html.Hidden("SearchText", Model.SearchText)
+  </form>
 }
 <div class="nhsuk-back-link nhsuk-u-margin-left-1 nhsuk-u-margin-top-6">
   <a class="nhsuk-back-link__link" asp-action="EditCompetencyLearningResources" asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -30,20 +30,19 @@
     @Model.NameOfCompetency
   </p>
 </div>
-<form method="get" role="search" asp-route="~/Frameworks/{@Model.FrameworkId}/Competency/{@Model.FrameworkCompetencyId}/CompetencyGroup/{@Model.FrameworkCompetencyGroupId}/AddResource">
+<form method="get" role="search" asp-action="SearchLearningResourcesAsync">
   <h2>Search the Learning Hub</h2>
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-three-quarters">
       <div class="search-box-container" id="search">
         @Html.LabelFor(m => m.SearchText, "Search", new { @class = "nhsuk-u-visually-hidden", @for = "search-field" })
         @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
-        <button class="nhsuk-search__submit sort-submit" type="submit" asp-route-page="1">
+        <button class="nhsuk-search__submit sort-submit" type="submit" asp-route-page="1"  asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">
           Search
         </button>
       </div>
     </div>
   </div>
-  <input id="Page" name="Page" type="hidden" value="@Model.Page" />
 </form>
 @if (Model.LearningHubApiError)
 {


### PR DESCRIPTION


### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-491

### Description
Created override methods in CompetencyResourceSignpostingViewModel for using Shared\SearchablePage\_Pagination.cshtml and inherited from BasePaginatedViewModel. The urls and behaviuor should be the same as the implemented in Delegates/All Delegates.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/154717668-ec348103-d1eb-4632-953b-c353b51d5962.png)

Furthermore this change fixes problem with controller method preserving page number when user runs new search, as it could result in a different number of pages. So it makes more sense to reset current page to 1 when search button is clicked or user presses enter key on search field. 

```asp
        <button class="nhsuk-search__submit sort-submit" type="submit" asp-route-page="1">
          Search
        </button>
```

-----
### Developer checks
Pagination works either when
- Arriving by clicking on "Add resource" button (no parameters supplied for page and search text)
- After entering new search text and navigating to other pages in search results.

And also

- Result count is shown
- Next button is hidden on the last results page
- Previous button is hidden on first results page