### PR TITLE
Uar 898 fix login

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
@@ -101,7 +101,7 @@
 
         [Test]
         public void
-            AttemptLogin_returns_invalid_password_when_user_account_password_is_incorrect_and_delegate_old_passwords_null_returns_incorrect_password()
+            AttemptLogin_returns_invalid_password_when_user_account_password_is_incorrect_and_delegate_old_passwords_null()
         {
             // Given
             var userEntity = new UserEntity(

--- a/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LoginServiceTests.cs
@@ -85,7 +85,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new[] { 3 }));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new[] { 3 }));
 
             // When
             var result = loginService.AttemptLogin(Username, Password);
@@ -94,6 +94,37 @@
             using (new AssertionScope())
             {
                 result.LoginAttemptResult.Should().Be(LoginAttemptResult.AccountsHaveMismatchedPasswords);
+                result.UserEntity.Should().BeNull();
+                result.CentreToLogInto.Should().BeNull();
+            }
+        }
+
+        [Test]
+        public void
+            AttemptLogin_returns_invalid_password_when_user_account_password_is_incorrect_and_delegate_old_passwords_null_returns_incorrect_password()
+        {
+            // Given
+            var userEntity = new UserEntity(
+                UserTestHelper.GetDefaultUserAccount(),
+                new List<AdminAccount>(),
+                new List<DelegateAccount>
+                {
+                    UserTestHelper.GetDefaultDelegateAccount(),
+                    UserTestHelper.GetDefaultDelegateAccount(3, centreId: 101),
+                }
+            );
+            A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
+            A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
+                .Returns(new UserEntityVerificationResult(false, new[] { 2, 3 }, new List<int>(), new List<int>()));
+            A.CallTo(() => userService.UpdateFailedLoginCount(userEntity.UserAccount)).DoesNothing();
+
+            // When
+            var result = loginService.AttemptLogin(Username, Password);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.LoginAttemptResult.Should().Be(LoginAttemptResult.InvalidPassword);
                 result.UserEntity.Should().BeNull();
                 result.CentreToLogInto.Should().BeNull();
             }
@@ -123,7 +154,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(false, new List<int>(), new[] { 2, 3 }));
+                .Returns(new UserEntityVerificationResult(false, new List<int>(), new List<int>(), new[] { 2, 3 }));
             A.CallTo(() => userService.UpdateFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When
@@ -162,7 +193,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new List<int>()));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new List<int>()));
             A.CallTo(() => userService.ResetFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When
@@ -193,7 +224,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new List<int>()));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new List<int>()));
             A.CallTo(() => userService.ResetFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When
@@ -221,7 +252,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new List<int>()));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new List<int>()));
             A.CallTo(() => userService.ResetFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When
@@ -248,7 +279,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new List<int>()));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new List<int>()));
             A.CallTo(() => userService.ResetFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When
@@ -275,7 +306,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new List<int>()));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new List<int>()));
             A.CallTo(() => userService.ResetFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When
@@ -302,7 +333,7 @@
             );
             A.CallTo(() => userService.GetUserByUsername(Username)).Returns(userEntity);
             A.CallTo(() => userVerificationService.VerifyUserEntity(Password, userEntity))
-                .Returns(new UserEntityVerificationResult(true, new[] { 2 }, new List<int>()));
+                .Returns(new UserEntityVerificationResult(true, new List<int>(), new[] { 2 }, new List<int>()));
             A.CallTo(() => userService.ResetFailedLoginCount(userEntity.UserAccount)).DoesNothing();
 
             // When

--- a/DigitalLearningSolutions.Data/Models/User/UserEntity.cs
+++ b/DigitalLearningSolutions.Data/Models/User/UserEntity.cs
@@ -21,7 +21,8 @@
         public IEnumerable<AdminAccount> AdminAccounts { get; set; }
         public IEnumerable<DelegateAccount> DelegateAccounts { get; set; }
 
-        public bool IsLocked => UserAccount.FailedLoginCount >= AuthHelper.FailedLoginThreshold && AdminAccounts.Any();
+        private bool AllAdminAccountsInactive => AdminAccounts.All(a => !a.Active);
+        public bool IsLocked => UserAccount.FailedLoginCount >= AuthHelper.FailedLoginThreshold && AdminAccounts.Any() && !AllAdminAccountsInactive;
 
         public bool IsSingleCentreAccount()
         {

--- a/DigitalLearningSolutions.Data/Models/User/UserEntityVerificationResult.cs
+++ b/DigitalLearningSolutions.Data/Models/User/UserEntityVerificationResult.cs
@@ -7,6 +7,7 @@
     {
         public UserEntityVerificationResult(
             bool userAccountPassed,
+            IEnumerable<int> nullPasswordDelegateIds,
             IEnumerable<int> passedDelegateIds,
             IEnumerable<int> failedDelegateIds
         )
@@ -14,9 +15,11 @@
             UserAccountPassedVerification = userAccountPassed;
             PassedVerificationDelegateAccountIds = passedDelegateIds;
             FailedVerificationDelegateAccountIds = failedDelegateIds;
+            DelegateAccountsWithNoPassword = nullPasswordDelegateIds;
         }
 
         public bool UserAccountPassedVerification { get; set; }
+        public IEnumerable<int> DelegateAccountsWithNoPassword { get; set; }
         public IEnumerable<int> PassedVerificationDelegateAccountIds { get; set; }
         public IEnumerable<int> FailedVerificationDelegateAccountIds { get; set; }
 

--- a/DigitalLearningSolutions.Data/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Data/Services/LoginService.cs
@@ -75,7 +75,8 @@
                 userEntity.DelegateAccounts.SingleOrDefault(da => da.CentreId == singleCentreToLogUserInto.Value);
 
             var centreIsActive = adminAccountToLogInto?.CentreActive ?? delegateAccountToLogInto?.CentreActive ?? false;
-            var accountAtCentreIsActive = adminAccountToLogInto?.Active ?? delegateAccountToLogInto?.Active ?? false;
+            var accountAtCentreIsActive = (adminAccountToLogInto?.Active == null || adminAccountToLogInto.Active) &&
+                                          (delegateAccountToLogInto?.Active == null || delegateAccountToLogInto.Active);
 
             if (!centreIsActive || !accountAtCentreIsActive || delegateAccountToLogInto is { Approved: false })
             {

--- a/DigitalLearningSolutions.Data/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Data/Services/LoginService.cs
@@ -86,6 +86,7 @@
             return new LoginResult(LoginAttemptResult.LogIntoSingleCentre, userEntity, singleCentreToLogUserInto.Value);
         }
 
+        // If there are no accounts this will also return null, as there is no single centre to log into
         private static int? GetCentreIdIfLoggingUserIntoSingleCentre(UserEntity userEntity, string username)
         {
             // Determine if there is only a single account

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -93,7 +93,7 @@
 
         [HttpGet]
         [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
-        [Authorize(Policy = CustomPolicies.UserOnly)]
+        [Authorize(Policy = CustomPolicies.BasicUser)]
         public IActionResult ChooseACentre(string? returnUrl)
         {
             // TODO HEEDLS-912: sort out ChooseACentre page
@@ -102,7 +102,7 @@
         }
 
         [HttpGet]
-        [Authorize(Policy = CustomPolicies.UserOnly)]
+        [Authorize(Policy = CustomPolicies.BasicUser)]
         public async Task<IActionResult> ChooseCentre(int centreId, string? returnUrl)
         {
             // TODO HEEDLS-912: sort out ChooseACentre page

--- a/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
@@ -4,7 +4,7 @@
 
     public class CustomPolicies
     {
-        public const string UserOnly = "UserOnly";
+        public const string BasicUser = "BasicUser";
         public const string UserDelegateOnly = "UserDelegateOnly";
         public const string UserCentreAdmin = "UserCentreAdmin";
         public const string UserFrameworksAdminOnly = "UserFrameworksAdminOnly";
@@ -13,7 +13,7 @@
         public const string UserCentreAdminOrFrameworksAdmin = "UserCentreAdminOrFrameworksAdmin";
         public const string UserSuperAdmin = "UserSuperAdmin";
 
-        public static AuthorizationPolicyBuilder ConfigurePolicyUserOnly(AuthorizationPolicyBuilder policy)
+        public static AuthorizationPolicyBuilder ConfigurePolicyBasicUser(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(context => context.User.GetUserId() != null);
         }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -70,8 +70,8 @@ namespace DigitalLearningSolutions.Web
                 options =>
                 {
                     options.AddPolicy(
-                        CustomPolicies.UserOnly,
-                        policy => CustomPolicies.ConfigurePolicyUserOnly(policy)
+                        CustomPolicies.BasicUser,
+                        policy => CustomPolicies.ConfigurePolicyBasicUser(policy)
                     );
                     options.AddPolicy(
                         CustomPolicies.UserDelegateOnly,

--- a/DigitalLearningSolutions.Web/Views/Login/AccountLocked.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/AccountLocked.cshtml
@@ -12,7 +12,10 @@
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading" class="nhsuk-heading-xl">Account locked</h1>
     <p class="nhsuk-body-l">
-      Because there have been @Model failed login attempts for this account since the last successful login, the account is locked. Reset your password or contact your centre manager to unlock your account.
+      Because there have been @Model failed login attempts for this account since the last successful login,
+      the account is locked. Reset your password or contact your centre manager to unlock your account.
     </p>
+
+    <vc:action-link asp-controller="ForgotPassword" asp-action="Index" link-text="Reset your password" />
   </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-898

### Description
Fixes some incorrect logic around inactive accounts and DelegateAccounts with no old password and adds an action link to the Account Locked screen.

Documentation has been sorted as well https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/19467173889/Sign+in

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/170296463-cf8083dd-994a-4b1c-86aa-d2ecbef4eb4b.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
