### PR TITLE
Heedls 863 unlock account by resetting password

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
@@ -365,30 +365,6 @@
         }
 
         [Test]
-        public void
-            AttemptLogin_does_not_increment_failed_count_for_locked_admin_if_delegate_exists_and_returns_single_centre_login_result()
-        {
-            // Given
-            var adminUser = UserTestHelper.GetDefaultAdminUser(emailAddress: "email@test.com", failedLoginCount: 6);
-            var delegateUser = UserTestHelper.GetDefaultDelegateUser();
-            GivenAdminUserAndDelegateUserAreVerified(adminUser, delegateUser);
-            GivenNoLinkedAccountsFound();
-            GivenDelegateUserHasActiveCentre(delegateUser);
-
-            // When
-            var result = loginService.AttemptLogin(Username, Password);
-
-            // Then
-            using (new AssertionScope())
-            {
-                A.CallTo(() => userService.IncrementFailedLoginCount(adminUser)).MustNotHaveHappened();
-                result.LoginAttemptResult.Should().Be(LoginAttemptResult.LogIntoSingleCentre);
-                result.Accounts.AdminAccount.Should().BeNull();
-                result.Accounts.DelegateAccounts.Single().Should().Be(delegateUser);
-            }
-        }
-
-        [Test]
         public void AttemptLogin_find_multiple_delegates_and_returns_choose_a_centre_login_result()
         {
             // Given

--- a/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
@@ -341,7 +341,8 @@
         }
 
         [Test]
-        public void AttemptLogin_does_not_use_linked_admin_if_admin_account_found_is_at_different_centre_and_returns_single_centre_login_result()
+        public void
+            AttemptLogin_does_not_use_linked_admin_if_admin_account_found_is_at_different_centre_and_returns_single_centre_login_result()
         {
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser(centreId: 2);
@@ -474,14 +475,20 @@
         private void GivenNoLinkedDelegateAccountsFound()
         {
             A.CallTo(
-                () => userVerificationService.GetActiveApprovedVerifiedDelegateUsersAssociatedWithAdminUser(A<AdminUser?>._, Password)
+                () => userVerificationService.GetActiveApprovedVerifiedDelegateUsersAssociatedWithAdminUser(
+                    A<AdminUser?>._,
+                    Password
+                )
             ).Returns(new List<DelegateUser>());
         }
 
         private void GivenLinkedDelegateAccountsFound(List<DelegateUser> delegateUsers)
         {
             A.CallTo(
-                () => userVerificationService.GetActiveApprovedVerifiedDelegateUsersAssociatedWithAdminUser(A<AdminUser?>._, Password)
+                () => userVerificationService.GetActiveApprovedVerifiedDelegateUsersAssociatedWithAdminUser(
+                    A<AdminUser?>._,
+                    Password
+                )
             ).Returns(delegateUsers);
         }
 

--- a/DigitalLearningSolutions.Data/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Data/Services/LoginService.cs
@@ -58,18 +58,12 @@
             if (shouldIncreaseFailedLoginCount)
             {
                 userService.IncrementFailedLoginCount(unverifiedAdminUser!);
+                unverifiedAdminUser!.FailedLoginCount += 1;
             }
 
             if (adminAccountIsLocked)
             {
-                if (delegateAccountVerificationSuccessful)
-                {
-                    verifiedAdminUser = null;
-                }
-                else
-                {
-                    return new LoginResult(LoginAttemptResult.AccountLocked, unverifiedAdminUser);
-                }
+                return new LoginResult(LoginAttemptResult.AccountLocked, unverifiedAdminUser);
             }
 
             if (verifiedAdminUser == null && !delegateAccountVerificationSuccessful)

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -68,7 +68,7 @@
                     ModelState.AddModelError("Password", "The password you have entered is incorrect");
                     return View("Index", model);
                 case LoginAttemptResult.AccountLocked:
-                    return RedirectToAction("AccountLocked", new { failedCount = loginResult.Accounts.AdminAccount!.FailedLoginCount + 1 });
+                    return RedirectToAction("AccountLocked", new { failedCount = loginResult.Accounts.AdminAccount!.FailedLoginCount });
                 case LoginAttemptResult.AccountNotApproved:
                     return View("AccountNotApproved");
                 case LoginAttemptResult.InactiveCentre:
@@ -175,7 +175,7 @@
                 IsPersistent = rememberMe,
                 IssuedUtc = DateTime.UtcNow
             };
-            
+
             await HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
 
             return RedirectToReturnUrl(returnUrl) ?? RedirectToAction("Index", "Home");

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -62,13 +62,19 @@
             switch (loginResult.LoginAttemptResult)
             {
                 case LoginAttemptResult.InvalidUsername:
-                    ModelState.AddModelError("Username", "A user with this email address or user ID could not be found");
+                    ModelState.AddModelError(
+                        "Username",
+                        "A user with this email address or user ID could not be found"
+                    );
                     return View("Index", model);
                 case LoginAttemptResult.InvalidPassword:
                     ModelState.AddModelError("Password", "The password you have entered is incorrect");
                     return View("Index", model);
                 case LoginAttemptResult.AccountLocked:
-                    return RedirectToAction("AccountLocked", new { failedCount = loginResult.Accounts.AdminAccount!.FailedLoginCount });
+                    return RedirectToAction(
+                        "AccountLocked",
+                        new { failedCount = loginResult.Accounts.AdminAccount!.FailedLoginCount }
+                    );
                 case LoginAttemptResult.AccountNotApproved:
                     return View("AccountNotApproved");
                 case LoginAttemptResult.InactiveCentre:

--- a/DigitalLearningSolutions.Web/Controllers/SetPassword/ResetPasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SetPassword/ResetPasswordController.cs
@@ -1,6 +1,7 @@
 namespace DigitalLearningSolutions.Web.Controllers.SetPassword
 {
     using System.Threading.Tasks;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Extensions;
@@ -13,14 +14,17 @@ namespace DigitalLearningSolutions.Web.Controllers.SetPassword
     {
         private readonly IPasswordResetService passwordResetService;
         private readonly IPasswordService passwordService;
+        private readonly IUserService userService;
 
         public ResetPasswordController(
             IPasswordResetService passwordResetService,
-            IPasswordService passwordService
+            IPasswordService passwordService,
+            IUserService userService
         )
         {
             this.passwordResetService = passwordResetService;
             this.passwordService = passwordService;
+            this.userService = userService;
         }
 
         [HttpGet]
@@ -77,6 +81,12 @@ namespace DigitalLearningSolutions.Web.Controllers.SetPassword
 
             await passwordResetService.InvalidateResetPasswordForEmailAsync(resetPasswordData.Email);
             await passwordService.ChangePasswordAsync(resetPasswordData.Email, viewModel.Password!);
+            var adminUser = userService.GetUsersByEmailAddress(resetPasswordData.Email).adminUser;
+
+            if (adminUser != null)
+            {
+                userService.ResetFailedLoginCount(adminUser);
+            }
 
             TempData.Clear();
 

--- a/DigitalLearningSolutions.Web/Views/Login/AccountLocked.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/AccountLocked.cshtml
@@ -12,7 +12,7 @@
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">Account locked</h1>
     <p class="nhsuk-body-l">
-      Because there have been @Model failed login attempts for this account since the last successful login, the account is locked. Contact your centre manager to unlock your account.
+      Because there have been @Model failed login attempts for this account since the last successful login, the account is locked. Reset your password to unlock your account.
     </p>
   </div>
 </div>


### PR DESCRIPTION
### JIRA link
[_HEEDLS-863_](https://softwiretech.atlassian.net/jira/software/c/projects/HEEDLS/boards/753?modal=detail&selectedIssue=HEEDLS-863)

### Description
When an admin account reaches 5 failed logins, the account is locked. I added the possibility of unlocking an account by resetting the password. Previously only a centre manager could unlock an account.

### Screenshots

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
