### PR TITLE
DLSV2-521 Allow a Supervisor to remove a self assessment from a staff member if it has not been started

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -175,7 +175,7 @@
             var delegateSelfAssessments = supervisorService.GetSelfAssessmentsForSupervisorDelegateId(supervisorDelegateId, adminId);
             var model = new DelegateSelfAssessmentsViewModel()
             {
-                IsNominatedSupervisor = loggedInAdminUser?.IsNominatedSupervisor ?? false,
+                IsNominatedSupervisor = loggedInAdminUser?.IsSupervisor == true ? false : loggedInAdminUser?.IsNominatedSupervisor ?? false,
                 SupervisorDelegateDetail = superviseDelegate,
                 DelegateSelfAssessments = delegateSelfAssessments
             };


### PR DESCRIPTION
Allow a Supervisor to remove a self assessment from a staff member if it has not been started.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-521

### Description
**Remove link changes: We're leaving it as it is for the being.**
The code for displaying remove link was already in place on partial view _DelegateProfileAssessmentGrid. But Remove link is shown when `CandidateAssessments.LaunchCount` is zero. In regards to property `LastAccessed` its value can be CandidateAssessments.LastAccessed or CandidateAssessments.StartedDate if the former is null (see SupervisorService.cs, line 236, method: `GetSelfAssessmentsForSupervisorDelegateId`). 

**Changes made:** On view Supervisor\DelegateProfileAssessments.cshtml, if admin was promoted to supervisor, `IsNominated` property should return false, so it doesn't prevent access to all supervisor features. Used similar approach taken in MyStaffListViewModel.cs:(line 53).

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/159729717-54b6027a-ffb7-454a-b0d0-347e82ba59ff.png)

-----
### Developer checks

- Checked that even when nominated supervisor is set to 1 on table AdminUsers, the button "Enrol on new assessment" is present.
- Checked that when admin user is nominated supervisor, the the button "Enrol on new assessment" is hidden.