### PR TITLE
DLSV2-538 Add Clear result button for self assessed questions

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/checkboxes.ts
+++ b/DigitalLearningSolutions.Web/Scripts/checkboxes.ts
@@ -19,22 +19,22 @@ class Checkboxes {
     });
   }
 
-  static selectAllInGroup(group: string): void {
+  static checkInputGroup(group: string, checked: boolean): void {
     const allCheckboxes = document.querySelectorAll('.select-all-checkbox') as NodeListOf<HTMLInputElement>;
-    allCheckboxes.forEach((checkbox) => {
-      if (checkbox.getAttribute('data-group') === group) {
-        if (!checkbox.checked) checkbox.click();
+    allCheckboxes.forEach((tag) => {
+      const input = tag;
+      if (input.getAttribute('data-group') === group) {
+        if (input.checked !== checked) input.checked = checked;
       }
     });
   }
 
+  static selectAllInGroup(group: string): void {
+    Checkboxes.checkInputGroup(group, true);
+  }
+
   static deselectAllinGroup(group: string): void {
-    const allCheckboxes = document.querySelectorAll('.select-all-checkbox') as NodeListOf<HTMLInputElement>;
-    allCheckboxes.forEach((checkbox) => {
-      if (checkbox.getAttribute('data-group') === group) {
-        if (checkbox.checked) checkbox.click();
-      }
-    });
+    Checkboxes.checkInputGroup(group, false);
   }
 
   static selectAll(selectorClass: string): void {

--- a/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
@@ -16,9 +16,4 @@ inputs.forEach((e) => {
   e.addEventListener('change', () => onSliderUpdate(e));
 });
 
-const clearButtons = document.getElementsByName('clearButton');
-clearButtons.forEach((e) => {
-  e.style.display = 'block';
-});
-
 Checkboxes.default.setUpSelectAndDeselectInGroupButtons();

--- a/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
@@ -16,4 +16,9 @@ inputs.forEach((e) => {
   e.addEventListener('change', () => onSliderUpdate(e));
 });
 
+const clearButtons = document.getElementsByName('clearButton');
+clearButtons.forEach((e) => {
+  e.style.display = 'block';
+});
+
 Checkboxes.default.setUpSelectAndDeselectInGroupButtons();

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -71,13 +71,6 @@
           <nhs-form-group nhs-validation-for="Competency.AssessmentQuestions[1].Result">
             <partial name="SelfAssessments/_RadioQuestion" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />
           </nhs-form-group>
-          <div name="clearButton" class="nhsuk-u-margin-bottom-3" style="overflow:auto; display:none;">
-            <a class="nhsuk-button select-all-button deselect-all status-tag nhsuk-button--danger" style="display:block;"
-               data-group="group@(question.value.Id)"
-               name="selectAll" value="true">
-              Clear
-            </a>
-          </div>
         }
         @if (question.value.SignedOff != null && question.value.SignedOff == true)
         {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -68,9 +68,16 @@
         }
         else
         {
-            <nhs-form-group nhs-validation-for="Competency.AssessmentQuestions[1].Result">
-              <partial name="SelfAssessments/_RadioQuestion" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />
-            </nhs-form-group>
+          <nhs-form-group nhs-validation-for="Competency.AssessmentQuestions[1].Result">
+            <partial name="SelfAssessments/_RadioQuestion" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />
+          </nhs-form-group>
+          <div class="nhsuk-u-margin-bottom-3" style="overflow:auto;">
+            <a class="nhsuk-button select-all-button deselect-all status-tag nhsuk-button--danger" style="display:block;"
+               data-group="group@(question.value.Id)"
+               name="selectAll" value="true">
+              Clear
+            </a>
+          </div>
         }
         @if (question.value.SignedOff != null && question.value.SignedOff == true)
         {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentCompetency.cshtml
@@ -71,7 +71,7 @@
           <nhs-form-group nhs-validation-for="Competency.AssessmentQuestions[1].Result">
             <partial name="SelfAssessments/_RadioQuestion" model="question.value" view-data="@(new ViewDataDictionary(ViewData) { { "index", question.i } })" />
           </nhs-form-group>
-          <div class="nhsuk-u-margin-bottom-3" style="overflow:auto;">
+          <div name="clearButton" class="nhsuk-u-margin-bottom-3" style="overflow:auto; display:none;">
             <a class="nhsuk-button select-all-button deselect-all status-tag nhsuk-button--danger" style="display:block;"
                data-group="group@(question.value.Id)"
                name="selectAll" value="true">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
@@ -26,4 +26,11 @@
     </div>
   }
 </div>
+<div name="clearButton" class="js-only-inline nhsuk-u-margin-top-1 nhsuk-u-margin-bottom-3">
+  <a class="deselect-all" href="javascript:void(0);"
+     data-group="group@(Model.Id)"
+     name="selectAll" value="true">
+    Clear selection
+  </a>
+</div>
 <input hidden name="[@ViewData["index"]].Id" value="@Model.Id" />

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
@@ -12,7 +12,11 @@
   @foreach (var levelDescriptor in Model.LevelDescriptors)
   {
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" name="[@ViewData["index"]].Result" id="radio-@Model.Id-@levelDescriptor.LevelValue" checked="@(Model.Result == @levelDescriptor.LevelValue)" type="radio" value="@levelDescriptor.LevelValue" aria-describedby="radio-@Model.Id-@levelDescriptor.LevelValue-item-hint">
+      <input class="nhsuk-radios__input select-all-checkbox"
+             name="[@ViewData["index"]].Result" id="radio-@Model.Id-@levelDescriptor.LevelValue"
+             data-group="group@(Model.Id)"
+             checked="@(Model.Result == @levelDescriptor.LevelValue)" type="radio" value="@levelDescriptor.LevelValue"
+             aria-describedby="radio-@Model.Id-@levelDescriptor.LevelValue-item-hint">
       <label class="nhsuk-label nhsuk-radios__label" for="radio-@Model.Id-@levelDescriptor.LevelValue">
         @levelDescriptor.LevelLabel
       </label>


### PR DESCRIPTION
Add "Clear" result button for self assessed competency assessment questions

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-538

### Description
Updated existing typescript code to cover both checkbox and radio button group deselect all. Basically, assuming the element is checked, replacing `checkbox.click()` by `checkbox.checked = false` should work both for radios and checkboxes. But I also refactored the code and remove some redundancy.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/160593014-a76bf63f-b625-436c-8a6e-b1d9d6ae3451.png)

-----
### Developer checks

- Clear button works with multiple groups of radio buttons on the same page and only clear the selection for current group.
- When Javascript is disabled, Clear button is not present on the page.
- Change not causing issues in "Choose optional capabilities" that uses same typescript class "Checkboxes" I have modified in this PR

"Choose optional capabilities" should not be affected (LearningPortal/SelfAssessment/{selfAssessmentId}/Capabilities/Optional)

![image](https://user-images.githubusercontent.com/94055251/160593154-2561b291-4730-4641-b186-3f8e3fced9ba.png)
