### PR TITLE
Heedls 597 make return page logic more robust

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/search.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/search.ts
@@ -16,7 +16,7 @@ export function setUpSearch(onSearchUpdated: VoidFunction): void {
 
 export function search(searchableElements: ISearchableElement[]): ISearchableElement[] {
   const query = getQuery();
-  if (query.length === 0) {
+  if (query == null || query.length === 0) {
     return searchableElements;
   }
 
@@ -31,7 +31,7 @@ export function search(searchableElements: ISearchableElement[]): ISearchableEle
 
 export function getQuery(): string {
   const searchBox = getSearchBox();
-  return searchBox.value.trim();
+  return searchBox?.value.trim();
 }
 
 function getSearchBox(): HTMLInputElement {

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -28,6 +28,12 @@ export class SearchSortFilterAndPaginate {
 
   private readonly filterEnabled: boolean;
 
+  private spinnerContainer: HTMLElement;
+
+  private spinner: HTMLElement;
+
+  private areaToHide: HTMLElement;
+
   // Route provided should be a relative path with no leading /
   constructor(
     route: string,
@@ -37,6 +43,10 @@ export class SearchSortFilterAndPaginate {
     filterCookieName = '',
     searchableElementClassSuffixes = ['title'],
   ) {
+    this.spinnerContainer = document.getElementById('loading-spinner-container') as HTMLElement;
+    this.spinner = document.getElementById('dynamic-loading-spinner') as HTMLElement;
+    this.areaToHide = document.getElementById('area-to-hide-while-loading') as HTMLElement;
+    this.startLoadingSpinner();
     this.page = paginationEnabled ? SearchSortFilterAndPaginate.getPageNumber() : 1;
     this.searchEnabled = searchEnabled;
     this.paginationEnabled = paginationEnabled;
@@ -66,6 +76,7 @@ export class SearchSortFilterAndPaginate {
           this.updateSearchableElementLinks(searchableData);
         }
         this.searchSortAndPaginate(searchableData, false);
+        this.stopLoadingSpinner();
       });
   }
 
@@ -282,5 +293,17 @@ export class SearchSortFilterAndPaginate {
         anchor.search = params.toString();
       });
     });
+  }
+
+  private startLoadingSpinner(): void {
+    this.spinnerContainer?.classList.remove('display-none');
+    this.spinner?.classList.remove('loading-spinner');
+    this.areaToHide?.classList.add('display-none');
+  }
+
+  private stopLoadingSpinner(): void {
+    this.spinnerContainer?.classList.add('display-none');
+    this.spinner?.classList.add('loading-spinner');
+    this.areaToHide?.classList.remove('display-none');
   }
 }

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -279,7 +279,9 @@ export class SearchSortFilterAndPaginate {
   }
 
   private updateSearchableElementLinks(searchableData: ISearchableData): void {
-    const setReturnPage = !this.searchEnabled || getQuery().length === 0;
+    const searchBoxContent = getQuery();
+    const setReturnPage = !this.searchEnabled
+      || (searchBoxContent != null && searchBoxContent.length === 0);
 
     _.forEach(searchableData.searchableElements, (searchableElement) => {
       _.forEach(searchableElement.element.getElementsByTagName('a'), (anchor: HTMLAnchorElement) => {

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -298,12 +298,13 @@ export class SearchSortFilterAndPaginate {
   private startLoadingSpinner(): void {
     this.spinnerContainer?.classList.remove('display-none');
     this.spinner?.classList.remove('loading-spinner');
-    this.areaToHide?.classList.add('display-none');
   }
 
   private stopLoadingSpinner(): void {
     this.spinnerContainer?.classList.add('display-none');
     this.spinner?.classList.add('loading-spinner');
-    this.areaToHide?.classList.remove('display-none');
+    if (this.areaToHide !== null) {
+      this.areaToHide.style.display = 'inline';
+    }
   }
 }

--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -117,6 +117,12 @@ nav, .nhsuk-header__navigation, #header-navigation {
   }
 }
 
+#area-to-hide-while-loading {
+  .js-enabled & {
+    display: none;
+  }
+}
+
 #loading-spinner-container {
   height: 500px;
 }

--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -116,6 +116,11 @@ nav, .nhsuk-header__navigation, #header-navigation {
     display: block;
   }
 }
+
+#loading-spinner-container {
+  height: 500px;
+}
+
 .loading-spinner {
   margin: 0;
   height: 0;
@@ -131,12 +136,24 @@ nav, .nhsuk-header__navigation, #header-navigation {
   top: 50%;
   left: 50%;
   transform: var(--center);
+
+  &.page-has-side-nav-menu {
+    @include mq($from: desktop) {
+      left: 55%;
+    }
+  }
 }
 
 .outer-spin, .inner-spin {
   position: absolute;
   top: 50%;
   left: 50%;
+
+  &.page-has-side-nav-menu {
+    @include mq($from: desktop) {
+      left: 55%;
+    }
+  }
 }
 
 .outer-spin {

--- a/DigitalLearningSolutions.Web/ViewComponents/LoadingSpinnerViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/LoadingSpinnerViewComponent.cs
@@ -1,0 +1,14 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+    using Microsoft.AspNetCore.Mvc;
+
+    public class LoadingSpinnerViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(bool pageHasSideNavMenu)
+        {
+            var model = new LoadingSpinnerViewModel(pageHasSideNavMenu);
+            return View(model);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/LoadingSpinnerViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/LoadingSpinnerViewModel.cs
@@ -1,0 +1,12 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+{
+    public class LoadingSpinnerViewModel
+    {
+        public LoadingSpinnerViewModel(bool pageHasSideNavMenu)
+        {
+            PageHasSideNavMenu = pageHasSideNavMenu;
+        }
+
+        public bool PageHasSideNavMenu { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -17,7 +17,7 @@
 }
 
 <vc:loading-spinner page-has-side-nav-menu="false" />
-<div class="nhsuk-grid-row area-to-hide-while-loading">
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">Available Activities</h1>
     @if (Model.BannerText != null) {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -16,36 +16,31 @@
   <partial name="Shared/_NavMenuItems" />
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">Available Activities</h1>
-    @if (Model.BannerText != null)
-    {
+    @if (Model.BannerText != null) {
       <h2 class="page-subheading">@Model.BannerText</h2>
     }
 
     <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
 
     <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
-    @if (Model.NoDataFound)
-    {
+    @if (Model.NoDataFound) {
       <p class="nhsuk-u-margin-top-4" role="alert">
         <b>No data to display</b>
       </p>
-    }
-    else
-    {
+    } else {
       <partial name="SearchablePage/_SearchResultsCount" model="Model" />
 
       <div id="searchable-elements">
-        @foreach (var availableCourse in Model.AvailableCourses)
-        {
+        @foreach (var availableCourse in Model.AvailableCourses) {
           <partial name="Available/_AvailableCourseCard" model="availableCourse" />
         }
       </div>
     }
-    @if (Model.TotalPages > 1)
-    {
+    @if (Model.TotalPages > 1) {
       <partial name="SearchablePage/_Pagination" model="Model" />
     }
   </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -8,7 +8,8 @@
   ViewData["Title"] = "Learning Portal - Completed";
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">My Completed Activities</h1>
     @if (Model.BannerText != null) {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -9,7 +9,7 @@
 }
 
 <vc:loading-spinner page-has-side-nav-menu="false" />
-<div class="nhsuk-grid-row area-to-hide-while-loading">
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">My Completed Activities</h1>
     @if (Model.BannerText != null) {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -18,7 +18,8 @@
   <partial name="Shared/_NavMenuItems" />
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">My Current Activities</h1>
     @if (Model.BannerText != null) {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -19,7 +19,7 @@
 }
 
 <vc:loading-spinner page-has-side-nav-menu="false" />
-<div class="nhsuk-grid-row area-to-hide-while-loading">
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">My Current Activities</h1>
     @if (Model.BannerText != null) {
@@ -31,13 +31,13 @@
                                     text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
     }
 
+    <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
+
     @if (Model.NoDataFound) {
       <p class="nhsuk-u-margin-top-4" role="alert">
         <b>You are not enrolled on anything.</b> View <a asp-action="Available">Available activities</a>.
       </p>
     } else {
-      <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
-
       <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
       <partial name="SearchablePage/_SearchResultsCount" model="Model" />
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/RecommendedLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/RecommendedLearning.cshtml
@@ -24,7 +24,7 @@
 }
 
 <vc:loading-spinner page-has-side-nav-menu="false" />
-<div class="nhsuk-grid-row area-to-hide-while-loading">
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/RecommendedLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/RecommendedLearning/RecommendedLearning.cshtml
@@ -23,7 +23,8 @@
   <li class="nhsuk-breadcrumb__item">Recommended Learning</li>
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
 
@@ -32,9 +33,8 @@
         <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
                                       text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
       }
-      <vc:inset-text
-        css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
-        text="@LearningHubWarningTextHelper.AutomaticLogin" />
+      <vc:inset-text css-class="nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
+                     text="@LearningHubWarningTextHelper.AutomaticLogin" />
     </div>
 
     <partial name="SearchablePage/_Search" model="Model" />

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/LoadingSpinner/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/LoadingSpinner/Default.cshtml
@@ -1,0 +1,40 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@model LoadingSpinnerViewModel
+@{
+  var sideNavMenuCentreClass = Model.PageHasSideNavMenu ? "page-has-side-nav-menu" : null;
+}
+
+<div id="loading-spinner-container" class="display-none">
+  <div id="dynamic-loading-spinner" class="loading-spinner" role="alert" aria-live="assertive">
+    <p class="visually-hidden">Content is loading...</p>
+    <div role="none" aria-hidden="true">
+      <div class="center-this @sideNavMenuCentreClass"></div>
+
+      <div class="inner-spin @sideNavMenuCentreClass">
+
+        <div class="inner-arc inner-arc_start-a"></div>
+        <div class="inner-arc inner-arc_end-a"></div>
+
+        <div class="inner-arc inner-arc_start-b"></div>
+        <div class="inner-arc inner-arc_end-b"></div>
+
+        <div class="inner-moon-a"></div>
+        <div class="inner-moon-b"></div>
+
+      </div>
+
+      <div class="outer-spin @sideNavMenuCentreClass">
+
+        <div class="outer-arc outer-arc_start-a"></div>
+        <div class="outer-arc outer-arc_end-a"></div>
+
+        <div class="outer-arc outer-arc_start-b"></div>
+        <div class="outer-arc outer-arc_end-b"></div>
+
+        <div class="outer-moon-a"></div>
+        <div class="outer-moon-b"></div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
@@ -23,77 +23,81 @@
     </p>
   </nav>
 }
-<h1>My Staff</h1>
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    @if (Model.SuperviseDelegateDetailViewModels.Any() | Model.SearchString != null)
-    {
-      <form method="get" role="search" asp-action="Index" asp-route-page="@Model.Page">
-        <div class="nhsuk-grid-row">
-          <partial name="SearchablePage/_Search" model="Model" />
-        </div>
-        <div class="nhsuk-grid-row">
-          <div class="nhsuk-grid-column-full">
-            <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-            <input type="hidden" id="select-sort-by" value="Name" />
-            <input type="hidden" id="select-sort-direction" value="Ascending" />
-            @if (@Model.SuperviseDelegateDetailViewModels.Any())
-            {
-              <div id="searchable-elements">
-                @foreach (var supervisorDelegateDetail in Model.SuperviseDelegateDetailViewModels)
-                {
-                  <partial name="Shared/_StaffMemberCard" model="supervisorDelegateDetail" />
-                }
-              </div>
-              if (Model.TotalPages > 1)
+
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div id="area-to-hide-while-loading">
+  <h1>My Staff</h1>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      @if (Model.SuperviseDelegateDetailViewModels.Any() | Model.SearchString != null)
+      {
+        <form method="get" role="search" asp-action="Index" asp-route-page="@Model.Page">
+          <div class="nhsuk-grid-row">
+            <partial name="SearchablePage/_Search" model="Model" />
+          </div>
+          <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-full">
+              <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+              <input type="hidden" id="select-sort-by" value="Name" />
+              <input type="hidden" id="select-sort-direction" value="Ascending" />
+              @if (@Model.SuperviseDelegateDetailViewModels.Any())
               {
-                <partial name="SearchablePage/_Pagination" model="Model" />
+                <div id="searchable-elements">
+                  @foreach (var supervisorDelegateDetail in Model.SuperviseDelegateDetailViewModels)
+                  {
+                    <partial name="Shared/_StaffMemberCard" model="supervisorDelegateDetail" />
+                  }
+                </div>
+                if (Model.TotalPages > 1)
+                {
+                  <partial name="SearchablePage/_Pagination" model="Model" />
+                }
               }
-            }
-            else
-            {
-              <p>Please change your search criteria and try again.</p>
-            }
+              else
+              {
+                <p>Please change your search criteria and try again.</p>
+              }
+            </div>
+          </div>
+        </form>
+      }
+      else
+      {
+        <p>You are not supervising any staff, yet.</p>
+      }
+    </div>
+  </div>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <form method="post">
+        <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
+          <h2>Add a member of staff</h2>
+        </label>
+        <div class="nhsuk-form-group">
+          <div class=" sort-select-container">
+            <label class="nhsuk-label" for="delegateEmail">
+              User email address
+            </label>
+            <div class="nhsuk-hint" id="add-user-hint">
+              Provide the work email address of a member of staff to add to your supervision list.
+            </div>
+            <input class="nhsuk-input" id="delegateEmail" aria-describedby="add-user-hint" type="email" name="delegateEmail" />
           </div>
         </div>
+        <button class="nhsuk-button" type="submit">
+          Submit
+        </button>
       </form>
-    }
-    else
-    {
-      <p>You are not supervising any staff, yet.</p>
-    }
     </div>
   </div>
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <form method="post">
-      <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
-        <h2>Add a member of staff</h2>
-      </label>
-      <div class="nhsuk-form-group">
-        <div class=" sort-select-container">
-          <label class="nhsuk-label" for="delegateEmail">
-            User email address
-          </label>
-          <div class="nhsuk-hint" id="add-user-hint">
-            Provide the work email address of a member of staff to add to your supervision list.
-          </div>
-          <input class="nhsuk-input" id="delegateEmail" aria-describedby="add-user-hint" type="email" name="delegateEmail" />
-        </div>
-      </div>
-      <button class="nhsuk-button" type="submit">
-        Submit
-      </button>
-    </form>
-    </div>
- </div>
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-4" asp-action="AddMultipleSuperviseDelegates">
-      Add multiple staff members
-    </a>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-4" asp-action="AddMultipleSuperviseDelegates">
+        Add multiple staff members
+      </a>
     </div>
   </div>
-    @section scripts {
-      <script src="@Url.Content("~/js/supervisor/staffList.js")" asp-append-version="true"></script>
-    }
+</div>
+@section scripts {
+  <script src="@Url.Content("~/js/supervisor/staffList.js")" asp-append-version="true"></script>
+}

--- a/DigitalLearningSolutions.Web/Views/Support/Faqs/Faqs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Faqs/Faqs.cshtml
@@ -21,29 +21,31 @@
   </div>
 
   <div class="nhsuk-grid-column-three-quarters">
-    <h1 class="nhsuk-heading-xl">FAQs</h1>
+    <vc:loading-spinner page-has-side-nav-menu="true" />
+    <div id="area-to-hide-while-loading">
+      <h1 class="nhsuk-heading-xl">FAQs</h1>
 
-    <partial name="SearchablePage/_Search" model="Model" />
-    <input type="hidden" id="select-sort-by" value="@Model.SortBy" data-sort-by-multiple="true" />
-    <input type="hidden" id="select-sort-direction" value="@Model.SortDirection" />
+      <partial name="SearchablePage/_Search" model="Model" />
+      <input type="hidden" id="select-sort-by" value="@Model.SortBy" data-sort-by-multiple="true" />
+      <input type="hidden" id="select-sort-direction" value="@Model.SortDirection" />
 
-    @if (Model.NoDataFound) {
-      <p class="nhsuk-u-margin-top-4" role="alert">
-        <b>No FAQs found.</b>
-      </p>
-    } else {
-      <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+      @if (Model.NoDataFound) {
+        <p class="nhsuk-u-margin-top-4" role="alert">
+          <b>No FAQs found.</b>
+        </p>
+      } else {
+        <partial name="SearchablePage/_SearchResultsCount" model="Model" />
 
-      <div id="searchable-elements">
-        @foreach (var faq in Model.Faqs) {
-          <partial name="_SearchableFaqCard" model="faq" />
-        }
-      </div>
-    }
-    @if (Model.TotalPages > 1) {
-      <partial name="SearchablePage/_Pagination" model="Model" />
-    }
-
+        <div id="searchable-elements">
+          @foreach (var faq in Model.Faqs) {
+            <partial name="_SearchableFaqCard" model="faq" />
+          }
+        </div>
+      }
+      @if (Model.TotalPages > 1) {
+        <partial name="SearchablePage/_Pagination" model="Model" />
+      }
+    </div>
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/Support/Shared/_SupportSideNavMenu.cshtml" model="@Model" />
     </nav>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/Index.cshtml
@@ -18,13 +18,15 @@
   </div>
 
   <div class="nhsuk-grid-column-three-quarters">
-    <div class="nhsuk-u-margin-bottom-4">
-      <h1 class="nhsuk-heading-xl">Centre administrators</h1>
+    <vc:loading-spinner page-has-side-nav-menu="true" />
+    <div id="area-to-hide-while-loading">
+      <div class="nhsuk-u-margin-bottom-4">
+        <h1 class="nhsuk-heading-xl">Centre administrators</h1>
 
-      <vc:number-of-administrators centre-id="Model.CentreId" />
-    </div>
+        <vc:number-of-administrators centre-id="Model.CentreId" />
+      </div>
 
-    <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchAndFilter" model="Model" />
+      <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchAndFilter" model="Model" />
 
     @if (Model.NoDataFound) {
       <p class="nhsuk-u-margin-top-4" role="alert">
@@ -33,15 +35,16 @@
     } else {
       <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
 
-      <div id="searchable-elements">
-        @foreach (var admin in Model.Admins) {
-          <partial name="_SearchableAdminCard" model="admin" />
-        }
-      </div>
-    }
-    @if (Model.TotalPages > 1) {
-      <partial name="SearchablePage/_Pagination" model="Model" />
-    }
+        <div id="searchable-elements">
+          @foreach (var admin in Model.Admins) {
+            <partial name="_SearchableAdminCard" model="admin" />
+          }
+        </div>
+      }
+      @if (Model.TotalPages > 1) {
+        <partial name="SearchablePage/_Pagination" model="Model" />
+      }
+    </div>
 
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml" model="CentrePage.Administrators" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/Index.cshtml
@@ -9,35 +9,36 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
+    <vc:loading-spinner page-has-side-nav-menu="false" />
+    <div id="area-to-hide-while-loading">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-three-quarters">
+          <h1 class="nhsuk-heading-xl">Centre course setup</h1>
+        </div>
+        <div class="nhsuk-grid-column-one-quarter heading-button-group">
+          <a class="nhsuk-button heading-button nhsuk-u-margin-bottom-5" asp-controller="CourseSetup" asp-action="AddCourseNew" role="button">
+            Add
+          </a>
+        </div>
+      </div>
 
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-three-quarters">
-        <h1 class="nhsuk-heading-xl">Centre course setup</h1>
-      </div>
-      <div class="nhsuk-grid-column-one-quarter heading-button-group">
-        <a class="nhsuk-button heading-button nhsuk-u-margin-bottom-5" asp-controller="CourseSetup" asp-action="AddCourseNew" role="button">
-          Add
-        </a>
-      </div>
+      <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
+
+      @if (Model.NoDataFound) {
+        <p>The centre has no courses set up yet.</p>
+      } else {
+        <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
+
+        <div id="searchable-elements">
+          @foreach (var course in Model.Courses) {
+            <partial name="_CentreCourseCard" model="course" />
+          }
+        </div>
+      }
+      @if (Model.TotalPages > 1) {
+        <partial name="SearchablePage/_Pagination" model="Model" />
+      }
     </div>
-
-    <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
-
-    @if (Model.NoDataFound) {
-      <p>The centre has no courses set up yet.</p>
-    } else {
-      <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
-
-      <div id="searchable-elements">
-        @foreach (var course in Model.Courses) {
-          <partial name="_CentreCourseCard" model="course" />
-        }
-      </div>
-    }
-    @if (Model.TotalPages > 1) {
-      <partial name="SearchablePage/_Pagination" model="Model" />
-    }
-
   </div>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/Index.cshtml
@@ -18,49 +18,47 @@
   </div>
 
   <div class="nhsuk-grid-column-three-quarters">
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-one-third">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Delegates</h1>
+    <vc:loading-spinner page-has-side-nav-menu="true" />
+    <div id="area-to-hide-while-loading">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-one-third">
+          <h1 id="page-heading" class="nhsuk-heading-xl">Delegates</h1>
+        </div>
+        <div class="nhsuk-grid-column-two-thirds heading-button-group">
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" asp-controller="RegisterDelegateByCentre" asp-action="Index" role="button">
+            Register
+          </a>
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" asp-controller="EmailDelegates" asp-action="Index" role="button">
+            Email
+          </a>
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" asp-controller="BulkUpload" asp-action="Index" role="button">
+            Upload
+          </a>
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
+            Export
+          </a>
+        </div>
       </div>
-      <div class="nhsuk-grid-column-two-thirds heading-button-group">
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" asp-controller="RegisterDelegateByCentre" asp-action="Index" role="button">
-          Register
-        </a>
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" asp-controller="EmailDelegates" asp-action="Index" role="button">
-          Email
-        </a>
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" asp-controller="BulkUpload" asp-action="Index" role="button">
-          Upload
-        </a>
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
-          Export
-        </a>
-      </div>
+
+      <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
+
+      @if (Model.NoDataFound) {
+        <p class="nhsuk-u-margin-top-4" role="alert">
+          <b>No delegates found.</b>
+        </p>
+      } else {
+        <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
+
+        <div id="searchable-elements">
+          @foreach (var delegateModel in Model.Delegates) {
+            <partial name="_SearchableDelegateCard" model="delegateModel" />
+          }
+        </div>
+      }
+      @if (Model.TotalPages > 1) {
+        <partial name="SearchablePage/_Pagination" model="Model" />
+      }
     </div>
-
-    <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
-
-    @if (Model.NoDataFound)
-    {
-      <p class="nhsuk-u-margin-top-4" role="alert">
-        <b>No delegates found.</b>
-      </p>
-    }
-    else
-    {
-      <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
-
-      <div id="searchable-elements">
-        @foreach (var delegateModel in Model.Delegates)
-        {
-          <partial name="_SearchableDelegateCard" model="delegateModel" />
-        }
-      </div>
-    }
-    @if (Model.TotalPages > 1)
-    {
-      <partial name="SearchablePage/_Pagination" model="Model" />
-    }
 
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.AllDelegates" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
@@ -20,89 +20,92 @@
   </div>
 
   <div class="nhsuk-grid-column-three-quarters">
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-one-third">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Course delegates</h1>
+    <vc:loading-spinner page-has-side-nav-menu="true" />
+    <div id="area-to-hide-while-loading">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-one-third">
+          <h1 id="page-heading" class="nhsuk-heading-xl">Course delegates</h1>
+        </div>
+        <div class="nhsuk-grid-column-two-thirds heading-button-group">
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
+            Export all
+          </a>
+          <a class="nhsuk-button nhsuk-button--secondary heading-button"
+             id="export-current"
+             asp-controller="CourseDelegates"
+             asp-action="DownloadCurrent"
+             asp-route-customisationId="@Model.CustomisationId"
+             asp-route-sortBy="@Model.CourseDetails?.SortBy"
+             asp-route-sortDirection="@Model.CourseDetails?.SortDirection"
+             asp-route-filterBy="@Model.CourseDetails?.FilterBy"
+             role="button">
+            Export current
+          </a>
+        </div>
       </div>
-      <div class="nhsuk-grid-column-two-thirds heading-button-group">
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
-          Export all
-        </a>
-        <a class="nhsuk-button nhsuk-button--secondary heading-button"
-           id="export-current"
-           asp-controller="CourseDelegates"
-           asp-action="DownloadCurrent"
-           asp-route-customisationId="@Model.CustomisationId"
-           asp-route-sortBy="@Model.CourseDetails?.SortBy"
-           asp-route-sortDirection="@Model.CourseDetails?.SortDirection"
-           asp-route-filterBy="@Model.CourseDetails?.FilterBy"
-           role="button">
-          Export current
-        </a>
-      </div>
-    </div>
-
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
-        <p>
-          Choose a course to see delegates enrolled on it. If you'd like to export delegates on all courses, click "Export all" above.
-        </p>
-      </div>
-    </div>
-
-    @if (Model.Courses.Any() && Model.CourseDetails != null) {
-      @if (!Model.CourseDetails.Active) {
-        <partial name="~/Views/TrackingSystem/Shared/_InactiveCourseInset.cshtml" />
-      }
 
       <div class="nhsuk-grid-row">
-        <form method="get" role="search">
-          <div class="nhsuk-grid-column-full nhsuk-form-group">
-            <label class="nhsuk-label--s nhsuk-u-margin-bottom-1">Choose course</label>
-            <div class="course-dropdown-container">
-              <select id="selected-customisation-Id" class="nhsuk-select nhsuk-search__input nhsuk-search__input--withdropdown course-dropdown"
-                      asp-for="CustomisationId"
-                      asp-items="Model.Courses"
-                      aria-label="Choose course">
-              </select>
-              <button class="nhsuk-search__submit course-submit" type="submit">
-                Select
-              </button>
+        <div class="nhsuk-grid-column-full">
+          <p>
+            Choose a course to see delegates enrolled on it. If you'd like to export delegates on all courses, click "Export all" above.
+          </p>
+        </div>
+      </div>
+
+      @if (Model.Courses.Any() && Model.CourseDetails != null) {
+        @if (!Model.CourseDetails.Active) {
+          <partial name="~/Views/TrackingSystem/Shared/_InactiveCourseInset.cshtml" />
+        }
+
+        <div class="nhsuk-grid-row">
+          <form method="get" role="search">
+            <div class="nhsuk-grid-column-full nhsuk-form-group">
+              <label class="nhsuk-label--s nhsuk-u-margin-bottom-1">Choose course</label>
+              <div class="course-dropdown-container">
+                <select id="selected-customisation-Id" class="nhsuk-select nhsuk-search__input nhsuk-search__input--withdropdown course-dropdown"
+                        asp-for="CustomisationId"
+                        asp-items="Model.Courses"
+                        aria-label="Choose course">
+                </select>
+                <button class="nhsuk-search__submit course-submit" type="submit">
+                  Select
+                </button>
+              </div>
             </div>
+          </form>
+        </div>
+
+        <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSortAndFilter" model="Model.CourseDetails" />
+
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-full">
+            @if (Model.CourseDetails.NoDataFound) {
+              <p class="nhsuk-u-margin-top-4" role="alert">
+                <b>No delegates are enrolled on this course.</b>
+              </p>
+            } else {
+              <partial name="SearchablePage/_SearchResultsCount" model="Model.CourseDetails" />
+
+              <div id="searchable-elements">
+                @foreach (var delegateUser in Model.CourseDetails.Delegates) {
+                  <partial name="_SearchableCourseDelegateCard" model="delegateUser" />
+                }
+              </div>
+            }
+            @if (Model.CourseDetails.TotalPages > 1) {
+              <partial name="SearchablePage/_Pagination" model="Model.CourseDetails" />
+            }
           </div>
-        </form>
-      </div>
-
-      <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSortAndFilter" model="Model.CourseDetails" />
-
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-full">
-          @if (Model.CourseDetails.NoDataFound) {
-            <p class="nhsuk-u-margin-top-4" role="alert">
-              <b>No delegates are enrolled on this course.</b>
-            </p>
-          } else {
-            <partial name="SearchablePage/_SearchResultsCount" model="Model.CourseDetails" />
-
-            <div id="searchable-elements">
-              @foreach (var delegateUser in Model.CourseDetails.Delegates) {
-                <partial name="_SearchableCourseDelegateCard" model="delegateUser" />
-              }
-            </div>
-          }
-          @if (Model.CourseDetails.TotalPages > 1) {
-            <partial name="SearchablePage/_Pagination" model="Model.CourseDetails" />
-          }
         </div>
-      </div>
-    } else {
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-full">
-          <p class="nhsuk-body-m">There are no courses set up in your centre for the category you manage.</p>
-          <vc:action-link asp-controller="CourseSetup" asp-action="Index" link-text="Course setup"></vc:action-link>
+      } else {
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-full">
+            <p class="nhsuk-body-m">There are no courses set up in your centre for the category you manage.</p>
+            <vc:action-link asp-controller="CourseSetup" asp-action="Index" link-text="Course setup"></vc:action-link>
+          </div>
         </div>
-      </div>
-    }
+      }
+    </div>
 
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.CourseDelegates" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/Index.cshtml
@@ -18,39 +18,42 @@
   </div>
 
   <div class="nhsuk-grid-column-three-quarters">
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-one-third">
-        <h1 id="page-heading" class="nhsuk-heading-xl">Groups</h1>
+    <vc:loading-spinner page-has-side-nav-menu="true" />
+    <div id="area-to-hide-while-loading">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-one-third">
+          <h1 id="page-heading" class="nhsuk-heading-xl">Groups</h1>
+        </div>
+        <div class="nhsuk-grid-column-two-thirds heading-button-group">
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button" asp-action="AddDelegateGroup">
+            Add
+          </a>
+          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
+            Generate
+          </a>
+        </div>
       </div>
-      <div class="nhsuk-grid-column-two-thirds heading-button-group">
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button" asp-action="AddDelegateGroup">
-          Add
-        </a>
-        <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
-          Generate
-        </a>
-      </div>
+
+      <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
+
+      @if (Model.NoDataFound) {
+        <p class="nhsuk-u-margin-top-4" role="alert">
+          <b>No delegate groups found.</b>
+        </p>
+      } else {
+        <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+
+        <div id="searchable-elements">
+          @foreach (var groupModel in Model.DelegateGroups) {
+            <partial name="_SearchableDelegateGroupCard" model="groupModel" />
+          }
+        </div>
+      }
+      @if (Model.TotalPages > 1) {
+        <partial name="SearchablePage/_Pagination" model="Model" />
+      }
+
     </div>
-
-    <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
-
-    @if (Model.NoDataFound) {
-      <p class="nhsuk-u-margin-top-4" role="alert">
-        <b>No delegate groups found.</b>
-      </p>
-    } else {
-      <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-
-      <div id="searchable-elements">
-        @foreach (var groupModel in Model.DelegateGroups) {
-          <partial name="_SearchableDelegateGroupCard" model="groupModel" />
-        }
-      </div>
-    }
-    @if (Model.TotalPages > 1) {
-      <partial name="SearchablePage/_Pagination" model="Model" />
-    }
-
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateGroups" />
     </nav>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/Index.cshtml
@@ -9,10 +9,13 @@
   ViewData["Title"] = "Send welcome messages";
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   var exampleDate = DateTime.Today;
-  var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}" };
+  var hintTextLines = new List<string> {
+    $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}",
+  };
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">Send welcome messages</h1>
     @if (errorHasOccurred) {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupCourses/AddCourseToGroupSelectCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupCourses/AddCourseToGroupSelectCourse.cshtml
@@ -10,7 +10,8 @@
   };
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl word-break">@ViewData["Title"]</h1>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupDelegates/SelectDelegate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupDelegates/SelectDelegate.cshtml
@@ -12,7 +12,8 @@
   };
 }
 
-<div class="nhsuk-grid-row">
+<vc:loading-spinner page-has-side-nav-menu="false" />
+<div class="nhsuk-grid-row" id="area-to-hide-while-loading">
   <div class="nhsuk-grid-column-full">
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-597

### Description
A bug was occurring on the supervisor staff list page when trying to set the link return pages when no data was available. This caused an exception, preventing the JS from reaching the point where the loading spinner stops. The cause was the return page code not being able to handle a case where the Search Box does not exist (not rendered when no data is found).

Because of this bug, the initial loading spinner commits were reverted. As part of this PR, I've reverted those two revertions (first two commits). In the third commit, I've made the JS more robust, so it should be able to handle any further pages where the search box is not rendered.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
