### PR TITLE
DLSV2-519 When user submits comment without selecting a question, an error is thrown

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
@@ -5,6 +5,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
     using DigitalLearningSolutions.Web.Helpers.ExternalApis;
+    using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
     using FakeItEasy;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -69,10 +70,10 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
                 config,
                 actionPlanService,
                 candidateAssessmentDownloadFileService
-            )
-            {
-                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } },
-            };
+            );
+            controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
+            controller = controller.WithMockTempData();
+
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -124,7 +124,7 @@
                         question.SupportingComments = postedBackQuestion.SupportingComments;
                     }
                 }
-                ModelState.AddModelError(htmlTagId, "Selecting a question is mandatory when a comment is provided.");
+                ModelState.AddModelError(htmlTagId, "Please choose a response to the question before submitting comments.");
             }
 
             return View("SelfAssessments/SelfAssessmentCompetency", model);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -140,14 +140,6 @@
             int? competencyGroupId
         )
         {
-            var unansweredRadioQuestion = assessmentQuestions.FirstOrDefault(q => q.AssessmentQuestionInputTypeID != 2 && q.Result == null && q.SupportingComments != null);
-            if (unansweredRadioQuestion?.SupportingComments != null)
-            {
-                TempData["CommentSubmittedWithoutSelectingQuestionId"] = unansweredRadioQuestion.Id;
-                TempData.Set<List<AssessmentQuestion>>(assessmentQuestions.ToList());
-                return RedirectToAction("SelfAssessmentCompetency", new { selfAssessmentId, competencyNumber });
-            }
-
             var candidateId = User.GetCandidateIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId);
             if (assessment == null)
@@ -156,6 +148,14 @@
                     $"Attempt to set self assessment competency for candidate {candidateId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            }
+
+            var unansweredRadioQuestion = assessmentQuestions.FirstOrDefault(q => q.AssessmentQuestionInputTypeID != 2 && q.Result == null && q.SupportingComments != null);
+            if (unansweredRadioQuestion?.SupportingComments != null)
+            {
+                TempData["CommentSubmittedWithoutSelectingQuestionId"] = unansweredRadioQuestion.Id;
+                TempData.Set<List<AssessmentQuestion>>(assessmentQuestions.ToList());
+                return RedirectToAction("SelfAssessmentCompetency", new { selfAssessmentId, competencyNumber });
             }
 
             foreach (var assessmentQuestion in assessmentQuestions)

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -108,6 +108,15 @@
                 competencyNumber,
                 assessment.NumberOfCompetencies
             );
+
+            var commentSubmittedWithoutSelectingQuestionId = (int?)TempData["CommentSubmittedWithoutSelectingQuestionId"];
+            if (commentSubmittedWithoutSelectingQuestionId.HasValue)
+            {
+                var question = competency.AssessmentQuestions.FirstOrDefault(q => q.Id == commentSubmittedWithoutSelectingQuestionId);
+                var htmlTagId = $"radio-{question?.Id}-{question?.LevelDescriptors?.FirstOrDefault()?.LevelValue}";
+                ModelState.AddModelError(htmlTagId, "Selecting a question is mandatory when a comment is provided.");
+            }
+
             return View("SelfAssessments/SelfAssessmentCompetency", model);
         }
 
@@ -121,6 +130,13 @@
             int? competencyGroupId
         )
         {
+            var unansweredRadioQuestion = assessmentQuestions.FirstOrDefault(q => q.AssessmentQuestionInputTypeID != 2 && q.Result == null && q.SupportingComments != null);
+            if (unansweredRadioQuestion?.SupportingComments != null)
+            {
+                TempData["CommentSubmittedWithoutSelectingQuestionId"] = unansweredRadioQuestion.Id;
+                return RedirectToAction("SelfAssessmentCompetency", new { selfAssessmentId, competencyNumber });
+            }
+
             var candidateId = User.GetCandidateIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId);
             if (assessment == null)

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -112,8 +112,18 @@
             var commentSubmittedWithoutSelectingQuestionId = (int?)TempData["CommentSubmittedWithoutSelectingQuestionId"];
             if (commentSubmittedWithoutSelectingQuestionId.HasValue)
             {
-                var question = competency.AssessmentQuestions.FirstOrDefault(q => q.Id == commentSubmittedWithoutSelectingQuestionId);
-                var htmlTagId = $"radio-{question?.Id}-{question?.LevelDescriptors?.FirstOrDefault()?.LevelValue}";
+                var unansweredRadioQuestion = competency.AssessmentQuestions.FirstOrDefault(q => q.Id == commentSubmittedWithoutSelectingQuestionId);
+                var htmlTagId = $"radio-{unansweredRadioQuestion?.Id}-{unansweredRadioQuestion?.LevelDescriptors?.FirstOrDefault()?.LevelValue}";
+                var postedBackQuestions = TempData.Get<List<AssessmentQuestion>>();
+                foreach (var question in competency.AssessmentQuestions)
+                {
+                    var postedBackQuestion = postedBackQuestions.FirstOrDefault(p => p.Id == question.Id);
+                    if(postedBackQuestion != null)
+                    {
+                        question.Result = postedBackQuestion.Result;
+                        question.SupportingComments = postedBackQuestion.SupportingComments;
+                    }
+                }
                 ModelState.AddModelError(htmlTagId, "Selecting a question is mandatory when a comment is provided.");
             }
 
@@ -134,6 +144,7 @@
             if (unansweredRadioQuestion?.SupportingComments != null)
             {
                 TempData["CommentSubmittedWithoutSelectingQuestionId"] = unansweredRadioQuestion.Id;
+                TempData.Set<List<AssessmentQuestion>>(assessmentQuestions.ToList());
                 return RedirectToAction("SelfAssessmentCompetency", new { selfAssessmentId, competencyNumber });
             }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -1,8 +1,9 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @model SelfAssessmentCompetencyViewModel
 @{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
     Layout = "SelfAssessments/_Layout";
-    ViewData["Title"] = "Self Assessment";
+    ViewData["Title"] = errorHasOccurred ? "Error: Self Assessment" : "Self Assessment";
     ViewData["SelfAssessmentTitle"] = @Model.Assessment.Name;
 }
 @section breadcrumbs {
@@ -24,6 +25,10 @@
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/pagination.css")" asp-append-version="true">
+@if (errorHasOccurred)
+{
+  <vc:error-summary order-of-property-names="@(new[] { nameof(Model) })" />
+}
 <h1 class="competency-group-header nhsuk-u-font-size-32">@Model.Competency.CompetencyGroup</h1>
 <div class=" nhsuk-u-margin-top-8 nhsuk-u-margin-bottom-8">
     @if (Model.Competency.Description != null && Model.Assessment.UseDescriptionExpanders && !Model.Competency.AlwaysShowDescription)
@@ -63,21 +68,22 @@
         }
         else
         {
-            <partial name="SelfAssessments/_RadioQuestion" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />
+            <nhs-form-group nhs-validation-for="Competency.AssessmentQuestions[1].Result">
+              <partial name="SelfAssessments/_RadioQuestion" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />
+            </nhs-form-group>
         }
-        @if (question.value.SignedOff != null)
-            if ((bool)question.value.SignedOff)
-            {
-                <div class="nhsuk-warning-callout">
-                    <h3 class="nhsuk-warning-callout__label">
-                        <span role="text">
-                            <span class="nhsuk-u-visually-hidden">Important: </span>
-                            Response confirmed
-                        </span>
-                    </h3>
-                    <p>Your self assessment response against this question has been confirmed. Changing your response will reset confirmation.</p>
-                </div>
-            }
+        @if (question.value.SignedOff != null && question.value.SignedOff == true)
+        {
+            <div class="nhsuk-warning-callout">
+                <h3 class="nhsuk-warning-callout__label">
+                    <span role="text">
+                        <span class="nhsuk-u-visually-hidden">Important: </span>
+                        Response confirmed
+                    </span>
+                </h3>
+                <p>Your self assessment response against this question has been confirmed. Changing your response will reset confirmation.</p>
+            </div>
+        }
         @if (question.value.IncludeComments)
         {
             <partial name="SelfAssessments/_CommentsInput" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />


### PR DESCRIPTION
When a user submits a comment without responding to the assessment question an error is thrown.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-519

### Description
Since the model for getting and posting back the form is different, I am using `TempData` and redirecting to the original view when an error is detected. In addition, radio buttons are generated dynamically,. So in order to use standard validation applied trough the application, the controller method could predict html tag `id` for the first option button for the competency that's throwing the error and insert and error in `ModelState` for this element.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/158697342-004d5e45-c1d8-40fc-8181-25a0cd53764b.png)
![image](https://user-images.githubusercontent.com/94055251/158697355-657a407c-d0d7-449c-80ed-8ef40bfb25ac.png)

-----
### Developer checks
Inserted data for reproducing the error and checked that standard error validation used in the application is shown when comment is provided but not radio button is selected for a competency.