### PR TITLE
HEEDLS-942 add ReturnPageQuery to posted form

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/EditDescription.cshtml
@@ -29,6 +29,7 @@
 
       <button class="nhsuk-button" type="submit" value="save">Save</button>
       <input type="hidden" asp-for="GroupName" />
+      <input type="hidden" asp-for="ReturnPageQuery" />
     </form>
     <vc:cancel-link-with-return-page-query asp-controller="DelegateGroups" asp-action="Index" return-page-query="@Model.ReturnPageQuery" />
   </div>


### PR DESCRIPTION
### JIRA link
_[HEEDLS-942](https://softwiretech.atlassian.net/browse/HEEDLS-942)_

### Description
Added the `ReturnPageQuery` as a hidden field in `EditDescription.cshtml` following the discussion in this slack thread: https://softwire.slack.com/archives/C016Q1GR2G5/p1653646844692239

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
