### PR TITLE
HEEDLS-896 Disallow duplicate admin fields

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
@@ -174,16 +174,13 @@
         public void GetCourseFieldPromptIdsForCustomisation_returns_expected_results()
         {
             // Given
-            var expectedResult = new int[] { 1, 2, 0 };
+            var expectedResult = new [] { 1, 2, 0 };
 
             // When
             var result = courseAdminFieldsDataService.GetCourseFieldPromptIdsForCustomisation(100);
 
             // Then
-            using (new AssertionScope())
-            {
-                result.Should().BeEquivalentTo(expectedResult);
-            }
+            result.Should().BeEquivalentTo(expectedResult);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseAdminFieldsDataServiceTests.cs
@@ -169,5 +169,21 @@
                 result.Should().BeEquivalentTo(expectedResult);
             }
         }
+
+        [Test]
+        public void GetCourseFieldPromptIdsForCustomisation_returns_expected_results()
+        {
+            // Given
+            var expectedResult = new int[] { 1, 2, 0 };
+
+            // When
+            var result = courseAdminFieldsDataService.GetCourseFieldPromptIdsForCustomisation(100);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(expectedResult);
+            }
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -182,7 +182,7 @@
                 new { customisationId }
             ).Single();
 
-            return new int[] { result.Item1, result.Item2, result.Item3 };
+            return new [] { result.Item1, result.Item2, result.Item3 };
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -32,6 +32,8 @@
             int customisationId,
             int centreId
         );
+
+        int[] GetCourseFieldPromptIdsForCustomisation(int customisationId);
     }
 
     public class CourseAdminFieldsDataService : ICourseAdminFieldsDataService
@@ -164,6 +166,23 @@
                         AND RemovedDate IS NULL",
                 new { customisationId, centreId }
             );
+        }
+
+        public int[] GetCourseFieldPromptIdsForCustomisation(
+            int customisationId
+        )
+        {
+            var result = connection.Query<(int, int, int)>(
+                @"SELECT
+                        CourseField1PromptID,
+                        CourseField2PromptID,
+                        CourseField3PromptID
+                    FROM Customisations
+                    WHERE CustomisationID = @customisationId",
+                new { customisationId }
+            ).Single();
+
+            return new int[] { result.Item1, result.Item2, result.Item3 };
         }
     }
 }

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCentreRegistrationPromptsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCentreRegistrationPromptsAccessibilityTests.cs
@@ -25,16 +25,16 @@
             Driver.SelectDropdownItemValue("CustomPromptId", "20");
             Driver.SubmitForm();
 
-            ValidatePageHeading("Configure answers");
+            ValidatePageHeading("Configure responses");
             var configureAnswerInitialResult = new AxeBuilder(Driver).Analyze();
 
             AddAnswer("Answer 1");
             AddAnswer("Answer 2");
-            ValidatePageHeading("Configure answers");
+            ValidatePageHeading("Configure responses");
             var configureAnswerWithAnswersResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Bulk edit");
-            ValidatePageHeading("Configure answers in bulk");
+            ValidatePageHeading("Configure responses in bulk");
             var bulkAdditionResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Next");

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCourseAdminFieldsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/AddCourseAdminFieldsAccessibilityTests.cs
@@ -30,7 +30,7 @@
             var addAnswersResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Bulk edit");
-            ValidatePageHeading("Configure answers in bulk");
+            ValidatePageHeading("Configure responses in bulk");
             var bulkAdditionResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Submit");

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCentreRegistrationPromptsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCentreRegistrationPromptsAccessibilityTests.cs
@@ -24,7 +24,7 @@
             var editPageResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Bulk edit");
-            ValidatePageHeading("Configure answers in bulk");
+            ValidatePageHeading("Configure responses in bulk");
             var bulkAdditionResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Next");

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseAdminFieldsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseAdminFieldsAccessibilityTests.cs
@@ -24,7 +24,7 @@
             var editPageResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Bulk edit");
-            ValidatePageHeading("Configure answers in bulk");
+            ValidatePageHeading("Configure responses in bulk");
             var bulkAdditionResult = new AxeBuilder(Driver).Analyze();
 
             Driver.ClickButtonByText("Submit");

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
@@ -32,19 +32,19 @@
                 yield return new TestCaseData(
                     new string('x', 4000),
                     "xx",
-                    "The complete list of answers must be 4000 characters or fewer (0 characters remaining for the new answer, 2 characters were entered)"
+                    "The complete list of responses must be 4000 characters or fewer (0 characters remaining for the new response, 2 characters were entered)"
                 ).SetName("Error_message_shows_zero_characters_remaining_if_options_string_is_at_max_length");
                 yield return new TestCaseData(
                     new string('x', 3998),
                     "xx",
-                    "The complete list of answers must be 4000 characters or fewer (0 characters remaining for the new answer, 2 characters were entered)"
+                    "The complete list of responses must be 4000 characters or fewer (0 characters remaining for the new response, 2 characters were entered)"
                 ).SetName(
                     "Error_message_shows_zero_characters_remaining_if_options_string_is_two_less_than_max_length"
                 );
                 yield return new TestCaseData(
                     new string('x', 3996),
                     "xxxx",
-                    "The complete list of answers must be 4000 characters or fewer (2 characters remaining for the new answer, 4 characters were entered)"
+                    "The complete list of responses must be 4000 characters or fewer (2 characters remaining for the new response, 4 characters were entered)"
                 ).SetName("Error_message_shows_two_less_than_number_of_characters_remaining_if_possible_to_add_answer");
             }
         }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -32,19 +32,19 @@
                 yield return new TestCaseData(
                     new string('x', 1000),
                     "xx",
-                    "The complete list of answers must be 1000 characters or fewer (0 characters remaining for the new answer, 2 characters were entered)"
+                    "The complete list of responses must be 1000 characters or fewer (0 characters remaining for the new response, 2 characters were entered)"
                 ).SetName("Error_message_shows_zero_characters_remaining_if_options_string_is_at_max_length");
                 yield return new TestCaseData(
                     new string('x', 998),
                     "xx",
-                    "The complete list of answers must be 1000 characters or fewer (0 characters remaining for the new answer, 2 characters were entered)"
+                    "The complete list of responses must be 1000 characters or fewer (0 characters remaining for the new response, 2 characters were entered)"
                 ).SetName(
                     "Error_message_shows_zero_characters_remaining_if_options_string_is_two_less_than_max_length"
                 );
                 yield return new TestCaseData(
                     new string('x', 996),
                     "xxxx",
-                    "The complete list of answers must be 1000 characters or fewer (2 characters remaining for the new answer, 4 characters were entered)"
+                    "The complete list of responses must be 1000 characters or fewer (2 characters remaining for the new response, 4 characters were entered)"
                 ).SetName("Error_message_shows_two_less_than_number_of_characters_remaining_if_possible_to_add_answer");
             }
         }
@@ -591,7 +591,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<AddAdminFieldViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each answer must be unique");
+                AssertModelStateErrorIsExpected(result, "Each response must be unique");
             }
         }
 
@@ -612,7 +612,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<EditAdminFieldViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each answer must be unique");
+                AssertModelStateErrorIsExpected(result, "Each response must be unique");
             }
         }
 
@@ -629,7 +629,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<AddBulkAdminFieldAnswersViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each answer must be unique");
+                AssertModelStateErrorIsExpected(result, "Each response must be unique");
             }
         }
 
@@ -646,7 +646,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<BulkAdminFieldAnswersViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each answer must be unique");
+                AssertModelStateErrorIsExpected(result, "Each response must be unique");
             }
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -562,7 +562,7 @@
             const string action = "save";
 
             A.CallTo(() => courseAdminFieldsDataService.GetCourseFieldPromptIdsForCustomisation(A<int>._))
-                .Returns(new int[] { 1, 0, 0 });
+                .Returns(new [] { 1, 0, 0 });
 
             // When
             var result = controller.AddAdminField(100, model, action);
@@ -585,8 +585,7 @@
             const string action = "addPrompt";
 
             // When
-            var result =
-                controller.AddAdminField(1, model, action);
+            var result = controller.AddAdminField(1, model, action);
 
             // Then
             using (new AssertionScope())
@@ -607,8 +606,7 @@
             const string action = "addPrompt";
 
             // When
-            var result =
-                controller.EditAdminField(1, model, action);
+            var result = controller.EditAdminField(1, model, action);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -342,7 +342,7 @@
 
             if (model.OptionsStringContainsDuplicates())
             {
-                ModelState.AddModelError("", "The list of answers contains duplicate options");
+                ModelState.AddModelError("", "The list of responses contains duplicate options");
                 return View("EditRegistrationPrompt", model);
             }
 
@@ -412,7 +412,7 @@
 
             if (model.OptionsStringContainsDuplicates())
             {
-                ModelState.AddModelError("", "The list of answers contains duplicate options");
+                ModelState.AddModelError("", "The list of responses contains duplicate options");
                 return View("AddRegistrationPromptConfigureAnswers", model);
             }
 
@@ -474,8 +474,8 @@
 
             ModelState.AddModelError(
                 nameof(RegistrationPromptAnswersViewModel.Answer),
-                "The complete list of answers must be 4000 characters or fewer " +
-                $"({remainingLengthShownToUser} character{remainingLengthPluralitySuffix} remaining for the new answer, " +
+                "The complete list of responses must be 4000 characters or fewer " +
+                $"({remainingLengthShownToUser} character{remainingLengthPluralitySuffix} remaining for the new response, " +
                 $"{answerLength} character{answerLengthPluralitySuffix} {verb} entered)"
             );
         }
@@ -512,7 +512,7 @@
             {
                 ModelState.AddModelError(
                     nameof(BulkRegistrationPromptAnswersViewModel.OptionsString),
-                    "The complete list of answers must be 4000 characters or fewer"
+                    "The complete list of responses must be 4000 characters or fewer"
                 );
             }
 
@@ -521,7 +521,7 @@
             {
                 ModelState.AddModelError(
                     nameof(BulkRegistrationPromptAnswersViewModel.OptionsString),
-                    "Each answer must be 100 characters or fewer"
+                    "Each response must be 100 characters or fewer"
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -436,8 +436,8 @@
 
             ModelState.AddModelError(
                 nameof(AdminFieldAnswersViewModel.Answer),
-                "The complete list of answers must be 1000 characters or fewer " +
-                $"({remainingLengthShownToUser} character{remainingLengthPluralitySuffix} remaining for the new answer, " +
+                "The complete list of responses must be 1000 characters or fewer " +
+                $"({remainingLengthShownToUser} character{remainingLengthPluralitySuffix} remaining for the new response, " +
                 $"{answerLength} character{answerLengthPluralitySuffix} {verb} entered)"
             );
         }
@@ -473,7 +473,7 @@
             {
                 ModelState.AddModelError(
                     nameof(BulkAdminFieldAnswersViewModel.OptionsString),
-                    "The complete list of answers must be 1000 characters or fewer"
+                    "The complete list of responses must be 1000 characters or fewer"
                 );
             }
 
@@ -482,7 +482,7 @@
             {
                 ModelState.AddModelError(
                     nameof(BulkAdminFieldAnswersViewModel.OptionsString),
-                    "Each answer must be 100 characters or fewer"
+                    "Each response must be 100 characters or fewer"
                 );
             }
 
@@ -490,7 +490,7 @@
             {
                 ModelState.AddModelError(
                     nameof(BulkAdminFieldAnswersViewModel.OptionsString),
-                    "Each answer must be unique"
+                    "Each response must be unique"
                 );
             }
         }
@@ -527,7 +527,7 @@
             {
                 ModelState.AddModelError(
                     nameof(AdminFieldAnswersViewModel.OptionsString),
-                    "Each answer must be unique"
+                    "Each response must be unique"
                 );
             }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -308,10 +308,10 @@
             }
 
             if (courseAdminFieldsService.AddAdminFieldToCourse(
-                    customisationId,
-                    model.AdminFieldId!.Value,
-                    model.OptionsString
-                ))
+                customisationId,
+                model.AdminFieldId!.Value,
+                model.OptionsString
+            ))
             {
                 return RedirectToAction("Index", new { customisationId });
             }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswersViewModel.cs
@@ -23,8 +23,8 @@
 
         public string? OptionsString { get; set; }
 
-        [Required(ErrorMessage = "Enter an answer")]
-        [MaxLength(100, ErrorMessage = "Answer must be 100 characters or fewer")]
+        [Required(ErrorMessage = "Enter a response")]
+        [MaxLength(100, ErrorMessage = "Response must be 100 characters or fewer")]
         public string? Answer { get; set; }
 
         public bool IncludeAnswersTableCaption { get; set; }
@@ -41,7 +41,7 @@
             {
                 validationResults.Add(
                     new ValidationResult(
-                        "That answer is already in the list of options",
+                        "That response is already in the list of options",
                         new[]
                         {
                             nameof(Answer),
@@ -54,7 +54,7 @@
             {
                 validationResults.Add(
                     new ValidationResult(
-                        "The list of answers contains duplicate options",
+                        "The list of responses contains duplicate options",
                         new string[] { }
                     )
                 );

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldAnswersViewModel.cs
@@ -23,8 +23,8 @@
 
         public List<string> Options => NewlineSeparatedStringListHelper.SplitNewlineSeparatedList(OptionsString);
 
-        [Required(ErrorMessage = "Enter an answer")]
-        [MaxLength(100, ErrorMessage = "Answer must be 100 characters or fewer")]
+        [Required(ErrorMessage = "Enter a response")]
+        [MaxLength(100, ErrorMessage = "Response must be 100 characters or fewer")]
         public string? Answer { get; set; }
 
         public bool IncludeAnswersTableCaption { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -15,7 +15,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(EditRegistrationPromptViewModel.OptionsString), nameof(EditRegistrationPromptViewModel.Answer)}" />
     }
 
-    <h1 class="nhsuk-heading-xl">Configure answers</h1>
+    <h1 class="nhsuk-heading-xl">Configure responses</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
       <div class="hidden-submit">
@@ -32,7 +32,7 @@
 
       <div class="divider">
         <vc:text-input asp-for="Answer"
-                       label="Add a new answer?"
+                       label="Add a new response?"
                        populate-with-current-value="true"
                        type="text"
                        spell-check="true"
@@ -43,7 +43,7 @@
       </div>
 
       <div class="divider">
-        <p class="nhsuk-label">Want to edit answers in bulk?</p>
+        <p class="nhsuk-label">Want to edit responses in bulk?</p>
         <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@RegistrationPromptsController.BulkAction">Bulk edit</button>
       </div>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptSummary.cshtml
@@ -57,7 +57,7 @@
         </dd>
         <dd class="nhsuk-summary-list__actions">
           <a asp-action="AddRegistrationPromptConfigureAnswers">
-            Change<span class="nhsuk-u-visually-hidden"> answers</span>
+            Change<span class="nhsuk-u-visually-hidden"> responses</span>
           </a>
         </dd>
       </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/BulkRegistrationPromptAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/BulkRegistrationPromptAnswers.cshtml
@@ -5,7 +5,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Configure answers in bulk" : "Configure answers in bulk";
+  ViewData["Title"] = errorHasOccurred ? "Error: Configure responses in bulk" : "Configure responses in bulk";
 }
 
 <div class="nhsuk-grid-row">
@@ -14,7 +14,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(BulkRegistrationPromptAnswersViewModel.OptionsString) }" />
     }
 
-    <h1 class="nhsuk-heading-xl">Configure answers in bulk</h1>
+    <h1 class="nhsuk-heading-xl">Configure responses in bulk</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="@(Model.IsAddPromptJourney ? "AddRegistrationPromptBulkPost" : "EditRegistrationPromptBulkPost")">
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -64,7 +64,7 @@
   <div class="nhsuk-grid-row divider">
     <div class="nhsuk-grid-column-one-half">
       <vc:text-input asp-for="Answer"
-                     label="Add a new answer?"
+                     label="Add a new response?"
                      populate-with-current-value="true"
                      type="text"
                      spell-check="true"
@@ -77,7 +77,7 @@
 
   <div class="nhsuk-grid-row divider">
     <div class="nhsuk-grid-column-one-half">
-      <p class="nhsuk-label">Want to edit answers in bulk?</p>
+      <p class="nhsuk-label">Want to edit responses in bulk?</p>
       <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@RegistrationPromptsController.BulkAction">Bulk edit</button>
     </div>
   </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_CentreRegistrationPromptExpander.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_CentreRegistrationPromptExpander.cshtml
@@ -21,7 +21,7 @@
     <div class="nhsuk-grid-row nhsuk-u-margin-bottom-3">
       <div class="nhsuk-grid-column-full">
         @if (Model.Options.Count != 0) {
-          <p class="nhsuk-u-font-weight-bold">Answers delegate can choose from:</p>
+          <p class="nhsuk-u-font-weight-bold">Responses delegate can choose from:</p>
           <ul>
             @foreach (var answer in Model.Options) {
               <li class="word-break">@answer</li>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_NoConfiguredAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_NoConfiguredAnswers.cshtml
@@ -1,5 +1,5 @@
 ﻿<p class="nhsuk-body-m">
-  There are no answers configured for this registration prompt.
-  If you would like the user to choose their answer from a specified
-  list of options, please configure answers.
+  There are no responses configured for this registration prompt.
+  If you would like the user to choose their response from a specified
+  list of options, please configure responses.
 </p>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/_RegistrationPromptAnswerTable.cshtml
@@ -5,12 +5,12 @@
 
 <table class="nhsuk-table">
   @if (Model.IncludeAnswersTableCaption) {
-    <caption class="nhsuk-table__caption">Configured Answers:</caption>
+    <caption class="nhsuk-table__caption">Configured Responses:</caption>
   }
   <thead role="rowgroup" class="nhsuk-table__head">
   <tr role="row">
     <th role="columnheader" class="" scope="col">
-      Answer
+      Response
     </th>
     <th role="columnheader" class="" scope="col">
       Action

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
@@ -47,7 +47,7 @@
       <div class="nhsuk-grid-row divider">
         <div class="nhsuk-grid-column-one-half">
           <vc:text-input asp-for="@nameof(Model.Answer)"
-                         label="Add a new answer?"
+                         label="Add a new response?"
                          populate-with-current-value="true"
                          type="text"
                          spell-check="true"
@@ -60,7 +60,7 @@
 
       <div class="nhsuk-grid-row divider">
         <div class="nhsuk-grid-column-one-half">
-          <p class="nhsuk-label">Want to edit answers in bulk?</p>
+          <p class="nhsuk-label">Want to edit responses in bulk?</p>
           <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.BulkAction">Bulk edit</button>
         </div>
       </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
@@ -6,7 +6,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Configure answers in bulk" : "Configure answers in bulk";
+  ViewData["Title"] = errorHasOccurred ? "Error: Configure responses in bulk" : "Configure responses in bulk";
   var cancelLinkData = Html.GetRouteValues();
 }
 
@@ -16,7 +16,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(Model.OptionsString) }" />
     }
 
-    <h1 class="nhsuk-heading-xl">Configure answers in bulk</h1>
+    <h1 class="nhsuk-heading-xl">Configure responses in bulk</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddAdminFieldAnswersBulk">
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/BulkAdminFieldAnswers.cshtml
@@ -6,7 +6,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Configure answers in bulk" : "Configure answers in bulk";
+  ViewData["Title"] = errorHasOccurred ? "Error: Configure responses in bulk" : "Configure responses in bulk";
   var cancelLinkData = Html.GetRouteValues();
 }
 
@@ -16,7 +16,7 @@
       <vc:error-summary order-of-property-names="@new []{ nameof(Model.OptionsString) }" />
     }
 
-    <h1 class="nhsuk-heading-xl">Configure answers in bulk</h1>
+    <h1 class="nhsuk-heading-xl">Configure responses in bulk</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="EditAdminFieldAnswersBulk">
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -50,7 +50,7 @@
       <div class="nhsuk-grid-row divider">
         <div class="nhsuk-grid-column-one-half">
           <vc:text-input asp-for="@nameof(Model.Answer)"
-                         label="Add a new answer?"
+                         label="Add a new response?"
                          populate-with-current-value="true"
                          type="text"
                          spell-check="true"
@@ -63,7 +63,7 @@
 
       <div class="nhsuk-grid-row divider">
         <div class="nhsuk-grid-column-one-half">
-          <p class="nhsuk-label">Want to edit answers in bulk?</p>
+          <p class="nhsuk-label">Want to edit responses in bulk?</p>
           <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.BulkAction">Bulk edit</button>
         </div>
       </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/_AdminFieldAnswerTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/_AdminFieldAnswerTable.cshtml
@@ -4,12 +4,12 @@
 
 <table class="nhsuk-table">
   @if (Model.IncludeAnswersTableCaption) {
-    <caption class="nhsuk-table__caption">Configured Answers:</caption>
+    <caption class="nhsuk-table__caption">Configured Responses:</caption>
   }
   <thead role="rowgroup" class="nhsuk-table__head">
   <tr role="row">
     <th role="columnheader" class="" scope="col">
-      Answer
+      Response
     </th>
     <th role="columnheader" class="" scope="col">
       Action

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/_AdminFieldCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/_AdminFieldCard.cshtml
@@ -16,7 +16,7 @@
           @if (Model.Options.Count == 0) {
             <p>This is a free text field. Admins can input any text.</p>
           } else {
-            <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-0">Answers to choose from:</p>
+            <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-0">Responses to choose from:</p>
             <ul>
               @foreach (var answer in Model.Options) {
                 <li class="word-break">@answer</li>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/_NoConfiguredAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/_NoConfiguredAnswers.cshtml
@@ -1,5 +1,5 @@
 ﻿<p class="nhsuk-body-m">
-  There are no answers configured for this admin field.
-  If you would like the user to choose their answer from a specified
-  list of options, please configure answers.
+  There are no responses configured for this admin field.
+  If you would like the user to choose their response from a specified
+  list of options, please configure responses.
 </p>


### PR DESCRIPTION
### JIRA link
[HEEDLS-896](https://softwiretech.atlassian.net/browse/HEEDLS-896)

### Description
On `/TrackingSystem/CourseSetup/:customisationId/AdminFields` pages:
* Attempts to add an admin field that is already present for the course will display the error message "That field name already exists for this course" when the Save button is pressed
* Attempts to add answers which match existing answers (case-insensitively, when trimmed) will display the error message "Each answer must be unique", either in single or bulk edit mode

### Screenshots
![already-exists](https://user-images.githubusercontent.com/1258014/168563969-cbb1ac59-d161-4ddb-9912-231bdf917f9d.png)
---
![edit-bulk](https://user-images.githubusercontent.com/1258014/168563973-4b5243b2-b12a-4170-a0ab-91a21ab675d6.png)
---
![edit-single](https://user-images.githubusercontent.com/1258014/168563976-23b3375c-c6ec-458a-b577-91cd193aa776.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
