### PR TITLE
HEEDLS-NONE Different chrome driver version 99

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/DigitalLearningSolutions.Web.AutomatedUiTests.csproj
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/DigitalLearningSolutions.Web.AutomatedUiTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Selenium.Axe" Version="2.0.3" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="100.0.4896.2000" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="99.0.4844.5100" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### JIRA link
_HEEDLS-XXXX_

### Description
Apparently jenkins doesn't have chrome 100 yet, and driver version 100 doesn't work with browser version 99, but they do the other way round.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
