### PR TITLE
HEEDLS-647 Fix Clear Filters resetting sort and items per page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewComponents/CurrentFiltersViewComponentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewComponents/CurrentFiltersViewComponentTests.cs
@@ -68,6 +68,9 @@
             var expectedFilterViewModel = new CurrentFiltersViewModel(
                 expectedAppliedFilters,
                 searchString,
+                null,
+                null,
+                10,
                 new Dictionary<string, string>()
             );
 

--- a/DigitalLearningSolutions.Web.Tests/ViewComponents/CurrentFiltersViewComponentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewComponents/CurrentFiltersViewComponentTests.cs
@@ -40,16 +40,19 @@
             var categories = new List<Category>
                 { new Category { CategoryName = "Word" }, new Category { CategoryName = "Excel" } };
             const string searchString = "test";
+            const string sortBy = "sort";
+            const string sortDirection = "sortDirection";
+            const int itemsPerPage = 10;
 
             var availableFilters = AdministratorsViewModelFilterOptions.GetAllAdministratorsFilterModels(categories);
 
             var inputViewModel = new CentreAdministratorsViewModel(
                 1,
                 new SearchSortFilterPaginationResult<AdminUser>(
-                    new PaginationResult<AdminUser>(new List<AdminUser>(), 1, 1, 10, 0),
+                    new PaginationResult<AdminUser>(new List<AdminUser>(), 1, 1, itemsPerPage, 0),
                     searchString,
-                    null,
-                    null,
+                    sortBy,
+                    sortDirection,
                     "CategoryName|CategoryName|Word╡Role|IsCentreAdmin|true"
                 ),
                 availableFilters,
@@ -68,9 +71,9 @@
             var expectedFilterViewModel = new CurrentFiltersViewModel(
                 expectedAppliedFilters,
                 searchString,
-                null,
-                null,
-                10,
+                sortBy,
+                sortDirection,
+                itemsPerPage,
                 new Dictionary<string, string>()
             );
 

--- a/DigitalLearningSolutions.Web/ViewComponents/CurrentFiltersViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/CurrentFiltersViewComponent.cs
@@ -23,6 +23,9 @@
             var model = new CurrentFiltersViewModel(
                 appliedFilters,
                 searchablePageViewModel.SearchString,
+                searchablePageViewModel.SortBy,
+                searchablePageViewModel.SortDirection,
+                searchablePageViewModel.ItemsPerPage,
                 searchablePageViewModel.RouteData
             );
 

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/CurrentFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/CurrentFiltersViewModel.cs
@@ -1,9 +1,13 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage
 {
+    using System;
     using System.Collections.Generic;
 
     public class CurrentFiltersViewModel
     {
+        [Obsolete("This is currently only used in SearchSelfAssessmentOvervieviewViewModel.cs, " +
+                  "but this version has been superseded by the version with sortBy etc. " +
+                  "parameters to fix a bug with Clear Filters resetting Sort and Items per page")]
         public CurrentFiltersViewModel(
             IEnumerable<AppliedFilterViewModel> filters,
             string? searchString,
@@ -15,9 +19,32 @@
             RouteData = routeData;
         }
 
+        public CurrentFiltersViewModel(
+            IEnumerable<AppliedFilterViewModel> appliedFilters,
+            string? searchString,
+            string? sortBy,
+            string? sortDirection,
+            int itemsPerPage,
+            Dictionary<string, string> routeData
+        )
+        {
+            AppliedFilters = appliedFilters;
+            SearchString = searchString;
+            SortBy = sortBy;
+            SortDirection = sortDirection;
+            ItemsPerPage = itemsPerPage;
+            RouteData = routeData;
+        }
+
         public IEnumerable<AppliedFilterViewModel> AppliedFilters { get; set; }
 
         public string? SearchString { get; set; }
+
+        public string? SortBy { get; set; }
+
+        public string? SortDirection { get; set; }
+
+        public int ItemsPerPage { get; set; }
 
         public Dictionary<string, string> RouteData { get; set; }
     }

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/CurrentFilters/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/CurrentFilters/Default.cshtml
@@ -6,6 +6,9 @@
   <form method="get" asp-action="@ViewContext.RouteData.Values["action"].ToString()" asp-route-page="1">
     <input type="hidden" name="clearFilters" value="true" />
     <input type="hidden" name="searchString" value="@Model.SearchString" />
+    <input type="hidden" name="sortBy" value="@Model.SortBy" />
+    <input type="hidden" name="sortDirection" value="@Model.SortDirection" />
+    <input type="hidden" name="itemsPerPage" value="@Model.ItemsPerPage" />
     @foreach (var (key, value) in Model.RouteData) {
       <input type="hidden" name="@key" value="@value" />
     }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-647

### Description
Fixes the Clear Filters button also clearing the sort and items per page for no JS.

I don't think the rest of the issues raised are to be fixed here, but if they are I'll just raise a new PR.

### Screenshots
No visual changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
