### PR TITLE
DLV2-539-Self assessment Overview filter label should say "confirmed"…

### DIFF
--- a/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
@@ -24,7 +24,7 @@ namespace DigitalLearningSolutions.Web.Extensions
                 case SelfAssessmentCompetencyFilter.SelfAssessed:
                     return "Self-assessed";
                 case SelfAssessmentCompetencyFilter.Verified:
-                    return "Verified";
+                    return "Confirmed";
                 case SelfAssessmentCompetencyFilter.MeetingRequirements:
                     return "Meeting requirements";
                 case SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements:


### PR DESCRIPTION
Self assessment Overview filter label should say "confirmed" instead of "verified".

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-539

### Description
Edited the text shown to user for displaying "Confirmed" in the filter dropdown instead of "Verified". Variable names remain the same for the time being, as this was the approach taken for similar recent change.

### Screenshots
Filter dropdown

![image](https://user-images.githubusercontent.com/94055251/160126782-d1c2734b-473d-49b7-a507-5b0396f5d472.png)

Applied confirmed filter

![image](https://user-images.githubusercontent.com/94055251/160126702-bdb608b2-43c7-486e-9eae-7fe0777e0097.png)

-----
### Developer checks

- Checked that filter can be applied and works as expected after the change
