### PR TITLE
DLSV2-530 Make PRN number of Staff visible for Supervisors only

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Supervisor/SupervisorDelegateDetail.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/SupervisorDelegateDetail.cs
@@ -26,6 +26,7 @@
         public Guid? InviteHash { get; set; }
         public bool DelegateIsNominatedSupervisor { get; set; }
         public bool DelegateIsSupervisor { get; set; }
+        public string ProfessionalRegistrationNumber { get; set; }        
         public DlsRole DlsRole
         {
             get

--- a/DigitalLearningSolutions.Data/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkNotificationService.cs
@@ -15,6 +15,7 @@
         void SendReviewRequest(int id, int invitedByAdminId, bool required, bool reminder);
         void SendReviewOutcomeNotification(int reviewId);
         void SendSupervisorDelegateInvite(int supervisorDelegateId, int adminId);
+        void SendSupervisorDelegateConfirmed(int superviseDelegateId, int adminId, int delegateId);
         void SendSupervisorResultReviewed(int adminId, int supervisorDelegateId, int candidateAssessmentId, int resultId);
         void SendSupervisorEnroledDelegate(int adminId, int supervisorDelegateId, int candidateAssessmentId, DateTime? completeByDate);
         void SendReminderDelegateSelfAssessment(int adminId, int supervisorDelegateId, int candidateAssessmentId);
@@ -215,6 +216,22 @@
                 builder.HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'><p>Dear colleague,</p><p>You have been invited to register to access the NHS Health Education England, Digital Learning Solutions platform as a supervised delegate by <a href='mailto:{supervisorDelegate.SupervisorEmail}'>{supervisorDelegate.SupervisorName}</a>.</p><p><a href='{dlsUrlBuilder.Uri.ToString()}'>Click here</a> to register and confirm your acceptance of the invite.</p><p>Your supervisor will then be able to assign role profile assessments and view and validate your self assessment results.</p></body>";
                 emailService.SendEmail(new Email(emailSubjectLine, builder, supervisorDelegate.DelegateEmail));
             }            
+        }
+
+        public void SendSupervisorDelegateConfirmed(int supervisorDelegateId, int adminId, int delegateId)
+        {
+            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, adminId, delegateId);
+            string emailSubjectLine = "Supervisor Confirmed - Digital Learning Solutions";
+            var builder = new BodyBuilder();
+            builder.TextBody = $@"Dear {supervisorDelegate.FirstName}
+You have been identified as a supervised delegate by {supervisorDelegate.SupervisorName} ({supervisorDelegate.SupervisorEmail}) in the NHS Health Education England, Digital Learning Solutions (DLS) platform.
+
+You are already registered as a delegate at the supervisor's DLS centre so they can now assign competency self assessments and view and validate your self assessment results.
+
+If this looks like a mistake, please contact {supervisorDelegate.SupervisorName} ({supervisorDelegate.SupervisorEmail}) directly to correct.";
+            builder.HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'><p>Dear {supervisorDelegate.FirstName}</p><p>{supervisorDelegate.SupervisorName} has accepted your request to be your supervisor for profile asessment activities in the NHS Health Education England, Digital Learning Solutions platform.</p><p><a href='{GetCurrentActivitiesUrl()}'>Click here</a> to access your role profile assessments.</p></body>";
+            string toEmail = (@adminId == 0 ? supervisorDelegate.DelegateEmail : supervisorDelegate.SupervisorEmail);
+            emailService.SendEmail(new Email(emailSubjectLine, builder, toEmail));
         }
 
         public void SendSupervisorResultReviewed(int adminId, int supervisorDelegateId, int candidateAssessmentId, int resultId)

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -33,6 +33,7 @@
         SelfAssessmentResultSummary GetSelfAssessmentResultSummary(int candidateAssessmentId, int supervisorDelegateId);
         IEnumerable<CandidateAssessmentSupervisorVerificationSummary> GetCandidateAssessmentSupervisorVerificationSummaries(int candidateAssessmentId);
         //UPDATE DATA
+        bool ConfirmSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId);
         bool RemoveSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId);
         bool UpdateSelfAssessmentResultSupervisorVerifications(int selfAssessmentResultSupervisorVerificationId, string? comments, bool signedOff, int adminId);
         bool RemoveCandidateAssessment(int candidateAssessmentId);
@@ -51,10 +52,9 @@
         private readonly IDbConnection connection;
         private readonly ILogger<SupervisorService> logger;
         private const string supervisorDelegateDetailFields = @"sd.ID, sd.SupervisorEmail, sd.SupervisorAdminID,
-        COALESCE(au.Forename + ' ' + au.Surname + (CASE WHEN au.Active = 1 THEN '' ELSE ' (Inactive)' END), sd.SupervisorEmail) AS SupervisorName,
         sd.DelegateEmail, sd.CandidateID, sd.Added, sd.AddedByDelegate, sd.NotificationSent, sd.Removed,
         sd.InviteHash, c.FirstName, c.LastName, jg.JobGroupName, c.Answer1, c.Answer2, c.Answer3, c.Answer4, c.Answer5,
-        c.Answer6, c.CandidateNumber, c.EmailAddress AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2,
+        c.Answer6, c.CandidateNumber, c.ProfessionalRegistrationNumber, c.EmailAddress AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2,
         cp3.CustomPrompt AS CustomPrompt3, cp4.CustomPrompt AS CustomPrompt4, cp5.CustomPrompt AS CustomPrompt5,
         cp6.CustomPrompt AS CustomPrompt6, COALESCE(au.CentreID, c.CentreID) AS CentreID,
         au.Forename + ' ' + au.Surname AS SupervisorName, (SELECT COUNT(cas.ID)
@@ -200,6 +200,22 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                     FROM   {supervisorDelegateDetailTables}
                     WHERE (sd.ID = @supervisorDelegateId) AND (sd.CandidateID = @delegateId OR sd.SupervisorAdminID = @adminId) AND (Removed IS NULL)", new { supervisorDelegateId, adminId, delegateId }
                ).FirstOrDefault();
+        }
+
+        public bool ConfirmSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId)
+        {
+            var numberOfAffectedRows = connection.Execute(
+         @"UPDATE SupervisorDelegates SET Confirmed = getUTCDate()
+            WHERE ID = @supervisorDelegateId AND Confirmed IS NULL AND Removed IS NULL AND (CandidateID = @candidateId OR SupervisorAdminID = @adminId)",
+        new { supervisorDelegateId, candidateId, adminId });
+            if (numberOfAffectedRows < 1)
+            {
+                logger.LogWarning(
+                    $"Not confirming SupervisorDelegate as db update failed. supervisorDelegateId: {supervisorDelegateId}, candidateId: {candidateId}, adminId: {adminId}"
+                );
+                return false;
+            }
+            return true;
         }
 
         public bool RemoveSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId)
@@ -525,12 +541,11 @@ WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
         public bool RemoveCandidateAssessmentSupervisor(int selfAssessmentId, int supervisorDelegateId)
         {
             var numberOfAffectedRows = connection.Execute(
-                @"UPDATE cas 
-                    SET Removed = getUTCDate() 
-                    FROM CandidateAssessmentSupervisors AS cas 
-                    INNER JOIN CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID
-                    WHERE (ca.SelfAssessmentID = @selfAssessmentID) AND (cas.SupervisorDelegateId = @supervisorDelegateId)",
-                new { selfAssessmentId, supervisorDelegateId });
+         @"DELETE FROM cas
+FROM  CandidateAssessmentSupervisors AS cas INNER JOIN
+         CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID
+WHERE (ca.SelfAssessmentID = @selfAssessmentId) AND (cas.SupervisorDelegateId = @supervisorDelegateId)",
+        new { selfAssessmentId, supervisorDelegateId });
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
@@ -539,9 +554,8 @@ WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
                 return false;
             }
             connection.Execute(
-                 @"UPDATE SupervisorDelegates SET Removed = getUTCDate() 
-                    WHERE ID = @supervisorDelegateId AND
-                        (SELECT COUNT(*) FROM CandidateAssessmentSupervisors WHERE SupervisorDelegateId = @supervisorDelegateId AND Removed IS NULL) = 0",
+         @"UPDATE SupervisorDelegates SET Removed = getUTCDate() 
+            WHERE ID = @supervisorDelegateId AND (SELECT COUNT(*) FROM CandidateAssessmentSupervisors WHERE SupervisorDelegateId = @supervisorDelegateId) = 0",
         new { supervisorDelegateId });
             return true;
         }

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/AllStaffListViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/AllStaffListViewModel.cs
@@ -13,7 +13,8 @@
 
         public AllStaffListViewModel(
             IEnumerable<SupervisorDelegateDetail> supervisorDelegates,
-            CentreRegistrationPrompts centreRegistrationPrompts
+            CentreRegistrationPrompts centreRegistrationPrompts,
+            bool isSupervisor
         )
         {
             SupervisorDelegateDetailViewModels =
@@ -24,7 +25,8 @@
                             1,
                             $"{supervisor.ID}-card",
                             PaginationOptions.DefaultItemsPerPage
-                        )
+                        ) ,
+                        isSupervisor
                     )
                 );
             CentreRegistrationPrompts = centreRegistrationPrompts;

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateDetailViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateDetailViewModel.cs
@@ -7,14 +7,16 @@
     {
         public SupervisorDelegateDetailViewModel() { }
 
-        public SupervisorDelegateDetailViewModel(SupervisorDelegateDetail supervisorDelegateDetail, ReturnPageQuery returnPageQuery)
+        public SupervisorDelegateDetailViewModel(SupervisorDelegateDetail supervisorDelegateDetail, ReturnPageQuery returnPageQuery , bool isUserSupervisor = false)
         {
             SupervisorDelegateDetail = supervisorDelegateDetail;
             ReturnPageQuery = returnPageQuery;
+            IsUserSupervisor = isUserSupervisor;
         }
 
         public SupervisorDelegateDetail SupervisorDelegateDetail { get; set; }
         public ReturnPageQuery ReturnPageQuery { get; set; }
+        public bool IsUserSupervisor { get; set; }
 
         public override string SearchableName
         {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
@@ -12,6 +12,17 @@
   <dd class="nhsuk-summary-list__actions">
   </dd>
   </div>
+  @if (Model.DelegateIsSupervisor)
+  {
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      PRN
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @(Model.ProfessionalRegistrationNumber == null ? "Not Recorded" : Model.ProfessionalRegistrationNumber)
+    </dd>
+    </div>
+  }
   <div class="nhsuk-summary-list__row">
   <dt class="nhsuk-summary-list__key">
     ID

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
@@ -1,6 +1,10 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Supervisor
 @using DigitalLearningSolutions.Web.Extensions
 @model SupervisorDelegateDetail
+@{
+    bool IsSupervisor = (bool)(ViewData["isSupervisor"] ?? false);   
+}
+
 <dl class="nhsuk-summary-list">
   <div class="nhsuk-summary-list__row">
   <dt class="nhsuk-summary-list__key">
@@ -12,7 +16,7 @@
   <dd class="nhsuk-summary-list__actions">
   </dd>
   </div>
-  @if (Model.DelegateIsSupervisor)
+  @if (IsSupervisor)
   {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -68,7 +68,7 @@
       }
       else
       {
-        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" view-data="@(new ViewDataDictionary(ViewData){{"isSupervisor", Model.IsUserSupervisor}})" />
       }
       </div>
       <a class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4 button-small"
@@ -91,5 +91,15 @@
         asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
       View self assessments (@Model.SupervisorDelegateDetail.CandidateAssessmentCount)
     </a>
+  }
+  else if (Model.SupervisorDelegateDetail.AddedByDelegate)
+  {
+        <a class="nhsuk-button nhsuk-u-margin-left-4 nhsuk-u-margin-top-0"
+           aria-describedby="@Model.SupervisorDelegateDetail.ID-name"
+           asp-controller="Supervisor"
+           asp-action="ConfirmSupervise"
+           asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+          Confirm
+        </a>
   }
   </div>


### PR DESCRIPTION
### JIRA link
[DLSV2-530](https://hee-dls.atlassian.net/browse/DLSV2-530)

### Description
When accessing the supervisor interface, the “Staff list” should display the candidate Professional Registration Number (PRN) if the logged in user is a Supervisor.

### Screenshots

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
