### PR TITLE
HEEDLS-862 Add missed AS from SQL query with LTRIM/RTRIM

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -141,6 +141,9 @@ namespace DigitalLearningSolutions.Data.DataServices
                 WHERE aa.CustomisationID = cu.CustomisationID AND aa.[Status] = 1
                 AND can.CandidateId = ca.CandidateId) AS AttemptsPassed";
 
+        private readonly IDbConnection connection;
+        private readonly ILogger<CourseDataService> logger;
+
         private readonly string selectDelegateCourseInfoQuery =
             @$"SELECT
                 cu.CustomisationID AS CustomisationId,
@@ -190,9 +193,6 @@ namespace DigitalLearningSolutions.Data.DataServices
             LEFT OUTER JOIN AdminUsers auSupervisor ON auSupervisor.AdminID = pr.SupervisorAdminId
             LEFT OUTER JOIN AdminUsers auEnrolledBy ON auEnrolledBy.AdminID = pr.EnrolledByAdminID
             INNER JOIN Candidates AS ca ON ca.CandidateID = pr.CandidateID";
-
-        private readonly IDbConnection connection;
-        private readonly ILogger<CourseDataService> logger;
 
         public CourseDataService(IDbConnection connection, ILogger<CourseDataService> logger)
         {
@@ -376,7 +376,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public IEnumerable<DelegateCourseInfo> GetDelegateCourseInfosForCourse(int customisationId, int centreId)
         {
-           return connection.Query<DelegateCourseInfo>(
+            return connection.Query<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
                     WHERE cu.CentreID = @centreId
                         AND ca.CentreID = @centreId

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -161,9 +161,9 @@ namespace DigitalLearningSolutions.Data.DataServices
                 pr.LoginCount,
                 pr.Duration AS LearningTime,
                 pr.DiagnosticScore,
-                LTRIM(RTRIM(pr.Answer1)),
-                LTRIM(RTRIM(pr.Answer2)),
-                LTRIM(RTRIM(pr.Answer3)),
+                LTRIM(RTRIM(pr.Answer1)) AS Answer1,
+                LTRIM(RTRIM(pr.Answer2)) AS Answer2,
+                LTRIM(RTRIM(pr.Answer3)) AS Answer3,
                 {DelegateAllAttemptsQuery},
                 {DelegateAttemptsPassedQuery},
                 pr.FirstSubmittedTime AS Enrolled,
@@ -376,7 +376,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public IEnumerable<DelegateCourseInfo> GetDelegateCourseInfosForCourse(int customisationId, int centreId)
         {
-            return connection.Query<DelegateCourseInfo>(
+           return connection.Query<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
                     WHERE cu.CentreID = @centreId
                         AND ca.CentreID = @centreId

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/CourseDelegatesController.cs
@@ -110,6 +110,7 @@
             }
         }
 
+        [NoCaching]
         [Route("AllCourseDelegates/{customisationId:int}")]
         public IActionResult AllCourseDelegates(int customisationId)
         {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-862

### Description
Add missed `AS AnswerX` to SQL query where we are trimming the answers. This was causing answers to never appear.
Added NoCaching to the All Items endpoint just in case.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/171151723-0e911777-68ed-43a8-a556-61f92c73d1ff.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
