### PR TITLE
HEEDLS-786 - add admin fields to course delegates page

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDelegatesDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDelegatesDataServiceTests.cs
@@ -43,6 +43,9 @@
                 AllAttempts = 0,
                 AttemptsPassed = 0,
                 ProfessionalRegistrationNumber = null,
+                Answer1 = string.Empty,
+                Answer2 = string.Empty,
+                Answer3 = string.Empty,
             };
 
             // When

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseDelegatesServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseDelegatesServiceTests.cs
@@ -5,6 +5,7 @@
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Services;
     using FakeItEasy;
     using FluentAssertions;
@@ -13,6 +14,7 @@
 
     public class CourseDelegatesServiceTests
     {
+        private ICourseAdminFieldsService courseAdminFieldsService = null!;
         private ICourseDataService courseDataService = null!;
         private ICourseDelegatesDataService courseDelegatesDataService = null!;
         private ICourseDelegatesService courseDelegatesService = null!;
@@ -20,10 +22,12 @@
         [SetUp]
         public void Setup()
         {
+            courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
             courseDataService = A.Fake<ICourseDataService>();
             courseDelegatesDataService = A.Fake<ICourseDelegatesDataService>();
 
             courseDelegatesService = new CourseDelegatesService(
+                courseAdminFieldsService,
                 courseDataService,
                 courseDelegatesDataService
             );
@@ -35,10 +39,21 @@
             // Given
             const int centreId = 2;
             const int categoryId = 1;
+            const int customisationId = 1;
             A.CallTo(() => courseDataService.GetCoursesAvailableToCentreByCategory(centreId, categoryId))
-                .Returns(new List<CourseAssessmentDetails> { new CourseAssessmentDetails { CustomisationId = 1 } });
+                .Returns(
+                    new List<CourseAssessmentDetails>
+                        { new CourseAssessmentDetails { CustomisationId = customisationId } }
+                );
             A.CallTo(() => courseDelegatesDataService.GetDelegatesOnCourse(A<int>._, A<int>._))
                 .Returns(new List<CourseDelegate> { new CourseDelegate() });
+            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._))
+                .Returns(
+                    new CourseAdminFields(
+                        customisationId,
+                        new List<CustomPrompt> { new CustomPrompt(1, "prompt", null, true) }
+                    )
+                );
 
             // When
             var result = courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(
@@ -52,7 +67,8 @@
             {
                 result.Courses.Should().HaveCount(1);
                 result.Delegates.Should().HaveCount(1);
-                result.CustomisationId.Should().Be(1);
+                result.CustomisationId.Should().Be(customisationId);
+                result.CourseAdminFields.Should().HaveCount(1);
             }
         }
 
@@ -74,6 +90,7 @@
                 result.Courses.Should().BeEmpty();
                 result.Delegates.Should().BeEmpty();
                 result.CustomisationId.Should().BeNull();
+                result.CourseAdminFields.Should().BeEmpty();
             }
         }
 
@@ -88,6 +105,13 @@
                 .Returns(new List<CourseAssessmentDetails> { new CourseAssessmentDetails { CustomisationId = 1 } });
             A.CallTo(() => courseDelegatesDataService.GetDelegatesOnCourse(A<int>._, A<int>._))
                 .Returns(new List<CourseDelegate> { new CourseDelegate() });
+            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._))
+                .Returns(
+                    new CourseAdminFields(
+                        customisationId,
+                        new List<CustomPrompt> { new CustomPrompt(1, "prompt", null, true) }
+                    )
+                );
 
             // When
             var result = courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(
@@ -99,6 +123,8 @@
             // Then
             A.CallTo(() => courseDelegatesDataService.GetDelegatesOnCourse(customisationId, centreId))
                 .MustHaveHappened();
+            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(customisationId))
+                .MustHaveHappenedOnceExactly();
             result.Should().NotBeNull();
         }
 
@@ -114,12 +140,16 @@
                 .Returns(new List<CourseAssessmentDetails> { new CourseAssessmentDetails { CustomisationId = 1 } });
 
             // Then
-            Assert.Throws<CourseAccessDeniedException>(() => courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(
-                centreId,
-                categoryId,
-                customisationId
-            ));
+            Assert.Throws<CourseAccessDeniedException>(
+                () => courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(
+                    centreId,
+                    categoryId,
+                    customisationId
+                )
+            );
             A.CallTo(() => courseDelegatesDataService.GetDelegatesOnCourse(A<int>._, A<int>._))
+                .MustNotHaveHappened();
+            A.CallTo(() => courseAdminFieldsService.GetCustomPromptsForCourse(A<int>._))
                 .MustNotHaveHappened();
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
@@ -54,6 +54,9 @@
                         p.RemovedDate,
                         p.Completed,
                         p.CustomisationId,
+                        p.Answer1,
+                        p.Answer2,
+                        p.Answer3,
                         {AllAttemptsQuery},
                         {AttemptsPassedQuery}
                     FROM Candidates AS c

--- a/DigitalLearningSolutions.Data/Helpers/FilteringHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/FilteringHelper.cs
@@ -11,8 +11,10 @@
     {
         public const char Separator = '|';
         public const char FilterSeparator = '╡';
-        public const char EmptyValue = '╳';
+        public const string EmptyValue = "╳";
         public const string ClearString = "CLEAR";
+        public const string FreeTextBlankValue = "FREETEXTBLANKVALUE";
+        public const string FreeTextNotBlankValue = "FREETEXTNOTBLANKVALUE";
 
         public static string BuildFilterValueString(string group, string propertyName, string propertyValue)
         {
@@ -86,9 +88,16 @@
         {
             var propertyType = typeof(T).GetProperty(propertyName)!.PropertyType;
             var propertyValue = TypeDescriptor.GetConverter(propertyType).ConvertFromString(propertyValueString);
-            return EmptyValue.ToString().Equals(propertyValue)
-                ? items.WhereNullOrEmpty(propertyName)
-                : items.Where(propertyName, propertyValue);
+            switch (propertyValue)
+            {
+                case EmptyValue:
+                case FreeTextBlankValue:
+                    return items.WhereNullOrEmpty(propertyName);
+                case FreeTextNotBlankValue:
+                    return items.Where(item => !items.WhereNullOrEmpty(propertyName).Contains(item));
+                default:
+                    return items.Where(propertyName, propertyValue);
+            }
         }
 
         private class AppliedFilter

--- a/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegate.cs
@@ -19,6 +19,9 @@
         public DateTime? CompleteByDate { get; set; }
         public DateTime? RemovedDate { get; set; }
         public DateTime? Completed { get; set; }
+        public string? Answer1 { get; set; }
+        public string? Answer2 { get; set; }
+        public string? Answer3 { get; set; }
         public int AllAttempts { get; set; }
         public int AttemptsPassed { get; set; }
         public int CustomisationId { get; set; }

--- a/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegatesData.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegatesData.cs
@@ -2,18 +2,21 @@
 {
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public class CourseDelegatesData
     {
         public CourseDelegatesData(
             int? customisationId,
             IEnumerable<Course> courses,
-            IEnumerable<CourseDelegate> delegates
+            IEnumerable<CourseDelegate> delegates,
+            IEnumerable<CustomPrompt> courseAdminFields
         )
         {
             CustomisationId = customisationId;
             Courses = courses;
             Delegates = delegates;
+            CourseAdminFields = courseAdminFields;
         }
 
         public int? CustomisationId { get; set; }
@@ -21,5 +24,7 @@
         public IEnumerable<Course> Courses { get; set; }
 
         public IEnumerable<CourseDelegate> Delegates { get; set; }
+
+        public IEnumerable<CustomPrompt> CourseAdminFields { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CourseDelegatesService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseDelegatesService.cs
@@ -5,6 +5,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
 
     public interface ICourseDelegatesService
     {
@@ -19,14 +20,17 @@
 
     public class CourseDelegatesService : ICourseDelegatesService
     {
+        private readonly ICourseAdminFieldsService courseAdminFieldsService;
         private readonly ICourseDataService courseDataService;
         private readonly ICourseDelegatesDataService courseDelegatesDataService;
 
         public CourseDelegatesService(
+            ICourseAdminFieldsService courseAdminFieldsService,
             ICourseDataService courseDataService,
             ICourseDelegatesDataService courseDelegatesDataService
         )
         {
+            this.courseAdminFieldsService = courseAdminFieldsService;
             this.courseDataService = courseDataService;
             this.courseDelegatesDataService = courseDelegatesDataService;
         }
@@ -59,7 +63,11 @@
                 ? GetCourseDelegatesForCentre(currentCustomisationId.Value, centreId)
                 : new List<CourseDelegate>();
 
-            return new CourseDelegatesData(currentCustomisationId, orderedCourses, courseDelegates);
+            var courseAdminFields = currentCustomisationId.HasValue
+                ? courseAdminFieldsService.GetCustomPromptsForCourse(currentCustomisationId.Value).AdminFields
+                : new List<CustomPrompt>();
+
+            return new CourseDelegatesData(currentCustomisationId, orderedCourses, courseDelegates, courseAdminFields);
         }
 
         public IEnumerable<CourseDelegate> GetCourseDelegatesForCentre(int customisationId, int centreId)

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -4,6 +4,7 @@
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -21,16 +22,22 @@
     {
         private const int UserCentreId = 3;
         private CourseDelegatesController controller = null!;
+        private ICourseAdminFieldsService courseAdminFieldsService = null!;
         private ICourseDelegatesDownloadFileService courseDelegatesDownloadFileService = null!;
         private ICourseDelegatesService courseDelegatesService = null!;
 
         [SetUp]
         public void SetUp()
         {
+            courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
             courseDelegatesService = A.Fake<ICourseDelegatesService>();
             courseDelegatesDownloadFileService = A.Fake<ICourseDelegatesDownloadFileService>();
 
-            controller = new CourseDelegatesController(courseDelegatesService, courseDelegatesDownloadFileService)
+            controller = new CourseDelegatesController(
+                    courseAdminFieldsService,
+                    courseDelegatesService,
+                    courseDelegatesDownloadFileService
+                )
                 .WithDefaultContext()
                 .WithMockUser(true, UserCentreId);
         }
@@ -41,7 +48,14 @@
             // Given
             var course = new Course { CustomisationId = 1, Active = true };
             A.CallTo(() => courseDelegatesService.GetCoursesAndCourseDelegatesForCentre(UserCentreId, null, null))
-                .Returns(new CourseDelegatesData(1, new List<Course> { course }, new List<CourseDelegate>()));
+                .Returns(
+                    new CourseDelegatesData(
+                        1,
+                        new List<Course> { course },
+                        new List<CourseDelegate>(),
+                        new List<CustomPrompt>()
+                    )
+                );
 
             // When
             var result = controller.Index();
@@ -84,7 +98,14 @@
                         customisationId
                     )
                 )
-                .Returns(new CourseDelegatesData(customisationId, new List<Course> { course }, courseDelegate));
+                .Returns(
+                    new CourseDelegatesData(
+                        customisationId,
+                        new List<Course> { course },
+                        courseDelegate,
+                        new List<CustomPrompt>()
+                    )
+                );
 
             var httpRequest = A.Fake<HttpRequest>();
             var httpResponse = A.Fake<HttpResponse>();
@@ -92,6 +113,7 @@
             const string cookieValue = "AccountStatus|Active|true";
 
             var courseDelegatesController = new CourseDelegatesController(
+                    courseAdminFieldsService,
                     courseDelegatesService,
                     courseDelegatesDownloadFileService
                 )

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/CourseDelegates/CourseDelegateViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/CourseDelegates/CourseDelegateViewModelFilterOptionsTests.cs
@@ -1,0 +1,85 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.TrackingSystem.Delegates.CourseDelegates
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Helpers;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class CourseDelegateViewModelFilterOptionsTests
+    {
+        [Test]
+        public void GetAllCourseDelegatesFilterViewModels_should_return_correct_admin_field_filters()
+        {
+            // Given
+            var (adminFields, expectedFilters) = GetSampleAdminFieldsAndFilters();
+
+            // When
+            var result = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels(
+                adminFields
+            );
+
+            // Then
+            expectedFilters.ForEach(expectedFilter => result.Should().ContainEquivalentOf(expectedFilter));
+        }
+
+        private static (List<CustomPrompt> adminFields, List<FilterViewModel> filters) GetSampleAdminFieldsAndFilters()
+        {
+            var adminField1 = CustomPromptsTestHelper.GetDefaultCustomPrompt(
+                1,
+                "System access",
+                "Yes\r\nNo"
+            );
+            var adminField3 = CustomPromptsTestHelper.GetDefaultCustomPrompt(3, "Some Free Text Field");
+            var adminFields = new List<CustomPrompt> { adminField1, adminField3 };
+
+            var adminField1Options = new[]
+            {
+                new FilterOptionViewModel(
+                    "Yes",
+                    "Answer1" + FilteringHelper.Separator +
+                    "Answer1" + FilteringHelper.Separator + "Yes",
+                    FilterStatus.Default
+                ),
+                new FilterOptionViewModel(
+                    "No",
+                    "Answer1" + FilteringHelper.Separator +
+                    "Answer1" + FilteringHelper.Separator + "No",
+                    FilterStatus.Default
+                ),
+                new FilterOptionViewModel(
+                    "No option selected",
+                    "Answer1" + FilteringHelper.Separator +
+                    "Answer1" + FilteringHelper.Separator + FilteringHelper.EmptyValue,
+                    FilterStatus.Default
+                ),
+            };
+            var adminField3Options = new[]
+            {
+                new FilterOptionViewModel(
+                    "Not blank",
+                    "Answer3" + FilteringHelper.Separator +
+                    "Answer3" + FilteringHelper.Separator + FilteringHelper.FreeTextNotBlankValue,
+                    FilterStatus.Default
+                ),
+                new FilterOptionViewModel(
+                    "Blank",
+                    "Answer3" + FilteringHelper.Separator +
+                    "Answer3" + FilteringHelper.Separator + FilteringHelper.FreeTextBlankValue,
+                    FilterStatus.Default
+                ),
+            };
+            var adminFieldFilters = new List<FilterViewModel>
+            {
+                new FilterViewModel("CustomPrompt1", "System access", adminField1Options),
+                new FilterViewModel("CustomPrompt3", "Some Free Text Field", adminField3Options),
+            };
+
+            return (adminFields, adminFieldFilters);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
@@ -23,14 +23,17 @@
     public class CourseDelegatesController : Controller
     {
         private const string CourseDelegatesFilterCookieName = "CourseDelegatesFilter";
+        private readonly ICourseAdminFieldsService courseAdminFieldsService;
         private readonly ICourseDelegatesDownloadFileService courseDelegatesDownloadFileService;
         private readonly ICourseDelegatesService courseDelegatesService;
 
         public CourseDelegatesController(
+            ICourseAdminFieldsService courseAdminFieldsService,
             ICourseDelegatesService courseDelegatesService,
             ICourseDelegatesDownloadFileService courseDelegatesDownloadFileService
         )
         {
+            this.courseAdminFieldsService = courseAdminFieldsService;
             this.courseDelegatesService = courseDelegatesService;
             this.courseDelegatesDownloadFileService = courseDelegatesDownloadFileService;
         }
@@ -90,8 +93,8 @@
         {
             var centreId = User.GetCentreId();
             var courseDelegates = courseDelegatesService.GetCourseDelegatesForCentre(customisationId, centreId);
-
-            var model = new AllCourseDelegatesViewModel(courseDelegates);
+            var adminFields = courseAdminFieldsService.GetCustomPromptsForCourse(customisationId);
+            var model = new AllCourseDelegatesViewModel(courseDelegates, adminFields.AdminFields);
 
             return View(model);
         }

--- a/DigitalLearningSolutions.Web/Helpers/AdminFieldsHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/AdminFieldsHelper.cs
@@ -1,0 +1,45 @@
+﻿namespace DigitalLearningSolutions.Web.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models.CourseDelegates;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using DigitalLearningSolutions.Web.ViewModels.Common;
+
+    public static class AdminFieldsHelper
+    {
+        public static List<CustomFieldViewModel> GetCourseAdminFieldViewModels(
+            CourseDelegate courseDelegate,
+            IEnumerable<CustomPrompt> customPrompts
+        )
+        {
+            var answers = new List<string?>
+            {
+                courseDelegate.Answer1,
+                courseDelegate.Answer2,
+                courseDelegate.Answer3,
+            };
+
+            return customPrompts.Select(
+                cp => new CustomFieldViewModel(
+                    cp.CustomPromptNumber,
+                    cp.CustomPromptText,
+                    cp.Mandatory,
+                    answers[cp.CustomPromptNumber - 1]
+                )
+            ).ToList();
+        }
+
+        public static string GetAdminFieldAnswerName(int customPromptNumber)
+        {
+            return customPromptNumber switch
+            {
+                1 => nameof(CourseDelegate.Answer1),
+                2 => nameof(CourseDelegate.Answer2),
+                3 => nameof(CourseDelegate.Answer3),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/AllCourseDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/AllCourseDelegatesViewModel.cs
@@ -3,15 +3,24 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Web.Extensions;
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public class AllCourseDelegatesViewModel : BaseJavaScriptFilterableViewModel
     {
-        public AllCourseDelegatesViewModel(IEnumerable<CourseDelegate> delegates)
+        public AllCourseDelegatesViewModel(IEnumerable<CourseDelegate> delegates, IList<CustomPrompt> adminFields)
         {
-            Delegates = delegates.Select(d => new SearchableCourseDelegateViewModel(d));
-            Filters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels()
+            Delegates = delegates.Select(
+                d =>
+                {
+                    var adminFieldViewModels = AdminFieldsHelper.GetCourseAdminFieldViewModels(d, adminFields);
+                    var adminFieldsWithOptions = adminFields.Where(field => field.Options.Count > 0);
+                    return new SearchableCourseDelegateViewModel(d, adminFieldViewModels, adminFieldsWithOptions);
+                }
+            );
+            Filters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels(adminFields)
                 .SelectAppliedFilterViewModels();
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/CourseDelegateViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/CourseDelegateViewModelFilterOptions.cs
@@ -1,8 +1,15 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates
 {
     using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Helpers;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Helpers.FilterOptions;
+    using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ViewModels.Common;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Shared;
 
     public class CourseDelegateViewModelFilterOptions
     {
@@ -24,14 +31,96 @@
             CourseDelegateProgressRemovedFilterOptions.NotRemoved,
         };
 
-        public static List<FilterViewModel> GetAllCourseDelegatesFilterViewModels()
+        public static List<FilterViewModel> GetAllCourseDelegatesFilterViewModels(IEnumerable<CustomPrompt> adminFields)
         {
-            return new List<FilterViewModel>
+            var filters = new List<FilterViewModel>
             {
                 new FilterViewModel("ActiveStatus", "Active Status", ActiveStatusOptions),
                 new FilterViewModel("LockedStatus", "Locked Status", LockedStatusOptions),
                 new FilterViewModel("RemovedStatus", "Removed Status", RemovedStatusOptions),
             };
+            filters.AddRange(
+                adminFields.Select(
+                    field => new FilterViewModel(
+                        $"CustomPrompt{field.CustomPromptNumber}",
+                        field.CustomPromptText,
+                        GetCourseDelegateAdminFieldOptions(field)
+                    )
+                )
+            );
+            return filters;
+        }
+
+        public static Dictionary<int, string> GetAdminFieldFilters(
+            IEnumerable<CustomFieldViewModel> adminFields,
+            IEnumerable<CustomPrompt> fieldsWithOptions
+        )
+        {
+            var fieldsWithOptionsIds = fieldsWithOptions.Select(c => c.CustomPromptNumber);
+            return adminFields
+                .Select(
+                    adminField => new KeyValuePair<int, string>(
+                        adminField.CustomFieldId,
+                        GetFilterValueForAdminField(adminField, fieldsWithOptionsIds.Contains(adminField.CustomFieldId))
+                    )
+                ).ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        private static string GetFilterValueForAdminField(CustomFieldViewModel customField, bool adminFieldHasOptions)
+        {
+            var filterValueName =
+                AdminFieldsHelper.GetAdminFieldAnswerName(customField.CustomFieldId);
+
+            string propertyValue;
+
+            if (adminFieldHasOptions)
+            {
+                propertyValue = string.IsNullOrEmpty(customField.Answer)
+                    ? FilteringHelper.EmptyValue
+                    : customField.Answer;
+            }
+            else
+            {
+                propertyValue = string.IsNullOrEmpty(customField.Answer)
+                    ? FilteringHelper.FreeTextBlankValue
+                    : FilteringHelper.FreeTextNotBlankValue;
+            }
+
+            return FilteringHelper.BuildFilterValueString(filterValueName, filterValueName, propertyValue);
+        }
+
+        private static IEnumerable<FilterOptionViewModel> GetCourseDelegateAdminFieldOptions(CustomPrompt adminField)
+        {
+            if (adminField.Options.Count > 0)
+            {
+                return DelegatesViewModelFilters.GetCustomPromptOptions(adminField);
+            }
+
+            var filterValueName =
+                AdminFieldsHelper.GetAdminFieldAnswerName(adminField.CustomPromptNumber);
+
+            var options = new List<FilterOptionViewModel>
+            {
+                new FilterOptionViewModel(
+                    "Not blank",
+                    FilteringHelper.BuildFilterValueString(
+                        filterValueName,
+                        filterValueName,
+                        FilteringHelper.FreeTextNotBlankValue
+                    ),
+                    FilterStatus.Default
+                ),
+                new FilterOptionViewModel(
+                    "Blank",
+                    FilteringHelper.BuildFilterValueString(
+                        filterValueName,
+                        filterValueName,
+                        FilteringHelper.FreeTextBlankValue
+                    ),
+                    FilterStatus.Default
+                ),
+            };
+            return options;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SearchableCourseDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SearchableCourseDelegateViewModel.cs
@@ -1,17 +1,27 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates
 {
+    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
+    using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ViewModels.Common;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public class SearchableCourseDelegateViewModel : BaseFilterableViewModel
     {
-        public SearchableCourseDelegateViewModel(CourseDelegate courseDelegate)
+        public SearchableCourseDelegateViewModel(
+            CourseDelegate courseDelegate,
+            IList<CustomFieldViewModel> adminFields,
+            IEnumerable<CustomPrompt> adminFieldsWithOptions
+        )
         {
             DelegateId = courseDelegate.DelegateId;
             CandidateNumber = courseDelegate.CandidateNumber;
             ProfessionalRegistrationNumber = courseDelegate.ProfessionalRegistrationNumber;
-            TitleName = DisplayStringHelper.GetNameWithEmailForDisplay(courseDelegate.FullNameForSearchingSorting, courseDelegate.EmailAddress);
+            TitleName = DisplayStringHelper.GetNameWithEmailForDisplay(
+                courseDelegate.FullNameForSearchingSorting,
+                courseDelegate.EmailAddress
+            );
             Active = courseDelegate.Active;
             ProgressId = courseDelegate.ProgressId;
             Locked = courseDelegate.Locked;
@@ -23,6 +33,9 @@
             CustomisationId = courseDelegate.CustomisationId;
             PassRate = courseDelegate.PassRate;
             Tags = FilterableTagHelper.GetCurrentTagsForCourseDelegate(courseDelegate);
+            AdminFields = adminFields;
+            AdminFieldFilters =
+                CourseDelegateViewModelFilterOptions.GetAdminFieldFilters(adminFields, adminFieldsWithOptions);
         }
 
         public int DelegateId { get; set; }
@@ -39,5 +52,7 @@
         public double PassRate { get; set; }
         public int CustomisationId { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
+        public IEnumerable<CustomFieldViewModel> AdminFields { get; set; }
+        public Dictionary<int, string> AdminFieldFilters { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedCourseDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedCourseDetailsViewModel.cs
@@ -5,6 +5,7 @@
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public class SelectedCourseDetailsViewModel : BaseSearchablePageViewModel
@@ -20,10 +21,21 @@
         {
             Active = courseDelegatesData.Courses.Single(c => c.CustomisationId == courseDelegatesData.CustomisationId)
                 .Active;
-
             var courseDelegatesToShow = SortFilterAndPaginate(courseDelegatesData.Delegates);
-            Delegates = courseDelegatesToShow.Select(d => new SearchableCourseDelegateViewModel(d));
-            Filters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels();
+            var adminFieldsWithOptions = courseDelegatesData.CourseAdminFields.Where(field => field.Options.Count > 0);
+            Delegates = courseDelegatesToShow.Select(
+                d =>
+                {
+                    var adminFields = AdminFieldsHelper.GetCourseAdminFieldViewModels(
+                        d,
+                        courseDelegatesData.CourseAdminFields
+                    );
+                    return new SearchableCourseDelegateViewModel(d, adminFields, adminFieldsWithOptions);
+                }
+            );
+            Filters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels(
+                courseDelegatesData.CourseAdminFields
+            );
         }
 
         public bool Active { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegatesViewModelFilters.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegatesViewModelFilters.cs
@@ -47,7 +47,7 @@
                     FilteringHelper.BuildFilterValueString(
                         filterValueName,
                         filterValueName,
-                        FilteringHelper.EmptyValue.ToString()
+                        FilteringHelper.EmptyValue
                     ),
                     FilterStatus.Default
                 )
@@ -77,7 +77,7 @@
             var filterValueName =
                 CentreCustomPromptHelper.GetDelegateCustomPromptAnswerName(customField.CustomFieldId);
             var propertyValue = string.IsNullOrEmpty(customField.Answer)
-                ? FilteringHelper.EmptyValue.ToString()
+                ? FilteringHelper.EmptyValue
                 : customField.Answer;
             return FilteringHelper.BuildFilterValueString(filterValueName, filterValueName, propertyValue);
         }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -21,12 +21,14 @@
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="delegate-id">
             @Model.CandidateNumber
           </dd>
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
             Professional Registration Number
           </dt>
           <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
@@ -35,6 +37,7 @@
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="last-updated-date">
             @Model.LastUpdated
           </dd>
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
@@ -43,6 +46,7 @@
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="enrolled-date">
             @Model.Enrolled
           </dd>
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
@@ -51,6 +55,7 @@
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="complete-by-date">
             @(Model.CompleteBy ?? "-")
           </dd>
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
@@ -59,12 +64,14 @@
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="completed-date">
             @(Model.Completed ?? "-")
           </dd>
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
             Removed
           </dt>
           <partial name="_SummaryFieldValue" model="@Model.RemovedDate" />
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
@@ -73,13 +80,29 @@
           <dd class="nhsuk-summary-list__value" data-name-for-sorting="pass-rate">
             @Model.PassRate%
           </dd>
+          <dd class="nhsuk-summary-list__actions" />
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
             Progress locked
           </dt>
           <partial name="_SummaryBooleanField" model="Model.Locked" />
+          <dd class="nhsuk-summary-list__actions" />
         </div>
+        @foreach (var adminField in Model.AdminFields) {
+          <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">@adminField.CustomPrompt</dt>
+            <partial name="_SummaryFieldValue" model="@adminField.Answer" />
+            @if (Model.AdminFieldFilters.ContainsKey(adminField.CustomFieldId)) {
+              <div hidden data-filter-value="@Model.AdminFieldFilters[adminField.CustomFieldId]"></div>
+            }
+            <dd class="nhsuk-summary-list__actions">
+              <a>
+                Edit<span class="nhsuk-u-visually-hidden"> @adminField.CustomPrompt</span>
+              </a>
+            </dd>
+          </div>
+        }
       </dl>
 
       <a class="nhsuk-button expander-card__button"


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-786

### Description
Added admin fields to the course delegates cards. Also implemented filtering on these fields, with new functionality for free-text fields.

### Screenshots
<img src="https://user-images.githubusercontent.com/80777689/156173181-3b997517-4f96-49f7-8e8f-80a0171964ab.PNG" width=320px />

![No JS filters](https://user-images.githubusercontent.com/80777689/156173184-b77484c4-9250-45c2-bd79-5f03527a74ff.PNG)

![Desktop course delegates page](https://user-images.githubusercontent.com/80777689/156173185-e29a9b17-9372-4dc9-b073-0252bf91740b.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
