### PR TITLE
HEEDLS-780 Edit course admin field for delegate

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/ProgressDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ProgressDataServiceTests.cs
@@ -430,7 +430,9 @@
                 first.TotalTime.Should().Be(5);
                 first.AverageTime.Should().Be(28);
 
-                first.PostLearningAssessPath.Should().Be("https://www.dls.nhs.uk/tracking/MOST/Word07Core/Assess/L2_Word_2007_Post_1.dcr");
+                first.PostLearningAssessPath.Should().Be(
+                    "https://www.dls.nhs.uk/tracking/MOST/Word07Core/Assess/L2_Word_2007_Post_1.dcr"
+                );
                 first.IsAssessed.Should().BeTrue();
                 first.Attempts.Should().Be(0);
                 first.Outcome.Should().Be(0);
@@ -469,7 +471,8 @@
             connection.Execute(
                 @"UPDATE tutorials
                         SET OverrideTutorialMins = 1
-                        WHERE TutorialID = 53");
+                        WHERE TutorialID = 53"
+            );
 
             // When
             var result = progressDataService.GetTutorialProgressDataForSection(157704, 75).ToList();
@@ -492,7 +495,8 @@
             connection.Execute(
                 @"UPDATE aspProgress
                         SET DiagAttempts = 0
-                        WHERE aspProgressID = 3373869");
+                        WHERE aspProgressID = 3373869"
+            );
 
             // When
             var result = progressDataService.GetTutorialProgressDataForSection(157704, 75).ToList();
@@ -515,7 +519,8 @@
             connection.Execute(
                 @"UPDATE CustomisationTutorials
                         SET DiagStatus = 0
-                        WHERE CusTutID = 324886");
+                        WHERE CusTutID = 324886"
+            );
 
             // When
             var result = progressDataService.GetTutorialProgressDataForSection(157704, 75).ToList();
@@ -527,6 +532,28 @@
                 var first = result.First();
 
                 first.DiagnosticScore.Should().Be(null);
+            }
+        }
+
+        [Test]
+        public void UpdateCourseAdminFieldForDelegate_updates_admin_field_answer_on_progress_record()
+        {
+            using var transaction = new TransactionScope();
+            try
+            {
+                // Given
+                const string answer = "Test answer";
+
+                // When
+                progressDataService.UpdateCourseAdminFieldForDelegate(100, 1, answer);
+                var progressAnswer1 = progressTestHelper.GetAdminFieldAnswersByProgressId(100);
+
+                // Then
+                progressAnswer1.Should().Be(answer);
+            }
+            finally
+            {
+                transaction.Dispose();
             }
         }
     }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/ProgressDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ProgressDataServiceTests.cs
@@ -546,7 +546,7 @@
 
                 // When
                 progressDataService.UpdateCourseAdminFieldForDelegate(100, 1, answer);
-                var progressAnswer1 = progressTestHelper.GetAdminFieldAnswersByProgressId(100);
+                var progressAnswer1 = progressTestHelper.GetAdminFieldAnswer1ByProgressId(100);
 
                 // Then
                 progressAnswer1.Should().Be(answer);

--- a/DigitalLearningSolutions.Data.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ProgressServiceTests.cs
@@ -271,13 +271,36 @@
                 new DetailedSectionProgress
                     { SectionId = 3, SectionName = "Section3", Tutorials = testTutorialProgress2 },
             };
-            var expectedResult = new DetailedCourseProgress(testCourseProgress, testSectionProgressWithTutorials, testCourseInfo);
+            var expectedResult = new DetailedCourseProgress(
+                testCourseProgress,
+                testSectionProgressWithTutorials,
+                testCourseInfo
+            );
 
             // When
             var result = progressService.GetDetailedCourseProgress(1);
 
             // Then
             result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Test]
+        public void UpdateAdminFieldForCourse_calls_data_service_with_correct_values()
+        {
+            // Given
+            const int progressId = 101;
+            const int promptNumber = 1;
+            const string answer = "Test answer";
+
+            A.CallTo(() => progressDataService.UpdateCourseAdminFieldForDelegate(A<int>._, A<int>._, A<string>._))
+                .DoesNothing();
+
+            // When
+            progressService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, answer);
+
+            // Then
+            A.CallTo(() => progressDataService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, answer))
+                .MustHaveHappenedOnceExactly();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/ProgressTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/ProgressTestHelper.cs
@@ -69,5 +69,15 @@
                 new { progressId }
             ).Single();
         }
+
+        public string GetAdminFieldAnswersByProgressId(int progressId)
+        {
+            return connection.Query<string>(
+                @"SELECT Answer1
+                    FROM Progress
+                    WHERE ProgressId = @ProgressId",
+                new { progressId }
+            ).Single();
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/ProgressTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/ProgressTestHelper.cs
@@ -70,7 +70,7 @@
             ).Single();
         }
 
-        public string GetAdminFieldAnswersByProgressId(int progressId)
+        public string GetAdminFieldAnswer1ByProgressId(int progressId)
         {
             return connection.Query<string>(
                 @"SELECT Answer1

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -44,6 +44,12 @@
         IEnumerable<DetailedSectionProgress> GetSectionProgressDataForProgressEntry(int progressId);
 
         IEnumerable<DetailedTutorialProgress> GetTutorialProgressDataForSection(int progressId, int sectionId);
+
+        public void UpdateCourseAdminFieldForDelegate(
+            int progressId,
+            int promptNumber,
+            string? answer
+        );
     }
 
     public class ProgressDataService : IProgressDataService
@@ -356,6 +362,20 @@
                         AND (t.ArchivedDate IS NULL)
                     ORDER BY t.TutorialID",
                 new { progressId, sectionId }
+            );
+        }
+
+        public void UpdateCourseAdminFieldForDelegate(
+            int progressId,
+            int promptNumber,
+            string? answer
+        )
+        {
+            connection.Execute(
+                $@"UPDATE Progress
+                        SET Answer{promptNumber} = @answer
+                        WHERE ProgressID = @progressId",
+                new { progressId, promptNumber, answer }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/Exceptions/InvalidPromptNumberException.cs
+++ b/DigitalLearningSolutions.Data/Exceptions/InvalidPromptNumberException.cs
@@ -1,0 +1,6 @@
+﻿namespace DigitalLearningSolutions.Data.Exceptions
+{
+    using System;
+
+    public class InvalidPromptNumberException : Exception { }
+}

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -126,5 +126,16 @@
         public bool IsProgressLocked { get; set; }
         public bool HasBeenPromptedForPrn { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
+
+        public string? GetAnswer(int promptNumber)
+        {
+            return promptNumber switch
+            {
+                1 => Answer1,
+                2 => Answer2,
+                3 => Answer3,
+                _ => throw new Exception("Invalid prompt number"),
+            };
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.Courses
 {
     using System;
+    using DigitalLearningSolutions.Data.Exceptions;
 
     public class DelegateCourseInfo : CourseNameInfo
     {
@@ -134,7 +135,7 @@
                 1 => Answer1,
                 2 => Answer2,
                 3 => Answer3,
-                _ => throw new Exception("Invalid prompt number"),
+                _ => throw new InvalidPromptNumberException(),
             };
         }
     }

--- a/DigitalLearningSolutions.Data/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Data/Services/ProgressService.cs
@@ -20,6 +20,12 @@
         void UnlockProgress(int progressId);
 
         DetailedCourseProgress? GetDetailedCourseProgress(int progressId);
+
+        void UpdateCourseAdminFieldForDelegate(
+            int progressId,
+            int promptNumber,
+            string? answer
+        );
     }
 
     public class ProgressService : IProgressService
@@ -115,6 +121,15 @@
             }
 
             return new DetailedCourseProgress(progress, sections, courseInfo);
+        }
+
+        public void UpdateCourseAdminFieldForDelegate(
+            int progressId,
+            int promptNumber,
+            string? answer
+        )
+        {
+            progressDataService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, answer);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -105,6 +105,10 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
             "Edit completed date for Digital Literacy for the Workplace - CC Test"
         )]
         [InlineData(
+            "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/285035/EditAdminField/1",
+            "Edit System Access Granted field for Digital Literacy for the Workplace - CC Test"
+        )]
+        [InlineData(
             "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/243104/LearningLog",
             "Delegate learning log"
         )]

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -105,8 +105,8 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
             "Edit completed date for Digital Literacy for the Workplace - CC Test"
         )]
         [InlineData(
-            "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/285035/EditAdminField/1",
-            "Edit System Access Granted field for Digital Literacy for the Workplace - CC Test"
+            "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/22657/EditAdminField/1",
+            "Edit System Access Granted field for Entry Level - Win XP, Office 2003/07 OLD - Standard"
         )]
         [InlineData(
             "/TrackingSystem/Delegates/CourseDelegates/DelegateProgress/243104/LearningLog",

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
@@ -10,7 +10,6 @@
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress;
     using FakeItEasy;
-    using FluentAssertions;
     using FluentAssertions.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using NUnit.Framework;
@@ -218,8 +217,7 @@
                 formData,
                 promptNumber,
                 progressId,
-                accessedVia,
-                1
+                accessedVia
             );
 
             // Then
@@ -257,15 +255,13 @@
                 formData,
                 promptNumber,
                 progressId,
-                DelegateAccessRoute.CourseDelegates,
-                1
+                DelegateAccessRoute.CourseDelegates
             );
 
             // Then
             A.CallTo(() => progressService.UpdateCourseAdminFieldForDelegate(A<int>._, A<int>._, A<string>._))
                 .MustNotHaveHappened();
             result.Should().BeViewResult().ModelAs<EditDelegateCourseAdminFieldViewModel>();
-            delegateProgressController.ModelState.IsValid.Should().BeFalse();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -187,6 +187,58 @@
             return RedirectToPreviousPage(formData.DelegateId, progressId, accessedVia, formData.ReturnPage);
         }
 
+        [HttpGet]
+        [Route("EditAdminField/{promptNumber:int}")]
+        public IActionResult EditDelegateCourseAdminField(
+            int progressId,
+            int promptNumber,
+            DelegateAccessRoute accessedVia,
+            int? returnPage
+        )
+        {
+            var delegateCourseProgress =
+                courseService.GetDelegateCourseProgress(progressId);
+
+            var model = new EditDelegateCourseAdminFieldViewModel(
+                progressId,
+                promptNumber,
+                delegateCourseProgress!,
+                accessedVia,
+                returnPage
+            );
+            return View(model);
+        }
+
+        [HttpPost]
+        [Route("EditAdminField/{promptNumber:int}")]
+        public IActionResult EditDelegateCourseAdminField(
+            EditDelegateCourseAdminFieldFormData formData,
+            int promptNumber,
+            int progressId,
+            DelegateAccessRoute accessedVia,
+            int? returnPage
+        )
+        {
+            if (!ModelState.IsValid)
+            {
+                var delegateCourseProgress =
+                    courseService.GetDelegateCourseProgress(progressId);
+
+                var model = new EditDelegateCourseAdminFieldViewModel(
+                    formData,
+                    delegateCourseProgress!,
+                    progressId,
+                    promptNumber,
+                    accessedVia,
+                    returnPage
+                );
+                return View(model);
+            }
+
+            progressService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, formData.Answer?.Trim());
+            return RedirectToPreviousPage(formData.DelegateId, progressId, accessedVia, formData.ReturnPage);
+        }
+
         private IActionResult RedirectToPreviousPage(
             int delegateId,
             int progressId,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -227,8 +227,7 @@
             EditDelegateCourseAdminFieldFormData formData,
             int promptNumber,
             int progressId,
-            DelegateAccessRoute accessedVia,
-            int? returnPage
+            DelegateAccessRoute accessedVia
         )
         {
             if (!ModelState.IsValid)
@@ -241,8 +240,7 @@
                     delegateCourseProgress!,
                     progressId,
                     promptNumber,
-                    accessedVia,
-                    returnPage
+                    accessedVia
                 );
                 return View(model);
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -27,6 +27,7 @@
     public class DelegateProgressController : Controller
     {
         private readonly IConfiguration configuration;
+        private readonly ICourseAdminFieldsService courseAdminFieldsService;
         private readonly ICourseService courseService;
         private readonly IProgressService progressService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
@@ -34,6 +35,7 @@
 
         public DelegateProgressController(
             ICourseService courseService,
+            ICourseAdminFieldsService courseAdminFieldsService,
             IUserService userService,
             IProgressService progressService,
             IConfiguration configuration,
@@ -41,6 +43,7 @@
         )
         {
             this.courseService = courseService;
+            this.courseAdminFieldsService = courseAdminFieldsService;
             this.userService = userService;
             this.progressService = progressService;
             this.configuration = configuration;
@@ -199,6 +202,15 @@
             var delegateCourseProgress =
                 courseService.GetDelegateCourseProgress(progressId);
 
+            var courseAdminField = courseAdminFieldsService.GetCourseAdminFieldsForCourse(
+                delegateCourseProgress!.DelegateCourseInfo.CustomisationId
+            ).AdminFields.Find(caf => caf.PromptNumber == promptNumber);
+
+            if (courseAdminField == null)
+            {
+                return new NotFoundResult();
+            }
+
             var model = new EditDelegateCourseAdminFieldViewModel(
                 progressId,
                 promptNumber,
@@ -236,6 +248,7 @@
             }
 
             progressService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, formData.Answer?.Trim());
+            // TODO: HEEDLS-862 Account for all possible access routes in redirection
             return RedirectToPreviousPage(formData.DelegateId, progressId, accessedVia, formData.ReturnPage);
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldFormData.cs
@@ -1,0 +1,37 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
+{
+    using System.ComponentModel.DataAnnotations;
+    using DigitalLearningSolutions.Data.Models.Courses;
+
+    public class EditDelegateCourseAdminFieldFormData
+    {
+        public EditDelegateCourseAdminFieldFormData() { }
+
+        protected EditDelegateCourseAdminFieldFormData(DelegateCourseDetails details, int? returnPage)
+        {
+            DelegateId = details.DelegateCourseInfo.DelegateId;
+            CustomisationId = details.DelegateCourseInfo.CustomisationId;
+            DelegateName = details.DelegateCourseInfo.DelegateFirstName == null
+                ? details.DelegateCourseInfo.DelegateLastName
+                : $"{details.DelegateCourseInfo.DelegateFirstName} {details.DelegateCourseInfo.DelegateLastName}";
+            ReturnPage = returnPage;
+        }
+
+        protected EditDelegateCourseAdminFieldFormData(EditDelegateCourseAdminFieldFormData formData)
+        {
+            Answer = formData.Answer;
+            DelegateId = formData.DelegateId;
+            CustomisationId = formData.CustomisationId;
+            DelegateName = formData.DelegateName;
+            ReturnPage = formData.ReturnPage;
+        }
+
+        [MaxLength(100, ErrorMessage = "Answer must be 100 characters or fewer")]
+        public string? Answer { get; set; }
+
+        public int DelegateId { get; set; }
+        public string? DelegateName { get; set; }
+        public int CustomisationId { get; set; }
+        public int? ReturnPage { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldFormData.cs
@@ -14,11 +14,12 @@
             ReturnPage = returnPage;
         }
 
-        protected EditDelegateCourseAdminFieldFormData(EditDelegateCourseAdminFieldFormData formData, int? returnPage)
+        protected EditDelegateCourseAdminFieldFormData(EditDelegateCourseAdminFieldFormData formData)
         {
+            Answer = formData.Answer;
             DelegateId = formData.DelegateId;
             CustomisationId = formData.CustomisationId;
-            ReturnPage = returnPage;
+            ReturnPage = formData.ReturnPage;
         }
 
         [MaxLength(100, ErrorMessage = "Answer must be 100 characters or fewer")]

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldFormData.cs
@@ -11,26 +11,20 @@
         {
             DelegateId = details.DelegateCourseInfo.DelegateId;
             CustomisationId = details.DelegateCourseInfo.CustomisationId;
-            DelegateName = details.DelegateCourseInfo.DelegateFirstName == null
-                ? details.DelegateCourseInfo.DelegateLastName
-                : $"{details.DelegateCourseInfo.DelegateFirstName} {details.DelegateCourseInfo.DelegateLastName}";
             ReturnPage = returnPage;
         }
 
-        protected EditDelegateCourseAdminFieldFormData(EditDelegateCourseAdminFieldFormData formData)
+        protected EditDelegateCourseAdminFieldFormData(EditDelegateCourseAdminFieldFormData formData, int? returnPage)
         {
-            Answer = formData.Answer;
             DelegateId = formData.DelegateId;
             CustomisationId = formData.CustomisationId;
-            DelegateName = formData.DelegateName;
-            ReturnPage = formData.ReturnPage;
+            ReturnPage = returnPage;
         }
 
         [MaxLength(100, ErrorMessage = "Answer must be 100 characters or fewer")]
         public string? Answer { get; set; }
 
         public int DelegateId { get; set; }
-        public string? DelegateName { get; set; }
         public int CustomisationId { get; set; }
         public int? ReturnPage { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldViewModel.cs
@@ -70,7 +70,7 @@
                 option => new RadiosItemViewModel(option, option, option == info.GetAnswer(promptNumber), null)
             ).ToList();
             var noOptionIsSelected = answerOptions.All(ao => !ao.Selected);
-            answerOptions.Add(new RadiosItemViewModel("", "Leave blank", noOptionIsSelected, null));
+            answerOptions.Add(new RadiosItemViewModel(string.Empty, "Leave blank", noOptionIsSelected, null));
             return answerOptions;
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldViewModel.cs
@@ -1,0 +1,75 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+
+    public class EditDelegateCourseAdminFieldViewModel : EditDelegateCourseAdminFieldFormData
+    {
+        public EditDelegateCourseAdminFieldViewModel(
+            int progressId,
+            int promptNumber,
+            DelegateCourseDetails details,
+            DelegateAccessRoute accessedVia,
+            int? returnPage
+        ) : base(details, returnPage)
+        {
+            var courseAdminField = details.CourseAdminFields.Find(c => c.PromptNumber == promptNumber);
+
+            Options = courseAdminField!.Options;
+            Answer = GetAnswer(details.DelegateCourseInfo, promptNumber);
+            Radios = GetRadioItems(details.DelegateCourseInfo, promptNumber);
+            PromptText = courseAdminField.PromptText;
+            ProgressId = progressId;
+            AccessedVia = accessedVia;
+            ReturnPage = returnPage;
+        }
+
+        public EditDelegateCourseAdminFieldViewModel(
+            EditDelegateCourseAdminFieldFormData formData,
+            DelegateCourseDetails details,
+            int progressId,
+            int promptNumber,
+            DelegateAccessRoute accessedVia,
+            int? returnPage
+        ) : base(formData)
+        {
+            var courseAdminField = details.CourseAdminFields.Find(c => c.PromptNumber == promptNumber);
+
+            Options = courseAdminField!.Options;
+            Radios = GetRadioItems(details.DelegateCourseInfo, promptNumber);
+            PromptText = courseAdminField.PromptText;
+            ProgressId = progressId;
+            AccessedVia = accessedVia;
+        }
+
+        public List<string> Options { get; set; }
+        public List<RadiosItemViewModel> Radios { get; set; }
+        public string PromptText { get; set; }
+        public int ProgressId { get; set; }
+        public DelegateAccessRoute AccessedVia { get; set; }
+
+        private static string? GetAnswer(DelegateCourseInfo info, int promptNumber)
+        {
+            return promptNumber switch
+            {
+                1 => info.Answer1,
+                2 => info.Answer2,
+                3 => info.Answer3,
+                _ => throw new Exception("Invalid prompt number"),
+            };
+        }
+
+        private List<RadiosItemViewModel> GetRadioItems(DelegateCourseInfo info, int promptNumber)
+        {
+            var answerOptions = Options.Select(
+                option => new RadiosItemViewModel(option, option, option == GetAnswer(info, promptNumber), null)
+            ).ToList();
+            answerOptions.Add(new RadiosItemViewModel("", "Leave blank", "" == GetAnswer(info, promptNumber), null));
+            return answerOptions;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminFieldViewModel.cs
@@ -37,11 +37,10 @@
             DelegateCourseDetails details,
             int progressId,
             int promptNumber,
-            DelegateAccessRoute accessedVia,
-            int? returnPage
-        ) : base(formData, returnPage)
+            DelegateAccessRoute accessedVia
+        ) : base(formData)
         {
-            var courseAdminField = details.CourseAdminFields.Find(c => c.PromptNumber == promptNumber);
+            var courseAdminField = details.CourseAdminFields.Single(c => c.PromptNumber == promptNumber);
 
             Options = courseAdminField!.Options;
             Radios = GetRadioItems(details.DelegateCourseInfo, promptNumber);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/_SearchableCourseDelegateCard.cshtml
@@ -99,8 +99,12 @@
               <div hidden data-filter-value="@Model.AdminFieldFilters[delegateCourseAdminField.PromptNumber]"></div>
             }
             <dd class="nhsuk-summary-list__actions">
-              <a>
-                Edit<span class="nhsuk-u-visually-hidden"> @delegateCourseAdminField.PromptNumber</span>
+              <a asp-controller="DelegateProgress"
+                 asp-action="EditDelegateCourseAdminField"
+                 asp-route-progressId="@Model.ProgressId"
+                 asp-route-promptNumber="@delegateCourseAdminField.PromptNumber"
+                 asp-route-accessedVia="@DelegateAccessRoute.CourseDelegates">
+                Edit<span class="nhsuk-u-visually-hidden"> @delegateCourseAdminField.Prompt</span>
               </a>
             </dd>
           </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
@@ -10,6 +10,7 @@
 
   string cancelLinkController;
 
+  // TODO: HEEDLS-862 Account for all possible access routes in back link
   if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)) {
     routeParamsForBackLink.Add("accessedVia", Model.AccessedVia.ToString());
     routeParamsForBackLink.Add("progressId", Model.ProgressId.ToString());
@@ -21,7 +22,7 @@
   }
 }
 
-@*TODO: HEEDLS-780 - finalise these breadcrumbs once we hear from HEE about Delegate Progress page*@
+@*TODO: HEEDLS-862 - Change these breadcrumbs to account for all access routes*@
 @section NavBreadcrumbs {
   @if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)) {
     <partial name="~/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml" model="(Model.CustomisationId, Model.ProgressId)" />
@@ -36,7 +37,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(@Model.Answer)}" />
     }
 
-    <h1 class="nhsuk-heading-xl word-break">Edit @Model.PromptText field for course</h1>
+    <h1 class="nhsuk-heading-xl word-break">Edit @Model.PromptText field for @Model.CourseName</h1>
 
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">
@@ -53,7 +54,6 @@
         <form class="nhsuk-u-margin-bottom-3" method="post" novalidate>
           <input type="hidden" asp-for="DelegateId" />
           <input type="hidden" asp-for="ProgressId" />
-          <input type="hidden" asp-for="DelegateName" />
           <input type="hidden" asp-for="ReturnPage" />
 
           @if (Model.Options.Count > 0) {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
@@ -1,0 +1,94 @@
+﻿@using DigitalLearningSolutions.Web.Models.Enums
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
+@model EditDelegateCourseAdminFieldViewModel
+
+@{
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+  ViewData["Title"] = errorHasOccurred ? $"Error: Edit {Model.PromptText} field for course" : $"Edit {Model.PromptText} field for course";
+
+  var routeParamsForBackLink = new Dictionary<string, string?>();
+
+  string cancelLinkController;
+
+  if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)) {
+    routeParamsForBackLink.Add("accessedVia", Model.AccessedVia.ToString());
+    routeParamsForBackLink.Add("progressId", Model.ProgressId.ToString());
+    routeParamsForBackLink.Add("returnPage", Model.ReturnPage.ToString());
+    cancelLinkController = "DelegateProgress";
+  } else {
+    routeParamsForBackLink.Add("delegateId", Model.DelegateId.ToString());
+    cancelLinkController = "ViewDelegate";
+  }
+}
+
+@*TODO: HEEDLS-780 - finalise these breadcrumbs once we hear from HEE about Delegate Progress page*@
+@section NavBreadcrumbs {
+  @if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)) {
+    <partial name="~/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml" model="(Model.CustomisationId, Model.ProgressId)" />
+  } else {
+    <partial name="~/Views/TrackingSystem/Delegates/Shared/_ViewDelegateProgressBreadcrumbs.cshtml" model="(Model.DelegateId, Model.ProgressId)" />
+  }
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@new []{ nameof(@Model.Answer)}" />
+    }
+
+    <h1 class="nhsuk-heading-xl word-break">Edit @Model.PromptText field for course</h1>
+
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">
+        Delegate
+      </div>
+      <div class="nhsuk-grid-column-three-quarters nhsuk-body-l nhsuk-u-font-weight-bold word-break">
+        @Model.DelegateName
+      </div>
+    </div>
+
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-one-half">
+
+        <form class="nhsuk-u-margin-bottom-3" method="post" novalidate>
+          <input type="hidden" asp-for="DelegateId" />
+          <input type="hidden" asp-for="ProgressId" />
+          <input type="hidden" asp-for="DelegateName" />
+          <input type="hidden" asp-for="ReturnPage" />
+
+          @if (Model.Options.Count > 0) {
+            <div class="nhsuk-radios nhsuk-u-margin-bottom-4">
+              @foreach (var radio in Model.Radios) {
+                <div class="nhsuk-radios__item nhsuk-u-margin-bottom-3">
+                  <input class="nhsuk-radios__input"
+                         id="@radio.Value"
+                         name="@nameof(Model.Answer)"
+                         type="radio"
+                         value="@radio.Value"
+                         aria-describedby="@radio.Value-item-hint"
+                         @(radio.Selected ? "checked" : string.Empty) />
+                  <label class="nhsuk-label nhsuk-radios__label" for="@radio.Value">
+                    @radio.Label
+                  </label>
+                </div>
+              }
+            </div>
+          } else {
+            <vc:text-input asp-for="@nameof(Model.Answer)"
+                           label="Answer"
+                           populate-with-current-value="true"
+                           type="text"
+                           spell-check="true"
+                           autocomplete=""
+                           hint-text="Answer must be 100 characters or fewer."
+                           css-class="nhsuk-u-width-full" />
+          }
+
+          <button class="nhsuk-button" type="submit">Save</button>
+        </form>
+      </div>
+    </div>
+
+    <vc:cancel-link asp-controller="@cancelLinkController" asp-action="Index" link-text="Go back" asp-all-route-data="@routeParamsForBackLink" />
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
@@ -6,8 +6,9 @@
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? $"Error: Edit {Model.PromptText} field for course" : $"Edit {Model.PromptText} field for course";
 
-  var routeParamsForBackLink = new Dictionary<string, string?>();
+  const string blankRadioId = "leave-blank";
 
+  var routeParamsForBackLink = new Dictionary<string, string?>();
   string cancelLinkController;
 
   // TODO: HEEDLS-862 Account for all possible access routes in back link
@@ -23,6 +24,7 @@
 }
 
 @*TODO: HEEDLS-862 - Change these breadcrumbs to account for all access routes*@
+
 @section NavBreadcrumbs {
   @if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates)) {
     <partial name="~/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml" model="(Model.CustomisationId, Model.ProgressId)" />
@@ -59,15 +61,16 @@
           @if (Model.Options.Count > 0) {
             <div class="nhsuk-radios nhsuk-u-margin-bottom-4">
               @foreach (var radio in Model.Radios) {
-                <div class="nhsuk-radios__item nhsuk-u-margin-bottom-3">
+                var isBlankOption = radio.Value == string.Empty;
+                <div class="nhsuk-radios__item nhsuk-u-margin-bottom-3 @(isBlankOption ? "nhsuk-u-margin-top-6" : "")">
                   <input class="nhsuk-radios__input"
-                         id="@radio.Value"
+                         id="@(isBlankOption ? blankRadioId : radio.Value)"
                          name="@nameof(Model.Answer)"
                          type="radio"
                          value="@radio.Value"
-                         aria-describedby="@radio.Value-item-hint"
+                         aria-describedby="@(isBlankOption ? blankRadioId : radio.Value)-item-hint"
                          @(radio.Selected ? "checked" : string.Empty) />
-                  <label class="nhsuk-label nhsuk-radios__label" for="@radio.Value">
+                  <label class="nhsuk-label nhsuk-radios__label" for="@(isBlankOption ? blankRadioId : radio.Value)">
                     @radio.Label
                   </label>
                 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditDelegateCourseAdminField.cshtml
@@ -4,7 +4,8 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? $"Error: Edit {Model.PromptText} field for course" : $"Edit {Model.PromptText} field for course";
+  var pageTitle = $"Edit {Model.PromptText} field for {Model.CourseName}";
+  ViewData["Title"] = errorHasOccurred ? $"Error: {pageTitle}" : pageTitle;
 
   const string blankRadioId = "leave-blank";
 
@@ -39,7 +40,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(@Model.Answer)}" />
     }
 
-    <h1 class="nhsuk-heading-xl word-break">Edit @Model.PromptText field for @Model.CourseName</h1>
+    <h1 class="nhsuk-heading-xl word-break">@pageTitle</h1>
 
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-quarter nhsuk-body-l">
@@ -62,15 +63,16 @@
             <div class="nhsuk-radios nhsuk-u-margin-bottom-4">
               @foreach (var radio in Model.Radios) {
                 var isBlankOption = radio.Value == string.Empty;
+                var radioId = isBlankOption ? blankRadioId : radio.Value;
                 <div class="nhsuk-radios__item nhsuk-u-margin-bottom-3 @(isBlankOption ? "nhsuk-u-margin-top-6" : "")">
                   <input class="nhsuk-radios__input"
-                         id="@(isBlankOption ? blankRadioId : radio.Value)"
+                         id="@radioId"
                          name="@nameof(Model.Answer)"
                          type="radio"
                          value="@radio.Value"
-                         aria-describedby="@(isBlankOption ? blankRadioId : radio.Value)-item-hint"
+                         aria-describedby="@radioId-item-hint"
                          @(radio.Selected ? "checked" : string.Empty) />
-                  <label class="nhsuk-label nhsuk-radios__label" for="@(isBlankOption ? blankRadioId : radio.Value)">
+                  <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
                     @radio.Label
                   </label>
                 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
@@ -68,7 +68,7 @@
          asp-route-progressId="@Model.ProgressId"
          asp-route-accessedVia="@Model.AccessedVia"
          asp-route-returnPage="@Model.Page">
-        Edit
+        Edit<span class="nhsuk-u-visually-hidden"> completion date</span>
       </a>
     </dd>
   </div>
@@ -161,15 +161,20 @@
     </div>
   }
 
-  @foreach (var prompt in Model.AdminFields) {
+  @foreach (var delegateCourseAdminField in Model.AdminFields) {
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
-        @prompt.Prompt
+        @delegateCourseAdminField.Prompt
       </dt>
-      <partial name="_SummaryFieldValue" model="prompt.Answer" />
+      <partial name="_SummaryFieldValue" model="delegateCourseAdminField.Answer" />
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
-          Edit<span class="nhsuk-u-visually-hidden"> @prompt.Prompt</span>
+        <a asp-controller="DelegateProgress"
+           asp-action="EditDelegateCourseAdminField"
+           asp-route-progressId="@Model.ProgressId"
+           asp-route-promptNumber="@delegateCourseAdminField.PromptNumber"
+           asp-route-accessedVia="@Model.AccessedVia"
+           asp-route-returnPage="@Model.Page">
+          Edit<span class="nhsuk-u-visually-hidden"> @delegateCourseAdminField.Prompt</span>
         </a>
       </dd>
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/_DelegateProgressSummary.cshtml
@@ -68,7 +68,7 @@
          asp-route-progressId="@Model.ProgressId"
          asp-route-accessedVia="@Model.AccessedVia"
          asp-route-returnPage="@Model.Page">
-        Edit<span class="nhsuk-u-visually-hidden"> completion date</span>
+        Edit<span class="nhsuk-u-visually-hidden"> completed date</span>
       </a>
     </dd>
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
@@ -154,7 +154,15 @@
               @courseCustomPrompt.PromptText
             </dt>
             <partial name="_SummaryFieldValue" model="@courseCustomPrompt.Answer" />
-            <dd class="nhsuk-summary-list__actions"></dd>
+            <dd class="nhsuk-summary-list__actions">
+              <a asp-controller="DelegateProgress"
+                 asp-action="EditDelegateCourseAdminField"
+                 asp-route-progressId="@Model.ProgressId"
+                 asp-route-promptNumber="@courseCustomPrompt.PromptNumber"
+                 asp-route-accessedVia="@DelegateAccessRoute.ViewDelegate">
+                Edit<span class="nhsuk-u-visually-hidden"> @courseCustomPrompt.PromptText</span>
+              </a>
+            </dd>
           </div>
         }
       </dl>


### PR DESCRIPTION
### JIRA link
[_HEEDLS-780_](https://softwiretech.atlassian.net/browse/HEEDLS-780)

### Description
Allow admins to edit a course admin field for a delegate. The page shows radio buttons or a free text field depending on whether the admin field has options. Admins can leave the field blank or select the "Leave blank" radio button.

There are a few known issues I'll wait to resolve once HEE has given us an answer about whether we are keeping the Delegate Progress page. These are:
- The breadcrumbs in the view not accounting for accessing the page from the cards on the Course Delegates or View Delegate pages (bypassing the Delegate Progress page)
- The redirect upon save from Course delegates page - currently if you click save when accessing the page from the Course delegates page, it takes you to the Delegate progress page rather than back to Course Delegates.
- The redirect upon save from View Delegate > Delegate Progress route - if you click save from the Delegate progress page accessed through the View Delegate route, it takes you to the View delegate page rather than Delegate Progress. This is an existing issue with the other Edit buttons on the course card as well.

### Screenshots
![localhost_5001_TrackingSystem_Delegates_ViewDelegate_DelegateProgress_3_EditAdminField_1](https://user-images.githubusercontent.com/70278044/160391999-9147c89e-3b8b-49de-8411-51e535e462bc.png)
![localhost_5001_TrackingSystem_Delegates_ViewDelegate_DelegateProgress_3_EditAdminField_2](https://user-images.githubusercontent.com/70278044/160391994-e91b73d9-ae2c-4a17-ae8d-93a79801f6d2.png)
![localhost_5001_TrackingSystem_Delegates_ViewDelegate_DelegateProgress_3_EditAdminField_2 (1)](https://user-images.githubusercontent.com/70278044/160392009-47d4aaa0-d74e-44b3-a66e-05ec97876898.png)
![localhost_5001_TrackingSystem_Delegates_ViewDelegate_DelegateProgress_3_EditAdminField_2 (2)](https://user-images.githubusercontent.com/70278044/160392017-9c432aae-bf75-47e2-b9c4-03344f52156f.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
