### PR TITLE
DLSV2-546 - fix for duplicate supervisors in the list

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -108,7 +108,7 @@
         )
         {
             return connection.Query<SelfAssessmentSupervisor>(
-                @"SELECT
+                @"SELECT DISTINCT
                     sd.ID AS SupervisorDelegateID,
                     sd.SupervisorAdminID,
                     sd.SupervisorEmail,

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -440,7 +440,9 @@
             if (assessment.HasDelegateNominatedRoles)
             {
                 suggestedSupervisors = selfAssessmentService
-                    .GetOtherSupervisorsForCandidate(selfAssessmentId, candidateId).ToList();
+                    .GetOtherSupervisorsForCandidate(selfAssessmentId, candidateId)
+                    .Where(item => supervisors.All(s => !item.SupervisorAdminID.Equals(s.SupervisorAdminID)))
+                    .ToList();
             }
 
             var model = new ManageSupervisorsViewModel
@@ -758,6 +760,26 @@
             return RedirectToAction("ManageSupervisors", new { selfAssessmentId });
         }
 
+        public IActionResult ConfirmSupervisor(int supervisorDelegateId, int selfAssessmentId)
+        {
+            supervisorService.ConfirmSupervisorDelegateById(supervisorDelegateId, GetCandidateId(), 0);
+            frameworkNotificationService.SendSupervisorDelegateConfirmed(
+                supervisorDelegateId,
+                0,
+                User.GetCandidateIdKnownNotNull()
+            );
+            return RedirectToAction("ManageSupervisors", new { selfAssessmentId });
+        }
+
+        public IActionResult RejectSupervisor(int supervisorDelegateId, int selfAssessmentId)
+        {
+            supervisorService.RemoveSupervisorDelegateById(supervisorDelegateId, GetCandidateId(), 0);
+            frameworkNotificationService.SendSupervisorDelegateRejected(
+                supervisorDelegateId,
+                User.GetCandidateIdKnownNotNull()
+            );
+            return RedirectToAction("ManageSupervisors", new { selfAssessmentId });
+        }
 
         public IActionResult StartRequestVerification(int selfAssessmentId)
         {


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-546

### Description
 excluding all existing supervisors for the activity and only list each supervisor once.


I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
