### PR TITLE
HEEDLS-411 - implement StoreASPProgressNoSession tracker endpoint

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/SessionDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SessionDataServiceTests.cs
@@ -204,11 +204,11 @@
                 result.Should().NotBeNull();
                 var expectedLoginTime = new DateTime(2010, 9, 22, 6, 52, 9, 540);
                 result!.SessionId.Should().Be(1);
-                result!.CandidateId.Should().Be(1);
-                result!.CustomisationId.Should().Be(100);
-                result!.LoginTime.Should().Be(expectedLoginTime);
-                result!.Duration.Should().Be(51);
-                result!.Active.Should().BeFalse();
+                result.CandidateId.Should().Be(1);
+                result.CustomisationId.Should().Be(100);
+                result.LoginTime.Should().Be(expectedLoginTime);
+                result.Duration.Should().Be(51);
+                result.Active.Should().BeFalse();
             }
         }
 

--- a/DigitalLearningSolutions.Data.Tests/DataServices/SessionDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SessionDataServiceTests.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FluentAssertions;
+    using FluentAssertions.Execution;
     using NUnit.Framework;
 
     internal class SessionDataServiceTests
@@ -186,6 +187,45 @@
 
             // Then
             result.Should().BeFalse();
+        }
+
+        [Test]
+        public void GetSessionBySessionId_gets_session_correctly()
+        {
+            // Given
+            const int sessionId = 1;
+
+            // When
+            var result = sessionDataService.GetSessionById(sessionId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().NotBeNull();
+                var expectedLoginTime = new DateTime(2010, 9, 22, 6, 52, 9, 540);
+                result!.SessionId.Should().Be(1);
+                result!.CandidateId.Should().Be(1);
+                result!.CustomisationId.Should().Be(100);
+                result!.LoginTime.Should().Be(expectedLoginTime);
+                result!.Duration.Should().Be(51);
+                result!.Active.Should().BeFalse();
+            }
+        }
+
+        [Test]
+        public void AddTutorialTimeToSessionDuration_should_add_input_time_correctly_to_correct_record()
+        {
+            using var transaction = new TransactionScope();
+
+            // Given
+            const int sessionId = 1;
+
+            // When
+            sessionDataService.AddTutorialTimeToSessionDuration(1, 12);
+
+            // Then
+            var result = sessionDataService.GetSessionById(sessionId);
+            result!.Duration.Should().Be(63);
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/StoreAspProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/StoreAspProgressServiceTests.cs
@@ -1,0 +1,383 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    using System;
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.Progress;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using FakeItEasy;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using NUnit.Framework;
+
+    public class StoreAspProgressServiceTests
+    {
+        private const int DefaultProgressId = 101;
+        private const int DefaultCustomisationVersion = 1;
+        private const string? DefaultLmGvSectionRow = "Test";
+        private const int DefaultTutorialId = 123;
+        private const int DefaultTutorialTime = 2;
+        private const int DefaultTutorialStatus = 3;
+        private const int DefaultDelegateId = 4;
+        private const int DefaultCustomisationId = 5;
+        public const int DefaultSessionId = 312;
+
+        private readonly DetailedCourseProgress defaultCourseProgress =
+            ProgressTestHelper.GetDefaultDetailedCourseProgress(
+                DefaultProgressId,
+                DefaultDelegateId,
+                DefaultCustomisationId
+            );
+
+        private readonly Session defaultSession = SessionTestHelper.CreateDefaultSession(
+            DefaultSessionId,
+            DefaultDelegateId,
+            DefaultCustomisationId
+        );
+
+        private IProgressService progressService = null!;
+        private ISessionDataService sessionDataService = null!;
+        private IStoreAspProgressService storeAspProgressService = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            progressService = A.Fake<IProgressService>();
+            sessionDataService = A.Fake<ISessionDataService>();
+            storeAspProgressService = new StoreAspProgressService(progressService, sessionDataService);
+        }
+
+        [TestCase(null, 1, 123, 456, 789)]
+        [TestCase(101, null, 123, 456, 789)]
+        [TestCase(101, 1, null, 456, 789)]
+        [TestCase(101, 1, 123, null, 789)]
+        [TestCase(101, 1, 123, 456, null)]
+        public void
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints_returns_StoreAspProgressException_if_a_query_param_is_null(
+                int? progressId,
+                int? version,
+                int? tutorialId,
+                int? delegateId,
+                int? customisationId
+            )
+        {
+            // When
+            var result = storeAspProgressService.GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                progressId,
+                version,
+                tutorialId,
+                1,
+                1,
+                delegateId,
+                customisationId
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.validationResponse.Should().Be(TrackerEndpointResponse.StoreAspProgressException);
+                result.progress.Should().BeNull();
+                A.CallTo(() => progressService.GetDetailedCourseProgress(A<int>._)).MustNotHaveHappened();
+            }
+        }
+
+        [TestCase(null, 1)]
+        [TestCase(1, null)]
+        public void
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints_returns_NullTutorialStatusOrTime_if_tutorialTime_or_tutorialStatus_is_null(
+                int? tutorialTime,
+                int? tutorialStatus
+            )
+        {
+            // When
+            var result = storeAspProgressService.GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                101,
+                1,
+                123,
+                tutorialTime,
+                tutorialStatus,
+                456,
+                789
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.validationResponse.Should().Be(TrackerEndpointResponse.NullTutorialStatusOrTime);
+                result.progress.Should().BeNull();
+                A.CallTo(() => progressService.GetDetailedCourseProgress(A<int>._)).MustNotHaveHappened();
+            }
+        }
+
+        [Test]
+        public void
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints_returns_StoreAspProgressException_if_progress_is_null()
+        {
+            // Given
+            A.CallTo(
+                () => progressService.GetDetailedCourseProgress(DefaultProgressId)
+            ).Returns(null);
+
+            // When
+            var result = storeAspProgressService.GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                DefaultProgressId,
+                1,
+                123,
+                1,
+                1,
+                456,
+                789
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.validationResponse.Should().Be(TrackerEndpointResponse.StoreAspProgressException);
+                result.progress.Should().BeNull();
+                A.CallTo(() => progressService.GetDetailedCourseProgress(DefaultProgressId))
+                    .MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [TestCase(100, DefaultCustomisationId)]
+        [TestCase(DefaultDelegateId, 100)]
+        public void
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints_returns_StoreAspProgressException_if_a_param_does_not_match_progress_record(
+                int delegateId,
+                int customisationId
+            )
+        {
+            // Given
+            ProgressServiceReturnsDefaultDetailedCourseProgress();
+
+            // When
+            var result = storeAspProgressService.GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                DefaultProgressId,
+                DefaultCustomisationVersion,
+                DefaultTutorialId,
+                DefaultTutorialTime,
+                DefaultTutorialStatus,
+                delegateId,
+                customisationId
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.validationResponse.Should().Be(TrackerEndpointResponse.StoreAspProgressException);
+                result.progress.Should().BeNull();
+                A.CallTo(() => progressService.GetDetailedCourseProgress(DefaultProgressId))
+                    .MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [Test]
+        public void
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints_returns_progress_record_and_null_exception_when_all_is_valid()
+        {
+            // Given
+            ProgressServiceReturnsDefaultDetailedCourseProgress();
+
+            // When
+            var result = storeAspProgressService.GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                DefaultProgressId,
+                DefaultCustomisationVersion,
+                DefaultTutorialId,
+                DefaultTutorialTime,
+                DefaultTutorialStatus,
+                DefaultDelegateId,
+                DefaultCustomisationId
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.validationResponse.Should().BeNull();
+                result.progress.Should().Be(defaultCourseProgress);
+                A.CallTo(() => progressService.GetDetailedCourseProgress(DefaultProgressId))
+                    .MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [TestCase(null)]
+        [TestCase("non integer value")]
+        [TestCase("12.456")]
+        public void
+            ParseSessionIdAndValidateSessionForStoreAspProgressNoSession_returns_exception_when_session_ID_is_not_integer(
+                string? sessionId
+            )
+        {
+            // When
+            var result = storeAspProgressService.ParseSessionIdAndValidateSessionForStoreAspProgressNoSession(
+                sessionId,
+                DefaultDelegateId,
+                DefaultCustomisationVersion
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.parsedSessionId.Should().BeNull();
+                result.validationResponse.Should().Be(TrackerEndpointResponse.StoreAspProgressException);
+                A.CallTo(() => sessionDataService.GetSessionById(A<int>._)).MustNotHaveHappened();
+            }
+        }
+
+        [Test]
+        public void
+            ParseSessionIdAndValidateSessionForStoreAspProgressNoSession_returns_exception_when_session_is_null()
+        {
+            // Given
+            A.CallTo(() => sessionDataService.GetSessionById(DefaultSessionId))
+                .Returns(null);
+
+            // When
+            var result = storeAspProgressService.ParseSessionIdAndValidateSessionForStoreAspProgressNoSession(
+                DefaultSessionId.ToString(),
+                DefaultDelegateId,
+                DefaultCustomisationId
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.parsedSessionId.Should().BeNull();
+                result.validationResponse.Should().Be(TrackerEndpointResponse.StoreAspProgressException);
+                A.CallTo(() => sessionDataService.GetSessionById(DefaultSessionId)).MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [TestCase(DefaultCustomisationId + 1, DefaultDelegateId, true)]
+        [TestCase(DefaultCustomisationId, DefaultDelegateId + 1, true)]
+        [TestCase(DefaultCustomisationId, DefaultDelegateId, false)]
+        public void
+            ParseSessionIdAndValidateSessionForStoreAspProgressNoSession_returns_exception_when_session_details_do_not_match_necessary_requirements(
+                int customisationId,
+                int delegateId,
+                bool sessionActive
+            )
+        {
+            // Given
+            A.CallTo(() => sessionDataService.GetSessionById(DefaultSessionId))
+                .Returns(new Session(DefaultSessionId, delegateId, customisationId, DateTime.UtcNow, 1, sessionActive));
+
+            // When
+            var result = storeAspProgressService.ParseSessionIdAndValidateSessionForStoreAspProgressNoSession(
+                DefaultSessionId.ToString(),
+                DefaultDelegateId,
+                DefaultCustomisationId
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.parsedSessionId.Should().BeNull();
+                result.validationResponse.Should().Be(TrackerEndpointResponse.StoreAspProgressException);
+                A.CallTo(() => sessionDataService.GetSessionById(DefaultSessionId)).MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [Test]
+        public void
+            ParseSessionIdAndValidateSessionForStoreAspProgressNoSession_returns_parsed_session_ID_and_null_exception_when_session_is_valid()
+        {
+            // Given
+            SessionServiceReturnsDefaultSession();
+
+            // When
+            var result = storeAspProgressService.ParseSessionIdAndValidateSessionForStoreAspProgressNoSession(
+                DefaultSessionId.ToString(),
+                DefaultDelegateId,
+                DefaultCustomisationId
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.parsedSessionId.Should().Be(DefaultSessionId);
+                result.validationResponse.Should().Be(null);
+                A.CallTo(() => sessionDataService.GetSessionById(DefaultSessionId)).MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [TestCase(1)]
+        [TestCase(3)]
+        public void
+            StoreAspProgressAndSendEmailIfComplete_stores_AspProgress_and_does_not_CheckProgressForCompletion_if_TutorialStatus_is_not_2(
+                int tutorialStatus
+            )
+        {
+            // When
+            storeAspProgressService.StoreAspProgressAndSendEmailIfComplete(
+                defaultCourseProgress,
+                DefaultCustomisationVersion,
+                DefaultLmGvSectionRow,
+                DefaultTutorialId,
+                DefaultTutorialTime,
+                tutorialStatus
+            );
+
+            // Then
+            A.CallTo(
+                () => progressService.StoreAspProgressV2(
+                    DefaultProgressId,
+                    DefaultCustomisationVersion,
+                    DefaultLmGvSectionRow,
+                    DefaultTutorialId,
+                    DefaultTutorialTime,
+                    tutorialStatus
+                )
+            ).MustHaveHappenedOnceExactly();
+            A.CallTo(
+                () => progressService.CheckProgressForCompletionAndSendEmailIfCompleted(A<DetailedCourseProgress>._)
+            ).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void
+            StoreAspProgressAndSendEmailIfComplete_stores_AspProgress_and_calls_CheckProgressForCompletion_if_TutorialStatus_is_2()
+        {
+            // Given
+            const int tutorialStatus = 2;
+
+            // When
+            storeAspProgressService.StoreAspProgressAndSendEmailIfComplete(
+                defaultCourseProgress,
+                DefaultCustomisationVersion,
+                DefaultLmGvSectionRow,
+                DefaultTutorialId,
+                DefaultTutorialTime,
+                tutorialStatus
+            );
+
+            // Then
+            A.CallTo(
+                () => progressService.StoreAspProgressV2(
+                    DefaultProgressId,
+                    DefaultCustomisationVersion,
+                    DefaultLmGvSectionRow,
+                    DefaultTutorialId,
+                    DefaultTutorialTime,
+                    tutorialStatus
+                )
+            ).MustHaveHappenedOnceExactly();
+            A.CallTo(
+                () => progressService.CheckProgressForCompletionAndSendEmailIfCompleted(defaultCourseProgress)
+            ).MustHaveHappenedOnceExactly();
+        }
+
+        private void ProgressServiceReturnsDefaultDetailedCourseProgress()
+        {
+            A.CallTo(
+                () => progressService.GetDetailedCourseProgress(DefaultProgressId)
+            ).Returns(defaultCourseProgress);
+        }
+
+        private void SessionServiceReturnsDefaultSession()
+        {
+            A.CallTo(() => sessionDataService.GetSessionById(DefaultSessionId)).Returns(defaultSession);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/TrackerServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/TrackerServiceTests.cs
@@ -12,10 +12,30 @@
     public class TrackerServiceTests
     {
         private const string DefaultProgressText = "Test progress text";
+        private const string DefaultSessionId = "312";
+
+        private readonly TrackerEndpointQueryParams defaultStoreAspProgressQueryParams = new TrackerEndpointQueryParams
+        {
+            ProgressId = 101,
+            Version = 1,
+            TutorialId = 123,
+            TutorialTime = 2,
+            TutorialStatus = 3,
+            CandidateId = 456,
+            CustomisationId = 1,
+        };
 
         private readonly Dictionary<TrackerEndpointSessionVariable, string?> emptySessionVariablesDictionary =
             new Dictionary<TrackerEndpointSessionVariable, string?>
                 { { TrackerEndpointSessionVariable.LmGvSectionRow, null } };
+
+        private readonly Dictionary<TrackerEndpointSessionVariable, string?>
+            sessionVariablesForStoreAspProgressNoSession =
+                new Dictionary<TrackerEndpointSessionVariable, string?>
+                {
+                    { TrackerEndpointSessionVariable.LmGvSectionRow, DefaultProgressText },
+                    { TrackerEndpointSessionVariable.LmSessionId, DefaultSessionId },
+                };
 
         private readonly Dictionary<TrackerEndpointSessionVariable, string?> sessionVariablesForStoreAspProgressV2 =
             new Dictionary<TrackerEndpointSessionVariable, string?>
@@ -151,17 +171,8 @@
         public void ProcessQuery_with_StoreAspProgressV2_action_passes_query_params()
         {
             // Given
-            var query = new TrackerEndpointQueryParams
-            {
-                Action = "StoreAspProgressV2",
-                ProgressId = 101,
-                Version = 1,
-                TutorialId = 123,
-                TutorialTime = 2,
-                TutorialStatus = 3,
-                CandidateId = 456,
-                CustomisationId = 1,
-            };
+            var query = defaultStoreAspProgressQueryParams;
+            query.Action = "StoreAspProgressV2";
 
             var expectedResponse = TrackerEndpointResponse.Success;
 
@@ -185,14 +196,58 @@
             result.Should().Be(expectedResponse);
             A.CallTo(
                     () => actionService.StoreAspProgressV2(
-                        query.ProgressId.Value,
-                        query.Version.Value,
+                        query.ProgressId!.Value,
+                        query.Version!.Value,
                         DefaultProgressText,
-                        query.TutorialId.Value,
-                        query.TutorialTime.Value,
-                        query.TutorialStatus.Value,
-                        query.CandidateId.Value,
-                        query.CustomisationId.Value
+                        query.TutorialId!.Value,
+                        query.TutorialTime!.Value,
+                        query.TutorialStatus!.Value,
+                        query.CandidateId!.Value,
+                        query.CustomisationId!.Value
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void ProcessQuery_with_StoreAspProgressNoSession_action_passes_query_params()
+        {
+            // Given
+            var query = defaultStoreAspProgressQueryParams;
+            query.Action = "StoreAspProgressNoSession";
+
+            var expectedResponse = TrackerEndpointResponse.Success;
+
+            A.CallTo(
+                () => actionService.StoreAspProgressNoSession(
+                    A<int>._,
+                    A<int>._,
+                    A<string>._,
+                    A<int>._,
+                    A<int>._,
+                    A<int>._,
+                    A<int>._,
+                    A<int>._,
+                    A<string>._
+                )
+            ).Returns(expectedResponse);
+
+            // When
+            var result = trackerService.ProcessQuery(query, sessionVariablesForStoreAspProgressNoSession);
+
+            // Then
+            result.Should().Be(expectedResponse);
+            A.CallTo(
+                    () => actionService.StoreAspProgressNoSession(
+                        query.ProgressId!.Value,
+                        query.Version!.Value,
+                        DefaultProgressText,
+                        query.TutorialId!.Value,
+                        query.TutorialTime!.Value,
+                        query.TutorialStatus!.Value,
+                        query.CandidateId!.Value,
+                        query.CustomisationId!.Value,
+                        DefaultSessionId
                     )
                 )
                 .MustHaveHappenedOnceExactly();

--- a/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
@@ -97,7 +97,7 @@
         {
             connection.Query(
                 @"UPDATE Sessions SET Duration = Duration + @tutorialTime
-                   WHERE [SessionID] = @sessionId",
+                   WHERE SessionID = @sessionId",
                 new { sessionId, tutorialTime }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
@@ -2,6 +2,7 @@
 {
     using System.Data;
     using Dapper;
+    using DigitalLearningSolutions.Data.Models;
 
     public interface ISessionDataService
     {
@@ -14,6 +15,10 @@
         int StartAdminSession(int adminId);
 
         bool HasAdminGotSessions(int adminId);
+
+        Session? GetSessionById(int sessionId);
+
+        void AddTutorialTimeToSessionDuration(int sessionId, int tutorialTime);
     }
 
     public class SessionDataService : ISessionDataService
@@ -71,6 +76,29 @@
             return connection.ExecuteScalar<bool>(
                 "SELECT 1 WHERE EXISTS (SELECT AdminSessionId FROM AdminSessions WHERE AdminID = @adminId)",
                 new { adminId }
+            );
+        }
+
+        public Session? GetSessionById(int sessionId)
+        {
+            return connection.QueryFirstOrDefault<Session>(
+                @"SELECT SessionID,
+                        CandidateID,
+                        CustomisationID,
+                        LoginTime,
+                        Duration,
+                        Active
+                    FROM Sessions WHERE SessionID = @sessionId",
+                new { sessionId }
+            );
+        }
+
+        public void AddTutorialTimeToSessionDuration(int sessionId, int tutorialTime)
+        {
+            connection.Query(
+                @"UPDATE Sessions SET Duration = Duration + @tutorialTime
+                   WHERE [SessionID] = @sessionId",
+                new { sessionId, tutorialTime }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -6,5 +6,6 @@
         GetObjectiveArrayCc,
         StoreDiagnosticJson,
         StoreAspProgressV2,
+        StoreAspProgressNoSession,
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -17,8 +17,8 @@
         public static readonly TrackerEndpointResponse NullAction =
             new TrackerEndpointResponse(-15, nameof(NullAction));
 
-        public static readonly TrackerEndpointResponse StoreAspProgressV2Exception =
-            new TrackerEndpointResponse(-24, nameof(StoreAspProgressV2Exception));
+        public static readonly TrackerEndpointResponse StoreAspProgressException =
+            new TrackerEndpointResponse(-24, nameof(StoreAspProgressException));
 
         public static readonly TrackerEndpointResponse StoreDiagnosticScoreException =
             new TrackerEndpointResponse(-25, nameof(StoreDiagnosticScoreException));

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointSessionVariable.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointSessionVariable.cs
@@ -5,6 +5,9 @@
         public static readonly TrackerEndpointSessionVariable LmGvSectionRow =
             new TrackerEndpointSessionVariable(0, "lmGvSectionRow");
 
+        public static readonly TrackerEndpointSessionVariable LmSessionId =
+            new TrackerEndpointSessionVariable(1, "lmSessionID");
+
         public TrackerEndpointSessionVariable(int id, string name) : base(id, name) { }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/StoreAspProgressService.cs
+++ b/DigitalLearningSolutions.Data/Services/StoreAspProgressService.cs
@@ -6,7 +6,7 @@
 
     public interface IStoreAspProgressService
     {
-        public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+        (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
             GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
                 int? progressId,
                 int? version,

--- a/DigitalLearningSolutions.Data/Services/StoreAspProgressService.cs
+++ b/DigitalLearningSolutions.Data/Services/StoreAspProgressService.cs
@@ -1,0 +1,128 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Models.Progress;
+
+    public interface IStoreAspProgressService
+    {
+        public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                int? progressId,
+                int? version,
+                int? tutorialId,
+                int? tutorialTime,
+                int? tutorialStatus,
+                int? candidateId,
+                int? customisationId
+            );
+
+        (TrackerEndpointResponse? validationResponse, int? parsedSessionId)
+            ParseSessionIdAndValidateSessionForStoreAspProgressNoSession(
+                string? sessionId,
+                int candidateId,
+                int customisationId
+            );
+
+        void StoreAspProgressAndSendEmailIfComplete(
+            DetailedCourseProgress progress,
+            int version,
+            string? progressText,
+            int tutorialId,
+            int tutorialTime,
+            int tutorialStatus
+        );
+    }
+
+    public class StoreAspProgressService : IStoreAspProgressService
+    {
+        private readonly IProgressService progressService;
+        private readonly ISessionDataService sessionDataService;
+
+        public StoreAspProgressService(IProgressService progressService, ISessionDataService sessionDataService)
+        {
+            this.progressService = progressService;
+            this.sessionDataService = sessionDataService;
+        }
+
+        public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+            GetProgressAndValidateCommonInputsForStoreAspSessionEndpoints(
+                int? progressId,
+                int? version,
+                int? tutorialId,
+                int? tutorialTime,
+                int? tutorialStatus,
+                int? candidateId,
+                int? customisationId
+            )
+        {
+            if (progressId == null || version == null || tutorialId == null ||
+                candidateId == null || customisationId == null)
+            {
+                return (TrackerEndpointResponse.StoreAspProgressException, null);
+            }
+
+            if (tutorialTime == null || tutorialStatus == null)
+            {
+                return (TrackerEndpointResponse.NullTutorialStatusOrTime, null);
+            }
+
+            var progress = progressService.GetDetailedCourseProgress(progressId.Value);
+            if (progress == null || progress.DelegateId != candidateId ||
+                progress.CustomisationId != customisationId.Value)
+            {
+                return (TrackerEndpointResponse.StoreAspProgressException, null);
+            }
+
+            return (null, progress);
+        }
+
+        public (TrackerEndpointResponse? validationResponse, int? parsedSessionId)
+            ParseSessionIdAndValidateSessionForStoreAspProgressNoSession(
+                string? sessionId,
+                int candidateId,
+                int customisationId
+            )
+        {
+            var sessionIdValid = int.TryParse(sessionId, out var parsedSessionId);
+
+            if (!sessionIdValid)
+            {
+                return (TrackerEndpointResponse.StoreAspProgressException, null);
+            }
+
+            var session = sessionDataService.GetSessionById(parsedSessionId);
+            if (session == null || session.CandidateId != candidateId || session.CustomisationId != customisationId ||
+                !session.Active)
+            {
+                return (TrackerEndpointResponse.StoreAspProgressException, null);
+            }
+
+            return (null, parsedSessionId);
+        }
+
+        public void StoreAspProgressAndSendEmailIfComplete(
+            DetailedCourseProgress progress,
+            int version,
+            string? progressText,
+            int tutorialId,
+            int tutorialTime,
+            int tutorialStatus
+        )
+        {
+            progressService.StoreAspProgressV2(
+                progress.ProgressId,
+                version,
+                progressText,
+                tutorialId,
+                tutorialTime,
+                tutorialStatus
+            );
+
+            if (tutorialStatus == 2)
+            {
+                progressService.CheckProgressForCompletionAndSendEmailIfCompleted(progress);
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Data/Services/TrackerService.cs
@@ -86,6 +86,21 @@
                         );
                     }
 
+                    if (action == TrackerEndpointAction.StoreAspProgressNoSession)
+                    {
+                        return trackerActionService.StoreAspProgressNoSession(
+                            query.ProgressId,
+                            query.Version,
+                            sessionVariables[TrackerEndpointSessionVariable.LmGvSectionRow],
+                            query.TutorialId,
+                            query.TutorialTime,
+                            query.TutorialStatus,
+                            query.CandidateId,
+                            query.CustomisationId,
+                            sessionVariables[TrackerEndpointSessionVariable.LmSessionId]
+                        );
+                    }
+
                     throw new ArgumentOutOfRangeException();
                 }
 

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -213,6 +213,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ISectionService, SectionService>();
             services.AddScoped<ISelfAssessmentService, SelfAssessmentService>();
             services.AddScoped<ISessionService, SessionService>();
+            services.AddScoped<IStoreAspProgressService, StoreAspProgressService>();
             services.AddScoped<ISupervisorDelegateService, SupervisorDelegateService>();
             services.AddScoped<ISupervisorService, SupervisorService>();
             services.AddScoped<IDashboardInformationService, DashboardInformationService>();


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-411

### Description
Implemented the new StoreASPProgressNoSession tracker endpoint. As a lot of the logic is shared with the StoreASPProgressV2 endpoint, a good chunk of these changes are just moving that endpoint's methods and tests into a reusable format.
Note that there are still a few questions regarding differences in ticket scope vs the old code that are awaiting answers from Kevin when he gets back.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
