### PR TITLE
DLSV2-476 Summary of competencies in overview expander headings

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -51,7 +51,7 @@
         </summary>
         <div class="nhsuk-details__text">
           <partial name="SelfAssessments/_CompetencySummary"
-                   view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                   view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup }, { "selfAssessment", Model.SelfAssessment } })" />
 
           @if (Model.SelfAssessment.LinearNavigation)
           {
@@ -67,7 +67,7 @@
       </details>
       <div class="outer-score-container">
         <partial name="SelfAssessments/_CompetencySummary"
-                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup }, { "selfAssessment", Model.SelfAssessment } })" />
       </div>
       @if (Model.SelfAssessment.LinearNavigation)
       {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -50,6 +50,9 @@
           </span>
         </summary>
         <div class="nhsuk-details__text">
+          <partial name="SelfAssessments/_CompetencySummary"
+                   view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+
           @if (Model.SelfAssessment.LinearNavigation)
           {
             <partial name="SelfAssessments/_MeanScores"
@@ -62,6 +65,10 @@
 
         </div>
       </details>
+      <div class="outer-score-container">
+        <partial name="SelfAssessments/_CompetencySummary"
+                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+      </div>
       @if (Model.SelfAssessment.LinearNavigation)
       {
         <div class="outer-score-container nhsuk-u-padding-bottom-4">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
@@ -4,7 +4,7 @@
   var questions = ((IGrouping<string, Competency>)ViewData["competencyGroup"])
     .SelectMany(c => c.AssessmentQuestions)
     .Where(q => q.Required);
-  var selfAssessed = questions.Count(q => q.Verified == null && q.ResultId.HasValue);
+  var selfAssessed = questions.Count(q => q.ResultId.HasValue);
   var verified = questions.Count(q => q.Verified.HasValue);
 }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
@@ -1,0 +1,17 @@
+﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments
+@{
+    var questions = ((IGrouping<string, Competency>)ViewData["competencyGroup"])
+      .SelectMany(c => c.AssessmentQuestions)
+      .Where(q => q.Required);
+    var selfAssessed = questions.Count(q => q.Verified == null && q.ResultId.HasValue);
+    var verified = questions.Count(q => q.Verified.HasValue);
+}
+
+<span class="score">
+  Self assessed: @selfAssessed / @questions.Count()
+</span>
+<br />
+<span class="score">
+  Verified: @verified / @questions.Count()
+</span>
+<br />

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
@@ -1,17 +1,21 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments
 @{
-    var questions = ((IGrouping<string, Competency>)ViewData["competencyGroup"])
-      .SelectMany(c => c.AssessmentQuestions)
-      .Where(q => q.Required);
-    var selfAssessed = questions.Count(q => q.Verified == null && q.ResultId.HasValue);
-    var verified = questions.Count(q => q.Verified.HasValue);
+  var selfAssessment = (CurrentSelfAssessment)ViewData["selfAssessment"];
+  var questions = ((IGrouping<string, Competency>)ViewData["competencyGroup"])
+    .SelectMany(c => c.AssessmentQuestions)
+    .Where(q => q.Required);
+  var selfAssessed = questions.Count(q => q.Verified == null && q.ResultId.HasValue);
+  var verified = questions.Count(q => q.Verified.HasValue);
 }
 
 <span class="score">
   Self assessed: @selfAssessed / @questions.Count()
 </span>
 <br />
-<span class="score">
-  Verified: @verified / @questions.Count()
-</span>
-<br />
+@if (selfAssessment.IsSupervised)
+{
+  <span class="score">
+    Verified: @verified / @questions.Count()
+  </span>
+  <br />
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CompetencySummary.cshtml
@@ -12,7 +12,7 @@
   Self assessed: @selfAssessed / @questions.Count()
 </span>
 <br />
-@if (selfAssessment.IsSupervised)
+@if (selfAssessment.IsSupervisorResultsReviewed)
 {
   <span class="score">
     Verified: @verified / @questions.Count()

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
@@ -10,7 +10,7 @@
     Manage optional @Model.VocabPlural().ToLower()
   </a>
 }
-@if (Model.SelfAssessment.IsSupervised) {
+@if (Model.SelfAssessment.IsSupervisorResultsReviewed) {
   <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
      asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
      asp-action="StartRequestVerification"


### PR DESCRIPTION
Provide summary of competencies to be self-assessed in Overview expander headings.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-476

### Description
Added partial view and logics similar to `SelfAssessments/_MeanScores` and used logics for counting in competency search in [DLSV2-293](https://hee-dls.atlassian.net/browse/DLSV2-293).

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/155679712-3e3351a0-f9c3-45b9-80e0-936296c9c01a.png)

-----
### Developer checks

- Only `Required` questions are counted
- Count summary visible both when group collapsed and expanded
- Count for verified questions is shown only when self assessment is supervised
