### PR TITLE
DLSV2-522 Admin users active check in Manage Supervisors causes a Sql error

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -129,7 +129,7 @@
                     EXCEPT
                     {selectQuery}
                     WHERE (sd.Removed IS NULL) AND (sd.Confirmed IS NOT NULL) AND (sd.CandidateID = @candidateId) AND (ca.SelfAssessmentID = @selfAssessmentId)
-                    GROUP BY sd.ID, SupervisorAdminID, SupervisorEmail, sd.NotificationSent, au.Forename + ' ' + au.Surname",
+                    GROUP BY sd.ID, SupervisorAdminID, SupervisorEmail, sd.NotificationSent, au.Forename + ' ' + au.Surname, au.Active",
                 new { selfAssessmentId, candidateId }
             );
         }


### PR DESCRIPTION
Admin users active check in Manage Supervisors causes a SQL error.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-522

### Description
Added Active column to `group by` list, so it can be used in `select` statement. 

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/157840342-97c20f4f-da72-4bb7-a8cc-7eaaa77ad42f.png)
![image](https://user-images.githubusercontent.com/94055251/157840920-ee3936dd-d7c9-452e-94d3-6d79b4b214ef.png)

-----
### Developer checks
Checked that it works with active and inactive admins.
