### PR TITLE
HEEDLS-862 Fix constructor setting the wrong properties

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -28,8 +28,8 @@
             LearningTime = delegateCourseInfo.LearningTime;
             DiagnosticScore = delegateCourseInfo.DiagnosticScore;
             Answer1 = delegateCourseInfo.Answer1;
-            Answer2 = delegateCourseInfo.Answer1;
-            Answer3 = delegateCourseInfo.Answer1;
+            Answer2 = delegateCourseInfo.Answer2;
+            Answer3 = delegateCourseInfo.Answer3;
             AllAttempts = delegateCourseInfo.AllAttempts;
             AttemptsPassed = delegateCourseInfo.AttemptsPassed;
             Enrolled = delegateCourseInfo.Enrolled;


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-862

### Description
Fixed the DelegateCourseInfo constructor setting the wrong AnswerX properties. This fixes the issue seen where the answer gets populated from the other answers when reaching the edit screen.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
