### PR TITLE
HEEDLS-904 Hopefully fix Jenkins pipeline (again)

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -134,7 +134,7 @@
 
     <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
         <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-        <Exec Command="yarn install" />
+        <Exec Command="yarn install --frozen-lockfile" />
         <Exec Command="yarn build" />
         <!-- Include the newly-built files in the publish output -->
         <ItemGroup>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,9 @@ pipeline {
             }
             steps {
                 withCredentials([string(credentialsId: 'deploy-test-password', variable: 'PASSWORD')]) {
-                    bat "dotnet publish DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj /p:PublishProfile=DigitalLearningSolutions.Web/Properties/PublishProfiles/PublishToTest.pubxml /p:Password=$PASSWORD /p:AllowUntrustedCertificate=True"
+                    nodejs(nodeJSInstallationName: 'NodeJS-16') {
+                        bat "dotnet publish DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj /p:PublishProfile=DigitalLearningSolutions.Web/Properties/PublishProfiles/PublishToTest.pubxml /p:Password=$PASSWORD /p:AllowUntrustedCertificate=True"
+                    }
                 }
             }
         }
@@ -90,7 +92,9 @@ pipeline {
             }
             steps {
                 withCredentials([string(credentialsId: 'ftp-password', variable: 'PASSWORD')]) {
-                    bat "DeployToUAT.bat \"Frida.Tveit:$PASSWORD\" 40.69.40.103"
+                    nodejs(nodeJSInstallationName: 'NodeJS-16') {
+                        bat "DeployToUAT.bat \"Frida.Tveit:$PASSWORD\" 40.69.40.103"
+                    }
                 }
                 sendSlackMessageToTeamChannel(":tada: Successfully deployed to UAT", "good")
                 sendSlackNotificationToChannel("@kevin.whittaker", ":tada: Successfully deployed to UAT", "good")


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-904

### Description
The Jenkins pipeline failed when running `Deploy to test`: https://jenkins2.softwire.com/job/HEE/job/HEE%20DLS/job/master/1265/console

This commit hopefully fixes that stage of the pipeline, as well as `Deploy to UAT`. It also switches to using `yarn install --frozen-lockfile` in both those circumstances.

Note: there is no way to be sure that this will work without merging this PR.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
