### PR TITLE
Heedls 551 add new course

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/addNewCentreCourseSelectCourse.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/addNewCentreCourseSelectCourse.ts
@@ -104,14 +104,17 @@ function displaySearchableElements(searchableElements: ISearchableElement[]): vo
 }
 
 function getCategoryAndTopicFilterStringAndUpdateHiddenInputs() {
-  const categoryFilterElement = <HTMLSelectElement>document.getElementById('CategoryName');
-  const categoryFilterValue = categoryFilterElement.value;
-
   const topicFilterElement = <HTMLSelectElement>document.getElementById('CourseTopic');
   const topicFilterValue = topicFilterElement.value;
-
-  updateExistingFilterStringHiddenInput(categoryHiddenInputName, categoryFilterValue);
   updateExistingFilterStringHiddenInput(topicHiddenInputName, topicFilterValue);
+
+  const categoryFilterElement = <HTMLSelectElement>document.getElementById('CategoryName');
+  if (!categoryFilterElement) {
+    return topicFilterValue;
+  }
+
+  const categoryFilterValue = categoryFilterElement.value;
+  updateExistingFilterStringHiddenInput(categoryHiddenInputName, categoryFilterValue);
 
   if (isNullOrEmpty(categoryFilterValue) && isNullOrEmpty(topicFilterValue)) {
     return '';

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/addNewCentreCourseSelectCourse.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/addNewCentreCourseSelectCourse.ts
@@ -82,22 +82,38 @@ function filterElements(
 }
 
 function displaySearchableElements(searchableElements: ISearchableElement[]): void {
-  const searchableElementsContainer = document.getElementById('searchable-elements');
+  const searchableElementsContainer = <HTMLSelectElement>document.getElementById('searchable-elements');
   if (!searchableElementsContainer) {
     return;
   }
+
+  const selectedApplicationId = searchableElementsContainer.value;
 
   const defaultOption = document.getElementById('default-option');
   if (!defaultOption) {
     return;
   }
-  defaultOption.innerText = searchableElements.length === 0 ? 'No matching courses' : 'Select a course';
+  if (searchableElements.length === 0) {
+    defaultOption.innerText = 'No matching courses';
+    searchableElementsContainer.value = '';
+  } else {
+    defaultOption.innerText = 'Select a course';
+  }
 
   searchableElementsContainer.textContent = '';
   searchableElementsContainer.appendChild(defaultOption);
   searchableElements.forEach(
     (searchableElement) => searchableElementsContainer.appendChild(searchableElement.element),
   );
+
+  const selectedElement = searchableElements.find(
+    (x) => (<HTMLOptionElement>x.element).value === selectedApplicationId,
+  );
+  if (!selectedElement) {
+    searchableElementsContainer.selectedIndex = 0;
+  } else {
+    searchableElementsContainer.selectedIndex = searchableElements.indexOf(selectedElement) + 1;
+  }
 
   // This is required to polyfill the new elements in IE
   Details();

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AddNewCentreCourse/SelectCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AddNewCentreCourse/SelectCourse.cshtml
@@ -44,9 +44,9 @@
                   aria-describedby="@nameof(Model.ApplicationId)-error @nameof(Model.ApplicationId)-hint"
                   id="searchable-elements"
                   name="@nameof(Model.ApplicationId)"
-                  value="@Model.ApplicationId?.ToString()">
+                  value="@Model.ApplicationId">
 
-            <option id="default-option" disabled selected=@(Model.ApplicationId?.ToString() != null ? "" : "selected")>@defaultOptionText</option>
+            <option id="default-option" disabled selected=@(Model.ApplicationId != null ? "" : "selected")>@defaultOptionText</option>
             @foreach (var item in Model.ApplicationOptions) {
               <partial name="AddNewCentreCourse/_SelectCourseFilterableSelectListItem" model="@item" />
             }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-551_](https://softwiretech.atlassian.net/browse/HEEDLS-551)

### Description
This MR ensures the JS filtering doesn't break if the user has a non-zero CategoryID (meaning the category filter dropdown doesn't show for them).

I fixed a browser bug that was found - Firefox was selecting the last course in the dropdown when the filters were changed, rather than "Select a course". I've also fine-tuned the JS filtering so that if you select a course and then change the filters in a way that that course is no longer in the dropdown, "Select a course" will be selected rather than an empty option. 

### Screenshots
No UI changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
