### PR TITLE
HEEDLS-816 Revert Preview button to old site link

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/_CentreConfigurationCentreDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/_CentreConfigurationCentreDetails.cshtml
@@ -1,4 +1,5 @@
 ﻿@inject IConfiguration Configuration
+@using DigitalLearningSolutions.Data.Extensions
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Configuration
 @using Microsoft.Extensions.Configuration
 @model CentreConfigurationViewModel
@@ -56,7 +57,7 @@
       Edit
     </a>
 
-    <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="PreviewCertificate" asp-controller="Configuration" target="_blank">
+    <a class="nhsuk-button nhsuk-button--secondary" role="button" href="@Configuration.GetCurrentSystemBaseUrl()/tracking/finalise?Preview=1" target="_blank">
       Preview certificate
       <span class="nhsuk-u-visually-hidden">(opens in a new window)</span>
     </a>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-816

### Description
Reverted the Preview Certificate back to a link to the old site version.

### Screenshots
No visual changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
