### PR TITLE
DLSV2-366 Add Support tab to Frameworks

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/FrameworksController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/FrameworksController.cs
@@ -3,12 +3,15 @@
     using DigitalLearningSolutions.Data.ApiClients;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Models.Enums;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
 
     [Authorize(Policy = CustomPolicies.UserFrameworksAdminOnly)]
+    [SetDlsSubApplication(nameof(DlsSubApplication.Frameworks))]
     public partial class FrameworksController : Controller
     {
         private readonly IFrameworkService frameworkService;

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_NavMenuItems.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_NavMenuItems.cshtml
@@ -1,6 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.Extensions
 @using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.Models.Enums
+@using DigitalLearningSolutions.Data.Enums
 <li class="nhsuk-header__navigation-item @Html.IsSelected(controller: "Frameworks", action: "Index")">
   <a class="nhsuk-header__navigation-link" asp-controller="Frameworks" asp-action="Index">
     Dashboard
@@ -20,10 +21,16 @@
       <partial name="_NhsChevronRight" />
     </a>
   </li>
-  </feature>
-  <li class="nhsuk-header__navigation-item @Html.IsSelected(controller: "MyAccount", action: "Index")">
-    <a class="nhsuk-header__navigation-link" asp-controller="MyAccount" asp-action="Index" asp-route-dlsSubApplication="@DlsSubApplication.Frameworks.UrlSegment">
-      My account
-      <partial name="_NhsChevronRight" />
-    </a>
-  </li>
+</feature>
+<li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.Support)">
+  <a class="nhsuk-header__navigation-link" asp-controller="Support" asp-action="Index" asp-route-dlsSubApplication="@DlsSubApplication.Frameworks.UrlSegment">
+    Support
+    <partial name="_NhsChevronRight" />
+  </a>
+</li>
+<li class="nhsuk-header__navigation-item @Html.IsSelected(controller: "MyAccount", action: "Index")">
+  <a class="nhsuk-header__navigation-link" asp-controller="MyAccount" asp-action="Index" asp-route-dlsSubApplication="@DlsSubApplication.Frameworks.UrlSegment">
+    My account
+    <partial name="_NhsChevronRight" />
+  </a>
+</li>


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-366

### Description
Added a link to Support from the Nav Bar of the Frameworks application. When visiting the support page from Frameworks, the Frameworks nav bar should remain in place.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/154944549-1030df75-f6bc-4516-a1a2-79640dbed36d.png)
![image](https://user-images.githubusercontent.com/94055251/154944266-6bcb9233-11db-4d7d-bd3b-1332537af360.png)

-----
### Developer checks
- Looked into similar change for adding Support to Tracking System in [commit/abc4a47a](https://github.com/TechnologyEnhancedLearning/DLSV2/commit/abc4a47a) including `TrackingSystem/Shared/_NavMenuItems.cshtml` though controller decorator was added in a different commit after a merge.
- Checked that Framework Support behaves the same as Tracking System Support after my changes despite some links are broken when running in development environment.