### PR TITLE
HEEDLS-510 Retain registration prompt answers when error occurs

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -21,10 +21,10 @@
     [Authorize]
     public class MyAccountController : Controller
     {
-        private readonly PromptsService promptsService;
         private readonly ICentreRegistrationPromptsService centreRegistrationPromptsService;
         private readonly IImageResizeService imageResizeService;
         private readonly IJobGroupsDataService jobGroupsDataService;
+        private readonly PromptsService promptsService;
         private readonly IUserService userService;
 
         public MyAccountController(
@@ -142,7 +142,7 @@
 
             if (!ModelState.IsValid)
             {
-                return ReturnToEditDetailsViewWithErrors(formData, dlsSubApplication, userDelegateId);
+                return ReturnToEditDetailsViewWithErrors(formData, dlsSubApplication);
             }
 
             if (!userService.NewEmailAddressIsValid(formData.Email!, userAdminId, userDelegateId, User.GetCentreId()))
@@ -151,7 +151,7 @@
                     nameof(MyAccountEditDetailsFormData.Email),
                     "A user with this email address is already registered at this centre"
                 );
-                return ReturnToEditDetailsViewWithErrors(formData, dlsSubApplication, userDelegateId);
+                return ReturnToEditDetailsViewWithErrors(formData, dlsSubApplication);
             }
 
             var (accountDetailsData, centreAnswersData) = AccountDetailsDataHelper.MapToUpdateAccountData(
@@ -167,14 +167,12 @@
 
         private IActionResult ReturnToEditDetailsViewWithErrors(
             MyAccountEditDetailsFormData formData,
-            DlsSubApplication dlsSubApplication,
-            int? userDelegateId
+            DlsSubApplication dlsSubApplication
         )
         {
-            var (_, delegateUser) = userService.GetUsersById(null, userDelegateId);
             var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical().ToList();
             var customPrompts =
-                promptsService.GetEditDelegateRegistrationPromptViewModelsForCentre(delegateUser, User.GetCentreId());
+                promptsService.GetEditDelegateRegistrationPromptViewModelsForCentre(formData, User.GetCentreId());
             var model = new MyAccountEditDetailsViewModel(formData, jobGroups, customPrompts, dlsSubApplication);
             return View(model);
         }

--- a/DigitalLearningSolutions.Web/Helpers/PromptsService.cs
+++ b/DigitalLearningSolutions.Web/Helpers/PromptsService.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.ViewModels.Common;
+    using DigitalLearningSolutions.Web.ViewModels.MyAccount;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
 
     public class PromptsService
@@ -30,6 +31,22 @@
                 delegateUser?.Answer4,
                 delegateUser?.Answer5,
                 delegateUser?.Answer6
+            );
+        }
+
+        public List<EditDelegateRegistrationPromptViewModel> GetEditDelegateRegistrationPromptViewModelsForCentre(
+            MyAccountEditDetailsFormData formData,
+            int centreId
+        )
+        {
+            return GetEditDelegateRegistrationPromptViewModelsForCentre(
+                centreId,
+                formData.Answer1,
+                formData.Answer2,
+                formData.Answer3,
+                formData.Answer4,
+                formData.Answer5,
+                formData.Answer6
             );
         }
 


### PR DESCRIPTION
### JIRA link
_HEEDLS-510_

### Description
Ensure the user's registration prompt answers get retained on the Edit details page if an error occurs.

### Screenshots
No UI changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
