### PR TITLE
Heedls 866 fix reports page actions for no activity centres

### DIFF
--- a/DigitalLearningSolutions.Data/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActivityService.cs
@@ -30,6 +30,8 @@
             string endDateString,
             int centreId
         );
+
+        string GetCourseCategoryNameForActivityFilter(int? courseCategoryId);
     }
 
     public class ActivityService : IActivityService
@@ -211,20 +213,20 @@
             return (startDate, endDateIsSet ? endDate : (DateTime?)null);
         }
 
+        public string GetCourseCategoryNameForActivityFilter(int? courseCategoryId)
+        {
+            var courseCategoryName = courseCategoryId.HasValue
+                ? courseCategoriesDataService.GetCourseCategoryName(courseCategoryId.Value)
+                : "All";
+            return courseCategoryName ?? "All";
+        }
+
         private string GetJobGroupNameForActivityFilter(int? jobGroupId)
         {
             var jobGroupName = jobGroupId.HasValue
                 ? jobGroupsDataService.GetJobGroupName(jobGroupId.Value)
                 : "All";
             return jobGroupName ?? "All";
-        }
-
-        private string GetCourseCategoryNameForActivityFilter(int? courseCategoryId)
-        {
-            var courseCategoryName = courseCategoryId.HasValue
-                ? courseCategoriesDataService.GetCourseCategoryName(courseCategoryId.Value)
-                : "All";
-            return courseCategoryName ?? "All";
         }
 
         private string GetCourseNameForActivityFilter(int? courseId)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -62,7 +62,8 @@
                 evaluationResponseBreakdowns,
                 filterData.StartDate,
                 filterData.EndDate ?? DateTime.Today,
-                activityService.GetActivityStartDateForCentre(centreId, categoryIdFilter) != null
+                activityService.GetActivityStartDateForCentre(centreId, categoryIdFilter) != null,
+                activityService.GetCourseCategoryNameForActivityFilter(categoryIdFilter)
             );
             return View(model);
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/ReportsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/ReportsViewModel.cs
@@ -15,7 +15,8 @@
             IEnumerable<EvaluationResponseBreakdown> evaluationResponseBreakdowns,
             DateTime startDate,
             DateTime endDate,
-            bool hasActivity
+            bool hasActivity,
+            string category
         )
         {
             UsageStatsTableViewModel = new UsageStatsTableViewModel(activity, startDate, endDate);
@@ -23,12 +24,14 @@
             EvaluationSummaryBreakdown =
                 evaluationResponseBreakdowns.Select(model => new EvaluationSummaryViewModel(model));
             HasActivity = hasActivity;
+            Category = category;
         }
 
         public UsageStatsTableViewModel UsageStatsTableViewModel { get; set; }
         public ReportsFilterModel ReportsFilterModel { get; set; }
         public IEnumerable<EvaluationSummaryViewModel> EvaluationSummaryBreakdown { get; set; }
         public bool HasActivity { get; set; }
+        public string Category { get; set; }
     }
 
     public class UsageStatsTableViewModel

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -55,6 +55,14 @@
           </li>
         }
       </ul>
+
+      <a class="nhsuk-button"
+         asp-controller="Reports"
+         asp-action="DownloadEvaluationSummaries"
+         asp-all-route-data="@Model.ReportsFilterModel.FilterValues"
+         role="button">
+        Download evaluation summary
+      </a>
     } else {
       var place = Model.Category == "All" ? "at this centre" : $"for course category {Model.Category}";
       <p class="nhsuk-body-l">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -24,9 +24,11 @@
 
     @if (Model.HasActivity) {
       <partial name="_FilterDisplayCard.cshtml" model="@Model.ReportsFilterModel" />
+    }
 
-      <h2 class="nhsuk-heading-m">Usage stats</h2>
+    <h2 class="nhsuk-heading-m">Usage stats</h2>
 
+    @if (Model.HasActivity) {
       <div id="activity-graph" class="js-only-block">
         <partial name="_ActivityGraph.cshtml" />
       </div>
@@ -44,12 +46,8 @@
         Download usage data
       </a>
     } else {
-      var place =
-        Model.ReportsFilterModel.CourseCategoryName == "All"
-          ? "at this centre"
-          : $"for the course category {Model.ReportsFilterModel.CourseCategoryName}";
       <p class="nhsuk-body-l">
-        There has not yet been any activity @place.
+        There has not yet been any activity.
       </p>
     }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/Index.cshtml
@@ -20,15 +20,13 @@
   <div class="nhsuk-grid-column-three-quarters">
     <h1 id="page-heading" class="nhsuk-heading-xl">Centre reports</h1>
 
-    <span class="nhsuk-body-l">View reports for <span class="nhsuk-u-font-weight-bold">@Model.ReportsFilterModel.CourseCategoryName</span> courses.</span>
-
     @if (Model.HasActivity) {
+      <span class="nhsuk-body-l">View reports for <span class="nhsuk-u-font-weight-bold">@Model.ReportsFilterModel.CourseCategoryName</span> courses.</span>
+
       <partial name="_FilterDisplayCard.cshtml" model="@Model.ReportsFilterModel" />
-    }
 
-    <h2 class="nhsuk-heading-m">Usage stats</h2>
+      <h2 class="nhsuk-heading-m">Usage stats</h2>
 
-    @if (Model.HasActivity) {
       <div id="activity-graph" class="js-only-block">
         <partial name="_ActivityGraph.cshtml" />
       </div>
@@ -45,32 +43,23 @@
          role="button">
         Download usage data
       </a>
+
+      <hr />
+      <h2 class="nhsuk-heading-m">Evaluation summary</h2>
+      <p>Summary of evaluation responses collected from delegates on completion of learning activities.</p>
+
+      <ul class="nhsuk-card-group">
+        @foreach (var evaluationSummary in Model.EvaluationSummaryBreakdown) {
+          <li class="nhsuk-card-group__item">
+            <partial name="_EvaluationSummaryCard.cshtml" model="evaluationSummary" />
+          </li>
+        }
+      </ul>
     } else {
+      var place = Model.Category == "All" ? "at this centre" : $"for course category {Model.Category}";
       <p class="nhsuk-body-l">
-        There has not yet been any activity.
+        There has not yet been any activity @place.
       </p>
-    }
-
-    <hr />
-    <h2 class="nhsuk-heading-m">Evaluation summary</h2>
-    <p>Summary of evaluation responses collected from delegates on completion of learning activities.</p>
-
-    <ul class="nhsuk-card-group">
-      @foreach (var evaluationSummary in Model.EvaluationSummaryBreakdown) {
-        <li class="nhsuk-card-group__item">
-          <partial name="_EvaluationSummaryCard.cshtml" model="evaluationSummary" />
-        </li>
-      }
-    </ul>
-
-    @if (Model.HasActivity) {
-      <a class="nhsuk-button"
-         asp-controller="Reports"
-         asp-action="DownloadEvaluationSummaries"
-         asp-all-route-data="@Model.ReportsFilterModel.FilterValues"
-         role="button">
-        Download evaluation summary
-      </a>
     }
 
     <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">


### PR DESCRIPTION
### JIRA link
[HEEDLS-866](https://softwiretech.atlassian.net/jira/software/c/projects/HEEDLS/boards/753?modal=detail&selectedIssue=HEEDLS-866)

### Description
I replaced the entire content of the reports page with the no activity message for centres with no activity.

### Screenshots
![image](https://user-images.githubusercontent.com/105208326/169500817-e579bcc7-cee8-47bf-89ad-1e26096c7868.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
