### PR TITLE
HEEDLS-866 Refactor reports page when there is no activity at the centre

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/ActivityDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ActivityDataServiceTests.cs
@@ -102,5 +102,15 @@
             // then
             result.Should().Be(DateTime.Parse("2010-09-22 06:52:21.880"));
         }
+
+        [Test]
+        public void GetStartOfActivityForCentreWithoutActivity_returns_null()
+        {
+            // when
+            var result = service.GetStartOfActivityForCentre(46);
+
+            // then
+            result.Should().BeNull();
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/ActivityServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActivityServiceTests.cs
@@ -382,7 +382,8 @@
             // given
             var startDateString = "2012-06-06";
             var endDateString = "2021-06-06";
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101)).Returns(DateTime.Parse("2012-06-07"));
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
+                .Returns(DateTime.Parse("2012-06-07"));
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);
@@ -397,7 +398,8 @@
             // given
             var startDateString = "2022-06-06";
             var endDateString = "2021-06-06";
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101)).Returns(DateTime.Parse("2000-06-07"));
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
+                .Returns(DateTime.Parse("2000-06-07"));
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);
@@ -412,7 +414,8 @@
             // given
             var startDateString = "2012-06-06";
             var endDateString = "3021-06-06";
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101)).Returns(DateTime.Parse("2000-06-07"));
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
+                .Returns(DateTime.Parse("2000-06-07"));
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);
@@ -427,7 +430,8 @@
             // given
             var startDateString = "once upon a time";
             var endDateString = "2021-06-06";
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101)).Returns(DateTime.Parse("2000-06-07"));
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
+                .Returns(DateTime.Parse("2000-06-07"));
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);
@@ -442,7 +446,8 @@
             // given
             var startDateString = "2012-06-06";
             var endDateString = "happily ever after";
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101)).Returns(DateTime.Parse("2000-06-07"));
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
+                .Returns(DateTime.Parse("2000-06-07"));
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);
@@ -458,7 +463,8 @@
             // given
             var startDateString = "2012-06-06";
             var endDateString = "2021-06-06";
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101)).Returns(DateTime.Parse("2000-06-07"));
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
+                .Returns(DateTime.Parse("2000-06-07"));
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);
@@ -473,7 +479,7 @@
         {
             // given
             var dateWithTime = DateTime.Parse("2020/12/12 12:40:40");
-            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(A<int>._))
+            A.CallTo(() => activityDataService.GetStartOfActivityForCentre(A<int>._, A<int?>._))
                 .Returns(dateWithTime);
 
             // when

--- a/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
@@ -74,19 +74,12 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public DateTime? GetStartOfActivityForCentre(int centreId, int? courseCategoryId = null)
         {
-            return courseCategoryId == null
-                ? connection.QuerySingleOrDefault<DateTime?>(
-                    @"SELECT MIN(LogDate)
+            return connection.QuerySingleOrDefault<DateTime?>(
+                @"SELECT MIN(LogDate)
                     FROM tActivityLog
-                    WHERE CentreID = @centreId",
-                    new { centreId }
-                )
-                : connection.QuerySingleOrDefault<DateTime?>(
-                    @"SELECT MIN(LogDate)
-                    FROM tActivityLog
-                    WHERE CentreID = @centreId AND CourseCategoryId = @courseCategoryId",
-                    new { centreId, courseCategoryId }
-                );
+                    WHERE CentreID = @centreId AND (CourseCategoryID = @courseCategoryId OR @courseCategoryId IS NULL)",
+                new { centreId, courseCategoryId }
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
@@ -17,7 +17,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             int? customisationId
         );
 
-        DateTime GetStartOfActivityForCentre(int centreId);
+        DateTime? GetStartOfActivityForCentre(int centreId, int? courseCategoryId = null);
     }
 
     public class ActivityDataService : IActivityDataService
@@ -72,14 +72,21 @@ namespace DigitalLearningSolutions.Data.DataServices
             );
         }
 
-        public DateTime GetStartOfActivityForCentre(int centreId)
+        public DateTime? GetStartOfActivityForCentre(int centreId, int? courseCategoryId = null)
         {
-            return connection.QuerySingleOrDefault<DateTime>(
-                @"SELECT MIN(LogDate)
+            return courseCategoryId == null
+                ? connection.QuerySingleOrDefault<DateTime?>(
+                    @"SELECT MIN(LogDate)
                     FROM tActivityLog
                     WHERE CentreID = @centreId",
-                new { centreId }
-            );
+                    new { centreId }
+                )
+                : connection.QuerySingleOrDefault<DateTime?>(
+                    @"SELECT MIN(LogDate)
+                    FROM tActivityLog
+                    WHERE CentreID = @centreId AND CourseCategoryId = @courseCategoryId",
+                    new { centreId, courseCategoryId }
+                );
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -21,7 +21,7 @@
 
         ReportsFilterOptions GetFilterOptions(int centreId, int? courseCategoryId);
 
-        DateTime GetActivityStartDateForCentre(int centreId);
+        DateTime? GetActivityStartDateForCentre(int centreId, int? courseCategoryId = null);
 
         byte[] GetActivityDataFileForCentre(int centreId, ActivityFilterData filterData);
 
@@ -116,9 +116,10 @@
             return new ReportsFilterOptions(jobGroups, courseCategories, courses);
         }
 
-        public DateTime GetActivityStartDateForCentre(int centreId)
+        public DateTime? GetActivityStartDateForCentre(int centreId, int? courseCategoryId = null)
         {
-            return activityDataService.GetStartOfActivityForCentre(centreId).Date;
+            var activityStart = activityDataService.GetStartOfActivityForCentre(centreId, courseCategoryId);
+            return activityStart?.Date ?? activityStart;
         }
 
         public byte[] GetActivityDataFileForCentre(int centreId, ActivityFilterData filterData)
@@ -194,7 +195,8 @@
         )
         {
             var startDateInvalid = !DateTime.TryParse(startDateString, out var startDate);
-            if (startDateInvalid || startDate < GetActivityStartDateForCentre(centreId))
+            var activityStart = GetActivityStartDateForCentre(centreId);
+            if (startDateInvalid || activityStart == null || startDate < activityStart)
             {
                 return null;
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -61,7 +61,8 @@
                 filterModel,
                 evaluationResponseBreakdowns,
                 filterData.StartDate,
-                filterData.EndDate ?? DateTime.Today
+                filterData.EndDate ?? DateTime.Today,
+                activityService.GetActivityStartDateForCentre(centreId, categoryIdFilter) != null
             );
             return View(model);
         }
@@ -182,7 +183,7 @@
             string startDate,
             string endDate,
             ReportInterval reportInterval
-            )
+        )
         {
             var centreId = User.GetCentreId();
             var adminCategoryIdFilter = User.GetAdminCourseCategoryFilter();

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
@@ -17,7 +17,7 @@
             ActivityFilterData filterData,
             int? userCategoryFilter,
             ReportsFilterOptions filterOptions,
-            DateTime dataStartDate
+            DateTime? dataStartDate
         )
         {
             JobGroupId = filterData.JobGroupId;
@@ -62,7 +62,7 @@
         public int? EndYear { get; set; }
         public bool EndDate { get; set; }
         public ReportInterval ReportInterval { get; set; }
-        public DateTime DataStart { get; set; }
+        public DateTime? DataStart { get; set; }
         public bool CanFilterCourseCategories { get; set; }
 
         public IEnumerable<SelectListItem> JobGroupOptions { get; set; } = new List<SelectListItem>();

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/ReportsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/ReportsViewModel.cs
@@ -14,18 +14,21 @@
             ReportsFilterModel filterModel,
             IEnumerable<EvaluationResponseBreakdown> evaluationResponseBreakdowns,
             DateTime startDate,
-            DateTime endDate
+            DateTime endDate,
+            bool hasActivity
         )
         {
             UsageStatsTableViewModel = new UsageStatsTableViewModel(activity, startDate, endDate);
             ReportsFilterModel = filterModel;
             EvaluationSummaryBreakdown =
                 evaluationResponseBreakdowns.Select(model => new EvaluationSummaryViewModel(model));
+            HasActivity = hasActivity;
         }
 
         public UsageStatsTableViewModel UsageStatsTableViewModel { get; set; }
         public ReportsFilterModel ReportsFilterModel { get; set; }
         public IEnumerable<EvaluationSummaryViewModel> EvaluationSummaryBreakdown { get; set; }
+        public bool HasActivity { get; set; }
     }
 
     public class UsageStatsTableViewModel

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
@@ -52,7 +52,7 @@
                            end-year-id="@nameof(Model.EndYear)"
                            end-date-checkbox-id="@nameof(Model.EndDate)"
                            end-date-checkbox-label="End date"
-                           hint-text="The reporting in your centre starts on @Model.DataStart.ToString(DateHelper.StandardDateFormat). Please select any date range between that date and now."
+                           hint-text="The reporting in your centre starts on @Model.DataStart?.ToString(DateHelper.StandardDateFormat). Please select any date range between that date and now."
                            end-date-checkbox-hint-text="Check this box to specify an end date. If left unchecked will display data until today." />
 
       <vc:select-list asp-for="@nameof(Model.ReportInterval)"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -22,26 +22,36 @@
 
     <span class="nhsuk-body-l">View reports for <span class="nhsuk-u-font-weight-bold">@Model.ReportsFilterModel.CourseCategoryName</span> courses.</span>
 
-    <partial name="_FilterDisplayCard.cshtml" model="@Model.ReportsFilterModel" />
+    @if (Model.HasActivity) {
+      <partial name="_FilterDisplayCard.cshtml" model="@Model.ReportsFilterModel" />
 
-    <h2 class="nhsuk-heading-m">Usage stats</h2>
+      <h2 class="nhsuk-heading-m">Usage stats</h2>
 
-    <div id="activity-graph" class="js-only-block">
-      <partial name="_ActivityGraph.cshtml" />
-    </div>
-    <div id="activity-graph-data-error" class="js-only-block" hidden>
-      <vc:inset-text text="Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart."
-                     css-class="nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4" />
-    </div>
-    <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />
+      <div id="activity-graph" class="js-only-block">
+        <partial name="_ActivityGraph.cshtml" />
+      </div>
+      <div id="activity-graph-data-error" class="js-only-block" hidden>
+        <vc:inset-text text="Too many chart data points to display. Please select a smaller date range or a bigger reporting interval to view data on a chart."
+                       css-class="nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4" />
+      </div>
+      <partial name="_ActivityTable.cshtml" model="@Model.UsageStatsTableViewModel" />
 
-    <a class="nhsuk-button nhsuk-u-margin-top-6"
-       asp-controller="Reports"
-       asp-action="DownloadUsageData"
-       asp-all-route-data="@Model.ReportsFilterModel.FilterValues"
-       role="button">
-      Download usage data
-    </a>
+      <a class="nhsuk-button nhsuk-u-margin-top-6"
+         asp-controller="Reports"
+         asp-action="DownloadUsageData"
+         asp-all-route-data="@Model.ReportsFilterModel.FilterValues"
+         role="button">
+        Download usage data
+      </a>
+    } else {
+      var place =
+        Model.ReportsFilterModel.CourseCategoryName == "All"
+          ? "at this centre"
+          : $"for the course category {Model.ReportsFilterModel.CourseCategoryName}";
+      <p class="nhsuk-body-l">
+        There has not yet been any activity @place.
+      </p>
+    }
 
     <hr />
     <h2 class="nhsuk-heading-m">Evaluation summary</h2>
@@ -55,13 +65,15 @@
       }
     </ul>
 
-    <a class="nhsuk-button"
-       asp-controller="Reports"
-       asp-action="DownloadEvaluationSummaries"
-       asp-all-route-data="@Model.ReportsFilterModel.FilterValues"
-       role="button">
-      Download evaluation summary
-    </a>
+    @if (Model.HasActivity) {
+      <a class="nhsuk-button"
+         asp-controller="Reports"
+         asp-action="DownloadEvaluationSummaries"
+         asp-all-route-data="@Model.ReportsFilterModel.FilterValues"
+         role="button">
+        Download evaluation summary
+      </a>
+    }
 
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
       <partial name="~/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml" model="CentrePage.Reports" />


### PR DESCRIPTION
### JIRA link
[HEEDLS-866](https://softwiretech.atlassian.net/jira/software/c/projects/HEEDLS/boards/753?modal=detail&selectedIssue=HEEDLS-866)

### Description
On the reports page, if there was no activity at the centre, the query inside the `ActivityDataService.GetStartOfActivityForCentre` method was returning null. This caused the change filters and download buttons to give an error. I added a check and if there is no activity at the centre/for the course category that the current user has access to, I don't display the buttons and instead show an informative message.

### Screenshots
No activity for all course categories:
![image](https://user-images.githubusercontent.com/105208326/168574436-4c74d694-fa94-4ace-9e8c-633fcda43e33.png)

No activity for the specific course category the user has access to:
![image](https://user-images.githubusercontent.com/105208326/168574673-28453cff-1227-45ba-97d4-4203707dbe30.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
