### PR TITLE
HEEDLS-938 Change course category id filter logic to use admin catego…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -108,10 +108,10 @@
         [Route("EditFilters")]
         public IActionResult EditFilters(EditFiltersViewModel model)
         {
+            var categoryIdFilter = User.GetAdminCourseCategoryFilter();
             if (!ModelState.IsValid)
             {
                 var centreId = User.GetCentreId();
-                var categoryIdFilter = User.GetAdminCourseCategoryFilter();
                 var filterOptions = GetDropdownValues(centreId, categoryIdFilter);
                 model.SetUpDropdowns(filterOptions, categoryIdFilter);
                 model.DataStart = activityService.GetActivityStartDateForCentre(centreId);
@@ -122,7 +122,7 @@
                 model.GetValidatedStartDate(),
                 model.GetValidatedEndDate(),
                 model.JobGroupId,
-                model.CourseCategoryId,
+                categoryIdFilter ?? model.CourseCategoryId,
                 model.CustomisationId,
                 model.FilterType,
                 model.ReportInterval

--- a/DigitalLearningSolutions.Web/Helpers/ReportsFilterCookieHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ReportsFilterCookieHelper.cs
@@ -38,7 +38,13 @@
 
             try
             {
-                return JsonConvert.DeserializeObject<ActivityFilterData>(cookie);
+                var filterData = JsonConvert.DeserializeObject<ActivityFilterData>(cookie);
+                if (categoryIdFilter != null)
+                {
+                    filterData.CourseCategoryId = categoryIdFilter;
+                }
+
+                return filterData;
             }
             catch
             {


### PR DESCRIPTION
…ry id as well

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-938

### Description
Change the reading and setting of the reports filter cookie so that it always uses the admin's category ID if it isn't null. This means that when a course is selected as the filter option, we always have the admin's category ID (or All if null/0) displayed in the top text.

This also fixes the text at the top of the screen for https://softwiretech.atlassian.net/browse/HEEDLS-937

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/172134733-e7b3e39a-96bc-4151-87d6-20d5c732f10d.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
