### PR TITLE
HEEDLS-649 - make delegate progress field names consistent

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -104,7 +104,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
         )]
         [InlineData(
             "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/243104/EditCompletionDate",
-            "Edit completion date for Digital Literacy for the Workplace - CC Test"
+            "Edit completed date for Digital Literacy for the Workplace - CC Test"
         )]
         [InlineData(
             "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/243104/LearningLog",

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/DelegateCourseInfoViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/DelegateCourseInfoViewModelTests.cs
@@ -28,7 +28,7 @@
                 LastUpdated = updatedDate,
                 CompleteBy = completeByDate,
                 Completed = completedDate,
-                Evaluated = evaluatedDate
+                Evaluated = evaluatedDate,
             };
             var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
 
@@ -92,7 +92,7 @@
             // Given
             var info = new DelegateCourseInfo
             {
-                ApplicationName = "my application", CustomisationName = ""
+                ApplicationName = "my application", CustomisationName = "",
             };
             var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
 
@@ -110,7 +110,7 @@
             var info = new DelegateCourseInfo
             {
                 ApplicationName = "my application",
-                CustomisationName = "my customisation"
+                CustomisationName = "my customisation",
             };
             var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
 
@@ -127,7 +127,7 @@
             // Given
             var info = new DelegateCourseInfo
             {
-                SupervisorSurname = null
+                SupervisorSurname = null,
             };
             var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
 
@@ -135,7 +135,7 @@
             var model = new DelegateCourseInfoViewModel(details);
 
             // Then
-            model.Supervisor.Should().BeNull();
+            model.Supervisor.Should().Be("None");
         }
 
         [Test]
@@ -145,7 +145,7 @@
             var info = new DelegateCourseInfo
             {
                 SupervisorForename = "",
-                SupervisorSurname = "surname"
+                SupervisorSurname = "surname",
             };
             var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
 
@@ -163,7 +163,7 @@
             var info = new DelegateCourseInfo
             {
                 SupervisorForename = "firstname",
-                SupervisorSurname = "surname"
+                SupervisorSurname = "surname",
             };
             var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgress/DelegateProgressViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgress/DelegateProgressViewModelTests.cs
@@ -21,8 +21,8 @@
                 DelegateLastName = "Osbourne",
                 DelegateEmail = "Prince@Darkness",
                 SupervisorAdminId = null,
-                SupervisorForename = "Tony",
-                SupervisorSurname = "Iommi",
+                SupervisorForename = null,
+                SupervisorSurname = null,
                 EnrolledByAdminId = null,
                 EnrolledByForename = "Geezer",
                 EnrolledBySurname = "Butler",
@@ -65,11 +65,11 @@
             {
                 missingNamesViewModel.DelegateFullName.Should().Be("Osbourne");
                 missingNamesViewModel.DelegateNameAndEmail.Should().Be("Osbourne (Prince@Darkness)");
-                missingNamesViewModel.SupervisorFullName.Should().Be("None");
+                missingNamesViewModel.Supervisor.Should().Be("None");
                 missingNamesViewModel.EnrolledByFullName.Should().BeNull();
                 fullNamesViewModel.DelegateFullName.Should().Be("Ozzy Osbourne");
                 fullNamesViewModel.DelegateNameAndEmail.Should().Be("Ozzy Osbourne (Prince@Darkness)");
-                fullNamesViewModel.SupervisorFullName.Should().Be("Tony Iommi");
+                fullNamesViewModel.Supervisor.Should().Be("Tony Iommi");
                 fullNamesViewModel.EnrolledByFullName.Should().Be("Geezer Butler");
             }
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
@@ -56,7 +56,6 @@
         public int? EnrolledByAdminId { get; set; }
         public string? EnrolledByForename { get; set; }
         public string? EnrolledBySurname { get; set; }
-        public int DelegateId { get; set; }
         public string? DelegateFirstName { get; set; }
         public string DelegateLastName { get; set; }
         public string? DelegateEmail { get; set; }
@@ -71,9 +70,6 @@
 
         public string? EnrolledByFullName =>
             EnrolledByAdminId == null ? null : $"{EnrolledByForename} {EnrolledBySurname}";
-
-        public string SupervisorFullName =>
-            SupervisorAdminId == null ? "None" : $"{SupervisorForename} {SupervisorSurname}";
 
         public new string EnrolmentMethod
         {

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/DelegateCourseInfoViewModel.cs
@@ -67,19 +67,10 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.ViewD
         public double PassRate { get; set; }
         public bool IsProgressLocked { get; set; }
 
-        public string? Supervisor
-        {
-            get
-            {
-                // SupervisorSurname is not nullable in db; will only be null if no supervisor
-                if (SupervisorSurname == null)
-                {
-                    return null;
-                }
-
-                return (string.IsNullOrEmpty(SupervisorForename) ? "" : $"{SupervisorForename} ") + SupervisorSurname;
-            }
-        }
+        // SupervisorSurname is not nullable in db; will only be null if no supervisor
+        public string Supervisor => SupervisorSurname == null
+            ? "None"
+            : DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(SupervisorForename, SupervisorSurname);
 
         public string CourseName =>
             ApplicationName + (string.IsNullOrEmpty(CustomisationName) ? "" : $" - {CustomisationName}");

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -24,7 +24,7 @@
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
-            Last updated
+            Last access
           </dt>
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="last-updated-date">
             @Model.LastUpdated
@@ -48,7 +48,7 @@
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
-            Completed date
+            Completed
           </dt>
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="completed-date">
             @(Model.Completed ?? "-")
@@ -56,7 +56,7 @@
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
-            Removed date
+            Removed
           </dt>
           <partial name="_SummaryFieldValue" model="@Model.RemovedDate" />
         </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
@@ -1,16 +1,14 @@
 @using DigitalLearningSolutions.Web.Models.Enums
-@using DigitalLearningSolutions.Web.ViewComponents
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model EditCompletionDateViewModel
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Edit Completion Date" : "Edit Completion Date";
+  ViewData["Title"] = errorHasOccurred ? "Error: Edit Completed Date" : "Edit Completed Date";
 
   var routeParamsForBackLink = new Dictionary<string, string?>();
 
-  var cancelLinkController = "";
+  string cancelLinkController;
 
   if (Model.AccessedVia.Equals(DelegateProgressAccessRoute.CourseDelegates)) {
     routeParamsForBackLink.Add("accessedVia", Model.AccessedVia.ToString());
@@ -22,7 +20,9 @@
     cancelLinkController = "ViewDelegate";
   }
   var exampleDate = DateTime.Today;
-  var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the completion date" };
+  var hintTextLines = new List<string> {
+    $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the completion date",
+  };
 
 }
 
@@ -32,7 +32,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(@Model.Day), nameof(@Model.Month), nameof(@Model.Year)}" />
     }
 
-    <h1 class="nhsuk-heading-xl word-break">Edit completion date for @Model.CourseName</h1>
+    <h1 class="nhsuk-heading-xl word-break">Edit completed date for @Model.CourseName</h1>
 
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">
@@ -50,7 +50,7 @@
       <input type="hidden" asp-for="CourseName" />
       <input type="hidden" asp-for="ReturnPage" />
       <vc:date-input id="completion-date"
-                     label="Completion date"
+                     label="Completed date"
                      day-id="Day"
                      month-id="Month"
                      year-id="Year"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
@@ -21,7 +21,7 @@
   }
   var exampleDate = DateTime.Today;
   var hintTextLines = new List<string> {
-    $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the completion date",
+    $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the completed date",
   };
 
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
@@ -9,7 +9,7 @@
       Supervisor
     </dt>
     <dd class="nhsuk-summary-list__value">
-      @Model.SupervisorFullName
+      @Model.Supervisor
     </dd>
     <dd class="nhsuk-summary-list__actions">
       <a asp-controller="DelegateProgress"
@@ -50,7 +50,7 @@
 
   <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Last updated
+      Last access
     </dt>
     <dd class="nhsuk-summary-list__value">
       @Model.LastUpdated
@@ -60,7 +60,7 @@
 
   <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Completion date
+      Completed
     </dt>
     <partial name="_SummaryFieldValue" model="Model.Completed" />
     <dd class="nhsuk-summary-list__actions">
@@ -76,7 +76,7 @@
 
   <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Evaluation date
+      Evaluated
     </dt>
     <partial name="_SummaryFieldValue" model="Model.Evaluated" />
     <dd class="nhsuk-summary-list__actions" />
@@ -84,7 +84,7 @@
 
   <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Removed date
+      Removed
     </dt>
     <partial name="_SummaryFieldValue" model="Model.RemovedDate" />
     <dd class="nhsuk-summary-list__actions" />
@@ -112,7 +112,7 @@
 
   <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Learning time (mins)
+      Learning time
     </dt>
     <dd class="nhsuk-summary-list__value">
       @Model.LearningTime
@@ -124,7 +124,7 @@
     <dt class="nhsuk-summary-list__key">
       Diagnostic score
     </dt>
-    <partial name="_SummaryFieldValue" model="Model.DiagnosticScore?.ToString()" />
+    <partial name="_SummaryFieldValue" model="Model.DiagnosticScore.ToString()" />
     <dd class="nhsuk-summary-list__actions" />
   </div>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
@@ -124,7 +124,9 @@
     <dt class="nhsuk-summary-list__key">
       Diagnostic score
     </dt>
-    <partial name="_SummaryFieldValue" model="Model.DiagnosticScore.ToString()" />
+    <dd class="nhsuk-summary-list__value">
+      @(Model.DiagnosticScore?.ToString() ?? "N/A")
+    </dd>
     <dd class="nhsuk-summary-list__actions" />
   </div>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
@@ -52,7 +52,7 @@
 
         <div class="nhsuk-summary-list__row details-list-with-button__row">
           <dt class="nhsuk-summary-list__key">
-            Last updated
+            Last access
           </dt>
           <partial name="_SummaryFieldValue" model="@Model.LastUpdated" />
           <dd class="nhsuk-summary-list__actions"></dd>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
@@ -109,7 +109,9 @@
           <dt class="nhsuk-summary-list__key">
             Diagnostic score
           </dt>
-          <partial name="_SummaryFieldValue" model="@Model.DiagnosticScore.ToString()" />
+          <dd class="nhsuk-summary-list__value">
+            @(Model.DiagnosticScore?.ToString() ?? "N/A")
+          </dd>
           <dd class="nhsuk-summary-list__actions"></dd>
         </div>
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-649

### Description
Made changes to the Course Delegates cards, the View Delegate course cards, and the Delegate Progress page to make the names and display of various fields consistent. I'll comment on 567's PR to make sure the Detailed Progress page also has consistent names where appropriate.

### Screenshots
Delegate progress page:
![Delegate Progress](https://user-images.githubusercontent.com/80777689/154927977-a6bc0a5a-3620-4af8-8672-9b80bb058ba0.png)

View delegate course card:
![View Delegate cropped](https://user-images.githubusercontent.com/80777689/154927982-d81fb8a3-1ba8-4cde-a08d-a57783fda28b.png)

Course delegate card:
![Course delegate card](https://user-images.githubusercontent.com/80777689/154927984-9c5480da-eb59-4e53-b232-33ae209a557d.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
