### PR TITLE
HEEDLS-840 - replace FAQs URL generation with simpler methodolgy

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/support/faqs.ts
+++ b/DigitalLearningSolutions.Web/Scripts/support/faqs.ts
@@ -1,7 +1,7 @@
 import { SearchSortFilterAndPaginate } from '../searchSortFilterAndPaginate/searchSortFilterAndPaginate';
 
 (function initiateFaqsSearchAndPagination(): void {
-  const subApplication = getDlsSubApplicationFromFaqUrl();
+  const subApplication = (<HTMLSpanElement>document.getElementById('dls-sub-application')).innerText.trim();
 
   // eslint-disable-next-line no-new
   new SearchSortFilterAndPaginate(`${subApplication}/Support/FAQs/AllItems`,
@@ -11,8 +11,3 @@ import { SearchSortFilterAndPaginate } from '../searchSortFilterAndPaginate/sear
     undefined,
     ['title', 'content']);
 }());
-
-function getDlsSubApplicationFromFaqUrl(): string {
-  const pathMatchResults = window.location.pathname.match(/^\/(?<SubApplication>\w+)\/Support\/FAQs#?/);
-  return pathMatchResults?.groups?.SubApplication ?? '';
-}

--- a/DigitalLearningSolutions.Web/Views/Support/Faqs/Faqs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Faqs/Faqs.cshtml
@@ -22,7 +22,7 @@
     </nav>
   </div>
 
-  <span  id="dls-sub-application" class="display-none">@Model.DlsSubApplication</span>
+  <span id="dls-sub-application" class="display-none">@Model.DlsSubApplication</span>
 
   <div class="nhsuk-grid-column-three-quarters">
     @if (Model.JavascriptSearchSortFilterPaginateEnabled) {

--- a/DigitalLearningSolutions.Web/Views/Support/Faqs/Faqs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Faqs/Faqs.cshtml
@@ -22,6 +22,8 @@
     </nav>
   </div>
 
+  <span  id="dls-sub-application" class="display-none">@Model.DlsSubApplication</span>
+
   <div class="nhsuk-grid-column-three-quarters">
     @if (Model.JavascriptSearchSortFilterPaginateEnabled) {
       <vc:loading-spinner page-has-side-nav-menu="true" />


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-840

### Description
Changed the FAQs AllItems URL generation in JS to no longer use the Regex to extract the sub application, but to grab it from a new hidden span.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
