### PR TITLE
HEEDLS-NONE - fix the appsettings connection strings after a commit b…

### DIFF
--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=ACER\\SQLEXPRESS;Initial Catalog=mbdbx101;Integrated Security=True;"
+    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True;"
   },
   "CurrentSystemBaseUrl": "https://localhost:44367",
   "AppRootPath": "https://localhost:44363",

--- a/DigitalLearningSolutions.Web/appsettings.SIT.json
+++ b/DigitalLearningSolutions.Web/appsettings.SIT.json
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=ACER\\SQLEXPRESS;Initial Catalog=mbdbx101_test;Integrated Security=True;"
+    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101_test;Integrated Security=True;"
   },
   "CurrentSystemBaseUrl": "https://localhost:44367",
   "AppRootPath": "https://localhost:44363",

--- a/DigitalLearningSolutions.Web/appsettings.Test.json
+++ b/DigitalLearningSolutions.Web/appsettings.Test.json
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=ACER\\SQLEXPRESS;Initial Catalog=mbdbx101_test;Integrated Security=True;"
+    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101_test;Integrated Security=True;"
   },
   "CurrentSystemBaseUrl": "https://www.dls.nhs.uk/dev-prev",
   "AppRootPath": "https://hee-dls-test.softwire.com",

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -1,8 +1,8 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=ACER\\SQLEXPRESS;Initial Catalog=mbdbx101;Integrated Security=True;",
-    "UnitTestConnection": "Data Source=ACER\\SQLEXPRESS;Initial Catalog=mbdbx101_test;Integrated Security=True;"
+    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True;",
+    "UnitTestConnection": "Data Source=localhost;Initial Catalog=mbdbx101_test;Integrated Security=True;"
   },
   "CurrentSystemBaseUrl": "https://www.dls.nhs.uk",
   "AppRootPath": "https://localhost:44363",


### PR DESCRIPTION
…roke them.

### JIRA link
N/A

### Description
A branch was merged into master that converted the appsettings connection strings to be different from the required "localhost". The PR that broke it: https://github.com/TechnologyEnhancedLearning/DLSV2/pull/996/files . This prevented both Test and local environments from running. This PR fixes it.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
