### PR TITLE
HEEDLS-878 Refactor redirect to LearningPortal and query parameters f…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/ValidateAllowedDlsSubApplicationTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/ValidateAllowedDlsSubApplicationTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
 {
+    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Controllers;
@@ -9,9 +10,12 @@
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.Controllers;
     using Microsoft.AspNetCore.Mvc.Filters;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using Microsoft.Extensions.Logging;
     using Microsoft.FeatureManagement;
     using NUnit.Framework;
 
@@ -28,8 +32,162 @@
                 .Returns(true);
             A.CallTo(() => featureManager.IsEnabledAsync(FeatureFlags.RefactoredSuperAdminInterface))
                 .Returns(true);
+        }
 
-            SetUpContextWithActionParameter();
+        [Test]
+        public void
+            ValidateAllowedDlsSubApplication_sets_login_result_when_user_is_unauthenticated()
+        {
+            // Given
+            context = ContextHelper
+                .GetDefaultActionExecutingContext(
+                    new NotificationPreferencesController(A.Fake<INotificationPreferencesService>())
+                )
+                .WithMockUser(false, 101);
+            context.ActionDescriptor.Parameters = new[]
+            {
+                new ParameterDescriptor
+                {
+                    BindingInfo = new BindingInfo(),
+                    Name = "dlsSubApplication",
+                    ParameterType = typeof(DlsSubApplication),
+                },
+            };
+            GivenUserIsTryingToAccess(DlsSubApplication.TrackingSystem);
+
+            var attribute =
+                new ValidateAllowedDlsSubApplication(
+                    featureManager,
+                    new[] { nameof(DlsSubApplication.LearningPortal) }
+                );
+
+            // When
+            attribute.OnActionExecuting(context);
+
+            // Then
+            context.Result.Should().BeRedirectToActionResult().WithControllerName("Login").WithActionName("Index");
+        }
+
+        [Test]
+        public void
+            ValidateAllowedDlsSubApplication_add_dlsSubApplication_action_parameters_when_user_is_is_redirected_to_learning_portal_and_no_others_exist()
+        {
+            // Given
+            const string actionName = "EditDetails";
+            const string controllerName = "MyAccount";
+            var controller = new MyAccountController(
+                A.Fake<ICentreRegistrationPromptsService>(),
+                A.Fake<IUserService>(),
+                A.Fake<IImageResizeService>(),
+                A.Fake<IJobGroupsDataService>(),
+                A.Fake<PromptsService>(),
+                A.Fake<ILogger<MyAccountController>>()
+            )
+            {
+                ControllerContext = new ControllerContext
+                {
+                    ActionDescriptor = new ControllerActionDescriptor
+                    {
+                        ActionName = actionName,
+                        ControllerName = controllerName,
+                    },
+                },
+            };
+
+            context = ContextHelper
+                .GetDefaultActionExecutingContext(
+                    controller
+                )
+                .WithMockUser(true, 101, null);
+            context.ActionDescriptor = new ActionDescriptor
+            {
+                Parameters = new[]
+                {
+                    new ParameterDescriptor
+                    {
+                        BindingInfo = new BindingInfo(),
+                        Name = "dlsSubApplication",
+                        ParameterType = typeof(DlsSubApplication),
+                    },
+                },
+            };
+            GivenUserIsTryingToAccess(DlsSubApplication.Main);
+
+            var attribute =
+                new ValidateAllowedDlsSubApplication(
+                    featureManager,
+                    new[] { nameof(DlsSubApplication.Main) }
+                );
+
+            // When
+            attribute.OnActionExecuting(context);
+
+            // Then
+            context.Result.Should().BeRedirectToActionResult().WithControllerName(controllerName)
+                .WithActionName(actionName)
+                .WithRouteValue("dlsSubApplication", DlsSubApplication.LearningPortal);
+        }
+
+        [Test]
+        public void
+            ValidateAllowedDlsSubApplication_preserves_other_action_parameters_when_user_is_is_redirected_to_learning_portal()
+        {
+            // Given
+            const string actionName = "EditDetails";
+            const string controllerName = "MyAccount";
+            var controller = new MyAccountController(
+                A.Fake<ICentreRegistrationPromptsService>(),
+                A.Fake<IUserService>(),
+                A.Fake<IImageResizeService>(),
+                A.Fake<IJobGroupsDataService>(),
+                A.Fake<PromptsService>(),
+                A.Fake<ILogger<MyAccountController>>()
+            )
+            {
+                ControllerContext = new ControllerContext
+                {
+                    ActionDescriptor = new ControllerActionDescriptor
+                    {
+                        ActionName = actionName,
+                        ControllerName = controllerName,
+                    },
+                },
+            };
+
+            context = ContextHelper
+                .GetDefaultActionExecutingContext(
+                    controller
+                )
+                .WithMockUser(true, 101, null);
+            context.ActionDescriptor = new ActionDescriptor
+            {
+                Parameters = new[]
+                {
+                    new ParameterDescriptor
+                    {
+                        BindingInfo = new BindingInfo(),
+                        Name = "dlsSubApplication",
+                        ParameterType = typeof(DlsSubApplication),
+                    },
+                },
+            };
+            context.ActionArguments.Add("parameterToPreserve", true);
+            GivenUserIsTryingToAccess(DlsSubApplication.Main);
+
+            var attribute =
+                new ValidateAllowedDlsSubApplication(
+                    featureManager,
+                    new[] { nameof(DlsSubApplication.Main) }
+                );
+
+            // When
+            attribute.OnActionExecuting(context);
+
+            // Then
+            context.Result.Should().BeRedirectToActionResult().WithControllerName(controllerName)
+                .WithActionName(actionName)
+                .WithRouteValue("parameterToPreserve", true)
+                .WithRouteValue("dlsSubApplication", DlsSubApplication.LearningPortal);
         }
 
         [Test]
@@ -37,6 +195,7 @@
             ValidateAllowedDlsSubApplication_sets_not_found_result_if_accessing_wrong_application()
         {
             // Given
+            SetUpContextWithActionParameter();
             GivenUserIsTryingToAccess(DlsSubApplication.TrackingSystem);
 
             var attribute =
@@ -57,6 +216,7 @@
             ValidateAllowedDlsSubApplication_does_not_set_result_if_no_application_parameter_found()
         {
             // Given
+            SetUpContextWithActionParameter();
             GivenUserIsTryingToAccess(DlsSubApplication.TrackingSystem);
             context.ActionDescriptor.Parameters = new ParameterDescriptor[] { };
 
@@ -78,6 +238,7 @@
             ValidateAllowedDlsSubApplication_sets_not_found_result_if_application_is_null()
         {
             // Given
+            SetUpContextWithActionParameter();
             GivenUserIsTryingToAccess(null);
 
             var attribute =
@@ -98,6 +259,7 @@
             ValidateAllowedDlsSubApplication_does_not_set_not_found_result_for_matching_application()
         {
             // Given
+            SetUpContextWithActionParameter();
             GivenUserIsTryingToAccess(DlsSubApplication.LearningPortal);
 
             var attribute =
@@ -118,6 +280,7 @@
             ValidateAllowedDlsSubApplication_does_not_set_not_found_result_if_no_application_list_set()
         {
             // Given
+            SetUpContextWithActionParameter();
             GivenUserIsTryingToAccess(DlsSubApplication.LearningPortal);
 
             var attribute =
@@ -140,6 +303,7 @@
             )
         {
             // Given
+            SetUpContextWithActionParameter();
             GivenUserIsTryingToAccess(Enumeration.FromName<DlsSubApplication>(application));
 
             A.CallTo(() => featureManager.IsEnabledAsync(featureFlag))

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -147,12 +147,16 @@
             const bool isCheckDetailsRedirect = true;
             if (returnUrl == null)
             {
-                return RedirectToAction("EditDetails", "MyAccount", new {isCheckDetailsRedirect});
+                return RedirectToAction("EditDetails", "MyAccount", new { isCheckDetailsRedirect });
             }
 
             var dlsSubAppSection = returnUrl.Split('/')[1];
             DlsSubApplication.TryGetFromUrlSegment(dlsSubAppSection, out var dlsSubApplication);
-            return RedirectToAction("EditDetails", "MyAccount", new { returnUrl, dlsSubApplication, isCheckDetailsRedirect });
+            return RedirectToAction(
+                "EditDetails",
+                "MyAccount",
+                new { returnUrl, dlsSubApplication, isCheckDetailsRedirect }
+            );
         }
 
         private async Task CentrelessLogInAsync(UserEntity userEntity, bool rememberMe)

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -144,14 +144,15 @@
                 return this.RedirectToReturnUrl(returnUrl, logger) ?? RedirectToAction("Index", "Home");
             }
 
+            const bool isCheckDetailsRedirect = true;
             if (returnUrl == null)
             {
-                return RedirectToAction("EditDetails", "MyAccount");
+                return RedirectToAction("EditDetails", "MyAccount", new {isCheckDetailsRedirect});
             }
 
             var dlsSubAppSection = returnUrl.Split('/')[1];
             DlsSubApplication.TryGetFromUrlSegment(dlsSubAppSection, out var dlsSubApplication);
-            return RedirectToAction("EditDetails", "MyAccount", new { returnUrl, dlsSubApplication });
+            return RedirectToAction("EditDetails", "MyAccount", new { returnUrl, dlsSubApplication, isCheckDetailsRedirect });
         }
 
         private async Task CentrelessLogInAsync(UserEntity userEntity, bool rememberMe)

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -68,7 +68,11 @@
         [NoCaching]
         [HttpGet("EditDetails")]
         [SetSelectedTab(nameof(NavMenuTab.MyAccount))]
-        public IActionResult EditDetails(DlsSubApplication dlsSubApplication, string? returnUrl = null)
+        public IActionResult EditDetails(
+            DlsSubApplication dlsSubApplication,
+            string? returnUrl = null,
+            bool isCheckDetailsRedirect = false
+        )
         {
             var userAdminId = User.GetAdminId();
             var userDelegateId = User.GetCandidateId();
@@ -84,7 +88,8 @@
                 jobGroups,
                 customPrompts,
                 dlsSubApplication,
-                returnUrl
+                returnUrl,
+                isCheckDetailsRedirect
             );
 
             return View(model);

--- a/DigitalLearningSolutions.Web/ServiceFilter/ValidateAllowedDlsSubApplication.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/ValidateAllowedDlsSubApplication.cs
@@ -131,10 +131,27 @@
         )
         {
             var descriptor = ((ControllerBase)context.Controller).ControllerContext.ActionDescriptor;
-            var routeValues = new Dictionary<string, object>
+            IDictionary<string, object> routeValues;
+
+            if (context.ActionArguments.Keys.Any())
             {
-                [applicationArgumentName] = DlsSubApplication.LearningPortal,
-            };
+                routeValues = context.ActionArguments;
+                if (routeValues.ContainsKey(applicationArgumentName))
+                {
+                    routeValues[applicationArgumentName] = DlsSubApplication.LearningPortal;
+                }
+                else
+                {
+                    routeValues.Add(applicationArgumentName, DlsSubApplication.LearningPortal);
+                }
+            }
+            else
+            {
+                routeValues = new Dictionary<string, object>
+                {
+                    [applicationArgumentName] = DlsSubApplication.LearningPortal,
+                };
+            }
             context.Result = new RedirectToActionResult(descriptor.ActionName, descriptor.ControllerName, routeValues);
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsFormData.cs
@@ -17,7 +17,8 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
             AdminUser? adminUser,
             DelegateUser? delegateUser,
             List<(int id, string name)> jobGroups,
-            string? returnUrl
+            string? returnUrl,
+            bool isCheckDetailRedirect
         )
         {
             FirstName = adminUser?.FirstName ?? delegateUser?.FirstName;
@@ -44,6 +45,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
                 );
             ReturnUrl = returnUrl;
             IsSelfRegistrationOrEdit = true;
+            IsCheckDetailRedirect = isCheckDetailRedirect;
         }
 
         protected MyAccountEditDetailsFormData(MyAccountEditDetailsFormData formData)
@@ -65,6 +67,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
             ProfessionalRegistrationNumber = formData.ProfessionalRegistrationNumber;
             ReturnUrl = formData.ReturnUrl;
             IsSelfRegistrationOrEdit = true;
+            IsCheckDetailRedirect = formData.IsCheckDetailRedirect;
         }
 
         [Required(ErrorMessage = "Enter your current password")]
@@ -79,5 +82,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
         public bool IsDelegateUser { get; set; }
 
         public string? ReturnUrl { get; set; }
+
+        public bool IsCheckDetailRedirect { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsViewModel.cs
@@ -16,8 +16,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
             List<(int id, string name)> jobGroups,
             List<EditDelegateRegistrationPromptViewModel> editDelegateRegistrationPromptViewModels,
             DlsSubApplication dlsSubApplication,
-            string? returnUrl
-        ) : base(adminUser, delegateUser, jobGroups, returnUrl)
+            string? returnUrl,
+            bool isCheckDetailRedirect
+        ) : base(adminUser, delegateUser, jobGroups, returnUrl, isCheckDetailRedirect)
         {
             DlsSubApplication = dlsSubApplication;
             JobGroups = SelectListHelper.MapOptionsToSelectListItemsWithSelectedText(

--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -21,7 +21,7 @@
   </div>
 </div>
 
-@if (!string.IsNullOrWhiteSpace(Model.ReturnUrl)) {
+@if (Model.IsCheckDetailRedirect) {
   <vc:inset-text text="You should check that your details are up to date and accurate. Once you are confident that your details are up to date, please hit 'Save'." css-class="nhsuk-u-margin-top-0" />
 }
 
@@ -31,37 +31,35 @@
   </div>
 
   <input type="hidden" asp-for="ReturnUrl" />
+  <input type="hidden" asp-for="IsCheckDetailRedirect" />
   <div class="nhsuk-grid-row divider">
     <div class="nhsuk-grid-column-full">
-      <vc:text-input
-        asp-for="@nameof(Model.FirstName)"
-        label="First name"
-        populate-with-current-value="true"
-        type="text"
-        spell-check="false"
-        autocomplete="given-name"
-        hint-text=""
-        css-class="nhsuk-u-width-one-half" />
+      <vc:text-input asp-for="@nameof(Model.FirstName)"
+                     label="First name"
+                     populate-with-current-value="true"
+                     type="text"
+                     spell-check="false"
+                     autocomplete="given-name"
+                     hint-text=""
+                     css-class="nhsuk-u-width-one-half" />
 
-      <vc:text-input
-        asp-for="@nameof(Model.LastName)"
-        label="Last name"
-        populate-with-current-value="true"
-        type="text"
-        spell-check="false"
-        autocomplete="family-name"
-        hint-text=""
-        css-class="nhsuk-u-width-one-half" />
+      <vc:text-input asp-for="@nameof(Model.LastName)"
+                     label="Last name"
+                     populate-with-current-value="true"
+                     type="text"
+                     spell-check="false"
+                     autocomplete="family-name"
+                     hint-text=""
+                     css-class="nhsuk-u-width-one-half" />
 
-      <vc:text-input
-        asp-for="@nameof(Model.Email)"
-        label="Email address"
-        populate-with-current-value="true"
-        type="text"
-        spell-check="false"
-        autocomplete="email"
-        hint-text=""
-        css-class="nhsuk-u-width-one-half" />
+      <vc:text-input asp-for="@nameof(Model.Email)"
+                     label="Email address"
+                     populate-with-current-value="true"
+                     type="text"
+                     spell-check="false"
+                     autocomplete="email"
+                     hint-text=""
+                     css-class="nhsuk-u-width-one-half" />
 
       @if (Model.IsDelegateUser) {
         <partial name="_EditRegistrationNumber" model="@Model" />
@@ -73,37 +71,34 @@
     <input type="hidden" asp-for="IsDelegateUser" />
     <div class="nhsuk-grid-row divider">
       <div class="nhsuk-grid-column-full">
-        <vc:select-list
-          asp-for="@nameof(Model.JobGroupId)"
-          label="Job group"
-          value="@Model.JobGroupId.ToString()"
-          hint-text=""
-          deselectable="false"
-          css-class="nhsuk-u-width-one-half"
-          default-option="Select a job group"
-          select-list-options="@Model.JobGroups" />
+        <vc:select-list asp-for="@nameof(Model.JobGroupId)"
+                        label="Job group"
+                        value="@Model.JobGroupId.ToString()"
+                        hint-text=""
+                        deselectable="false"
+                        css-class="nhsuk-u-width-one-half"
+                        default-option="Select a job group"
+                        select-list-options="@Model.JobGroups" />
 
         @foreach (var customField in Model.DelegateRegistrationPrompts) {
           @if (customField.Options.Any()) {
-            <vc:select-list
-              asp-for="@("Answer" + customField.PromptNumber)"
-              label="@(customField.Prompt + (customField.Mandatory ? "" : " (optional)"))"
-              value="@customField.Answer"
-              hint-text=""
-              deselectable="@(!customField.Mandatory)"
-              css-class="nhsuk-u-width-one-half"
-              default-option="Select a @customField.Prompt.ToLower()"
-              select-list-options="@customField.Options" />
+            <vc:select-list asp-for="@("Answer" + customField.PromptNumber)"
+                            label="@(customField.Prompt + (customField.Mandatory ? "" : " (optional)"))"
+                            value="@customField.Answer"
+                            hint-text=""
+                            deselectable="@(!customField.Mandatory)"
+                            css-class="nhsuk-u-width-one-half"
+                            default-option="Select a @customField.Prompt.ToLower()"
+                            select-list-options="@customField.Options" />
           } else {
-            <vc:text-input
-              asp-for="@("Answer" + customField.PromptNumber)"
-              label="@(customField.Prompt + (customField.Mandatory ? "" : " (optional)"))"
-              populate-with-current-value="true"
-              type="text"
-              spell-check="false"
-              autocomplete=""
-              hint-text=""
-              css-class="nhsuk-u-width-one-half" />
+            <vc:text-input asp-for="@("Answer" + customField.PromptNumber)"
+                           label="@(customField.Prompt + (customField.Mandatory ? "" : " (optional)"))"
+                           populate-with-current-value="true"
+                           type="text"
+                           spell-check="false"
+                           autocomplete=""
+                           hint-text=""
+                           css-class="nhsuk-u-width-one-half" />
           }
         }
       </div>
@@ -113,14 +108,13 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-one-half">
       @{ var hintText = @"To change your profile picture, select a new image and click the Preview button to preview it.
-                                To remove your profile picture click the remove button.
-                                Changes will not be made until the Save button below is clicked."; }
+                                  To remove your profile picture click the remove button.
+                                  Changes will not be made until the Save button below is clicked."; }
       <input type="hidden" asp-for="ProfileImage" />
-      <vc:file-input
-        asp-for="@nameof(Model.ProfileImageFile)"
-        label="Profile picture (optional)"
-        hint-text="@hintText"
-        css-class="nhsuk-u-width-full" />
+      <vc:file-input asp-for="@nameof(Model.ProfileImageFile)"
+                     label="Profile picture (optional)"
+                     hint-text="@hintText"
+                     css-class="nhsuk-u-width-full" />
     </div>
     <div class="nhsuk-grid-column-one-half">
       @if (Model.ProfileImage != null) {
@@ -140,15 +134,14 @@
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      <vc:text-input
-        asp-for="@nameof(Model.Password)"
-        label="Confirm password to save changes:"
-        populate-with-current-value="false"
-        type="password"
-        spell-check="false"
-        autocomplete=""
-        hint-text=""
-        css-class="nhsuk-u-width-one-half" />
+      <vc:text-input asp-for="@nameof(Model.Password)"
+                     label="Confirm password to save changes:"
+                     populate-with-current-value="false"
+                     type="password"
+                     spell-check="false"
+                     autocomplete=""
+                     hint-text=""
+                     css-class="nhsuk-u-width-one-half" />
 
       <button name="action" class="nhsuk-button" value="save">Save</button>
     </div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-878

### Description
Fixed issue with ValidateAllowedDlsSubApplication removing query parameters when redirecting, and changed how the inset is displayed so it works all the time.

### Screenshots
No changes

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
