### PR TITLE
HEEDLS-889 new migration

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202205131200_LiftConstraintsOnDeprecatedColumns.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202205131200_LiftConstraintsOnDeprecatedColumns.cs
@@ -1,0 +1,28 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202205131200)]
+    public class LiftConstraintsOnDeprecatedColumns : Migration
+    {
+        public override void Up()
+        {
+            Delete.DefaultConstraint().OnTable("AdminAccounts").OnColumn("CategoryID");
+
+            Alter.Table("AdminAccounts").AlterColumn("Password_deprecated").AsString(250).Nullable();
+            Alter.Table("AdminAccounts").AlterColumn("EITSProfile_deprecated").AsCustom("varchar(max)").Nullable();
+
+            Alter.Table("DelegateAccounts").AlterColumn("LastName_deprecated").AsString(250).Nullable();
+        }
+
+        public override void Down()
+        {
+            Alter.Table("AdminAccounts").AlterColumn("CategoryID").AsInt32().Nullable().WithDefaultValue(0);
+
+            Alter.Table("AdminAccounts").AlterColumn("Password_deprecated").AsString(250).NotNullable();
+            Alter.Table("AdminAccounts").AlterColumn("EITSProfile_deprecated").AsCustom("varchar(max)").NotNullable();
+
+            Alter.Table("DelegateAccounts").AlterColumn("LastName_deprecated").AsString(250).NotNullable();
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
_[HEEDLS-889](https://softwiretech.atlassian.net/browse/HEEDLS-889)_

### Description
_Migration to remove the default on the CategoryID column and make deprecated columns with no default nullable, on AdminAccounts and DelegateAccounts tables._

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
