### PR TITLE
HEEDLS-927 Fixed course filter on centre reports for admins with non-zero category id

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_EditCourseCategoryFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_EditCourseCategoryFilters.cshtml
@@ -70,7 +70,7 @@
     </fieldset>
   </div>
 } else {
-  <input type="hidden" asp-for="FilterType" value="@CourseFilterType.CourseCategory" />
+  <input type="hidden" asp-for="FilterType" value="@CourseFilterType.Course" />
   <vc:select-list asp-for="@nameof(Model.CustomisationId)"
                   label="Choose a course filter"
                   value="@Model.CustomisationId.ToString()"


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-927

### Description
When logged in as an admin user whose CategoryId is not zero, on /TrackingSystem/Centre/Reports/EditFilters the "Choose a course filter" option is now retained when you press the "Apply filters" button

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
