### PR TITLE
HEEDLS-700 Exclude archived applications from dashboard count

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -288,6 +288,16 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         }
 
         [Test]
+        public void GetNumberOfActiveCoursesAtCentreFilteredByCategory_excludes_courses_from_archived_applications()
+        {
+            // When
+            var count = courseDataService.GetNumberOfActiveCoursesAtCentreFilteredByCategory(101, null);
+
+            // Then
+            count.Should().Be(141);
+        }
+
+        [Test]
         public void GetCourseStatisticsAtCentreFilteredByCategory_should_return_course_statistics_correctly()
         {
             // Given

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -279,11 +279,15 @@ namespace DigitalLearningSolutions.Data.DataServices
         {
             return (int)connection.ExecuteScalar(
                 @"SELECT COUNT(*)
-                        FROM Customisations AS c
-                        JOIN Applications AS a on a.ApplicationID = c.ApplicationID
-                        WHERE Active = 1 AND CentreID = @centreId
-	                    AND (a.CourseCategoryID = @adminCategoryId OR @adminCategoryId IS NULL)
-                        AND a.DefaultContentTypeID <> 4",
+                        FROM dbo.Customisations AS cu
+                        INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = cu.ApplicationID
+                        INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = ca.ApplicationID
+                        WHERE (ap.CourseCategoryID = @adminCategoryId OR @adminCategoryId IS NULL)
+                            AND cu.Active = 1
+                            AND cu.CentreID = @centreId
+                            AND ca.CentreID = @centreId
+                            AND ap.ArchivedDate IS NULL
+                            AND ap.DefaultContentTypeID <> 4",
                 new { centreId, adminCategoryId }
             );
         }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-700_](https://softwiretech.atlassian.net/browse/HEEDLS-700)

### Description
Exclude all archived applications from the dashboard course count so it is consistent with the number of active courses shown on the Course Setup page. To make them exactly consistent it was also necessary to join on CentreApplications and take only CentreApplications at the centre.

### Screenshots
No UI changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
