### PR TITLE
HEEDLS-797 : Fix return page on remove delegate

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
@@ -78,7 +78,8 @@
             var result = viewDelegateController.ConfirmRemoveFromCourse(
                 1,
                 1,
-                DelegateAccessRoute.ViewDelegate
+                DelegateAccessRoute.ViewDelegate,
+                1
             );
 
             // Then
@@ -102,7 +103,8 @@
             var result = viewDelegateController.ConfirmRemoveFromCourse(
                 1,
                 1,
-                DelegateAccessRoute.ViewDelegate
+                DelegateAccessRoute.ViewDelegate,
+                1
             );
 
             // Then

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -96,7 +96,8 @@
         public IActionResult ConfirmRemoveFromCourse(
             int delegateId,
             int customisationId,
-            DelegateAccessRoute accessedVia
+            DelegateAccessRoute accessedVia,
+            int? returnPage
         )
         {
             if (!courseService.DelegateHasCurrentProgress(delegateId, customisationId))
@@ -116,7 +117,8 @@
                 customisationId,
                 course!.CourseName,
                 false,
-                accessedVia
+                accessedVia,
+                returnPage
             );
 
             return View("ConfirmRemoveFromCourse", model);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -111,7 +111,7 @@
             var model = new RemoveFromCourseViewModel(
                 delegateId,
                 DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(
-                    delegateUser.FirstName,
+                    delegateUser!.FirstName,
                     delegateUser.LastName
                 ),
                 customisationId,
@@ -150,7 +150,11 @@
             );
 
             return model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)
-                ? RedirectToAction("Index", "CourseDelegates", new { customisationId })
+                ? RedirectToAction(
+                    "Index",
+                    "CourseDelegates",
+                    new { customisationId, page = model.ReturnPage.ToString() }
+                )
                 : RedirectToAction("Index", "ViewDelegate", new { delegateId });
         }
 
@@ -160,6 +164,7 @@
         {
             var centreId = User.GetCentreId();
             var delegateUser = userDataService.GetDelegateUserCardById(delegateId);
+
             if (delegateUser?.CentreId != centreId)
             {
                 return new NotFoundResult();

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/RemoveFromCourseViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/ViewDelegate/RemoveFromCourseViewModel.cs
@@ -6,7 +6,7 @@
 
     public class RemoveFromCourseViewModel : IValidatableObject
     {
-        public RemoveFromCourseViewModel() {}
+        public RemoveFromCourseViewModel() { }
 
         public RemoveFromCourseViewModel(
             int delegateId,
@@ -14,7 +14,8 @@
             int customisationId,
             string courseName,
             bool confirm,
-            DelegateAccessRoute accessedVia
+            DelegateAccessRoute accessedVia,
+            int? returnPage
         )
         {
             DelegateId = delegateId;
@@ -23,6 +24,7 @@
             CourseName = courseName;
             Confirm = confirm;
             AccessedVia = accessedVia;
+            ReturnPage = returnPage;
         }
 
         public int DelegateId { get; set; }
@@ -31,6 +33,7 @@
         public string CourseName { get; set; }
         public bool Confirm { get; set; }
         public DelegateAccessRoute AccessedVia { get; set; }
+        public int? ReturnPage { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
@@ -57,6 +57,7 @@
           asp-route-accessedVia="@Model.AccessedVia">
       <input type="hidden" name="name" value="@Model.Name" />
       <input type="hidden" name="courseName" value="@Model.CourseName" />
+      <input type="hidden" name="returnPage" value="@Model.ReturnPage" />
 
       <vc:single-checkbox asp-for="@nameof(Model.Confirm)"
                           label="I am sure that I wish to remove this enrolment"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/ConfirmRemoveFromCourse.cshtml
@@ -13,6 +13,7 @@
 
   if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)) {
     cancelLinkRouteData.Add("customisationId", Model.CustomisationId.ToString());
+    cancelLinkRouteData.Add("page", Model.ReturnPage.ToString());
     cancelLinkController = "CourseDelegates";
   } else {
     cancelLinkRouteData.Add("delegateId", Model.DelegateId.ToString());


### PR DESCRIPTION
### JIRA link
_[HEEDLS-797](https://softwiretech.atlassian.net/browse/HEEDLS-797)_

### Description
_An issue cropped up during testing where the user wasn't being returned to the correct page on Course Delegates when they used the cancel link on the remove confirmation page._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
