### PR TITLE
HEEDLS-895 : UAR Migration 7: Pull centre emails out into separate table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202205061441_SeparateCentreEmailsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202205061441_SeparateCentreEmailsTable.cs
@@ -1,0 +1,35 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202205061441)]
+    public class SeparateCentreEmailsTable : Migration
+    {
+        public override void Up()
+        {
+            Create.Table("UserCentreDetails")
+                .WithColumn("ID").AsInt32().NotNullable().PrimaryKey().Identity()
+                .WithColumn("UserID").AsInt32().NotNullable().ForeignKey("Users", "ID")
+                .WithColumn("CentreID").AsInt32().NotNullable().ForeignKey("Centres", "ID")
+                .WithColumn("Email").AsString(255).Nullable()
+                .WithColumn("EmailVerified").AsDateTime().Nullable();
+
+            Rename.Column("Email").OnTable("AdminAccounts").To("Email_deprecated");
+            Rename.Column("Email").OnTable("DelegateAccounts").To("Email_deprecated");
+
+            Delete.Column("EmailVerified").FromTable("AdminAccounts");
+            Delete.Column("EmailVerified").FromTable("DelegateAccounts");
+        }
+
+        public override void Down()
+        {
+            Delete.Table("UserCentreDetails");
+
+            Rename.Column("Email_deprecated").OnTable("AdminAccounts").To("Email");
+            Rename.Column("Email_deprecated").OnTable("DelegateAccounts").To("Email");
+
+            Alter.Table("AdminAccounts").AddColumn("EmailVerified");
+            Alter.Table("DelegateAccounts").AddColumn("EmailVerified");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202205061441_SeparateCentreEmailsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202205061441_SeparateCentreEmailsTable.cs
@@ -17,6 +17,15 @@
             Rename.Column("Email").OnTable("AdminAccounts").To("Email_deprecated");
             Rename.Column("Email").OnTable("DelegateAccounts").To("Email_deprecated");
 
+            Execute.Sql(
+                @"CREATE UNIQUE NONCLUSTERED INDEX IX_UserCenterDetails_CentreId_Email
+                ON UserCenterDetails (CentreId, Email)
+                WHERE Email IS NOT NULL"
+            );
+
+            Create.UniqueConstraint("IX_UserCenterDetails_UserId_CentreId").OnTable("UserCenterDetails")
+                .Columns("UserId", "CentreId");
+
             Delete.Column("EmailVerified").FromTable("AdminAccounts");
             Delete.Column("EmailVerified").FromTable("DelegateAccounts");
         }
@@ -28,8 +37,8 @@
             Rename.Column("Email_deprecated").OnTable("AdminAccounts").To("Email");
             Rename.Column("Email_deprecated").OnTable("DelegateAccounts").To("Email");
 
-            Alter.Table("AdminAccounts").AddColumn("EmailVerified");
-            Alter.Table("DelegateAccounts").AddColumn("EmailVerified");
+            Alter.Table("AdminAccounts").AddColumn("EmailVerified").AsDateTime().Nullable();
+            Alter.Table("DelegateAccounts").AddColumn("EmailVerified").AsDateTime().Nullable();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -9,6 +9,7 @@
     public interface IRegistrationDataService
     {
         string RegisterNewUserAndDelegateAccount(DelegateRegistrationModel delegateRegistrationModel);
+
         int RegisterAdmin(AdminRegistrationModel registrationModel);
     }
 
@@ -29,15 +30,15 @@
             using var transaction = connection.BeginTransaction();
 
             var userValues = new
-                {
-                    delegateRegistrationModel.FirstName,
-                    delegateRegistrationModel.LastName,
-                    delegateRegistrationModel.PrimaryEmail,
-                    delegateRegistrationModel.JobGroup,
-                    delegateRegistrationModel.Active,
-                    PasswordHash = "temp",
-                    ProfessionalRegistrationNumber = (string?)null,
-                };
+            {
+                delegateRegistrationModel.FirstName,
+                delegateRegistrationModel.LastName,
+                delegateRegistrationModel.PrimaryEmail,
+                delegateRegistrationModel.JobGroup,
+                delegateRegistrationModel.Active,
+                PasswordHash = "temp",
+                ProfessionalRegistrationNumber = (string?)null,
+            };
 
             var userId = connection.QuerySingle<int>(
                 @"INSERT INTO Users
@@ -61,16 +62,39 @@
                         @professionalRegistrationNumber,
                         @active
                     )",
-                    userValues,
-                    transaction
-                );
+                userValues,
+                transaction
+            );
+
+            var userCentreDetailsValues = new
+            {
+                userId,
+                CentreId = delegateRegistrationModel.Centre,
+                Email = delegateRegistrationModel.SecondaryEmail,
+            };
+
+            connection.Execute(
+                @"INSERT INTO UserCentreDetails
+                    (
+                        UserId,
+                        CentreId,
+                        Email
+                    )
+                    VALUES
+                    (
+                        @userId,
+                        @centreId,
+                        @email
+                    )",
+                userCentreDetailsValues,
+                transaction
+            );
 
             var initials = delegateRegistrationModel.FirstName.Substring(0, 1) +
                            delegateRegistrationModel.LastName.Substring(0, 1);
 
-            string candidateNumber;
             // this SQL is reproduced mostly verbatim from the uspSaveNewCandidate_V10 procedure in the legacy codebase.
-            candidateNumber = connection.QueryFirst<string>(
+            var candidateNumber = connection.QueryFirst<string>(
                 @"DECLARE @_MaxCandidateNumber AS integer
 		        SET @_MaxCandidateNumber = (SELECT TOP (1) CONVERT(int, SUBSTRING(CandidateNumber, 3, 250)) AS nCandidateNumber
 								FROM      DelegateAccounts WITH (TABLOCKX, HOLDLOCK)
@@ -91,7 +115,6 @@
                 CentreId = delegateRegistrationModel.Centre,
                 DateRegistered = DateTime.UtcNow,
                 candidateNumber,
-                Email = delegateRegistrationModel.SecondaryEmail,
                 delegateRegistrationModel.Answer1,
                 delegateRegistrationModel.Answer2,
                 delegateRegistrationModel.Answer3,
@@ -104,6 +127,7 @@
                 delegateRegistrationModel.IsSelfRegistered,
                 DetailsLastChecked = DateTime.UtcNow,
                 // null-equivalent data for non-nullable deprecated values
+                Email_deprecated = "",
                 LastName_deprecated = "",
                 JobGroupID_deprecated = 0,
                 SkipPW_deprecated = false,
@@ -163,9 +187,9 @@
                         @hasBeenPromptedForPrn_deprecated,
                         @hasDismissedLhLoginWarning_deprecated
                     )",
-                    candidateValues,
+                candidateValues,
                 transaction
-                );
+            );
 
             transaction.Commit();
 
@@ -239,6 +263,29 @@
                         @nominatedSupervisor
                     )",
                 values
+            );
+
+            var userCentreDetailsValues = new
+            {
+                adminUserId,
+                CentreId = registrationModel.Centre,
+                Email = registrationModel.SecondaryEmail,
+            };
+
+            connection.Execute(
+                @"INSERT INTO UserCentreDetails
+                    (
+                        UserId,
+                        CentreId,
+                        Email
+                    )
+                    VALUES
+                    (
+                        @userId,
+                        @centreId,
+                        @email
+                    )",
+                userCentreDetailsValues
             );
 
             connection.Execute(

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -127,7 +127,6 @@
                 delegateRegistrationModel.IsSelfRegistered,
                 DetailsLastChecked = DateTime.UtcNow,
                 // null-equivalent data for non-nullable deprecated values
-                Email_deprecated = "",
                 LastName_deprecated = "",
                 JobGroupID_deprecated = 0,
                 SkipPW_deprecated = false,
@@ -263,29 +262,6 @@
                         @nominatedSupervisor
                     )",
                 values
-            );
-
-            var userCentreDetailsValues = new
-            {
-                adminUserId,
-                CentreId = registrationModel.Centre,
-                Email = registrationModel.SecondaryEmail,
-            };
-
-            connection.Execute(
-                @"INSERT INTO UserCentreDetails
-                    (
-                        UserId,
-                        CentreId,
-                        Email
-                    )
-                    VALUES
-                    (
-                        @userId,
-                        @centreId,
-                        @email
-                    )",
-                userCentreDetailsValues
             );
 
             connection.Execute(


### PR DESCRIPTION
### JIRA link
_[HEEDLS-895](https://softwiretech.atlassian.net/browse/HEEDLS-895)_

### Description
_In early UAR we added email fields on `AdminAccounts` and `DelegateAccounts` for centre-specific notifications. Rather than allowing an admin to have a primary email, an email for their delegate account and an email for their admin account, we should only allow them to have a single secondary email. We’ll pull Email out of `AdminAccounts` and `DelegateAccounts` and put it in a new table called `UserCentreDetails`_

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
