### PR TITLE
DLSV2-544 Removed length restrictions for competency group description

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202205261100_IncreaseCompetencyGroupsDescriptionLength.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202205261100_IncreaseCompetencyGroupsDescriptionLength.cs
@@ -1,0 +1,22 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202205261100)]
+    public class IncreaseCompetencyGroupsDescriptionLength : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("CompetencyGroups").AlterColumn("Description").AsString(int.MaxValue).Nullable();
+        }
+        public override void Down()
+        {
+            const int OriginalDescriptionLength = 1000;
+
+            // Truncate any description longer than 1000 characters.
+            Execute.Sql($"UPDATE CompetencyGroups SET Description = LEFT(Description, {OriginalDescriptionLength})");
+
+            Alter.Table("CompetencyGroups").AlterColumn("Description").AsString(OriginalDescriptionLength).Nullable();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/Frameworks/CompetencyGroupBase.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/CompetencyGroupBase.cs
@@ -10,7 +10,6 @@
         [Required]
         public string Name { get; set; }
 
-        [StringLength(maximumLength: 1000)]
         public string? Description { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-544

### Description
Added migration and removed view model decorator that limited the number of characters for competency group description.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/170679489-bba5e36d-4247-49ce-b7ba-12baf492e96d.png)

Validation for name still in place. 

![image](https://user-images.githubusercontent.com/94055251/170681309-6af043e2-45fb-447a-916a-e064c6ece865.png)

-----
### Developer checks

- Checked that competency group description allows more than 1000 characters and no error messages are reported.
- Checked that Validation for "Name" field is still in place, as I have added error summary in previous PR.
- Checked that description is not mandatory.