### PR TITLE
Heedls 896 prompt journey fixes

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
@@ -477,6 +477,24 @@
             }
         }
 
+        [Test]
+        public void
+            EditRegistrationPromptBulkPost_adds_model_error_if_trimmed_case_insensitive_bulk_edit_is_not_unique()
+        {
+            // Given
+            var model = new BulkRegistrationPromptAnswersViewModel("test\r\n   tEsT   ", false, 1);
+
+            // When
+            var result = registrationPromptsController.EditRegistrationPromptBulkPost(model);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.As<ViewResult>().Model.Should().BeOfType<BulkRegistrationPromptAnswersViewModel>();
+                AssertModelStateErrorIsExpected(result, "The list of responses contains duplicate options");
+            }
+        }
+
         private void AssertSelectPromptViewModelIsExpectedModel(AddRegistrationPromptSelectPromptViewModel promptModel)
         {
             registrationPromptsController.TempData.Peek<AddRegistrationPromptData>()!.SelectPromptViewModel.Should()

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/AdminFieldsControllerTests.cs
@@ -562,7 +562,7 @@
             const string action = "save";
 
             A.CallTo(() => courseAdminFieldsDataService.GetCourseFieldPromptIdsForCustomisation(A<int>._))
-                .Returns(new [] { 1, 0, 0 });
+                .Returns(new[] { 1, 0, 0 });
 
             // When
             var result = controller.AddAdminField(100, model, action);
@@ -591,7 +591,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<AddAdminFieldViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each response must be unique");
+                AssertModelStateErrorIsExpected(result, "That response is already in the list of options");
             }
         }
 
@@ -612,7 +612,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<EditAdminFieldViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each response must be unique");
+                AssertModelStateErrorIsExpected(result, "That response is already in the list of options");
             }
         }
 
@@ -629,7 +629,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<AddBulkAdminFieldAnswersViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each response must be unique");
+                AssertModelStateErrorIsExpected(result, "The list of responses contains duplicate options");
             }
         }
 
@@ -646,7 +646,7 @@
             using (new AssertionScope())
             {
                 result.As<ViewResult>().Model.Should().BeOfType<BulkAdminFieldAnswersViewModel>();
-                AssertModelStateErrorIsExpected(result, "Each response must be unique");
+                AssertModelStateErrorIsExpected(result, "The list of responses contains duplicate options");
             }
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -276,11 +276,11 @@
             }
 
             if (centreRegistrationPromptsService.AddCentreRegistrationPrompt(
-                    User.GetCentreId(),
-                    data.SelectPromptViewModel.CustomPromptId!.Value,
-                    data.SelectPromptViewModel.Mandatory,
-                    data.ConfigureAnswersViewModel.OptionsString
-                ))
+                User.GetCentreId(),
+                data.SelectPromptViewModel.CustomPromptId!.Value,
+                data.SelectPromptViewModel.Mandatory,
+                data.ConfigureAnswersViewModel.OptionsString
+            ))
             {
                 TempData.Clear();
                 return RedirectToAction("Index");
@@ -506,6 +506,12 @@
             TempData.Set(data);
         }
 
+        private bool IsOptionsListUnique(List<string> optionsList)
+        {
+            var lowerCaseOptionsList = optionsList.Select(str => str.ToLower()).ToList();
+            return lowerCaseOptionsList.Count() == lowerCaseOptionsList.Distinct().Count();
+        }
+
         private void ValidateBulkOptionsString(string? optionsString)
         {
             if (optionsString != null && optionsString.Length > 4000)
@@ -522,6 +528,14 @@
                 ModelState.AddModelError(
                     nameof(BulkRegistrationPromptAnswersViewModel.OptionsString),
                     "Each response must be 100 characters or fewer"
+                );
+            }
+
+            if (!IsOptionsListUnique(optionsList))
+            {
+                ModelState.AddModelError(
+                    nameof(BulkRegistrationPromptAnswersViewModel.OptionsString),
+                    "The list of responses contains duplicate options"
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/AdminFieldsController.cs
@@ -490,7 +490,7 @@
             {
                 ModelState.AddModelError(
                     nameof(BulkAdminFieldAnswersViewModel.OptionsString),
-                    "Each response must be unique"
+                    "The list of responses contains duplicate options"
                 );
             }
         }
@@ -526,8 +526,8 @@
             if (!IsOptionsListUnique(NewlineSeparatedStringListHelper.SplitNewlineSeparatedList(optionsString)))
             {
                 ModelState.AddModelError(
-                    nameof(AdminFieldAnswersViewModel.OptionsString),
-                    "Each response must be unique"
+                    nameof(AdminFieldAnswersViewModel.Answer),
+                    "That response is already in the list of options"
                 );
             }
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-896

### Description
Addressing Alex's test failure report:
* Changed error messages for course admin interface to match those in custom prompts
* Highlight the correct field when there's an error with duplicate responses
* Changed the custom prompts bulk answers journey so that an error is displayed on the bulk edit screen when duplicate entries are submitted

### Screenshots
![fixed-error-message](https://user-images.githubusercontent.com/1258014/169497541-d4b4baab-f89a-43a4-87e2-bc831e78251b.png)
---
![fixed-highlighting](https://user-images.githubusercontent.com/1258014/169497543-9a3978f0-69be-4288-aeb8-2ba8c0c80061.png)
---
![registration-prompts-bulk-validation](https://user-images.githubusercontent.com/1258014/169497539-6416bc02-5fad-476c-aa1e-54a7a77c5941.png)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
