### PR TITLE
HEEDLS-510 Split custom prompt

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
@@ -44,7 +44,7 @@
         }
 
         [Test]
-        public void UpdateCustomPromptForCourse_correctly_updates_custom_prompt()
+        public void UpdateAdminFieldForCourse_correctly_updates_custom_prompt()
         {
             using var transaction = new TransactionScope();
             try
@@ -53,7 +53,7 @@
                 const string? options = "options";
 
                 // When
-                courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 1, 1, options);
+                courseAdminFieldsDataService.UpdateAdminFieldForCourse(100, 1, 1, options);
                 var courseAdminFields = courseAdminFieldsDataService.GetCourseAdminFields(100);
 
                 // Then
@@ -69,7 +69,7 @@
         }
 
         [Test]
-        public void GetPromptNameForCourseAndPromptNumber_returns_expected_prompt_name()
+        public void GetPromptName_returns_expected_prompt_name()
         {
             // When
             var result = courseAdminFieldsDataService.GetPromptName(100, 1);
@@ -79,7 +79,7 @@
         }
 
         [Test]
-        public void UpdateCustomPromptForCourse_correctly_adds_custom_prompt()
+        public void UpdateAdminFieldForCourse_correctly_adds_custom_prompt()
         {
             using var transaction = new TransactionScope();
             try
@@ -88,7 +88,7 @@
                 const string? options = "options";
 
                 // When
-                courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 3, 1, options);
+                courseAdminFieldsDataService.UpdateAdminFieldForCourse(100, 3, 1, options);
                 var courseCustomPrompts = courseAdminFieldsDataService.GetCourseAdminFields(100);
                 var customPrompt = courseAdminFieldsDataService.GetCoursePromptsAlphabetical()
                     .Single(c => c.id == 1)

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseAdminFieldsServiceTests.cs
@@ -32,64 +32,64 @@
         }
 
         [Test]
-        public void GetCustomPromptsForCourse_Returns_Populated_CourseAdminFields()
+        public void GetCoursePromptsForCourse_Returns_Populated_CourseAdminFields()
         {
             // Given
             var expectedPrompt1 =
-                CustomPromptsTestHelper.GetDefaultCustomPrompt(1, "System Access Granted", "Test");
-            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCustomPrompt(2, "Priority Access");
-            var customPrompts = new List<CustomPrompt> { expectedPrompt1, expectedPrompt2 };
+                CustomPromptsTestHelper.GetDefaultCoursePrompt(1, "System Access Granted", "Test");
+            var expectedPrompt2 = CustomPromptsTestHelper.GetDefaultCoursePrompt(2, "Priority Access");
+            var customPrompts = new List<CoursePrompt> { expectedPrompt1, expectedPrompt2 };
             var expectedCourseAdminFields = CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts);
             A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsForCourse(100);
+            var result = courseAdminFieldsService.GetCoursePromptsForCourse(100);
 
             // Then
             result.Should().BeEquivalentTo(expectedCourseAdminFields);
         }
 
         [Test]
-        public void GetCustomPromptsWithAnswersForCourse_Returns_Populated_List_of_CustomPromptWithAnswer()
+        public void GetCoursePromptsWithAnswersForCourse_Returns_Populated_List_of_CustomPromptWithAnswer()
         {
             // Given
             const string answer1 = "ans1";
             const string answer2 = "ans2";
-            var expected1 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(
+            var expected1 = CustomPromptsTestHelper.GetDefaultCoursePromptWithAnswer(
                 1,
                 "System Access Granted",
                 "Test",
                 answer: answer1
             );
-            var expected2 = CustomPromptsTestHelper.GetDefaultCustomPromptWithAnswer(
+            var expected2 = CustomPromptsTestHelper.GetDefaultCoursePromptWithAnswer(
                 2,
                 "Priority Access",
                 answer: answer2
             );
-            var expected = new List<CustomPromptWithAnswer> { expected1, expected2 };
+            var expected = new List<CoursePromptWithAnswer> { expected1, expected2 };
             A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
             var delegateCourseInfo = new DelegateCourseInfo { Answer1 = answer1, Answer2 = answer2 };
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(delegateCourseInfo, 100);
+            var result = courseAdminFieldsService.GetCoursePromptsWithAnswersForCourse(delegateCourseInfo, 100);
 
             // Then
             result.Should().BeEquivalentTo(expected);
         }
 
         [Test]
-        public void UpdateCustomPromptForCourse_calls_data_service()
+        public void UpdateAdminFieldForCourse_calls_data_service()
         {
             // Given
-            A.CallTo(() => courseAdminFieldsDataService.UpdateCustomPromptForCourse(1, 1, null)).DoesNothing();
+            A.CallTo(() => courseAdminFieldsDataService.UpdateAdminFieldForCourse(1, 1, null)).DoesNothing();
 
             // When
-            courseAdminFieldsService.UpdateCustomPromptForCourse(1, 1, null);
+            courseAdminFieldsService.UpdateAdminFieldForCourse(1, 1, null);
 
             // Then
-            A.CallTo(() => courseAdminFieldsDataService.UpdateCustomPromptForCourse(1, 1, null)).MustHaveHappened();
+            A.CallTo(() => courseAdminFieldsDataService.UpdateAdminFieldForCourse(1, 1, null)).MustHaveHappened();
         }
 
         [Test]
@@ -110,34 +110,34 @@
         }
 
         [Test]
-        public void AddCustomPromptToCourse_adds_prompt_to_course_at_next_prompt_number()
+        public void AddAdminFieldToCourse_adds_prompt_to_course_at_next_prompt_number()
         {
             // Given
             A.CallTo
             (
-                () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, A<int>._, A<int>._, null)
+                () => courseAdminFieldsDataService.UpdateAdminFieldForCourse(100, A<int>._, A<int>._, null)
             ).DoesNothing();
             A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.AddCustomPromptToCourse(100, 3, null);
+            var result = courseAdminFieldsService.AddAdminFieldToCourse(100, 3, null);
 
             // Then
             A.CallTo
             (
-                () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, 3, 3, null)
+                () => courseAdminFieldsDataService.UpdateAdminFieldForCourse(100, 3, 3, null)
             ).MustHaveHappened();
             result.Should().BeTrue();
         }
 
         [Test]
-        public void AddCustomPromptToCourse_does_not_add_prompt_if_course_has_all_prompts_defined()
+        public void AddAdminFieldToCourse_does_not_add_prompt_if_course_has_all_prompts_defined()
         {
             // Given
             A.CallTo
             (
-                () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(100, A<int>._, A<int>._, null)
+                () => courseAdminFieldsDataService.UpdateAdminFieldForCourse(100, A<int>._, A<int>._, null)
             ).DoesNothing();
             A.CallTo(() => courseAdminFieldsDataService.GetCourseAdminFields(100))
                 .Returns(
@@ -151,7 +151,7 @@
                 );
 
             // When
-            var result = courseAdminFieldsService.AddCustomPromptToCourse(
+            var result = courseAdminFieldsService.AddAdminFieldToCourse(
                 100,
                 3,
                 "Adding a fourth prompt"
@@ -161,7 +161,7 @@
             using (new AssertionScope())
             {
                 A.CallTo(
-                        () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(
+                        () => courseAdminFieldsDataService.UpdateAdminFieldForCourse(
                             100,
                             A<int>._,
                             A<int>._,
@@ -174,26 +174,26 @@
         }
 
         [Test]
-        public void RemoveCustomPromptFromCourse_calls_data_service_with_correct_values()
+        public void RemoveAdminFieldFromCourse_calls_data_service_with_correct_values()
         {
             // Given
-            A.CallTo(() => courseAdminFieldsDataService.UpdateCustomPromptForCourse(1, 1, 0, null))
+            A.CallTo(() => courseAdminFieldsDataService.UpdateAdminFieldForCourse(1, 1, 0, null))
                 .DoesNothing();
             A.CallTo(() => courseAdminFieldsDataService.DeleteAllAnswersForCourseAdminField(1, 1)).DoesNothing();
 
             // When
-            courseAdminFieldsService.RemoveCustomPromptFromCourse(1, 1);
+            courseAdminFieldsService.RemoveAdminFieldFromCourse(1, 1);
 
             // Then
             A.CallTo(
-                () => courseAdminFieldsDataService.UpdateCustomPromptForCourse(1, 1, 0, null)
+                () => courseAdminFieldsDataService.UpdateAdminFieldForCourse(1, 1, 0, null)
             ).MustHaveHappened();
             A.CallTo(() => courseAdminFieldsDataService.DeleteAllAnswersForCourseAdminField(1, 1))
                 .MustHaveHappened();
         }
 
         [Test]
-        public void GetCustomPromptsWithAnswerCountsForCourse_returns_empty_list_with_no_admin_fields()
+        public void GetCoursePromptsWithAnswerCountsForCourse_returns_empty_list_with_no_admin_fields()
         {
             // Given
             const int customisationId = 1;
@@ -202,7 +202,7 @@
                 .Returns(new CourseAdminFieldsResult());
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsWithAnswerCountsForCourse(customisationId, centreId);
+            var result = courseAdminFieldsService.GetCoursePromptsWithAnswerCountsForCourse(customisationId, centreId);
 
             // Then
             using (new AssertionScope())
@@ -215,7 +215,7 @@
         }
 
         [Test]
-        public void GetCustomPromptsWithAnswerCountsForCourse_counts_free_text_admin_fields_correctly()
+        public void GetCoursePromptsWithAnswerCountsForCourse_counts_free_text_admin_fields_correctly()
         {
             // Given
             const int customisationId = 1;
@@ -243,7 +243,7 @@
                 .Returns(delegateAnswers);
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsWithAnswerCountsForCourse(customisationId, centreId)
+            var result = courseAdminFieldsService.GetCoursePromptsWithAnswerCountsForCourse(customisationId, centreId)
                 .ToList();
 
             // Then
@@ -262,7 +262,7 @@
         }
 
         [Test]
-        public void GetCustomPromptsWithAnswerCountsForCourse_counts_configured_answers_admin_fields_correctly()
+        public void GetCoursePromptsWithAnswerCountsForCourse_counts_configured_answers_admin_fields_correctly()
         {
             // Given
             const int customisationId = 1;
@@ -293,7 +293,7 @@
                 .Returns(delegateAnswers);
 
             // When
-            var result = courseAdminFieldsService.GetCustomPromptsWithAnswerCountsForCourse(customisationId, centreId)
+            var result = courseAdminFieldsService.GetCoursePromptsWithAnswerCountsForCourse(customisationId, centreId)
                 .ToList();
 
             // Then

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseDelegatesDownloadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseDelegatesDownloadFileServiceTests.cs
@@ -149,11 +149,11 @@
             A.CallTo(() => customPromptsService.GetCustomPromptsForCentreByCentreId(centreId))
                 .Returns(new CentreCustomPrompts(centreId, customPrompts));
 
-            var adminFields = new List<CustomPrompt>
+            var adminFields = new List<CoursePrompt>
             {
-                new CustomPrompt(1, "Access Permissions", null, true),
+                new CoursePrompt(1, "Access Permissions", null, true),
             };
-            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(customisationId))
+            A.CallTo(() => courseAdminFieldsService.GetCoursePromptsForCourse(customisationId))
                 .Returns(new CourseAdminFields(customisationId, adminFields));
 
             // When

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -123,11 +123,11 @@
                 .Returns(attemptStatsReturnedByDataService);
 
             // When
-            var results = courseService.GetDelegateAttemptsAndCourseCustomPrompts(info);
+            var results = courseService.GetDelegateAttemptsAndCoursePrompts(info);
 
             // Then
             A.CallTo(
-                () => courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
+                () => courseAdminFieldsService.GetCoursePromptsWithAnswersForCourse(
                     info,
                     customisationId
                 )
@@ -147,11 +147,11 @@
                 { CustomisationId = customisationId, IsAssessed = false };
 
             // When
-            var result = courseService.GetDelegateAttemptsAndCourseCustomPrompts(info);
+            var result = courseService.GetDelegateAttemptsAndCoursePrompts(info);
 
             // Then
             A.CallTo(
-                () => courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
+                () => courseAdminFieldsService.GetCoursePromptsWithAnswersForCourse(
                     info,
                     customisationId
                 )

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/CustomPromptsTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/CustomPromptsTestHelper.cs
@@ -14,11 +14,11 @@
         }
 
         public static CourseAdminFields GetDefaultCourseAdminFields(
-            List<CustomPrompt> customPrompts,
+            List<CoursePrompt> coursePrompts,
             int customisationId = 100
         )
         {
-            return new CourseAdminFields(customisationId, customPrompts);
+            return new CourseAdminFields(customisationId, coursePrompts);
         }
 
         public static CustomPrompt GetDefaultCustomPrompt(
@@ -29,6 +29,16 @@
         )
         {
             return new CustomPrompt(promptNumber, text, options, mandatory);
+        }
+
+        public static CoursePrompt GetDefaultCoursePrompt(
+            int promptNumber,
+            string text = "Course Prompt",
+            string? options = "",
+            bool mandatory = false
+        )
+        {
+            return new CoursePrompt(promptNumber, text, options, mandatory);
         }
 
         public static CentreCustomPromptsWithAnswers GetDefaultCentreCustomPromptsWithAnswers(
@@ -48,6 +58,17 @@
         )
         {
             return new CustomPromptWithAnswer(promptNumber, text, options, mandatory, answer);
+        }
+
+        public static CoursePromptWithAnswer GetDefaultCoursePromptWithAnswer(
+            int promptNumber,
+            string text = "Course Prompt",
+            string? options = "",
+            bool mandatory = false,
+            string? answer = null
+        )
+        {
+            return new CoursePromptWithAnswer(promptNumber, text, options, mandatory, answer);
         }
 
         public static CentreCustomPromptsResult GetDefaultCentreCustomPromptsResult(
@@ -92,7 +113,7 @@
                 CustomField5Mandatory = customField5Mandatory,
                 CustomField6Prompt = customField6Prompt,
                 CustomField6Options = customField6Options,
-                CustomField6Mandatory = customField6Mandatory
+                CustomField6Mandatory = customField6Mandatory,
             };
         }
 
@@ -114,7 +135,7 @@
                 CustomField2Options = customField2Options,
                 CustomField3Prompt = customField3Prompt,
                 CustomField3Options = customField3Options,
-                CourseCategoryId = courseCategoryId
+                CourseCategoryId = courseCategoryId,
             };
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -11,11 +11,11 @@
     {
         CourseAdminFieldsResult GetCourseAdminFields(int customisationId);
 
-        void UpdateCustomPromptForCourse(int customisationId, int promptNumber, string? options);
+        void UpdateAdminFieldForCourse(int customisationId, int promptNumber, string? options);
 
         IEnumerable<(int id, string name)> GetCoursePromptsAlphabetical();
 
-        void UpdateCustomPromptForCourse(
+        void UpdateAdminFieldForCourse(
             int customisationId,
             int promptNumber,
             int promptId,
@@ -74,7 +74,7 @@
             return result;
         }
 
-        public void UpdateCustomPromptForCourse(int customisationId, int promptNumber, string? options)
+        public void UpdateAdminFieldForCourse(int customisationId, int promptNumber, string? options)
         {
             connection.Execute(
                 @$"UPDATE Customisations
@@ -96,7 +96,7 @@
             );
         }
 
-        public void UpdateCustomPromptForCourse(
+        public void UpdateAdminFieldForCourse(
             int customisationId,
             int promptNumber,
             int promptId,

--- a/DigitalLearningSolutions.Data/Helpers/CustomPromptHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/CustomPromptHelper.cs
@@ -14,6 +14,16 @@
             return prompt != null ? new CustomPrompt(promptNumber, prompt, options, mandatory) : null;
         }
 
+        public static CoursePrompt? PopulateCoursePrompt(
+            int promptNumber,
+            string? prompt,
+            string? options,
+            bool mandatory
+        )
+        {
+            return prompt != null ? new CoursePrompt(promptNumber, prompt, options, mandatory) : null;
+        }
+
         public static CustomPromptWithAnswer? PopulateCustomPromptWithAnswer(
             int promptNumber,
             string? prompt,
@@ -25,14 +35,25 @@
             return prompt != null ? new CustomPromptWithAnswer(promptNumber, prompt, options, mandatory, answer) : null;
         }
 
-        public static CustomPromptWithResponseCounts? GetBaseCustomPromptWithResponseCountsModel(
+        public static CoursePromptWithAnswer? PopulateCoursePromptWithAnswer(
+            int promptNumber,
+            string? prompt,
+            string? options,
+            bool mandatory,
+            string? answer
+        )
+        {
+            return prompt != null ? new CoursePromptWithAnswer(promptNumber, prompt, options, mandatory, answer) : null;
+        }
+
+        public static CoursePromptWithResponseCounts? GetBaseCoursePromptWithResponseCountsModel(
             int promptNumber,
             string? prompt,
             string? options,
             bool mandatory
         )
         {
-            return prompt != null ? new CustomPromptWithResponseCounts(promptNumber, prompt, options, mandatory) : null;
+            return prompt != null ? new CoursePromptWithResponseCounts(promptNumber, prompt, options, mandatory) : null;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
@@ -10,7 +10,7 @@
 
         public CourseStatisticsWithAdminFieldResponseCounts(
             CourseStatistics courseStatistics,
-            IEnumerable<CustomPromptWithResponseCounts> adminFieldsWithResponses
+            IEnumerable<CoursePromptWithResponseCounts> adminFieldsWithResponses
         )
         {
             AdminFieldsWithResponses = adminFieldsWithResponses;
@@ -32,7 +32,7 @@
             ApplicationName = courseStatistics.ApplicationName;
         }
 
-        public IEnumerable<CustomPromptWithResponseCounts> AdminFieldsWithResponses { get; set; }
+        public IEnumerable<CoursePromptWithResponseCounts> AdminFieldsWithResponses { get; set; }
 
         public bool HasAdminFields => AdminFieldsWithResponses.Any();
     }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseDetails.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseDetails.cs
@@ -7,17 +7,17 @@
     {
         public DelegateCourseDetails(
             DelegateCourseInfo delegateCourseInfo,
-            List<CustomPromptWithAnswer> customPrompts,
+            List<CoursePromptWithAnswer> coursePrompts,
             AttemptStats attemptStats
         )
         {
             DelegateCourseInfo = delegateCourseInfo;
-            CustomPrompts = customPrompts;
+            CoursePrompts = coursePrompts;
             AttemptStats = attemptStats;
         }
 
         public DelegateCourseInfo DelegateCourseInfo { get; set; }
-        public List<CustomPromptWithAnswer> CustomPrompts { get; set; }
+        public List<CoursePromptWithAnswer> CoursePrompts { get; set; }
         public AttemptStats AttemptStats { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CourseAdminFields.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CourseAdminFields.cs
@@ -4,7 +4,7 @@
 
     public class CourseAdminFields
     {
-        public CourseAdminFields(int customisationId, List<CustomPrompt> adminFields)
+        public CourseAdminFields(int customisationId, List<CoursePrompt> adminFields)
         {
             CustomisationId = customisationId;
             AdminFields = adminFields;
@@ -12,6 +12,6 @@
 
         public int CustomisationId { get; set; }
 
-        public List<CustomPrompt> AdminFields { get; set; }
+        public List<CoursePrompt> AdminFields { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CoursePrompt.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CoursePrompt.cs
@@ -1,0 +1,37 @@
+﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class CoursePrompt
+    {
+        public CoursePrompt(int coursePromptNumber, string text, string? options, bool mandatory)
+        {
+            CoursePromptNumber = coursePromptNumber;
+            CustomPromptText = text;
+            Options = SplitOptionsString(options);
+            Mandatory = mandatory;
+        }
+
+        public int CoursePromptNumber { get; set; }
+        public string CustomPromptText { get; set; }
+        public List<string> Options { get; set; }
+        public bool Mandatory { get; set; }
+
+        private List<string> SplitOptionsString(string? options)
+        {
+            var optionsList = new List<string>();
+            if (options != null)
+            {
+                optionsList.AddRange(
+                    options.Split(
+                        new[] { '\r', '\n' },
+                        StringSplitOptions.RemoveEmptyEntries
+                    )
+                );
+            }
+
+            return optionsList;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CoursePromptWithAnswer.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CoursePromptWithAnswer.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Data.Models.CustomPrompts
+{
+    public class CoursePromptWithAnswer : CoursePrompt
+    {
+        public CoursePromptWithAnswer(int coursePromptNumber, string text, string? options, bool mandatory, string? answer)
+            : base(coursePromptNumber, text, options, mandatory)
+        {
+            Answer = answer;
+        }
+
+        public string? Answer { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CoursePromptWithResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CoursePromptWithResponseCounts.cs
@@ -2,9 +2,9 @@
 {
     using System.Collections.Generic;
 
-    public class CustomPromptWithResponseCounts : CustomPrompt
+    public class CoursePromptWithResponseCounts : CoursePrompt
     {
-        public CustomPromptWithResponseCounts(int customPromptNumber, string text, string? options, bool mandatory) :
+        public CoursePromptWithResponseCounts(int customPromptNumber, string text, string? options, bool mandatory) :
             base(customPromptNumber, text, options, mandatory) { }
 
         public IEnumerable<ResponseCount> ResponseCounts { get; set; }

--- a/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
+++ b/DigitalLearningSolutions.Data/Models/CustomPrompts/CustomPrompt.cs
@@ -2,18 +2,19 @@
 {
     using System;
     using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Enums;
 
     public class CustomPrompt
     {
-        public CustomPrompt(int customPromptNumber, string text, string? options, bool mandatory)
+        public CustomPrompt(RegistrationField registrationField, string text, string? options, bool mandatory)
         {
-            CustomPromptNumber = customPromptNumber;
+            RegistrationField = registrationField;
             CustomPromptText = text;
             Options = SplitOptionsString(options);
             Mandatory = mandatory;
         }
 
-        public int CustomPromptNumber { get; set; }
+        public RegistrationField RegistrationField { get; set; }
         public string CustomPromptText { get; set; }
         public List<string> Options { get; set; }
         public bool Mandatory { get; set; }

--- a/DigitalLearningSolutions.Data/Services/CentreCustomPromptsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CentreCustomPromptsService.cs
@@ -117,7 +117,7 @@
         {
             var centreCustomPrompts = GetCustomPromptsForCentreByCentreId(centreId);
             var existingPromptNumbers = centreCustomPrompts.CustomPrompts
-                .Select(c => c.CustomPromptNumber);
+                .Select(c => c.RegistrationField.Id);
 
             var promptNumbers = new List<int> { 1, 2, 3, 4, 5, 6 };
             var unusedPromptNumbers = promptNumbers.Except(existingPromptNumbers).ToList();

--- a/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseAdminFieldsService.cs
@@ -11,28 +11,28 @@
 
     public interface ICourseAdminFieldsService
     {
-        public CourseAdminFields GetCustomPromptsForCourse(int customisationId);
+        public CourseAdminFields GetCoursePromptsForCourse(int customisationId);
 
-        public List<CustomPromptWithAnswer> GetCustomPromptsWithAnswersForCourse(
+        public List<CoursePromptWithAnswer> GetCoursePromptsWithAnswersForCourse(
             DelegateCourseInfo delegateCourseInfo,
             int customisationId
         );
 
-        public void UpdateCustomPromptForCourse(int customisationId, int promptId, string? options);
+        public void UpdateAdminFieldForCourse(int customisationId, int promptId, string? options);
 
         public IEnumerable<(int id, string value)> GetCoursePromptsAlphabeticalList();
 
-        public bool AddCustomPromptToCourse(
+        public bool AddAdminFieldToCourse(
             int customisationId,
             int promptId,
             string? options
         );
 
-        public void RemoveCustomPromptFromCourse(int customisationId, int promptNumber);
+        public void RemoveAdminFieldFromCourse(int customisationId, int promptNumber);
 
         public string GetPromptName(int customisationId, int promptNumber);
 
-        public IEnumerable<CustomPromptWithResponseCounts> GetCustomPromptsWithAnswerCountsForCourse(
+        public IEnumerable<CoursePromptWithResponseCounts> GetCoursePromptsWithAnswerCountsForCourse(
             int customisationId,
             int centreId
         );
@@ -52,30 +52,30 @@
             this.logger = logger;
         }
 
-        public CourseAdminFields GetCustomPromptsForCourse(
+        public CourseAdminFields GetCoursePromptsForCourse(
             int customisationId
         )
         {
             var result = courseAdminFieldsDataService.GetCourseAdminFields(customisationId);
             return new CourseAdminFields(
                 customisationId,
-                PopulateCustomPromptListFromCourseCustomPromptsResult(result)
+                PopulateCoursePromptListFromCourseAdminFieldsResult(result)
             );
         }
 
-        public List<CustomPromptWithAnswer> GetCustomPromptsWithAnswersForCourse(
+        public List<CoursePromptWithAnswer> GetCoursePromptsWithAnswersForCourse(
             DelegateCourseInfo delegateCourseInfo,
             int customisationId
         )
         {
-            var result = GetCourseCustomPromptsResultForCourse(customisationId);
+            var result = GetCourseAdminFieldsResultForCourse(customisationId);
 
-            return PopulateCustomPromptWithAnswerListFromCourseAdminFieldsResult(result, delegateCourseInfo);
+            return PopulateCoursePromptWithAnswerListFromCourseAdminFieldsResult(result, delegateCourseInfo);
         }
 
-        public void UpdateCustomPromptForCourse(int customisationId, int promptId, string? options)
+        public void UpdateAdminFieldForCourse(int customisationId, int promptId, string? options)
         {
-            courseAdminFieldsDataService.UpdateCustomPromptForCourse(customisationId, promptId, options);
+            courseAdminFieldsDataService.UpdateAdminFieldForCourse(customisationId, promptId, options);
         }
 
         public IEnumerable<(int id, string value)> GetCoursePromptsAlphabeticalList()
@@ -83,13 +83,13 @@
             return courseAdminFieldsDataService.GetCoursePromptsAlphabetical().ToList();
         }
 
-        public bool AddCustomPromptToCourse(
+        public bool AddAdminFieldToCourse(
             int customisationId,
             int promptId,
             string? options
         )
         {
-            var courseAdminFields = GetCustomPromptsForCourse(
+            var courseAdminFields = GetCoursePromptsForCourse(
                 customisationId
             );
 
@@ -97,7 +97,7 @@
 
             if (promptNumber != null)
             {
-                courseAdminFieldsDataService.UpdateCustomPromptForCourse(
+                courseAdminFieldsDataService.UpdateAdminFieldForCourse(
                     customisationId,
                     promptNumber.Value,
                     promptId,
@@ -112,13 +112,13 @@
             return false;
         }
 
-        public void RemoveCustomPromptFromCourse(int customisationId, int promptNumber)
+        public void RemoveAdminFieldFromCourse(int customisationId, int promptNumber)
         {
             using var transaction = new TransactionScope();
             try
             {
                 courseAdminFieldsDataService.DeleteAllAnswersForCourseAdminField(customisationId, promptNumber);
-                courseAdminFieldsDataService.UpdateCustomPromptForCourse(
+                courseAdminFieldsDataService.UpdateAdminFieldForCourse(
                     customisationId,
                     promptNumber,
                     0,
@@ -137,7 +137,7 @@
             return courseAdminFieldsDataService.GetPromptName(customisationId, promptNumber);
         }
 
-        public IEnumerable<CustomPromptWithResponseCounts> GetCustomPromptsWithAnswerCountsForCourse(
+        public IEnumerable<CoursePromptWithResponseCounts> GetCoursePromptsWithAnswerCountsForCourse(
             int customisationId,
             int centreId
         )
@@ -163,7 +163,7 @@
         }
 
         private static IEnumerable<ResponseCount> GetResponseCountsForPrompt(
-            CustomPrompt customPrompt,
+            CoursePrompt coursePrompt,
             IReadOnlyCollection<DelegateCourseAdminFieldAnswers> allAnswers
         )
         {
@@ -171,13 +171,13 @@
             const string notBlank = "not blank";
 
             var responseCounts = new List<ResponseCount>();
-            if (customPrompt.Options.Any())
+            if (coursePrompt.Options.Any())
             {
                 responseCounts.AddRange(
-                    customPrompt.Options.Select(
+                    coursePrompt.Options.Select(
                         x => new ResponseCount(
                             x,
-                            allAnswers.Count(a => a.AdminFieldAnswers[customPrompt.CustomPromptNumber - 1] == x)
+                            allAnswers.Count(a => a.AdminFieldAnswers[coursePrompt.CoursePromptNumber - 1] == x)
                         )
                     )
                 );
@@ -188,7 +188,7 @@
                     new ResponseCount(
                         notBlank,
                         allAnswers.Count(
-                            a => !string.IsNullOrEmpty(a.AdminFieldAnswers[customPrompt.CustomPromptNumber - 1])
+                            a => !string.IsNullOrEmpty(a.AdminFieldAnswers[coursePrompt.CoursePromptNumber - 1])
                         )
                     )
                 );
@@ -198,7 +198,7 @@
                 new ResponseCount(
                     blank,
                     allAnswers.Count(
-                        a => string.IsNullOrEmpty(a.AdminFieldAnswers[customPrompt.CustomPromptNumber - 1])
+                        a => string.IsNullOrEmpty(a.AdminFieldAnswers[coursePrompt.CoursePromptNumber - 1])
                     )
                 )
             );
@@ -209,30 +209,30 @@
         private static int? GetNextPromptNumber(CourseAdminFields courseAdminFields)
         {
             var existingPromptNumbers = courseAdminFields.AdminFields
-                .Select(c => c.CustomPromptNumber);
+                .Select(c => c.CoursePromptNumber);
 
             var promptNumbers = new List<int> { 1, 2, 3 };
             var unusedPromptNumbers = promptNumbers.Except(existingPromptNumbers).ToList();
             return unusedPromptNumbers.Any() ? unusedPromptNumbers.Min() : (int?)null;
         }
 
-        private CourseAdminFieldsResult GetCourseCustomPromptsResultForCourse(int customisationId)
+        private CourseAdminFieldsResult GetCourseAdminFieldsResultForCourse(int customisationId)
         {
             return courseAdminFieldsDataService.GetCourseAdminFields(customisationId);
         }
 
-        private static List<CustomPrompt> PopulateCustomPromptListFromCourseCustomPromptsResult(
+        private static List<CoursePrompt> PopulateCoursePromptListFromCourseAdminFieldsResult(
             CourseAdminFieldsResult? result
         )
         {
-            var list = new List<CustomPrompt>();
+            var list = new List<CoursePrompt>();
 
             if (result == null)
             {
                 return list;
             }
 
-            var prompt1 = CustomPromptHelper.PopulateCustomPrompt(
+            var prompt1 = CustomPromptHelper.PopulateCoursePrompt(
                 1,
                 result.CustomField1Prompt,
                 result.CustomField1Options,
@@ -243,7 +243,7 @@
                 list.Add(prompt1);
             }
 
-            var prompt2 = CustomPromptHelper.PopulateCustomPrompt(
+            var prompt2 = CustomPromptHelper.PopulateCoursePrompt(
                 2,
                 result.CustomField2Prompt,
                 result.CustomField2Options,
@@ -254,7 +254,7 @@
                 list.Add(prompt2);
             }
 
-            var prompt3 = CustomPromptHelper.PopulateCustomPrompt(
+            var prompt3 = CustomPromptHelper.PopulateCoursePrompt(
                 3,
                 result.CustomField3Prompt,
                 result.CustomField3Options,
@@ -268,19 +268,19 @@
             return list;
         }
 
-        private List<CustomPromptWithAnswer> PopulateCustomPromptWithAnswerListFromCourseAdminFieldsResult(
+        private List<CoursePromptWithAnswer> PopulateCoursePromptWithAnswerListFromCourseAdminFieldsResult(
             CourseAdminFieldsResult? result,
             DelegateCourseInfo delegateCourseInfo
         )
         {
-            var list = new List<CustomPromptWithAnswer>();
+            var list = new List<CoursePromptWithAnswer>();
 
             if (result == null)
             {
                 return list;
             }
 
-            var prompt1 = CustomPromptHelper.PopulateCustomPromptWithAnswer(
+            var prompt1 = CustomPromptHelper.PopulateCoursePromptWithAnswer(
                 1,
                 result.CustomField1Prompt,
                 result.CustomField1Options,
@@ -292,7 +292,7 @@
                 list.Add(prompt1);
             }
 
-            var prompt2 = CustomPromptHelper.PopulateCustomPromptWithAnswer(
+            var prompt2 = CustomPromptHelper.PopulateCoursePromptWithAnswer(
                 2,
                 result.CustomField2Prompt,
                 result.CustomField2Options,
@@ -304,7 +304,7 @@
                 list.Add(prompt2);
             }
 
-            var prompt3 = CustomPromptHelper.PopulateCustomPromptWithAnswer(
+            var prompt3 = CustomPromptHelper.PopulateCoursePromptWithAnswer(
                 3,
                 result.CustomField3Prompt,
                 result.CustomField3Options,
@@ -319,19 +319,19 @@
             return list;
         }
 
-        private static List<CustomPromptWithResponseCounts>
+        private static List<CoursePromptWithResponseCounts>
             GetBaseCustomPromptWithResponseCountsModelsFromCourseCustomPromptsResult(
                 CourseAdminFieldsResult? result
             )
         {
-            var list = new List<CustomPromptWithResponseCounts>();
+            var list = new List<CoursePromptWithResponseCounts>();
 
             if (result == null)
             {
                 return list;
             }
 
-            var prompt1 = CustomPromptHelper.GetBaseCustomPromptWithResponseCountsModel(
+            var prompt1 = CustomPromptHelper.GetBaseCoursePromptWithResponseCountsModel(
                 1,
                 result.CustomField1Prompt,
                 result.CustomField1Options,
@@ -342,7 +342,7 @@
                 list.Add(prompt1);
             }
 
-            var prompt2 = CustomPromptHelper.GetBaseCustomPromptWithResponseCountsModel(
+            var prompt2 = CustomPromptHelper.GetBaseCoursePromptWithResponseCountsModel(
                 2,
                 result.CustomField2Prompt,
                 result.CustomField2Options,
@@ -353,7 +353,7 @@
                 list.Add(prompt2);
             }
 
-            var prompt3 = CustomPromptHelper.GetBaseCustomPromptWithResponseCountsModel(
+            var prompt3 = CustomPromptHelper.GetBaseCoursePromptWithResponseCountsModel(
                 3,
                 result.CustomField3Prompt,
                 result.CustomField3Options,

--- a/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
@@ -80,7 +80,7 @@
             string sortDirection
         )
         {
-            var adminFields = courseAdminFieldsService.GetCustomPromptsForCourse(customisationId);
+            var adminFields = courseAdminFieldsService.GetCoursePromptsForCourse(customisationId);
 
             var customRegistrationPrompts = customPromptsService.GetCustomPromptsForCentreByCentreId(centreId);
 
@@ -149,7 +149,7 @@
                 dataTable.Columns.Add(
                     !dataTable.Columns.Contains(prompt.CustomPromptText)
                         ? prompt.CustomPromptText
-                        : $"{prompt.CustomPromptText} (Prompt {prompt.CustomPromptNumber})"
+                        : $"{prompt.CustomPromptText} (Prompt {prompt.CoursePromptNumber})"
                 );
             }
         }
@@ -197,15 +197,15 @@
 
             foreach (var prompt in adminFields.AdminFields)
             {
-                if (dataTable.Columns.Contains($"{prompt.CustomPromptText} (Prompt {prompt.CustomPromptNumber})"))
+                if (dataTable.Columns.Contains($"{prompt.CustomPromptText} (Prompt {prompt.CoursePromptNumber})"))
                 {
-                    row[$"{prompt.CustomPromptText} (Prompt {prompt.CustomPromptNumber})"] =
-                        courseDelegate.CustomAdminFieldAnswers[prompt.CustomPromptNumber - 1];
+                    row[$"{prompt.CustomPromptText} (Prompt {prompt.CoursePromptNumber})"] =
+                        courseDelegate.CustomAdminFieldAnswers[prompt.CoursePromptNumber - 1];
                 }
                 else
                 {
                     row[prompt.CustomPromptText] =
-                        courseDelegate.CustomAdminFieldAnswers[prompt.CustomPromptNumber - 1];
+                        courseDelegate.CustomAdminFieldAnswers[prompt.CoursePromptNumber - 1];
                 }
             }
 

--- a/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
@@ -129,7 +129,7 @@
                 dataTable.Columns.Add(
                     !dataTable.Columns.Contains(prompt.CustomPromptText)
                         ? prompt.CustomPromptText
-                        : $"{prompt.CustomPromptText} (Prompt {prompt.CustomPromptNumber})"
+                        : $"{prompt.CustomPromptText} (Prompt {prompt.RegistrationField.Id})"
                 );
             }
 
@@ -169,15 +169,15 @@
 
             foreach (var prompt in customRegistrationPrompts.CustomPrompts)
             {
-                if (dataTable.Columns.Contains($"{prompt.CustomPromptText} (Prompt {prompt.CustomPromptNumber})"))
+                if (dataTable.Columns.Contains($"{prompt.CustomPromptText} (Prompt {prompt.RegistrationField.Id})"))
                 {
-                    row[$"{prompt.CustomPromptText} (Prompt {prompt.CustomPromptNumber})"] =
-                        courseDelegate.CustomRegistrationPromptAnswers[prompt.CustomPromptNumber - 1];
+                    row[$"{prompt.CustomPromptText} (Prompt {prompt.RegistrationField.Id})"] =
+                        courseDelegate.CustomRegistrationPromptAnswers[prompt.RegistrationField.Id - 1];
                 }
                 else
                 {
                     row[prompt.CustomPromptText] =
-                        courseDelegate.CustomRegistrationPromptAnswers[prompt.CustomPromptNumber - 1];
+                        courseDelegate.CustomRegistrationPromptAnswers[prompt.RegistrationField.Id - 1];
                 }
             }
 

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -139,7 +139,7 @@
             return allCourses.Where(c => c.CentreId == centreId).Select(
                 c => new CourseStatisticsWithAdminFieldResponseCounts(
                     c,
-                    courseAdminFieldsService.GetCustomPromptsWithAnswerCountsForCourse(c.CustomisationId, centreId)
+                    courseAdminFieldsService.GetCoursePromptsWithAnswerCountsForCourse(c.CustomisationId, centreId)
                 )
             );
         }
@@ -153,7 +153,7 @@
             return courseDataService.GetDelegateCoursesInfo(delegateId)
                 .Where(info => info.CustomisationCentreId == centreId || info.AllCentresCourse)
                 .Where(info => courseCategoryId == null || info.CourseCategoryId == courseCategoryId)
-                .Select(GetDelegateAttemptsAndCourseCustomPrompts)
+                .Select(GetDelegateAttemptsAndCoursePrompts)
                 .Where(info => info.DelegateCourseInfo.RemovedDate == null);
         }
 
@@ -161,7 +161,7 @@
         {
             var info = courseDataService.GetDelegateCourseInfoByProgressId(progressId);
 
-            return info == null ? null : GetDelegateAttemptsAndCourseCustomPrompts(info);
+            return info == null ? null : GetDelegateAttemptsAndCoursePrompts(info);
         }
 
         public bool? VerifyAdminUserCanManageCourse(int customisationId, int centreId, int? categoryId)
@@ -391,11 +391,11 @@
             return new LearningLog(delegateCourseInfo, learningLogEntries);
         }
 
-        public DelegateCourseDetails GetDelegateAttemptsAndCourseCustomPrompts(
+        public DelegateCourseDetails GetDelegateAttemptsAndCoursePrompts(
             DelegateCourseInfo info
         )
         {
-            var customPrompts = courseAdminFieldsService.GetCustomPromptsWithAnswersForCourse(
+            var coursePrompts = courseAdminFieldsService.GetCoursePromptsWithAnswersForCourse(
                 info,
                 info.CustomisationId
             );
@@ -404,7 +404,7 @@
                 ? courseDataService.GetDelegateCourseAttemptStats(info.DelegateId, info.CustomisationId)
                 : new AttemptStats(0, 0);
 
-            return new DelegateCourseDetails(info, customPrompts, attemptStats);
+            return new DelegateCourseDetails(info, coursePrompts, attemptStats);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Data/Services/GroupsService.cs
@@ -643,7 +643,7 @@
         {
             var registrationPrompt = centreCustomPromptsService
                 .GetCustomPromptsThatHaveOptionsForCentreByCentreId(centreId).Single(
-                    cp => cp.CustomPromptNumber == registrationFieldOptionId
+                    cp => cp.RegistrationField.Id == registrationFieldOptionId
                 );
             var customPromptOptions = registrationPrompt.Options.Select((option, index) => (index, option))
                 .ToList<(int id, string name)>();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
@@ -67,9 +68,9 @@
         public void AdminFields_returns_AdminFields_page_when_appropriate_course_found_and_clears_TempData()
         {
             // Given
-            var samplePrompt1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(1, "System Access Granted", "Yes\r\nNo");
-            var customPrompts = new List<CustomPrompt> { samplePrompt1 };
-            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._))
+            var samplePrompt1 = CustomPromptsTestHelper.GetDefaultCoursePrompt(1, "System Access Granted", "Yes\r\nNo");
+            var customPrompts = new List<CoursePrompt> { samplePrompt1 };
+            A.CallTo(() => courseAdminFieldsService.GetCoursePromptsForCourse(A<int>._))
                 .Returns(CustomPromptsTestHelper.GetDefaultCourseAdminFields(customPrompts));
             controller.TempData.Set(samplePrompt1);
 
@@ -89,7 +90,7 @@
             const string action = "save";
 
             A.CallTo(
-                () => courseAdminFieldsService.UpdateCustomPromptForCourse(
+                () => courseAdminFieldsService.UpdateAdminFieldForCourse(
                     1,
                     1,
                     "Options"
@@ -101,7 +102,7 @@
 
             // Then
             A.CallTo(
-                () => courseAdminFieldsService.UpdateCustomPromptForCourse(
+                () => courseAdminFieldsService.UpdateAdminFieldForCourse(
                     1,
                     1,
                     "Options"
@@ -118,7 +119,7 @@
             const string action = "addPrompt";
 
             A.CallTo(
-                () => courseAdminFieldsService.UpdateCustomPromptForCourse(
+                () => courseAdminFieldsService.UpdateAdminFieldForCourse(
                     1,
                     1,
                     "Test"
@@ -247,7 +248,7 @@
             controller.TempData.Set(initialTempData);
 
             A.CallTo(
-                () => courseAdminFieldsService.AddCustomPromptToCourse(
+                () => courseAdminFieldsService.AddAdminFieldToCourse(
                     100,
                     1,
                     "Test"
@@ -271,7 +272,7 @@
             controller.TempData.Set(initialTempData);
 
             A.CallTo(
-                () => courseAdminFieldsService.AddCustomPromptToCourse(
+                () => courseAdminFieldsService.AddAdminFieldToCourse(
                     100,
                     1,
                     null
@@ -295,7 +296,7 @@
             controller.TempData.Set(initialTempData);
 
             A.CallTo(
-                () => courseAdminFieldsService.AddCustomPromptToCourse(
+                () => courseAdminFieldsService.AddAdminFieldToCourse(
                     100,
                     1,
                     "Test"

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessProgressTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessProgressTests.cs
@@ -69,7 +69,7 @@
                 .Returns(
                     new DelegateCourseDetails(
                         delegateCourseInfo,
-                        new List<CustomPromptWithAnswer>(),
+                        new List<CoursePromptWithAnswer>(),
                         new AttemptStats(0, 0)
                     )
                 );
@@ -96,7 +96,7 @@
                 .Returns(
                     new DelegateCourseDetails(
                         delegateCourseInfo,
-                        new List<CustomPromptWithAnswer>(),
+                        new List<CoursePromptWithAnswer>(),
                         new AttemptStats(0, 0)
                     )
                 );
@@ -123,7 +123,7 @@
                 .Returns(
                     new DelegateCourseDetails(
                         delegateCourseInfo,
-                        new List<CustomPromptWithAnswer>(),
+                        new List<CoursePromptWithAnswer>(),
                         new AttemptStats(0, 0)
                     )
                 );
@@ -150,7 +150,7 @@
                 .Returns(
                     new DelegateCourseDetails(
                         delegateCourseInfo,
-                        new List<CustomPromptWithAnswer>(),
+                        new List<CoursePromptWithAnswer>(),
                         new AttemptStats(0, 0)
                     )
                 );
@@ -177,7 +177,7 @@
                 .Returns(
                     new DelegateCourseDetails(
                         delegateCourseInfo,
-                        new List<CustomPromptWithAnswer>(),
+                        new List<CoursePromptWithAnswer>(),
                         new AttemptStats(0, 0)
                     )
                 );

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/DelegateCourseInfoViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/DelegateCourseInfoViewModelTests.cs
@@ -11,7 +11,7 @@
     public class DelegateCourseInfoViewModelTests
     {
         private readonly AttemptStats attemptStats = new AttemptStats(0, 0);
-        private readonly List<CustomPromptWithAnswer> customPromptsWithAnswers = new List<CustomPromptWithAnswer>();
+        private readonly List<CoursePromptWithAnswer> coursePromptsWithAnswers = new List<CoursePromptWithAnswer>();
 
         [Test]
         public void DelegateCourseInfoViewModel_sets_date_strings_correctly()
@@ -30,7 +30,7 @@
                 Completed = completedDate,
                 Evaluated = evaluatedDate
             };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);
@@ -54,7 +54,7 @@
         {
             // Given
             var info = new DelegateCourseInfo { EnrolmentMethodId = enrollmentMethodId };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);
@@ -75,7 +75,7 @@
             // Given
             var details = new DelegateCourseDetails(
                 new DelegateCourseInfo(),
-                customPromptsWithAnswers,
+                coursePromptsWithAnswers,
                 new AttemptStats(totalAttempts, attemptsPassed)
             );
 
@@ -94,7 +94,7 @@
             {
                 ApplicationName = "my application", CustomisationName = ""
             };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);
@@ -112,7 +112,7 @@
                 ApplicationName = "my application",
                 CustomisationName = "my customisation"
             };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);
@@ -129,7 +129,7 @@
             {
                 SupervisorSurname = null
             };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);
@@ -147,7 +147,7 @@
                 SupervisorForename = "",
                 SupervisorSurname = "surname"
             };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);
@@ -165,7 +165,7 @@
                 SupervisorForename = "firstname",
                 SupervisorSurname = "surname"
             };
-            var details = new DelegateCourseDetails(info, customPromptsWithAnswers, attemptStats);
+            var details = new DelegateCourseDetails(info, coursePromptsWithAnswers, attemptStats);
 
             // When
             var model = new DelegateCourseInfoViewModel(details);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateApprovalsViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateApprovalsViewModelTests.cs
@@ -40,7 +40,7 @@
                 var promptData = customPrompts.First();
                 promptModel.Answer.Should().Be(promptData.Answer);
                 promptModel.CustomPrompt.Should().Be(promptData.CustomPromptText);
-                promptModel.CustomFieldId.Should().Be(promptData.CustomPromptNumber);
+                promptModel.CustomFieldId.Should().Be(promptData.RegistrationField.Id);
                 promptModel.Mandatory.Should().Be(promptData.Mandatory);
             }
         }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgress/DelegateProgressViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgress/DelegateProgressViewModelTests.cs
@@ -32,7 +32,7 @@
                 DelegateProgressAccessRoute.ViewDelegate,
                 new DelegateCourseDetails(
                     missingNamesDelegateInfo,
-                    new List<CustomPromptWithAnswer>(),
+                    new List<CoursePromptWithAnswer>(),
                     new AttemptStats(0, 0)
                 ),
                 null
@@ -54,7 +54,7 @@
                 DelegateProgressAccessRoute.ViewDelegate,
                 new DelegateCourseDetails(
                     fullNamesDelegateInfo,
-                    new List<CustomPromptWithAnswer>(),
+                    new List<CoursePromptWithAnswer>(),
                     new AttemptStats(0, 0)
                 ),
                 null
@@ -89,7 +89,7 @@
                 DelegateProgressAccessRoute.ViewDelegate,
                 new DelegateCourseDetails(
                     delegateInfo,
-                    new List<CustomPromptWithAnswer>(),
+                    new List<CoursePromptWithAnswer>(),
                     new AttemptStats(0, 0)
                 ),
                 null
@@ -119,7 +119,7 @@
                 DelegateProgressAccessRoute.ViewDelegate,
                 new DelegateCourseDetails(
                     delegateInfo,
-                    new List<CustomPromptWithAnswer>(),
+                    new List<CoursePromptWithAnswer>(),
                     new AttemptStats(0, 0)
                 ),
                 null

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -68,7 +68,7 @@
             var centreId = User.GetCentreId();
 
             var customPrompt = centreCustomPromptsService.GetCustomPromptsForCentreByCentreId(centreId).CustomPrompts
-                .Single(cp => cp.CustomPromptNumber == promptNumber);
+                .Single(cp => cp.RegistrationField.Id == promptNumber);
 
             var data = TempData.Get<EditRegistrationPromptData>();
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -44,7 +44,7 @@
         public IActionResult Index(int customisationId)
         {
             TempData.Clear();
-            var courseAdminFields = courseAdminFieldsService.GetCustomPromptsForCourse(customisationId);
+            var courseAdminFields = courseAdminFieldsService.GetCoursePromptsForCourse(customisationId);
 
             var model = new AdminFieldsViewModel(courseAdminFields.AdminFields, customisationId);
             return View(model);
@@ -62,10 +62,10 @@
         [ServiceFilter(typeof(VerifyAdminUserCanManageCourse))]
         public IActionResult EditAdminField(int customisationId, int promptNumber)
         {
-            var courseAdminField = courseAdminFieldsService.GetCustomPromptsForCourse(
+            var courseAdminField = courseAdminFieldsService.GetCoursePromptsForCourse(
                     customisationId
                 ).AdminFields
-                .Single(cp => cp.CustomPromptNumber == promptNumber);
+                .Single(cp => cp.CoursePromptNumber == promptNumber);
 
             var data = TempData.Get<EditAdminFieldData>();
 
@@ -269,7 +269,7 @@
         {
             ModelState.ClearAllErrors();
 
-            courseAdminFieldsService.UpdateCustomPromptForCourse(
+            courseAdminFieldsService.UpdateAdminFieldForCourse(
                 customisationId,
                 model.PromptNumber,
                 model.OptionsString
@@ -304,7 +304,7 @@
                 return View(model);
             }
 
-            if (courseAdminFieldsService.AddCustomPromptToCourse(
+            if (courseAdminFieldsService.AddAdminFieldToCourse(
                 customisationId,
                 model.AdminFieldId!.Value,
                 model.OptionsString
@@ -334,7 +334,7 @@
 
         private IActionResult RemoveAdminFieldAndRedirect(int customisationId, int promptNumber)
         {
-            courseAdminFieldsService.RemoveCustomPromptFromCourse(customisationId, promptNumber);
+            courseAdminFieldsService.RemoveAdminFieldFromCourse(customisationId, promptNumber);
             return RedirectToAction("Index", new { customisationId });
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -251,7 +251,7 @@
             var registrationField = (RegistrationField)model.RegistrationFieldOptionId;
 
             var fieldIsValid = centreCustomPromptsService
-                .GetCustomPromptsThatHaveOptionsForCentreByCentreId(centreId).Select(cp => cp.CustomPromptNumber)
+                .GetCustomPromptsThatHaveOptionsForCentreByCentreId(centreId).Select(cp => cp.RegistrationField.Id)
                 .Contains(registrationField!.Id) || registrationField.Equals(RegistrationField.JobGroup);
 
             if (!fieldIsValid)

--- a/DigitalLearningSolutions.Web/Helpers/CentreCustomPromptHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CentreCustomPromptHelper.cs
@@ -65,11 +65,11 @@
 
             return customPrompts.CustomPrompts.Select(
                 cp => new EditCustomFieldViewModel(
-                    cp.CustomPromptNumber,
+                    cp.RegistrationField.Id,
                     cp.CustomPromptText,
                     cp.Mandatory,
                     cp.Options,
-                    answers[cp.CustomPromptNumber - 1]
+                    answers[cp.RegistrationField.Id - 1]
                 )
             ).ToList();
         }
@@ -89,10 +89,10 @@
 
             return customPrompts.CustomPrompts.Select(
                 cp => new CustomFieldViewModel(
-                    cp.CustomPromptNumber,
+                    cp.RegistrationField.Id,
                     cp.CustomPromptText,
                     cp.Mandatory,
-                    answers[cp.CustomPromptNumber - 1]
+                    answers[cp.RegistrationField.Id - 1]
                 )
             ).ToList();
         }
@@ -114,10 +114,10 @@
 
             return customPrompts.Select(
                 cp => new CustomFieldViewModel(
-                    cp.CustomPromptNumber,
+                    cp.RegistrationField.Id,
                     cp.CustomPromptText,
                     cp.Mandatory,
-                    answers[cp.CustomPromptNumber - 1]
+                    answers[cp.RegistrationField.Id - 1]
                 )
             ).ToList();
         }
@@ -210,7 +210,7 @@
             IEnumerable<CustomPrompt> centreCustomPrompts
         )
         {
-            var customPromptOptions = centreCustomPrompts.Select(cp => (cp.CustomPromptNumber, cp.CustomPromptText))
+            var customPromptOptions = centreCustomPrompts.Select(cp => (cp.RegistrationField.Id, cp.CustomPromptText))
                 .ToList<(int id, string name)>();
 
             var customPromptNames = customPromptOptions.Select(r => r.name).ToList();

--- a/DigitalLearningSolutions.Web/ViewModels/Common/DisplayPromptsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/DisplayPromptsViewModel.cs
@@ -11,7 +11,7 @@
             CustomFields = customPrompts.Select(
                     cp =>
                         new CustomPromptManagementViewModel(
-                            cp.CustomPromptNumber,
+                            cp.RegistrationField.Id,
                             cp.CustomPromptText,
                             cp.Mandatory,
                             cp.Options

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountViewModel.cs
@@ -34,7 +34,7 @@
                 CustomFields = customPrompts.CustomPrompts.Select(
                         cp =>
                             new CustomFieldViewModel(
-                                cp.CustomPromptNumber,
+                                cp.RegistrationField.Id,
                                 cp.CustomPromptText,
                                 cp.Mandatory,
                                 cp.Answer

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPromptViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPromptViewModel.cs
@@ -26,7 +26,7 @@
 
         public EditRegistrationPromptViewModel(CustomPrompt customPrompt)
         {
-            PromptNumber = customPrompt.CustomPromptNumber;
+            PromptNumber = customPrompt.RegistrationField.Id;
             Prompt = customPrompt.CustomPromptText;
             Mandatory = customPrompt.Mandatory;
             OptionsString = NewlineSeparatedStringListHelper.JoinNewlineSeparatedList(customPrompt.Options);

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldsViewModel.cs
@@ -6,13 +6,13 @@
 
     public class AdminFieldsViewModel
     {
-        public AdminFieldsViewModel(IEnumerable<CustomPrompt> customPrompts, int customisationId)
+        public AdminFieldsViewModel(IEnumerable<CoursePrompt> coursePrompts, int customisationId)
         {
-            CustomFields = customPrompts.Select(
+            CustomFields = coursePrompts.Select(
                     cp =>
                         new CourseAdminFieldManagementViewModel(
                             customisationId,
-                            cp.CustomPromptNumber,
+                            cp.CoursePromptNumber,
                             cp.CustomPromptText,
                             cp.Mandatory,
                             cp.Options

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/EditAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/EditAdminFieldViewModel.cs
@@ -7,11 +7,11 @@
     {
         public EditAdminFieldViewModel() { }
 
-        public EditAdminFieldViewModel(CustomPrompt customPrompt)
+        public EditAdminFieldViewModel(CoursePrompt coursePrompt)
         {
-            PromptNumber = customPrompt.CustomPromptNumber;
-            Prompt = customPrompt.CustomPromptText;
-            OptionsString = NewlineSeparatedStringListHelper.JoinNewlineSeparatedList(customPrompt.Options);
+            PromptNumber = coursePrompt.CoursePromptNumber;
+            Prompt = coursePrompt.CustomPromptText;
+            OptionsString = NewlineSeparatedStringListHelper.JoinNewlineSeparatedList(coursePrompt.Options);
             IncludeAnswersTableCaption = true;
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -35,7 +35,7 @@
         public string LearningMinutes { get; set; }
         public bool Assessed { get; set; }
 
-        public IEnumerable<CustomPromptWithResponseCounts> AdminFieldWithResponseCounts { get; set; }
+        public IEnumerable<CoursePromptWithResponseCounts> AdminFieldWithResponseCounts { get; set; }
         public bool HasAdminFields => AdminFieldWithResponseCounts.Any();
 
         public string CategoryFilter => nameof(CourseStatistics.CategoryName) + FilteringHelper.Separator +

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
@@ -54,7 +54,7 @@
             filters.AddRange(
                 promptsWithOptions.Select(
                     customPrompt => new FilterViewModel(
-                        $"CustomPrompt{customPrompt.CustomPromptNumber}",
+                        $"CustomPrompt{customPrompt.RegistrationField.Id}",
                         customPrompt.CustomPromptText,
                         DelegatesViewModelFilters.GetCustomPromptOptions(customPrompt)
                     )

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
@@ -32,10 +32,10 @@
             DelegateLastName = details.DelegateCourseInfo.DelegateLastName;
             DelegateEmail = details.DelegateCourseInfo.DelegateEmail;
             DelegateCentreId = details.DelegateCourseInfo.DelegateCentreId;
-            CustomFields = details.CustomPrompts.Select(
+            AdminFields = details.CoursePrompts.Select(
                     cp =>
                         new CustomFieldViewModel(
-                            cp.CustomPromptNumber,
+                            cp.CoursePromptNumber,
                             cp.CustomPromptText,
                             cp.Mandatory,
                             cp.Answer
@@ -61,7 +61,7 @@
         public string DelegateLastName { get; set; }
         public string? DelegateEmail { get; set; }
         public int DelegateCentreId { get; set; }
-        public IEnumerable<CustomFieldViewModel> CustomFields { get; set; }
+        public IEnumerable<CustomFieldViewModel> AdminFields { get; set; }
 
         public string DelegateFullName =>
             DelegateFirstName == null ? DelegateLastName : $"{DelegateFirstName} {DelegateLastName}";

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateApprovalsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateApprovalsViewModel.cs
@@ -33,7 +33,7 @@
             JobGroup = delegateUser.JobGroupName;
             CustomPrompts = customPrompts
                 .Select(
-                    cp => new CustomFieldViewModel(cp.CustomPromptNumber, cp.CustomPromptText, cp.Mandatory, cp.Answer)
+                    cp => new CustomFieldViewModel(cp.RegistrationField.Id, cp.CustomPromptText, cp.Mandatory, cp.Answer)
                 )
                 .ToList();
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptions.cs
@@ -25,7 +25,7 @@
                 prompt => new FilterOptionViewModel(
                     prompt.CustomPromptText,
                     nameof(Group.LinkedToField) + FilteringHelper.Separator + nameof(Group.LinkedToField) +
-                    FilteringHelper.Separator + GetLinkedFieldIdFromRegistrationPromptNumber(prompt.CustomPromptNumber),
+                    FilteringHelper.Separator + GetLinkedFieldIdFromRegistrationPromptNumber(prompt.RegistrationField.Id),
                     FilterStatus.Default
                 )
             );

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModelFilterOptions.cs
@@ -24,7 +24,7 @@
             filters.AddRange(
                 promptsWithOptions.Select(
                     customPrompt => new FilterViewModel(
-                        $"CustomPrompt{customPrompt.CustomPromptNumber}",
+                        $"CustomPrompt{customPrompt.RegistrationField.Id}",
                         customPrompt.CustomPromptText,
                         DelegatesViewModelFilters.GetCustomPromptOptions(customPrompt)
                     )

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/GroupDelegates/GroupDelegatesViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/GroupDelegates/GroupDelegatesViewModelFilterOptions.cs
@@ -24,7 +24,7 @@
             filters.AddRange(
                 promptsWithOptions.Select(
                     customPrompt => new FilterViewModel(
-                        $"CustomPrompt{customPrompt.CustomPromptNumber}",
+                        $"CustomPrompt{customPrompt.RegistrationField.Id}",
                         customPrompt.CustomPromptText,
                         DelegatesViewModelFilters.GetCustomPromptOptions(customPrompt)
                     )

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -14,7 +14,7 @@
             Id = delegateUser.Id;
             Name = delegateUser.SearchableName;
             CandidateNumber = delegateUser.CandidateNumber;
-            
+
             IsActive = delegateUser.Active;
             IsAdmin = delegateUser.IsAdmin;
             IsPasswordSet = delegateUser.IsPasswordSet;

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegatesViewModelFilters.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegatesViewModelFilters.cs
@@ -32,7 +32,7 @@
         public static IEnumerable<FilterOptionViewModel> GetCustomPromptOptions(CustomPrompt customPrompt)
         {
             var filterValueName =
-                CentreCustomPromptHelper.GetDelegateCustomPromptAnswerName(customPrompt.CustomPromptNumber);
+                CentreCustomPromptHelper.GetDelegateCustomPromptAnswerName(customPrompt.RegistrationField.Id);
 
             var options = customPrompt.Options.Select(
                 option => new FilterOptionViewModel(
@@ -60,7 +60,7 @@
             IEnumerable<CustomPrompt> promptsWithOptions
         )
         {
-            var promptsWithOptionsIds = promptsWithOptions.Select(c => c.CustomPromptNumber);
+            var promptsWithOptionsIds = promptsWithOptions.Select(c => c.RegistrationField.Id);
             var customFieldsWithOptions =
                 customFields.Where(customField => promptsWithOptionsIds.Contains(customField.CustomFieldId));
             return customFieldsWithOptions

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/DelegateCourseInfoViewModel.cs
@@ -37,7 +37,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.ViewD
 
             DelegateId = details.DelegateCourseInfo.DelegateId;
 
-            CourseCustomPromptsWithAnswers = details.CustomPrompts;
+            CoursePromptsWithAnswers = details.CoursePrompts;
             TotalAttempts = details.AttemptStats.TotalAttempts;
             AttemptsPassed = details.AttemptStats.AttemptsPassed;
             PassRate = details.AttemptStats.PassRate;
@@ -61,7 +61,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.ViewD
         public int? DiagnosticScore { get; set; }
         public bool IsAssessed { get; set; }
 
-        public List<CustomPromptWithAnswer> CourseCustomPromptsWithAnswers { get; set; }
+        public List<CoursePromptWithAnswer> CoursePromptsWithAnswers { get; set; }
         public int TotalAttempts { get; set; }
         public int AttemptsPassed { get; set; }
         public double PassRate { get; set; }

--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -29,7 +29,7 @@
 
   <div class="nhsuk-grid-row divider">
     <div class="nhsuk-grid-column-full">
-      <vc:text-input 
+      <vc:text-input
         asp-for="@nameof(Model.FirstName)"
         label="First name"
         populate-with-current-value="true"
@@ -39,7 +39,7 @@
         hint-text=""
         css-class="nhsuk-u-width-one-half" />
 
-      <vc:text-input 
+      <vc:text-input
         asp-for="@nameof(Model.LastName)"
         label="Last name"
         populate-with-current-value="true"
@@ -49,7 +49,7 @@
         hint-text=""
         css-class="nhsuk-u-width-one-half" />
 
-      <vc:text-input 
+      <vc:text-input
         asp-for="@nameof(Model.Email)"
         label="Email address"
         populate-with-current-value="true"
@@ -112,7 +112,7 @@
                                 To remove your profile picture click the remove button.
                                 Changes will not be made until the Save button below is clicked."; }
       <input type="hidden" asp-for="ProfileImage" />
-      <vc:file-input 
+      <vc:file-input
         asp-for="@nameof(Model.ProfileImageFile)"
         label="Profile picture (optional)"
         hint-text="@hintText"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
@@ -160,7 +160,7 @@
     </div>
   }
 
-  @foreach (var prompt in Model.CustomFields) {
+  @foreach (var prompt in Model.AdminFields) {
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
         @prompt.CustomPrompt

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
@@ -146,7 +146,7 @@
           </div>
         }
 
-        @foreach (var courseCustomPrompt in Model.CourseCustomPromptsWithAnswers) {
+        @foreach (var courseCustomPrompt in Model.CoursePromptsWithAnswers) {
           <div class="nhsuk-summary-list__row details-list-with-button__row">
             <dt class="nhsuk-summary-list__key">
               @courseCustomPrompt.CustomPromptText


### PR DESCRIPTION
### JIRA link
[_HEEDLS-510_](https://softwiretech.atlassian.net/browse/HEEDLS-510)

### Description
The model CustomPrompt was being used for registration prompts and Admin fields. Though they have the same structure, they come from different tables in the db, there are different numbers of each, and CustomPrompt needs to have a LinkedToFieldId. In the other HEEDLS-510 MR, I created an enum RegistrationField to make it easier to link the prompt number of a registration field to it's LinkedToFieldId. In this MR I have replaced the CustomPromptNumber on CustomPrompt with a RegistrationField, and I have created a new model CoursePrompt to be used in place of CustomPrompt for Admin Fields. This also involved renaming a lot of methods that used unclear language (custom prompt vs. course custom prompt vs. admin field).

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
