### PR TITLE
DLSV2-483 Indicate whether comments have been logged against self assessments

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionReviewCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionReviewCells.cshtml
@@ -1,6 +1,9 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
 @model AssessmentQuestion
-
+@{
+  var actionLinkText = Model.Requested != null && Model.Verified == null ? "Confirm" : "View";
+  if (!String.IsNullOrEmpty(Model.SupportingComments)) actionLinkText += " (comments)";
+}
 
 <partial name="Shared/_AssessmentQuestionCells" model="Model" />
 @if ((bool)(ViewData["isSupervisorResultsReviewed"] ?? true))
@@ -14,6 +17,13 @@
   @if (Model.ResultId != null)
   {
     <span class="nhsuk-table-responsive__heading">Actions </span>
-    <a asp-action="ReviewCompetencySelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-viewMode="@(Model.Requested != null && Model.Verified == null ? "Review" : "View")" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]" asp-route-resultId="@Model.ResultId">@(Model.Requested != null && Model.Verified == null ? "Confirm" : "View")<span class="nhsuk-u-visually-hidden"> capability</span></a>
+    <a asp-action="ReviewCompetencySelfAssessment"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+       asp-route-viewMode="@(Model.Requested != null && Model.Verified == null ? "Review" : "View")"
+       asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]"
+       asp-route-resultId="@Model.ResultId">
+          <span class="status-tag">@actionLinkText</span>
+          <span class="nhsuk-u-visually-hidden"> capability</span>
+    </a>
   }
 </td>


### PR DESCRIPTION
Indicate in Supervisor/Review whether comments have been logged against self assessments.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-483

### Description
Updated the partial view _AssessmentQuestionReviewCells.cshtml for including the requested information. Since there's a space between "View" and "(comments)", I have prevented text to wrap into two lines by including css class `status-tag` that contains `white-space: nowrap;`.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/159013663-d8e6c81d-147f-4538-8d78-837308a8823a.png)

-----
### Developer checks
Checked it works for "Confirm" and "View" links.
Checked that when the link contains the word "comments", comments can be seen by following the link.