### PR TITLE
HEEDLS-813 Move longer sign in duration to the problem tutorial endpoint

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ControllerHelpers/ControllerContextHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/ControllerHelpers/ControllerContextHelper.cs
@@ -5,6 +5,7 @@
     using System.Security.Claims;
     using System.Text;
     using System.Threading.Tasks;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using FakeItEasy;
     using Microsoft.AspNetCore.Authentication;
@@ -169,6 +170,13 @@
             {
                 HttpContext = httpContext,
             };
+
+            return controller;
+        }
+
+        public static T WithMockHttpContextSession<T>(this T controller) where T : Controller
+        {
+            controller.HttpContext.Session = new MockHttpContextSession();
 
             return controller;
         }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -36,6 +36,7 @@
         private ISectionContentDataService sectionContentDataService = null!;
         private ISessionService sessionService = null!;
         private ITutorialContentDataService tutorialContentDataService = null!;
+        private IClockService clockService = null!;
 
         [SetUp]
         public void SetUp()
@@ -50,6 +51,7 @@
             diagnosticAssessmentService = A.Fake<IDiagnosticAssessmentService>();
             postLearningAssessmentService = A.Fake<IPostLearningAssessmentService>();
             courseCompletionService = A.Fake<ICourseCompletionService>();
+            clockService = A.Fake<IClockService>();
 
             var user = new ClaimsPrincipal(
                 new ClaimsIdentity(
@@ -94,7 +96,8 @@
                 diagnosticAssessmentService,
                 postLearningAssessmentService,
                 sessionService,
-                courseCompletionService
+                courseCompletionService,
+                clockService
             )
             {
                 ControllerContext = new ControllerContext

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialTests.cs
@@ -1,17 +1,21 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningMenu
 {
+    using System;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
     using FakeItEasy;
     using FluentAssertions;
     using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Http;
     using NUnit.Framework;
 
     public partial class LearningMenuControllerTests
     {
         [Test]
-        public void Tutorial_should_StartOrUpdate_course_sessions_if_valid_tutorial()
+        public async Task Tutorial_should_StartOrUpdate_course_sessions_if_valid_tutorial()
         {
             // Given
             var defaultTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId);
@@ -20,7 +24,7 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(1);
 
             // When
-            controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(CandidateId, CustomisationId, httpContextSession)).MustHaveHappenedOnceExactly();
@@ -31,7 +35,57 @@
         }
 
         [Test]
-        public void Tutorial_should_not_StartOrUpdate_course_sessions_if_invalid_tutorial()
+        [TestCase(45)]
+        [TestCase(90)]
+        public async Task Tutorial_should_sign_in_with_longer_expiry_if_valid_tutorial_with_average_duration_of_45_minutes_or_over(int averageTutorialDuration)
+        {
+            // Given
+            var defaultTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId, averageTutorialDuration: averageTutorialDuration);
+            A.CallTo(() => tutorialContentDataService.GetTutorialInformation(CandidateId, CustomisationId, SectionId, TutorialId))
+                .Returns(defaultTutorialInformation);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(1);
+
+            // When
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
+
+            // Then
+            A.CallTo(
+                () => authenticationService.SignInAsync(
+                    A<HttpContext>._,
+                    A<string>._,
+                    A<ClaimsPrincipal>._,
+                    A<AuthenticationProperties>.That.Matches(ap => ap.ExpiresUtc!.Value > DateTimeOffset.UtcNow.AddHours(7))
+                )
+            ).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        [TestCase(44)]
+        [TestCase(10)]
+        public async Task Tutorial_should_not_sign_in_with_longer_expiry_if_valid_tutorial_with_less_than_45_minutes(int averageTutorialDuration)
+        {
+            // Given
+            var defaultTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId, averageTutorialDuration: averageTutorialDuration);
+            A.CallTo(() => tutorialContentDataService.GetTutorialInformation(CandidateId, CustomisationId, SectionId, TutorialId))
+                .Returns(defaultTutorialInformation);
+            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(1);
+
+            // When
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
+
+            // Then
+            A.CallTo(
+                () => authenticationService.SignInAsync(
+                    A<HttpContext>._,
+                    A<string>._,
+                    A<ClaimsPrincipal>._,
+                    A<AuthenticationProperties>._
+                )
+            ).MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task Tutorial_should_not_StartOrUpdate_course_sessions_if_invalid_tutorial()
         {
             // Given
             A.CallTo(() => tutorialContentDataService.GetTutorialInformation(CandidateId, CustomisationId, SectionId, TutorialId))
@@ -39,14 +93,14 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(1);
 
             // When
-            controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
         }
 
         [Test]
-        public void Tutorial_should_not_StartOrUpdate_course_sessions_if_unable_to_enrol()
+        public async Task Tutorial_should_not_StartOrUpdate_course_sessions_if_unable_to_enrol()
         {
             // Given
             var defaultTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId);
@@ -55,14 +109,14 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(null);
 
             // When
-            controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
         }
 
         [Test]
-        public void Tutorial_should_UpdateProgress_if_valid_tutorial()
+        public async Task Tutorial_should_UpdateProgress_if_valid_tutorial()
         {
             // Given
             const int progressId = 3;
@@ -72,14 +126,14 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(progressId);
 
             // When
-            controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
         }
 
         [Test]
-        public void Tutorial_should_not_UpdateProgress_if_invalid_tutorial()
+        public async Task Tutorial_should_not_UpdateProgress_if_invalid_tutorial()
         {
             // Given
             const int progressId = 3;
@@ -88,14 +142,14 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(progressId);
 
             // When
-            controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
         }
 
         [Test]
-        public void Tutorial_should_not_UpdateProgress_if_unable_to_enrol()
+        public async Task Tutorial_should_not_UpdateProgress_if_unable_to_enrol()
         {
             // Given
             var defaultTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId);
@@ -104,14 +158,14 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(null);
 
             // When
-            controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
         }
 
         [Test]
-        public void Tutorial_should_render_view()
+        public async Task Tutorial_should_render_view()
         {
             // Given
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId);
@@ -120,7 +174,7 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(3);
 
             // When
-            var result = controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            var result = await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             var expectedModel = new TutorialViewModel(config, expectedTutorialInformation, CustomisationId, SectionId);
@@ -129,7 +183,7 @@
         }
 
         [Test]
-        public void Tutorial_should_return_404_if_invalid_tutorial()
+        public async Task Tutorial_should_return_404_if_invalid_tutorial()
         {
             // Given
             A.CallTo(() => tutorialContentDataService.GetTutorialInformation(
@@ -142,7 +196,7 @@
                 .Returns(3);
 
             // When
-            var result = controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            var result = await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             result.Should()
@@ -153,7 +207,7 @@
         }
 
         [Test]
-        public void Tutorial_should_return_404_if_unable_to_enrol()
+        public async Task Tutorial_should_return_404_if_unable_to_enrol()
         {
             // Given
             var defaultTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(TutorialId);
@@ -167,7 +221,7 @@
                 .Returns(null);
 
             // When
-            var result = controller.Tutorial(CustomisationId, SectionId, TutorialId);
+            var result = await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
             result.Should()

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/TutorialContentHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/TutorialContentHelper.cs
@@ -14,7 +14,7 @@
             string? applicationInfo = null,
             string status = "Complete",
             int timeSpent = 30,
-            int averageTutorialDuration = 60,
+            int averageTutorialDuration = 30,
             int currentScore = 9,
             int possibleScore = 24,
             bool canShowDiagnosticStatus = true,

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -175,16 +175,7 @@
                 IsPersistent = rememberMe,
                 IssuedUtc = DateTime.UtcNow
             };
-
-
-            /* Course progress doesn't get updated if the auth token expires by the end of the tutorials. 
-               Some tutorials are longer than the default auth token lifetime, so we set the auth expiry to 8 hours.
-               See HEEDLS-637 for more details */
-            if (!rememberMe)
-            {
-                authProperties.ExpiresUtc = DateTime.UtcNow.AddHours(8);
-            }
-
+            
             await HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
 
             return RedirectToReturnUrl(returnUrl) ?? RedirectToAction("Index", "Home");


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-813

### Description
Returned the normal login expiry to normal and added a longer expiry before a user accesses a long tutorial, conditional on the average tutorial duration.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
