### PR TITLE
HEEDLS-795 Use display PRN string helper throughout the site

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -59,6 +59,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             101,
             false,
             "HG1",
+            false,
             null
         );
 

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/GroupTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/GroupTestHelper.cs
@@ -18,6 +18,7 @@
             string lastName = "xxxx",
             string? emailAddress = "gslectik.m@vao",
             string candidateNumber = "KT553",
+            bool hasBeenPromptedForPrn = false,
             string? professionalRegistrationNumber = null
         )
         {
@@ -33,6 +34,7 @@
                 EmailAddress = emailAddress,
                 CandidateNumber = candidateNumber,
                 AddedDate = addedDate,
+                HasBeenPromptedForPrn = hasBeenPromptedForPrn,
                 ProfessionalRegistrationNumber = professionalRegistrationNumber,
             };
         }

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -159,6 +159,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                 ca.EmailAddress AS DelegateEmail,
                 ca.CentreID AS DelegateCentreId,
                 ca.CandidateNumber AS DelegateNumber,
+                ca.HasBeenPromptedForPrn,
                 ca.ProfessionalRegistrationNumber
             FROM Customisations cu
             INNER JOIN Applications ap ON ap.ApplicationID = cu.ApplicationID

--- a/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDelegatesDataService.cs
@@ -45,6 +45,7 @@
                         c.LastName,
                         c.EmailAddress,
                         c.Active,
+                        c.HasBeenPromptedForPrn,
                         c.ProfessionalRegistrationNumber,
                         p.ProgressID,
                         p.PLLocked AS Locked,

--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -195,6 +195,7 @@
                         EmailAddress,
                         CandidateNumber,
                         AddedDate,
+                        HasBeenPromptedForPrn,
                         ProfessionalRegistrationNumber
                     FROM GroupDelegates AS gd
                     JOIN Candidates AS c ON c.CandidateID = gd.DelegateID

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -178,6 +178,7 @@
                         cd.Answer5,
                         cd.Answer6,
                         cd.JobGroupID,
+                        cd.HasBeenPromptedForPrn,
                         cd.ProfessionalRegistrationNumber,
                         jg.JobGroupName
                     FROM Candidates AS cd

--- a/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseDelegates/CourseDelegate.cs
@@ -10,6 +10,7 @@
         public string? FirstName { get; set; }
         public string LastName { get; set; }
         public string? EmailAddress { get; set; }
+        public bool HasBeenPromptedForPrn { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
         public bool Active { get; set; }
         public int ProgressId { get; set; }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -44,6 +44,7 @@
             int delegateCentreId,
             bool isProgressLocked,
             string delegateNumber,
+            bool hasBeenPromptedForPrn,
             string? professionalRegistrationNumber
         )
         {
@@ -84,6 +85,7 @@
             DelegateNumber = delegateNumber;
             DelegateCentreId = delegateCentreId;
             IsProgressLocked = isProgressLocked;
+            HasBeenPromptedForPrn = hasBeenPromptedForPrn;
             ProfessionalRegistrationNumber = professionalRegistrationNumber;
         }
 
@@ -122,6 +124,7 @@
         public string DelegateNumber { get; set; }
         public int DelegateCentreId { get; set; }
         public bool IsProgressLocked { get; set; }
+        public bool HasBeenPromptedForPrn { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/DelegateGroups/GroupDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateGroups/GroupDelegate.cs
@@ -21,8 +21,10 @@
 
         public DateTime AddedDate { get; set; }
 
+        public bool HasBeenPromptedForPrn { get; set; }
+
         public string? ProfessionalRegistrationNumber { get; set; }
-        
+
         public override string SearchableName
         {
             get => SearchableNameOverrideForFuzzySharp ?? NameQueryHelper.GetSortableFullName(FirstName, LastName);

--- a/DigitalLearningSolutions.Data/Models/DetailedProgress.cs
+++ b/DigitalLearningSolutions.Data/Models/DetailedProgress.cs
@@ -21,6 +21,7 @@
             DelegateLastName = delegateCourseInfo.DelegateLastName;
             DelegateEmail = delegateCourseInfo.DelegateEmail;
             DelegateNumber = delegateCourseInfo.DelegateNumber;
+            HasBeenPromptedForPrn = delegateCourseInfo.HasBeenPromptedForPrn;
             ProfessionalRegistrationNumber = delegateCourseInfo.ProfessionalRegistrationNumber;
 
             LastUpdated = delegateCourseInfo.LastUpdated;
@@ -40,6 +41,7 @@
         public string DelegateLastName { get; set; }
         public string? DelegateEmail { get; set; }
         public string DelegateNumber { get; set; }
+        public bool HasBeenPromptedForPrn { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
 
         public DateTime LastUpdated { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/SearchableDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/SearchableDelegateViewModel.cs
@@ -19,10 +19,7 @@
         )
         {
             DelegateInfo = new DelegateInfoViewModel(delegateUser, delegateRegistrationPrompts);
-            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
-                DelegateInfo.HasBeenPromptedForPrn,
-                DelegateInfo.ProfessionalRegistrationNumber
-            );
+            ProfessionalRegistrationNumber = DelegateInfo.ProfessionalRegistrationNumber;
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateUser(delegateUser);
             RegistrationPromptFilters = DelegatesViewModelFilters.GetRegistrationPromptFilters(
                 DelegateInfo.DelegateRegistrationPrompts,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/SearchableDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/SearchableDelegateViewModel.cs
@@ -19,7 +19,6 @@
         )
         {
             DelegateInfo = new DelegateInfoViewModel(delegateUser, delegateRegistrationPrompts);
-            ProfessionalRegistrationNumber = DelegateInfo.ProfessionalRegistrationNumber;
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateUser(delegateUser);
             RegistrationPromptFilters = DelegatesViewModelFilters.GetRegistrationPromptFilters(
                 DelegateInfo.DelegateRegistrationPrompts,
@@ -29,8 +28,6 @@
         }
 
         public DelegateInfoViewModel DelegateInfo { get; set; }
-
-        public string ProfessionalRegistrationNumber { get; set; }
 
         public string JobGroupFilter => FilteringHelper.BuildFilterValueString(
             nameof(DelegateUserCard.JobGroupId),

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/SearchableDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/SearchableDelegateViewModel.cs
@@ -19,6 +19,10 @@
         )
         {
             DelegateInfo = new DelegateInfoViewModel(delegateUser, delegateRegistrationPrompts);
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                DelegateInfo.HasBeenPromptedForPrn,
+                DelegateInfo.ProfessionalRegistrationNumber
+            );
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateUser(delegateUser);
             RegistrationPromptFilters = DelegatesViewModelFilters.GetRegistrationPromptFilters(
                 DelegateInfo.DelegateRegistrationPrompts,
@@ -28,6 +32,8 @@
         }
 
         public DelegateInfoViewModel DelegateInfo { get; set; }
+
+        public string ProfessionalRegistrationNumber { get; set; }
 
         public string JobGroupFilter => FilteringHelper.BuildFilterValueString(
             nameof(DelegateUserCard.JobGroupId),

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/DelegateProgressViewModel.cs
@@ -18,7 +18,10 @@
         {
             AccessedVia = accessedVia;
             IsCourseActive = details.DelegateCourseInfo.IsCourseActive;
-            ProfessionalRegistrationNumber = details.DelegateCourseInfo.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                details.DelegateCourseInfo.HasBeenPromptedForPrn,
+                details.DelegateCourseInfo.ProfessionalRegistrationNumber
+            );
             Supervisor = details.DelegateCourseInfo.SupervisorAdminId != null
                 ? DisplayStringHelper.GetPotentiallyInactiveAdminName(
                     details.DelegateCourseInfo.SupervisorForename,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SearchableCourseDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SearchableCourseDelegateViewModel.cs
@@ -17,7 +17,10 @@
         {
             DelegateId = courseDelegate.DelegateId;
             CandidateNumber = courseDelegate.CandidateNumber;
-            ProfessionalRegistrationNumber = courseDelegate.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                courseDelegate.HasBeenPromptedForPrn,
+                courseDelegate.ProfessionalRegistrationNumber
+            );
             TitleName = DisplayStringHelper.GetNameWithEmailForDisplay(
                 courseDelegate.FullNameForSearchingSorting,
                 courseDelegate.EmailAddress

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateApprovalsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateApprovalsViewModel.cs
@@ -20,7 +20,10 @@
 
     public class UnapprovedDelegate
     {
-        public UnapprovedDelegate(DelegateUser delegateUser, List<CentreRegistrationPromptWithAnswer> registrationPrompts)
+        public UnapprovedDelegate(
+            DelegateUser delegateUser,
+            List<CentreRegistrationPromptWithAnswer> registrationPrompts
+        )
         {
             Id = delegateUser.Id;
             CandidateNumber = delegateUser.CandidateNumber;
@@ -31,10 +34,18 @@
             TitleName = DisplayStringHelper.GetNameWithEmailForDisplay(fullName, delegateUser.EmailAddress);
             DateRegistered = delegateUser.DateRegistered;
             JobGroup = delegateUser.JobGroupName;
-            ProfessionalRegistrationNumber = delegateUser.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                delegateUser.HasBeenPromptedForPrn,
+                delegateUser.ProfessionalRegistrationNumber
+            );
             DelegateRegistrationPrompts = registrationPrompts
                 .Select(
-                    cp => new DelegateRegistrationPrompt(cp.RegistrationField.Id, cp.PromptText, cp.Mandatory, cp.Answer)
+                    cp => new DelegateRegistrationPrompt(
+                        cp.RegistrationField.Id,
+                        cp.PromptText,
+                        cp.Mandatory,
+                        cp.Answer
+                    )
                 )
                 .ToList();
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/DetailedCourseProgressViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/DetailedCourseProgressViewModel.cs
@@ -25,7 +25,10 @@
             );
             DelegateEmail = progress.DelegateEmail;
             DelegateNumber = progress.DelegateNumber;
-            ProfessionalRegistrationNumber = progress.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                progress.HasBeenPromptedForPrn,
+                progress.ProfessionalRegistrationNumber
+            );
 
             LastUpdated = progress.LastUpdated.ToString(DateHelper.StandardDateAndTimeFormat);
             Enrolled = progress.Enrolled.ToString(DateHelper.StandardDateAndTimeFormat);

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/GroupDelegates/GroupDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/GroupDelegates/GroupDelegateViewModel.cs
@@ -1,7 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.GroupDelegates
 {
-    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
+    using DigitalLearningSolutions.Web.Helpers;
 
     public class GroupDelegateViewModel
     {
@@ -11,10 +11,16 @@
             GroupId = groupDelegate.GroupId;
             DelegateId = groupDelegate.DelegateId;
             TitleName = groupDelegate.SearchableName;
-            Name = DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(groupDelegate.FirstName, groupDelegate.LastName);
+            Name = DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(
+                groupDelegate.FirstName,
+                groupDelegate.LastName
+            );
             EmailAddress = groupDelegate.EmailAddress;
             CandidateNumber = groupDelegate.CandidateNumber;
-            ProfessionalRegistrationNumber = groupDelegate.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                groupDelegate.HasBeenPromptedForPrn,
+                groupDelegate.ProfessionalRegistrationNumber
+            );
         }
 
         public int GroupDelegateId { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/RejectDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/RejectDelegateViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Web.Helpers;
 
     public class RejectDelegateViewModel
     {
@@ -11,8 +12,12 @@
             FullName = delegateUser.FirstName + " " + delegateUser.LastName;
             Email = delegateUser.EmailAddress;
             DateRegistered = delegateUser.DateRegistered;
-            ProfessionalRegistrationNumber = delegateUser.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                delegateUser.HasBeenPromptedForPrn,
+                delegateUser.ProfessionalRegistrationNumber
+            );
         }
+
         public int Id { get; set; }
         public string FullName { get; set; }
         public string? Email { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -29,8 +29,10 @@
             Email = delegateUser.EmailAddress;
             JobGroupId = delegateUser.JobGroupId;
             JobGroup = delegateUser.JobGroupName;
-            HasBeenPromptedForPrn = delegateUser.HasBeenPromptedForPrn;
-            ProfessionalRegistrationNumber = delegateUser.ProfessionalRegistrationNumber;
+            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
+                delegateUser.HasBeenPromptedForPrn,
+                delegateUser.ProfessionalRegistrationNumber
+            );
             if (delegateUser.DateRegistered.HasValue)
             {
                 RegistrationDate = delegateUser.DateRegistered.Value.ToString(DateHelper.StandardDateFormat);
@@ -56,8 +58,7 @@
         public string? JobGroup { get; set; }
         public string? RegistrationDate { get; set; }
         public string? AliasId { get; set; }
-        public bool HasBeenPromptedForPrn { get; set; }
-        public string? ProfessionalRegistrationNumber { get; set; }
+        public string ProfessionalRegistrationNumber { get; set; }
 
         public IEnumerable<DelegateRegistrationPrompt> DelegateRegistrationPrompts { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -8,7 +8,10 @@
 
     public class DelegateInfoViewModel
     {
-        public DelegateInfoViewModel(DelegateUserCard delegateUser, IEnumerable<DelegateRegistrationPrompt> delegateRegistrationPrompts)
+        public DelegateInfoViewModel(
+            DelegateUserCard delegateUser,
+            IEnumerable<DelegateRegistrationPrompt> delegateRegistrationPrompts
+        )
         {
             Id = delegateUser.Id;
             TitleName = delegateUser.SearchableName;
@@ -26,6 +29,7 @@
             Email = delegateUser.EmailAddress;
             JobGroupId = delegateUser.JobGroupId;
             JobGroup = delegateUser.JobGroupName;
+            HasBeenPromptedForPrn = delegateUser.HasBeenPromptedForPrn;
             ProfessionalRegistrationNumber = delegateUser.ProfessionalRegistrationNumber;
             if (delegateUser.DateRegistered.HasValue)
             {
@@ -52,6 +56,7 @@
         public string? JobGroup { get; set; }
         public string? RegistrationDate { get; set; }
         public string? AliasId { get; set; }
+        public bool HasBeenPromptedForPrn { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
 
         public IEnumerable<DelegateRegistrationPrompt> DelegateRegistrationPrompts { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/ViewDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/ViewDelegateViewModel.cs
@@ -21,8 +21,8 @@
             DelegateCourses = delegateCourses.Select(x => new DelegateCourseInfoViewModel(x)).ToList();
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateUser(delegateUser);
             ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
-                delegateUser.HasBeenPromptedForPrn,
-                delegateUser.ProfessionalRegistrationNumber
+                DelegateInfo.HasBeenPromptedForPrn,
+                DelegateInfo.ProfessionalRegistrationNumber
             );
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/ViewDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/ViewDelegateViewModel.cs
@@ -20,12 +20,10 @@
             DelegateInfo = new DelegateInfoViewModel(delegateUser, customFields);
             DelegateCourses = delegateCourses.Select(x => new DelegateCourseInfoViewModel(x)).ToList();
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateUser(delegateUser);
-            ProfessionalRegistrationNumber = DelegateInfo.ProfessionalRegistrationNumber;
         }
 
         public DelegateInfoViewModel DelegateInfo { get; set; }
         public IEnumerable<DelegateCourseInfoViewModel> DelegateCourses { get; set; }
         public IEnumerable<SearchableTagViewModel> Tags { get; set; }
-        public string ProfessionalRegistrationNumber { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/ViewDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/ViewDelegateViewModel.cs
@@ -20,10 +20,7 @@
             DelegateInfo = new DelegateInfoViewModel(delegateUser, customFields);
             DelegateCourses = delegateCourses.Select(x => new DelegateCourseInfoViewModel(x)).ToList();
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateUser(delegateUser);
-            ProfessionalRegistrationNumber = DisplayStringHelper.GetPrnDisplayString(
-                DelegateInfo.HasBeenPromptedForPrn,
-                DelegateInfo.ProfessionalRegistrationNumber
-            );
+            ProfessionalRegistrationNumber = DelegateInfo.ProfessionalRegistrationNumber;
         }
 
         public DelegateInfoViewModel DelegateInfo { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
@@ -56,7 +56,7 @@
           <dt class="nhsuk-summary-list__key">
             Professional Registration Number
           </dt>
-          <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
+          <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
         </div>
 
         @foreach (var delegateRegistrationPrompt in Model.DelegateInfo.DelegateRegistrationPrompts) {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
@@ -1,5 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Common
-@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.AllDelegates
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.AllDelegates
 @model SearchableDelegateViewModel
 
 <div class="searchable-element nhsuk-expander-group word-break" id="@Model.DelegateInfo.Id-card">
@@ -57,10 +56,10 @@
           <dt class="nhsuk-summary-list__key">
             Professional Registration Number
           </dt>
-          <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
+          <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
         </div>
 
-        @foreach (DelegateRegistrationPrompt delegateRegistrationPrompt in Model.DelegateInfo.DelegateRegistrationPrompts) {
+        @foreach (var delegateRegistrationPrompt in Model.DelegateInfo.DelegateRegistrationPrompts) {
           <div class="nhsuk-summary-list__row details-list-with-button__row">
             <dt class="nhsuk-summary-list__key">@delegateRegistrationPrompt.Prompt</dt>
             <partial name="_SummaryFieldValue" model="@delegateRegistrationPrompt.Answer" />
@@ -78,7 +77,7 @@
          asp-action="Index"
          asp-route-delegateId="@Model.DelegateInfo.Id"
          asp-route-isFromViewDelegatePage="false"
-         asp-route-returnPage="@Model.Page" >
+         asp-route-returnPage="@Model.Page">
         Set password
       </a>
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupDelegates/_AddGroupDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupDelegates/_AddGroupDelegateCard.cshtml
@@ -52,7 +52,7 @@
       <dt class="nhsuk-summary-list__key">
         Professional Registration Number
       </dt>
-      <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
+      <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
     </div>
 
     <div class="nhsuk-summary-list__row details-list-with-button__row">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupDelegates/_AddGroupDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/GroupDelegates/_AddGroupDelegateCard.cshtml
@@ -52,7 +52,7 @@
       <dt class="nhsuk-summary-list__key">
         Professional Registration Number
       </dt>
-      <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
+      <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
     </div>
 
     <div class="nhsuk-summary-list__row details-list-with-button__row">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -87,7 +87,7 @@
         <dt class="nhsuk-summary-list__key">
           Professional Registration Number
         </dt>
-        <partial name="_SummaryFieldValue" model="@Model.ProfessionalRegistrationNumber" />
+        <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
       </div>
     </dl>
 


### PR DESCRIPTION
### JIRA link
[_HEEDLS-795_](https://softwiretech.atlassian.net/browse/HEEDLS-795)

### Description
Makes the PRN display format consistent across the site. This is: show the PRN is the user has provided one, show "Not professionally registered" if they have been prompted for a PRN but have not provided one, and show "Not yet provided" if the user has not been prompted for one.

I think I caught all the places the PRN is shown, My Account and Manage Delegate already had the required format.
Here's a list of where the PRN is displayed:
- My account
- All delegates
- Delegate progress
- Detailed progress
- Manage delegate
- Group delegates 
- Add delegate to group
- Course delegates
- Approve registrations
- Reject registration confirmation

### Screenshots
![localhost_5001_TrackingSystem_Delegates_All_1 (1)](https://user-images.githubusercontent.com/70278044/157642491-ce9b3f43-a2fd-4290-b285-a786c1417ec4.png)
![localhost_5001_TrackingSystem_Delegates_All_1](https://user-images.githubusercontent.com/70278044/157642502-c63d51fb-44f2-4113-aacf-6f756b9719d1.png)
![localhost_5001_TrackingSystem_Delegates_All_1 (2)](https://user-images.githubusercontent.com/70278044/157642510-cc79ddde-226a-47fd-9787-58bc211a6852.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
