### PR TITLE
UAR-852 fix remaining db queries

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -56,7 +56,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             20,
             "xxxx",
             "xxxxxx",
-            "",
+            "87487c85-7d35-4b3f-9979-eb734ce90df2",
             101,
             false,
             "HG1",

--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -303,12 +303,12 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         public void GetNumsOfRecentProgressRecordsForBrand_returns_expected_dict()
         {
             // Given
-            var expectedDict = new Dictionary<int, int> { { 308, 1 } };
+            var expectedDict = new Dictionary<int, int> { { 206, 9 } };
 
             // When
             var dict = courseDataService.GetNumsOfRecentProgressRecordsForBrand(
-                1,
-                new DateTime(2022, 1, 5, 11, 30, 30)
+                2,
+                new DateTime(2020, 1, 5, 11, 30, 30)
             );
 
             // Then
@@ -524,7 +524,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
             // Given
             const int brandId = 1;
 
-            var expectedFirstApplication = new ApplicationDetails()
+            var expectedFirstApplication = new ApplicationDetails
             {
                 ApplicationId = 1,
                 ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,11 @@ pipeline {
                 bat "dotnet test DigitalLearningSolutions.Web.Tests"
             }
         }
-        /*
         stage('Data Tests') {
             steps {
                 bat "dotnet test DigitalLearningSolutions.Data.Tests"
             }
         }
-        */
         stage('Integration Tests') {
             environment {
                 DlsRefactor_ConnectionStrings__DefaultConnection = credentials('uar-ci-db-connection-string')


### PR DESCRIPTION
### JIRA link
[_HEEDLS-852_](https://softwiretech.atlassian.net/browse/HEEDLS-852)

### Description
Changed the delegate email in the ExpectedCourseInfo used for tests to the Guid generated during migrations
Changed the inputs for `GetNumsOfRecentProgressRecordsForBrand_returns_expected_dict`, which was failing because this accessibility test `LearningMenu_interface_has_no_accessibility_errors` was updating a progress record's SubmittedTime, interfering with the expected results.
Commented back in the data tests in the jenkins file

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
