### PR TITLE
DLSV2-520 Re-enabling one test after migration

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/SelfAssessmentAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/SelfAssessmentAccessibilityTests.cs
@@ -11,7 +11,7 @@
     {
         public SelfAssessmentAccessibilityTests(AccessibilityTestsFixture<Startup> fixture) : base(fixture) { }
 
-        [Fact(Skip = "Broken by unmerged migration in DLSV2-520.")] // TODO DLSV2-520: Re-enable this test.
+        [Fact]
         public void SelfAssessment_journey_has_no_accessibility_errors()
         {
             // Given


### PR DESCRIPTION
Re-enabling a test that should be working now after database migration executed in master. 

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-520

### Description
Re-enabled test `SelfAssessment_journey_has_no_accessibility_errors` that should be working now after database migration executed in master. This change was requested by Stephen Jackson in Slack on March 14th 2022.

-----
### Developer checks
- Checked that the test passed in TestView after above change
