### PR TITLE
HEEDLS-551 Fix bug with clearing filters on select course page

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/addNewCentreCourseSelectCourse.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/addNewCentreCourseSelectCourse.ts
@@ -45,9 +45,7 @@ function setUpFilterDropdowns() {
       e.preventDefault();
       const newFilter = getCategoryAndTopicFilterByAndUpdateHiddenInputs();
 
-      if (newFilter != null) {
-        updateFilterBy(newFilter);
-      }
+      updateFilterBy(newFilter);
     });
   });
 }
@@ -113,22 +111,20 @@ function getCategoryAndTopicFilterByAndUpdateHiddenInputs() {
   const topicFilterElement = <HTMLSelectElement>document.getElementById('CourseTopic');
   const topicFilterValue = topicFilterElement.value;
 
+  updateFilterByHiddenInput(categoryHiddenInputName, categoryFilterValue);
+  updateFilterByHiddenInput(topicHiddenInputName, topicFilterValue);
+
   if (isNullOrEmpty(categoryFilterValue) && isNullOrEmpty(topicFilterValue)) {
-    return null;
+    return '';
   }
 
   if (isNullOrEmpty(categoryFilterValue)) {
-    updateFilterByHiddenInput(topicHiddenInputName, topicFilterValue);
     return topicFilterValue;
   }
 
   if (isNullOrEmpty(topicFilterValue)) {
-    updateFilterByHiddenInput(categoryHiddenInputName, categoryFilterValue);
     return categoryFilterValue;
   }
-
-  updateFilterByHiddenInput(categoryHiddenInputName, categoryFilterValue);
-  updateFilterByHiddenInput(topicHiddenInputName, topicFilterValue);
 
   return topicFilterValue + filterSeparator + categoryFilterValue;
 }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-551_](https://softwiretech.atlassian.net/browse/HEEDLS-551)

### Description
Fix bug with clearing filters on select course page. Selecting "All categories" or "All topics" should successfully clear the respective filter applied when selected.

### Screenshots
(No UI changes)
![localhost_5001_TrackingSystem_CourseSetup_AddCourse_SelectCourse (8)](https://user-images.githubusercontent.com/70278044/156620975-2d67b622-e0a4-4ff5-8e16-90fea9a6a14f.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
