### PR TITLE
HEEDLS-867 Change grouping logic to only group when rows have actuall…

### DIFF
--- a/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
@@ -183,6 +183,9 @@
         {
             var sheet = workbook.Worksheets.Add("Course Delegates");
 
+            // Set sheet to have outlining expand buttons at the top of the expanded section.
+            sheet.Outline.SummaryVLocation = XLOutlineSummaryVLocation.Top;
+
             var customRegistrationPrompts =
                 registrationPromptsService.GetCentreRegistrationPromptsByCentreId(centreId);
 

--- a/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseDelegatesDownloadFileService.cs
@@ -265,8 +265,11 @@
             }
 
             var insertedDataRange = sheet.Cell(GetNextEmptyRowNumber(sheet), 1).InsertData(dataTable.Rows);
-            sheet.Rows(insertedDataRange.FirstRow().RowNumber(), insertedDataRange.LastRow().RowNumber())
-                .Group(true);
+            if (dataTable.Rows.Count > 0)
+            {
+                sheet.Rows(insertedDataRange.FirstRow().RowNumber(), insertedDataRange.LastRow().RowNumber())
+                    .Group(true);
+            }
         }
 
         private static int GetNextEmptyRowNumber(IXLWorksheet sheet)


### PR DESCRIPTION
…y been inserted

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-867

### Description
Changed the grouping logic to only happen when delegate rows have actually been inserted to the sheet.

### Screenshots
Courses with no delegates no longer get grouped:
![image](https://user-images.githubusercontent.com/59561751/165799148-35326dfc-e192-4df3-949c-7cbeccadc592.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
