### PR TITLE
HEEDLS-928 Allow course delegates page to show delegates at centre on…

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -395,6 +395,28 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         }
 
         [Test]
+        public void GetDelegateCourseInfosForCourse_should_return_course_info_correctly()
+        {
+            // When
+            var results = courseDataService.GetDelegateCourseInfosForCourse(27915, 101).ToList();
+
+            // Then
+            results.Should().HaveCount(34);
+            results.Should().ContainEquivalentOf(ExpectedCourseInfo);
+        }
+
+        [Test]
+        public void GetDelegateCourseInfosForCourse_should_return_course_info_for_all_centres_course()
+        {
+            // When
+            var results = courseDataService.GetDelegateCourseInfosForCourse(27409, 101).ToList();
+
+            // Then
+            results.Should().HaveCount(9);
+            results[0].CourseName.Should().Be("An Introduction to Cognition - New");
+        }
+
+        [Test]
         public void GetCourseNameAndApplication_returns_course_name_and_application()
         {
             // When

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -378,7 +378,13 @@ namespace DigitalLearningSolutions.Data.DataServices
         {
             return connection.Query<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
-                    WHERE cu.CentreID = @centreId
+                    WHERE (cu.CentreID = @centreId OR
+                            (cu.AllCentres = 1 AND
+                                EXISTS (SELECT CentreApplicationID
+                                        FROM CentreApplications
+                                        WHERE ApplicationID = cu.ApplicationID AND
+                                            CentreID = @centreID AND
+                                            Active = 1)))
                         AND ca.CentreID = @centreId
                         AND pr.CustomisationID = @customisationId",
                 new { customisationId, centreId }

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -381,10 +381,10 @@ namespace DigitalLearningSolutions.Data.DataServices
                     WHERE (cu.CentreID = @centreId OR
                             (cu.AllCentres = 1 AND
                                 EXISTS (SELECT CentreApplicationID
-                                        FROM CentreApplications
-                                        WHERE ApplicationID = cu.ApplicationID AND
-                                            CentreID = @centreID AND
-                                            Active = 1)))
+                                        FROM CentreApplications cap
+                                        WHERE cap.ApplicationID = cu.ApplicationID AND
+                                            cap.CentreID = @centreID AND
+                                            cap.Active = 1)))
                         AND ca.CentreID = @centreId
                         AND pr.CustomisationID = @customisationId",
                 new { customisationId, centreId }


### PR DESCRIPTION
… all centre courses again

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-928

### Description
Changed the SQL query that is only currently used by the course delegates page to allow it to query users at the current centre on an all centres course, like the old version used to be able to do.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/172185605-37eb0349-649e-4f81-8e4f-4313c91b78c7.png)
![image](https://user-images.githubusercontent.com/59561751/172185618-8c7df74f-6536-4bd7-87c6-1edf6d6de322.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
