### PR TITLE
add breadcrumbs & remove export all/side nav

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
@@ -12,24 +12,19 @@
   ViewData["Title"] = "Course delegates";
 }
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-one-quarter">
-    <nav class="side-nav-menu" aria-label="Side navigation bar">
-      <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.CourseDelegates" />
-    </nav>
-  </div>
+@section NavBreadcrumbs {
+  <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegateCoursesBreadcrumbs.cshtml" model="@Model.CustomisationId" />
+}
 
-  <div class="nhsuk-grid-column-three-quarters">
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
     <vc:loading-spinner page-has-side-nav-menu="true" />
     <div id="area-to-hide-while-loading">
       <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-one-third">
+        <div class="nhsuk-grid-column-three-quarters">
           <h1 id="page-heading" class="nhsuk-heading-xl">Course delegates</h1>
         </div>
-        <div class="nhsuk-grid-column-two-thirds heading-button-group">
-          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button">
-            Export all
-          </a>
+        <div class="nhsuk-grid-column-one-quarter heading-button-group">
           <a class="nhsuk-button nhsuk-button--secondary heading-button"
              id="export-current"
              asp-controller="CourseDelegates"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml
@@ -6,6 +6,14 @@
     <ol class="nhsuk-breadcrumb__list">
       <li class="nhsuk-breadcrumb__item">
         <a class="nhsuk-breadcrumb__link"
+           asp-controller="DelegateCourses"
+           asp-action="Index"
+           asp-route-customisationId="@Model.customisationId">
+          Delegate courses
+        </a>
+      </li>
+      <li class="nhsuk-breadcrumb__item">
+        <a class="nhsuk-breadcrumb__link"
            asp-controller="CourseDelegates"
            asp-action="Index"
            asp-route-customisationId="@Model.customisationId">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCoursesBreadcrumbs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCoursesBreadcrumbs.cshtml
@@ -6,12 +6,9 @@
       <li class="nhsuk-breadcrumb__item">
         <a class="nhsuk-breadcrumb__link" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Delegate courses</a>
       </li>
-      <li class="nhsuk-breadcrumb__item">
-        <a class="nhsuk-breadcrumb__link" asp-controller="CourseDelegates" asp-action="Index" asp-route-customisationId="@Model">Course delegates</a>
-      </li>
     </ol>
     <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="CourseDelegates" asp-action="Index" asp-route-customisationId="@Model">Back to course delegates</a>
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Back to delegate courses</a>
     </p>
   </div>
 </nav>


### PR DESCRIPTION
### JIRA link
_[HEEDLS-778](https://softwiretech.atlassian.net/browse/HEEDLS-778)_

### Description
_A few changes have been made to Course delegates to make way for the new precursor page that has been added. The changes include removing the side-nav, updating the breadcrumbs and removing the export all button._

### Screenshots
![image](https://user-images.githubusercontent.com/58184056/157654667-ea0dfd4e-f971-497d-8539-cf805fe76783.png)
![image](https://user-images.githubusercontent.com/58184056/157654748-e0d637f5-2729-47d3-be39-39aa7c4c64ee.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
