### PR TITLE
HEEDLS-621 - fix course delegates URL and Staff List return pages

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -22,7 +22,7 @@ export interface ISearchableData {
 export class SearchSortFilterAndPaginate {
   private page: number;
 
-  private queryParameterToRetain: string;
+  private readonly queryParameterToRetain: string;
 
   private readonly searchEnabled: boolean;
 

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -22,6 +22,8 @@ export interface ISearchableData {
 export class SearchSortFilterAndPaginate {
   private page: number;
 
+  private queryParameterToRetain: string;
+
   private readonly searchEnabled: boolean;
 
   private readonly paginationEnabled: boolean;
@@ -42,12 +44,14 @@ export class SearchSortFilterAndPaginate {
     filterEnabled: boolean,
     filterCookieName = '',
     searchableElementClassSuffixes = ['title'],
+    queryParameterToRetain = '',
   ) {
     this.spinnerContainer = document.getElementById('loading-spinner-container') as HTMLElement;
     this.spinner = document.getElementById('dynamic-loading-spinner') as HTMLElement;
     this.areaToHide = document.getElementById('area-to-hide-while-loading') as HTMLElement;
     this.startLoadingSpinner();
-    this.page = paginationEnabled ? SearchSortFilterAndPaginate.getPageNumber() : 1;
+    this.queryParameterToRetain = queryParameterToRetain;
+    this.page = paginationEnabled ? this.getPageNumber() : 1;
     this.searchEnabled = searchEnabled;
     this.paginationEnabled = paginationEnabled;
     this.filterEnabled = filterEnabled;
@@ -245,37 +249,55 @@ export class SearchSortFilterAndPaginate {
     }
 
     this.page = pageNumber;
-
-    SearchSortFilterAndPaginate.ensurePageNumberSetInUrl();
-    const currentPath = window.location.pathname;
-    const urlParts = currentPath.split('/');
-    const newUrl = `${urlParts.slice(0, -1).join('/')}/${pageNumber.toString()}`;
-    window.history.replaceState({}, '', newUrl);
-
+    this.ensurePageNumberSetInUrl();
     this.updateSearchableElementLinks(searchableData);
   }
 
-  private static getPageNumber(): number {
-    SearchSortFilterAndPaginate.ensurePageNumberSetInUrl();
+  private getPageNumber(): number {
+    this.ensurePageNumberSetInUrl();
     const currentPath = window.location.pathname;
     const urlParts = currentPath.split('/');
     return parseInt(urlParts[urlParts.length - 1], 10);
   }
 
-  /* Guarantees the last element of the path is a number with no trailing slashes */
-  private static ensurePageNumberSetInUrl(): void {
+  /* Guarantees the last element of the path is a number
+   * with any query parameters necessary and no trailing slashes */
+  private ensurePageNumberSetInUrl(): void {
     const currentPath = window.location.pathname;
     const urlParts = currentPath.split('/');
     if (urlParts[urlParts.length - 1] === '') {
       urlParts.pop();
     }
 
-    const pageNumber = parseInt(urlParts[urlParts.length - 1], 10);
-
-    if (Number.isNaN(pageNumber)) {
-      const newUrl = `${urlParts.join('/')}/1`;
-      window.history.replaceState({}, '', newUrl);
+    let currentPageNumber = parseInt(urlParts[urlParts.length - 1], 10);
+    if (Number.isNaN(currentPageNumber)) {
+      currentPageNumber = 1;
+    } else {
+      urlParts.pop();
     }
+
+    const pageNumber = this.page ?? currentPageNumber;
+    const queryParametersToRetain = this.getQueryParametersForUpdatedURL();
+    const newUrl = `${urlParts.join('/')}/${pageNumber}${queryParametersToRetain}`;
+    window.history.replaceState({}, '', newUrl);
+  }
+
+  private getQueryParametersForUpdatedURL(): string {
+    const currentQueryParameters = window.location.search.replace('?', '');
+    if (currentQueryParameters.length === 0 || this.queryParameterToRetain === '') {
+      return '';
+    }
+
+    const separatedParameters = currentQueryParameters.split('&');
+    const keptQueryParameters: string[] = [];
+    separatedParameters.forEach((param) => {
+      const paramName = param.split('=')[0];
+      if (paramName.toUpperCase() === this.queryParameterToRetain.toUpperCase()) {
+        keptQueryParameters.push(param);
+      }
+    });
+
+    return keptQueryParameters.length > 0 ? `?${keptQueryParameters.join('&')}` : '';
   }
 
   private updateSearchableElementLinks(searchableData: ISearchableData): void {

--- a/DigitalLearningSolutions.Web/Scripts/trackingSystem/courseDelegates.ts
+++ b/DigitalLearningSolutions.Web/Scripts/trackingSystem/courseDelegates.ts
@@ -16,4 +16,4 @@ exportCurrentLink.addEventListener('click', () => {
 });
 
 // eslint-disable-next-line no-new
-new SearchSortFilterAndPaginate(`TrackingSystem/Delegates/CourseDelegates/AllCourseDelegates/${customisationId}`, false, true, true, 'CourseDelegatesFilter');
+new SearchSortFilterAndPaginate(`TrackingSystem/Delegates/CourseDelegates/AllCourseDelegates/${customisationId}`, false, true, true, 'CourseDelegatesFilter', undefined, 'CUSTOMISATIONID');

--- a/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
@@ -8,6 +8,7 @@
   ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "My Staff - Confirm Remove";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/Supervisor/MyStaff";
   ViewData["HeaderPathName"] = "My Staff";
+  var cancelLinkRouteData = new Dictionary<string, string> {{"page", Model.ReturnPage.ToString()}};
 }
 
 @section NavMenuItems {
@@ -47,6 +48,6 @@
       @Html.HiddenFor(m=> m.DelegateEmail)
       @Html.HiddenFor(m=> m.CandidateAssessmentCount)
     </form>
-    <vc:cancel-link asp-controller="Supervisor" asp-action="MyStaffList" asp-route-returnPage="@Model.ReturnPage">Cancel</vc:cancel-link>
+    <vc:cancel-link asp-controller="Supervisor" asp-action="MyStaffList" asp-all-route-data="@cancelLinkRouteData" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
@@ -17,7 +17,7 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <vc:loading-spinner page-has-side-nav-menu="true" />
+    <vc:loading-spinner page-has-side-nav-menu="false" />
     <div id="area-to-hide-while-loading">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-three-quarters">


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-621

### Description
Fixed the Staff List return page issue for the removal confirmation page, but the link to the page is strangely set up and will point to a bad action when the user has no self assessments.
Fixed the course delegates page by modifying the JS to take query in a whitelisted query parameter and preserve any that match. 
Have not been able to fix the screen reader issue. 

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
