### PR TITLE
DLSV2-502 Make competency descriptions visible on the supervisor verification view

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -96,7 +96,34 @@
           {
             <tr role="row" class="nhsuk-table__row first-row">
               <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
+                <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
+                @if (competency.Description != null && !competency.AlwaysShowDescription)
+                {
+                  <details class="nhsuk-details">
+                    <summary class="nhsuk-details__summary">
+                      <h2 class="nhsuk-u-font-size-24 nhsuk-u-margin-bottom-0">
+                        <span class="nhsuk-details__summary-text">
+                          @competency.Name
+                        </span>
+                      </h2>
+                    </summary>
+                    <div class="nhsuk-details__text">
+                      @(Html.Raw(@competency.Description))
+                    </div>
+                  </details>
+                }
+                else
+                {
+                  <h2 class="nhsuk-u-margin-bottom-0 nhsuk-u-font-size-24">
+                    @competency.Name
+                  </h2>
+                  @if (competency.Description != null)
+                  {
+                    <p class="nhsuk-body-l">
+                      @(Html.Raw(competency.Description))
+                    </p>
+                  }
+                }
               </td>
               <partial name="Shared/_AssessmentQuestionReviewCells"
                        model="competency.AssessmentQuestions.First()"


### PR DESCRIPTION
Make competency descriptions visible on the supervisor verification view

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-502

### Description
Implemented same approach taken in LearningPortal\SelfAssessments\SelfAssessmentCompetency.cshtml for the ReviewSelfAssessment.cshtml view.

### Screenshots
First two competencies having `AlwaysShowDescription` set to True in `Competencies` table:

![image](https://user-images.githubusercontent.com/94055251/159944880-a142b037-d647-43e1-9247-491f86e23885.png)

First two competencies always show description while the last two contain an expandable description that is visible when user clicks on the competency name link.

![image](https://user-images.githubusercontent.com/94055251/159943414-0f073747-1ab6-4814-8500-3708fa9736a5.png)

-----
### Developer checks
- Checked different scenarios including null Description combined with AlwaysShowDescription set to True or False
