### PR TITLE
HEEDLS-855 fix queries in password data service

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/PasswordDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/PasswordDataServiceTests.cs
@@ -27,7 +27,7 @@
         }
 
         [Test]
-        public void Set_password_by_candidate_number_should_set_password_correctly()
+        public void SetPasswordByCandidateNumber_should_set_password_correctly()
         {
             using var transaction = new TransactionScope();
             try
@@ -48,7 +48,7 @@
         }
 
         [Test]
-        public async Task Setting_password_by_email_sets_password_for_matching_admins()
+        public async Task SetPasswordByEmailAsync_sets_password_for_matching_user()
         {
             using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
@@ -65,7 +65,7 @@
         }
 
         [Test]
-        public async Task Setting_password_by_email_does_not_set_password_for_all_admins()
+        public async Task SetPasswordByEmailAsync_does_not_set_password_for_all_users()
         {
             using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
@@ -83,24 +83,7 @@
         }
 
         [Test]
-        public async Task Setting_password_by_email_sets_password_for_matching_candidate()
-        {
-            using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
-            // Given
-            var existingDelegate = UserTestHelper.GetDefaultDelegateUser();
-            var newPasswordHash = PasswordHashNotYetInDb;
-
-            // When
-            await passwordDataService.SetPasswordByEmailAsync(existingDelegate.EmailAddress!, newPasswordHash);
-
-            // Then
-            userDataService.GetDelegateUserById(existingDelegate.Id)?.Password.Should()
-                .Be(PasswordHashNotYetInDb);
-        }
-
-        [Test]
-        public async Task SetPasswordForUsers_can_set_password_for_multiple_delegates()
+        public async Task SetPasswordForUsersAsync_can_set_password_for_multiple_delegates()
         {
             using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
@@ -130,25 +113,7 @@
         }
 
         [Test]
-        public async Task Setting_password_by_email_does_not_set_password_for_all_delegates()
-        {
-            using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
-            // Given
-            var existingDelegate = UserTestHelper.GetDefaultDelegateUser();
-            var existingDelegatePassword = existingDelegate.Password;
-            var newPasswordHash = PasswordHashNotYetInDb;
-
-            // When
-            await passwordDataService.SetPasswordByEmailAsync("random.email@address.com", newPasswordHash);
-
-            // Then
-            userDataService.GetDelegateUserById(existingDelegate.Id)?.Password.Should()
-                .Be(existingDelegatePassword);
-        }
-
-        [Test]
-        public async Task Setting_password_for_user_account_set_changes_password()
+        public async Task SetPasswordForUsersAsync_changes_password_for_given_users()
         {
             using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
@@ -170,7 +135,7 @@
         }
 
         [Test]
-        public async Task Can_set_password_for_delegate_only()
+        public async Task SetPasswordForUsersAsync_can_set_password_for_delegate_only()
         {
             using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 

--- a/DigitalLearningSolutions.Data.Tests/DataServices/PasswordDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/PasswordDataServiceTests.cs
@@ -14,9 +14,9 @@
     public class PasswordDataServiceTests
     {
         private const string PasswordHashNotYetInDb = "I haven't used this password before!";
+        private SqlConnection connection = null!;
         private PasswordDataService passwordDataService = null!;
         private UserDataService userDataService = null!;
-        private SqlConnection connection = null!;
 
         [SetUp]
         public void Setup()
@@ -107,8 +107,10 @@
             // Given
             var existingDelegate = UserTestHelper.GetDefaultDelegateUser();
             var newDelegate = Builder<DelegateUser>.CreateNew()
-                .With(d => d.EmailAddress = existingDelegate.EmailAddress)
+                .With(d => d.EmailAddress = "unique.email@test1234.com")
                 .With(d => d.CentreId = existingDelegate.CentreId)
+                .With(d => d.LastName = existingDelegate.LastName)
+                .With(d => d.JobGroupId = existingDelegate.JobGroupId)
                 .Build();
             UserTestHelper.GivenDelegateUserIsInDatabase(newDelegate, connection);
 

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -238,7 +238,7 @@
                     user.JobGroupId,
                 }
             );
-            // TODO: UAR - Remove LastName_deprecated from this query once the not-null constraint is lifted
+            // TODO: UAR-889 - Remove LastName_deprecated from this query once the not-null constraint is lifted
             sqlConnection.Execute(
                 @"INSERT INTO DelegateAccounts (
                         CentreID,

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -243,11 +243,11 @@
                 @"INSERT INTO DelegateAccounts (
                         CentreID,
                         LastName_deprecated,
-						DateRegistered,
-						CandidateNumber,
+                        DateRegistered,
+                        CandidateNumber,
                         Approved,
-					    ExternalReg,
-					    SelfReg,
+                        ExternalReg,
+                        SelfReg,
                         UserID)
                   VALUES (@CentreId, @LastName, @DateRegistered, @CandidateNumber,
                           @Approved, @ExternalReg, @SelfReg, @UserId);",

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -216,24 +216,51 @@
 
         public static void GivenDelegateUserIsInDatabase(DelegateUser user, SqlConnection sqlConnection)
         {
-            sqlConnection.Execute(
-                @"INSERT INTO Candidates (Active, CentreId, LastName, DateRegistered, CandidateNumber, JobGroupID,
-                    Approved, ExternalReg, SelfReg, SkipPW, PublicSkypeLink)
-                  VALUES (@Active, @CentreId, @LastName, @DateRegistered, @CandidateNumber, @JobGroupID,
-                    @Approved, @ExternalReg, @SelfReg, @SkipPW, @PublicSkypeLink);",
+            var userId = sqlConnection.QuerySingle<int>(
+                @"INSERT INTO Users
+                    (
+                        FirstName,
+                        LastName,
+                        PrimaryEmail,
+                        PasswordHash,
+                        Active,
+                        JobGroupID
+                    )
+                    OUTPUT Inserted.ID
+                    VALUES (@FirstName, @LastName, @EmailAddress, @Password, @Active, @JobGroupId)",
                 new
                 {
+                    user.FirstName,
+                    user.LastName,
+                    user.EmailAddress,
+                    user.Password,
                     user.Active,
+                    user.JobGroupId,
+                }
+            );
+            // TODO: Remove LastName_deprecated from this query once the not-null constraint is lifted
+            sqlConnection.Execute(
+                @"INSERT INTO DelegateAccounts (
+                        CentreID,
+                        LastName_deprecated,
+						DateRegistered,
+						CandidateNumber,
+                        Approved,
+					    ExternalReg,
+					    SelfReg,
+                        UserID)
+                  VALUES (@CentreId, @LastName, @DateRegistered, @CandidateNumber,
+                          @Approved, @ExternalReg, @SelfReg, @UserId);",
+                new
+                {
                     user.CentreId,
                     user.LastName,
                     user.DateRegistered,
                     user.CandidateNumber,
-                    user.JobGroupId,
                     user.Approved,
                     ExternalReg = false,
                     SelfReg = false,
-                    SkipPW = false,
-                    PublicSkypeLink = false,
+                    UserId = userId,
                 }
             );
         }

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -238,7 +238,7 @@
                     user.JobGroupId,
                 }
             );
-            // TODO: Remove LastName_deprecated from this query once the not-null constraint is lifted
+            // TODO: UAR - Remove LastName_deprecated from this query once the not-null constraint is lifted
             sqlConnection.Execute(
                 @"INSERT INTO DelegateAccounts (
                         CentreID,

--- a/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
@@ -50,7 +50,7 @@
                         SET PasswordHash = @passwordHash
                         FROM Users
                             LEFT JOIN DelegateAccounts AS d ON d.UserID = Users.ID
-	                        LEFT JOIN AdminAccounts AS a ON a.UserID = Users.ID
+                            LEFT JOIN AdminAccounts AS a ON a.UserID = Users.ID
                         WHERE Users.PrimaryEmail = @email
                     COMMIT TRANSACTION
                 END TRY
@@ -70,7 +70,7 @@
                         SET PasswordHash = @PasswordHash
                         FROM Users
                             LEFT JOIN DelegateAccounts AS d ON d.UserID = Users.ID
-	                        LEFT JOIN AdminAccounts AS a ON a.UserID = Users.ID
+                            LEFT JOIN AdminAccounts AS a ON a.UserID = Users.ID
                         WHERE a.ID IN @AdminIds OR d.ID IN @DelegateIds",
                 new
                 {

--- a/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
@@ -44,19 +44,10 @@
         )
         {
             await connection.ExecuteAsync(
-                @"BEGIN TRY
-                    BEGIN TRANSACTION
-                        UPDATE Users
+                @"UPDATE Users
                         SET PasswordHash = @passwordHash
                         FROM Users
-                            LEFT JOIN DelegateAccounts AS d ON d.UserID = Users.ID
-                            LEFT JOIN AdminAccounts AS a ON a.UserID = Users.ID
-                        WHERE Users.PrimaryEmail = @email
-                    COMMIT TRANSACTION
-                END TRY
-                BEGIN CATCH
-                    ROLLBACK TRANSACTION
-                END CATCH",
+                        WHERE Users.PrimaryEmail = @email",
                 new { email, passwordHash }
             );
         }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-855_](https://softwiretech.atlassian.net/browse/HEEDLS-855)

### Description
Changed the PasswordDataService queries to reference the new users tables.

It's possible we'll want to change SetPasswordByCandidateNumber and SetPasswordForUsersAsync when more refactoring of the registration logic has been done. SetPasswordByCandidateNumber could become SetPasswordByUserId and SetPasswordForUsersAsync may want to include Auth Users as a User type?

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
