### PR TITLE
HEEDLS-800 fix display of values in searchable summary value

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/_SearchableSummaryFieldValue.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_SearchableSummaryFieldValue.cshtml
@@ -10,6 +10,6 @@
   </dd>
 } else {
   <dd class="nhsuk-summary-list__value @searchClass">
-    @Model
+    @Model.value
   </dd>
 }


### PR DESCRIPTION
### JIRA link
_[HEEDLS-800](https://softwiretech.atlassian.net/browse/HEEDLS-800)_

### Description
Fixing a silly oversight in the value display for the new partial.

### Screenshots
![image](https://user-images.githubusercontent.com/34240850/159752261-4ccc990b-f344-4096-9add-853cc2fbbbdc.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
