### PR TITLE
DLSV2-541 Fixes error and adds validation to add contributor

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1519,8 +1519,17 @@ WHERE (FrameworkID = @frameworkId)",
                       VALUES (@question, @assessmentQuestionInputTypeId, @maxValueDescription, @minValueDescription, @scoringInstructions, @minValue, @maxValue, @includeComments, @adminId, @commentsPrompt, @commentsHint)",
                 new
                 {
-                    question, assessmentQuestionInputTypeId, maxValueDescription, minValueDescription,
-                    scoringInstructions, minValue, maxValue, includeComments, adminId, commentsPrompt, commentsHint,
+                    question,
+                    assessmentQuestionInputTypeId,
+                    maxValueDescription,
+                    minValueDescription,
+                    scoringInstructions,
+                    minValue,
+                    maxValue,
+                    includeComments,
+                    adminId,
+                    commentsPrompt,
+                    commentsHint,
                 }
             );
             if (id < 1)
@@ -1607,8 +1616,18 @@ WHERE (FrameworkID = @frameworkId)",
                     WHERE ID = @id",
                 new
                 {
-                    id, question, assessmentQuestionInputTypeId, maxValueDescription, minValueDescription,
-                    scoringInstructions, minValue, maxValue, includeComments, adminId, commentsPrompt, commentsHint,
+                    id,
+                    question,
+                    assessmentQuestionInputTypeId,
+                    maxValueDescription,
+                    minValueDescription,
+                    scoringInstructions,
+                    minValue,
+                    maxValue,
+                    includeComments,
+                    adminId,
+                    commentsPrompt,
+                    commentsHint,
                 }
             );
             if (numberOfAffectedRows < 1)
@@ -1811,14 +1830,14 @@ WHERE (FrameworkID = @frameworkId)",
                         fc.AdminID,
                         fc.CanModify,
                         fc.UserEmail,
-                        fc.Active AS UserActive,
+                        COALESCE(au.Active, 1) AS UserActive,
                         CASE WHEN fc.CanModify = 1 THEN 'Contributor' ELSE 'Reviewer' END AS FrameworkRole,
                         f.FrameworkName,
                         (SELECT Forename + ' ' + Surname + (CASE WHEN Active = 1 THEN '' ELSE ' (Inactive)' END) AS Expr1 FROM AdminUsers AS au1 WHERE (AdminID = @invitedByAdminId)) AS InvitedByName,
                         (SELECT Email FROM AdminUsers AS au2 WHERE (AdminID = @invitedByAdminId)) AS InvitedByEmail
                     FROM FrameworkCollaborators AS fc
                     INNER JOIN Frameworks AS f ON fc.FrameworkID = f.ID
-                    INNER JOIN AdminUsers AS au ON fc.AdminID = au.AdminID
+                    LEFT OUTER JOIN AdminUsers AS au ON fc.AdminID = au.AdminID
                     WHERE (fc.ID = @id)",
                 new { invitedByAdminId, id }
             ).FirstOrDefault();

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
@@ -485,7 +485,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             return View("Developer/Summary", sessionNewFramework.DetailFramework);
         }
         [Route("/Frameworks/Collaborators/{actionname}/{frameworkId}/")]
-        public IActionResult AddCollaborators(string actionname, int frameworkId)
+        public IActionResult AddCollaborators(string actionname, int frameworkId, bool error = false)
         {
             var adminId = GetAdminId();
             var collaborators = frameworkService.GetCollaboratorsForFrameworkId(frameworkId);
@@ -497,6 +497,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             {
                 BaseFramework = framework,
                 Collaborators = collaborators,
+                Error = error,
             };
             return View("Developer/Collaborators", model);
         }
@@ -507,8 +508,15 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         {
             var collaboratorId = frameworkService.AddCollaboratorToFramework(frameworkId, userEmail, canModify);
             if (collaboratorId > 0)
+            {
                 frameworkNotificationService.SendFrameworkCollaboratorInvite(collaboratorId, GetAdminId());
-            return RedirectToAction("AddCollaborators", "Frameworks", new { frameworkId, actionname });
+                return RedirectToAction("AddCollaborators", "Frameworks", new { frameworkId, actionname });
+            }
+            else
+            {
+                return RedirectToAction("AddCollaborators", "Frameworks", new { frameworkId, actionname, error = true });
+            }
+
         }
 
         public IActionResult RemoveCollaborator(int frameworkId, string actionname, int id)

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CollaboratorsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CollaboratorsViewModel.cs
@@ -9,5 +9,6 @@
         public BaseFramework BaseFramework { get; set; }
         public IEnumerable<CollaboratorDetail>? Collaborators { get; set; }
         public int AdminID { get; set; }
+        public bool Error { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Collaborators.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Collaborators.cshtml
@@ -115,15 +115,22 @@ else
   <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
     <h2>Add a user to the working group</h2>
   </label>
-  <div class="nhsuk-form-group">
+  <div class="@(Model.Error? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
     <div class=" sort-select-container">
       <label class="nhsuk-label" for="example">
         User email address
       </label>
-      <div class="nhsuk-hint" id="add-user-hint">
-        Provide a user email address to add as a Contributor (to help create your framework) or Reviewer (to sign off your framework). Working group members can be added and removed later.
+     
+            <div class="nhsuk-hint" id="add-user-hint">
+        Provide the email address of a user with a registered DLS admin account to add as a Contributor (to help create your framework) or Reviewer (to sign off your framework). Working group members can be added and removed later.
       </div>
-      <input class="nhsuk-input" id="userEmail" aria-describedby="add-user-hint" type="email" name="userEmail" />
+      @if(Model.Error)
+            {
+                <span class="nhsuk-error-message" id="no-admin-error">
+    <span class="nhsuk-u-visually-hidden">Error:</span> The email address must match a registered DLS admin account.
+  </span>
+            }
+      <input class="@(Model.Error? "nhsuk-input nhsuk-input--error" : "nhsuk-input")" id="userEmail" aria-describedby="add-user-hint" type="email" name="userEmail" />
     </div>
   </div>
   <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="True" asp-route-frameworkId="@Model.BaseFramework.ID">


### PR DESCRIPTION
### JIRA link
[DLSV2-541](https://hee-dls.atlassian.net/browse/DLSV2-541)

### Description
Fixes a bug with the Frameworks add contributor function. The data service method for retrieving info about the chosen administrator referred to a column (FrameworkCollaborators.Active) that wasn't present.

This method also relies on the email address matching a registered admin user but failed quietly if there wasn't one. This change introduces a validator error message to the page explaining why they weren't added.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/162389266-36ebc06e-eb2f-4e67-8bb0-ba44887f9371.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Scanned over my own MR to ensure everything is as expected.
