### PR TITLE
HEEDLS-958 - Refactor Promote To Admin to reactivate inactive account…

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/PasswordDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/PasswordDataServiceTests.cs
@@ -14,9 +14,9 @@
     public class PasswordDataServiceTests
     {
         private const string PasswordHashNotYetInDb = "I haven't used this password before!";
+        private SqlConnection connection = null!;
         private PasswordDataService passwordDataService = null!;
         private UserDataService userDataService = null!;
-        private SqlConnection connection = null!;
 
         [SetUp]
         public void Setup()
@@ -45,6 +45,22 @@
             {
                 transaction.Dispose();
             }
+        }
+
+        [Test]
+        public void SetPasswordByAdminId_should_set_password_correctly()
+        {
+            using var transaction = new TransactionScope();
+            // Given
+            const string? password = "hashedPassword";
+            const int adminId = 1;
+
+            // When
+            passwordDataService.SetPasswordByAdminId(adminId, password);
+            var result = userDataService.GetAdminUserById(1)!.Password;
+
+            // Then
+            result.Should().Be(password);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
@@ -228,17 +228,22 @@
             using var transaction = new TransactionScope();
             // Given
             const int adminId = 16;
+            connection.SetAdminToInactiveWithCentreManagerAndSuperAdminPermissions(adminId);
 
             // When
+            var deactivatedAdmin = userDataService.GetAdminUserById(adminId)!;
             userDataService.ReactivateAdmin(adminId);
-            var updatedAdminUser = userDataService.GetAdminUserById(adminId)!;
+            var reactivatedAdmin = userDataService.GetAdminUserById(adminId)!;
 
             // Then
             using (new AssertionScope())
             {
-                updatedAdminUser.Active.Should().Be(true);
-                updatedAdminUser.IsCentreManager.Should().Be(false);
-                updatedAdminUser.IsUserAdmin.Should().Be(false);
+                deactivatedAdmin.Active.Should().Be(false);
+                deactivatedAdmin.IsCentreManager.Should().Be(true);
+                deactivatedAdmin.IsUserAdmin.Should().Be(true);
+                reactivatedAdmin.Active.Should().Be(true);
+                reactivatedAdmin.IsCentreManager.Should().Be(false);
+                reactivatedAdmin.IsUserAdmin.Should().Be(false);
             }
         }
 

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
@@ -6,6 +6,7 @@
     using Dapper;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FluentAssertions;
+    using FluentAssertions.Execution;
     using NUnit.Framework;
 
     public partial class UserDataServiceTests
@@ -222,18 +223,23 @@
         }
 
         [Test]
-        public void ActivateAdminUser_updates_user()
+        public void ReactivateAdminUser_activates_user_and_resets_admin_permissions()
         {
             using var transaction = new TransactionScope();
             // Given
-            const int adminId = 8;
+            const int adminId = 16;
 
             // When
-            userDataService.ActivateAdmin(adminId);
+            userDataService.ReactivateAdmin(adminId);
             var updatedAdminUser = userDataService.GetAdminUserById(adminId)!;
 
             // Then
-            updatedAdminUser.Active.Should().Be(true);
+            using (new AssertionScope())
+            {
+                updatedAdminUser.Active.Should().Be(true);
+                updatedAdminUser.IsCentreManager.Should().Be(false);
+                updatedAdminUser.IsUserAdmin.Should().Be(false);
+            }
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
@@ -222,6 +222,21 @@
         }
 
         [Test]
+        public void ActivateAdminUser_updates_user()
+        {
+            using var transaction = new TransactionScope();
+            // Given
+            const int adminId = 8;
+
+            // When
+            userDataService.ActivateAdmin(adminId);
+            var updatedAdminUser = userDataService.GetAdminUserById(adminId)!;
+
+            // Then
+            updatedAdminUser.Active.Should().Be(true);
+        }
+
+        [Test]
         public void DeleteAdmin_deletes_admin_record()
         {
             // Given

--- a/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
@@ -17,6 +17,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions;
+    using FluentAssertions.Execution;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging.Abstractions;
     using NUnit.Framework;
@@ -32,7 +33,6 @@ namespace DigitalLearningSolutions.Data.Tests.Services
         private ICentresDataService centresDataService = null!;
         private IConfiguration config = null!;
         private IEmailService emailService = null!;
-        private IFrameworkNotificationService frameworkNotificationService = null!;
         private IPasswordDataService passwordDataService = null!;
         private IPasswordResetService passwordResetService = null!;
         private IRegistrationDataService registrationDataService = null!;
@@ -50,7 +50,6 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             centresDataService = A.Fake<ICentresDataService>();
             config = A.Fake<IConfiguration>();
             supervisorDelegateService = A.Fake<ISupervisorDelegateService>();
-            frameworkNotificationService = A.Fake<IFrameworkNotificationService>();
             userDataService = A.Fake<IUserDataService>();
 
             A.CallTo(() => config["CurrentSystemBaseUrl"]).Returns(OldSystemBaseUrl);
@@ -72,7 +71,6 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                 centresDataService,
                 config,
                 supervisorDelegateService,
-                frameworkNotificationService,
                 userDataService,
                 new NullLogger<RegistrationService>()
             );
@@ -543,7 +541,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                     model.Email,
                     NewCandidateNumber,
                     baseUrl,
-                    model.NotifyDate.Value,
+                    model.NotifyDate!.Value,
                     "RegisterDelegateByCentre_Refactor"
                 )
             ).MustHaveHappened(1, Times.Exactly);
@@ -659,7 +657,8 @@ namespace DigitalLearningSolutions.Data.Tests.Services
         }
 
         [Test]
-        public void PromoteDelegateToAdmin_throws_email_in_use_AdminCreationFailedException_if_admin_already_exists()
+        public void
+            PromoteDelegateToAdmin_throws_email_in_use_AdminCreationFailedException_if_active_admin_already_exists()
         {
             // Given
             var delegateUser = UserTestHelper.GetDefaultDelegateUser();
@@ -674,7 +673,80 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             );
 
             // Then
-            result.Error.Should().Be(AdminCreationError.EmailAlreadyInUse);
+            using (new AssertionScope())
+            {
+                UpdateToExistingAdminAccountMustNotHaveHappened();
+                result.Error.Should().Be(AdminCreationError.EmailAlreadyInUse);
+            }
+        }
+
+        [Test]
+        public void
+            PromoteDelegateToAdmin_throws_email_in_use_AdminCreationFailedException_if_inactive_admin_at_different_centre_already_exists()
+        {
+            // Given
+            var delegateUser = UserTestHelper.GetDefaultDelegateUser();
+            var adminUser = UserTestHelper.GetDefaultAdminUser(centreId: 3, active: false);
+            var adminRoles = new AdminRoles(true, true, true, true, true, true, true);
+            A.CallTo(() => userDataService.GetDelegateUserById(A<int>._)).Returns(delegateUser);
+            A.CallTo(() => userDataService.GetAdminUserByEmailAddress(A<string>._)).Returns(adminUser);
+
+            // When
+            var result = Assert.Throws<AdminCreationFailedException>(
+                () => registrationService.PromoteDelegateToAdmin(adminRoles, 1, 1)
+            );
+
+            // Then
+            using (new AssertionScope())
+            {
+                UpdateToExistingAdminAccountMustNotHaveHappened();
+                result.Error.Should().Be(AdminCreationError.EmailAlreadyInUse);
+            }
+        }
+
+        [Test]
+        public void PromoteDelegateToAdmin_updates_existing_admin_if_inactive_admin_at_same_centre_already_exists()
+        {
+            // Given
+            const int categoryId = 1;
+            var delegateUser = UserTestHelper.GetDefaultDelegateUser();
+            var adminUser = UserTestHelper.GetDefaultAdminUser(active: false);
+            var adminRoles = new AdminRoles(true, true, true, true, true, true, true);
+            A.CallTo(() => userDataService.GetDelegateUserById(A<int>._)).Returns(delegateUser);
+            A.CallTo(() => userDataService.GetAdminUserByEmailAddress(A<string>._)).Returns(adminUser);
+
+            // When
+            registrationService.PromoteDelegateToAdmin(adminRoles, categoryId, 1);
+
+            // Then
+            using (new AssertionScope())
+            {
+                A.CallTo(() => userDataService.ActivateAdmin(adminUser.Id)).MustHaveHappenedOnceExactly();
+                A.CallTo(
+                    () => userDataService.UpdateAdminUser(
+                        delegateUser.FirstName!,
+                        delegateUser.LastName,
+                        delegateUser.EmailAddress!,
+                        delegateUser.ProfileImage,
+                        adminUser.Id
+                    )
+                ).MustHaveHappenedOnceExactly();
+                A.CallTo(() => passwordDataService.SetPasswordByAdminId(adminUser.Id, delegateUser.Password!))
+                    .MustHaveHappenedOnceExactly();
+                A.CallTo(
+                    () => userDataService.UpdateAdminUserPermissions(
+                        adminUser.Id,
+                        adminRoles.IsCentreAdmin,
+                        adminRoles.IsSupervisor,
+                        adminRoles.IsNominatedSupervisor,
+                        adminRoles.IsTrainer,
+                        adminRoles.IsContentCreator,
+                        adminRoles.IsContentManager,
+                        adminRoles.ImportOnly,
+                        categoryId
+                    )
+                ).MustHaveHappenedOnceExactly();
+            }
         }
 
         [Test]
@@ -690,27 +762,31 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             registrationService.PromoteDelegateToAdmin(adminRoles, 1, 1);
 
             // Then
-            A.CallTo(
-                () => registrationDataService.RegisterAdmin(
-                    A<AdminRegistrationModel>.That.Matches(
-                        a =>
-                            a.FirstName == delegateUser.FirstName &&
-                            a.LastName == delegateUser.LastName &&
-                            a.Email == delegateUser.EmailAddress &&
-                            a.Centre == delegateUser.CentreId &&
-                            a.PasswordHash == delegateUser.Password &&
-                            a.Active &&
-                            a.Approved &&
-                            a.IsCentreAdmin == adminRoles.IsCentreAdmin &&
-                            !a.IsCentreManager &&
-                            a.IsContentManager == adminRoles.IsContentManager &&
-                            a.ImportOnly == adminRoles.IsCmsAdministrator &&
-                            a.IsContentCreator == adminRoles.IsContentCreator &&
-                            a.IsTrainer == adminRoles.IsTrainer &&
-                            a.IsSupervisor == adminRoles.IsSupervisor
+            using (new AssertionScope())
+            {
+                A.CallTo(
+                    () => registrationDataService.RegisterAdmin(
+                        A<AdminRegistrationModel>.That.Matches(
+                            a =>
+                                a.FirstName == delegateUser.FirstName &&
+                                a.LastName == delegateUser.LastName &&
+                                a.Email == delegateUser.EmailAddress &&
+                                a.Centre == delegateUser.CentreId &&
+                                a.PasswordHash == delegateUser.Password &&
+                                a.Active &&
+                                a.Approved &&
+                                a.IsCentreAdmin == adminRoles.IsCentreAdmin &&
+                                !a.IsCentreManager &&
+                                a.IsContentManager == adminRoles.IsContentManager &&
+                                a.ImportOnly == adminRoles.IsCmsAdministrator &&
+                                a.IsContentCreator == adminRoles.IsContentCreator &&
+                                a.IsTrainer == adminRoles.IsTrainer &&
+                                a.IsSupervisor == adminRoles.IsSupervisor
+                        )
                     )
-                )
-            ).MustHaveHappened();
+                ).MustHaveHappened();
+                UpdateToExistingAdminAccountMustNotHaveHappened();
+            }
         }
 
         private void GivenNoPendingSupervisorDelegateRecordsForEmail()
@@ -734,6 +810,34 @@ namespace DigitalLearningSolutions.Data.Tests.Services
                     )
                 )
                 .Returns(supervisorDelegates);
+        }
+
+        private void UpdateToExistingAdminAccountMustNotHaveHappened()
+        {
+            A.CallTo(() => userDataService.ActivateAdmin(A<int>._)).MustNotHaveHappened();
+            A.CallTo(
+                () => userDataService.UpdateAdminUser(
+                    A<string>._,
+                    A<string>._,
+                    A<string>._,
+                    A<byte[]>._,
+                    A<int>._
+                )
+            ).MustNotHaveHappened();
+            A.CallTo(() => passwordDataService.SetPasswordByAdminId(A<int>._, A<string>._)).MustNotHaveHappened();
+            A.CallTo(
+                () => userDataService.UpdateAdminUserPermissions(
+                    A<int>._,
+                    A<bool>._,
+                    A<bool>._,
+                    A<bool>._,
+                    A<bool>._,
+                    A<bool>._,
+                    A<bool>._,
+                    A<bool>._,
+                    A<int>._
+                )
+            ).MustNotHaveHappened();
         }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
@@ -721,7 +721,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => userDataService.ActivateAdmin(adminUser.Id)).MustHaveHappenedOnceExactly();
+                A.CallTo(() => userDataService.ReactivateAdmin(adminUser.Id)).MustHaveHappenedOnceExactly();
                 A.CallTo(
                     () => userDataService.UpdateAdminUser(
                         delegateUser.FirstName!,
@@ -814,7 +814,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
 
         private void UpdateToExistingAdminAccountMustNotHaveHappened()
         {
-            A.CallTo(() => userDataService.ActivateAdmin(A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => userDataService.ReactivateAdmin(A<int>._)).MustNotHaveHappened();
             A.CallTo(
                 () => userDataService.UpdateAdminUser(
                     A<string>._,

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -214,6 +214,18 @@
             return new CentreAnswersData(centreId, jobGroupId, answer1, answer2, answer3, answer4, answer5, answer6);
         }
 
+        public static void SetAdminToInactiveWithCentreManagerAndSuperAdminPermissions(this DbConnection connection, int adminId)
+        {
+            connection.Execute(
+                @"UPDATE AdminUsers SET
+                        Active = 0,
+                        IsCentreManager = 1,
+                        UserAdmin = 1
+                    WHERE AdminID = @adminId",
+                new { adminId }
+            );
+        }
+
         public static void GivenDelegateUserIsInDatabase(DelegateUser user, SqlConnection sqlConnection)
         {
             sqlConnection.Execute(

--- a/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
@@ -41,9 +41,9 @@
         public void SetPasswordByAdminId(int adminId, string passwordHash)
         {
             connection.Query(
-                @"UPDATE AdminUsers
-                        SET Password = @passwordHash
-                        WHERE AdminID = @adminID",
+                @"UPDATE AdminUsers SET
+                        Password = @passwordHash
+                    WHERE AdminID = @adminID",
                 new { passwordHash, adminId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PasswordDataService.cs
@@ -11,7 +11,11 @@
     public interface IPasswordDataService
     {
         void SetPasswordByCandidateNumber(string candidateNumber, string passwordHash);
+
+        void SetPasswordByAdminId(int adminId, string passwordHash);
+
         Task SetPasswordByEmailAsync(string email, string passwordHash);
+
         Task SetPasswordForUsersAsync(IEnumerable<UserReference> users, string passwordHash);
     }
 
@@ -31,6 +35,16 @@
                         SET Password = @passwordHash
                         WHERE CandidateNumber = @candidateNumber",
                 new { passwordHash, candidateNumber }
+            );
+        }
+
+        public void SetPasswordByAdminId(int adminId, string passwordHash)
+        {
+            connection.Query(
+                @"UPDATE AdminUsers
+                        SET Password = @passwordHash
+                        WHERE AdminID = @adminID",
+                new { passwordHash, adminId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -180,8 +180,8 @@
             connection.Execute(
                 @"UPDATE AdminUsers SET
                         Active = 1,
-						IsCentreManager = 0,
-						UserAdmin = 0
+                        IsCentreManager = 0,
+                        UserAdmin = 0
                     WHERE AdminID = @adminId",
                 new { adminId }
             );

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -143,7 +143,7 @@
                     isContentManager,
                     importOnly,
                     categoryId,
-                    adminId
+                    adminId,
                 }
             );
         }
@@ -151,12 +151,12 @@
         public void UpdateAdminUserFailedLoginCount(int adminId, int updatedCount)
         {
             connection.Execute(
-                    @"UPDATE AdminUsers
+                @"UPDATE AdminUsers
                         SET
                             FailedLoginCount = @updatedCount
                         WHERE AdminID = @adminId",
-                    new { adminId, updatedCount}
-                );
+                new { adminId, updatedCount }
+            );
         }
 
         public void DeactivateAdmin(int adminId)
@@ -165,6 +165,17 @@
                 @"UPDATE AdminUsers
                         SET
                             Active = 0
+                        WHERE AdminID = @adminId",
+                new { adminId }
+            );
+        }
+
+        public void ActivateAdmin(int adminId)
+        {
+            connection.Execute(
+                @"UPDATE AdminUsers
+                        SET
+                            Active = 1
                         WHERE AdminID = @adminId",
                 new { adminId }
             );

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -173,10 +173,9 @@
         public void ActivateAdmin(int adminId)
         {
             connection.Execute(
-                @"UPDATE AdminUsers
-                        SET
-                            Active = 1
-                        WHERE AdminID = @adminId",
+                @"UPDATE AdminUsers SET
+                        Active = 1
+                    WHERE AdminID = @adminId",
                 new { adminId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -170,11 +170,18 @@
             );
         }
 
-        public void ActivateAdmin(int adminId)
+        /// <summary>
+        /// When we reactivate an admin, we must ensure the admin permissions are not
+        /// greater than basic levels. Otherwise, a basic admin would be able to
+        /// "create" admins with more permissions than themselves.
+        /// </summary>
+        public void ReactivateAdmin(int adminId)
         {
             connection.Execute(
                 @"UPDATE AdminUsers SET
-                        Active = 1
+                        Active = 1,
+						IsCentreManager = 0,
+						UserAdmin = 0
                     WHERE AdminID = @adminId",
                 new { adminId }
             );

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -115,6 +115,8 @@
 
         void DeactivateAdmin(int adminId);
 
+        void ActivateAdmin(int adminId);
+
         void ActivateDelegateUser(int delegateId);
 
         int? GetDelegateUserLearningHubAuthId(int delegateId);

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -115,7 +115,7 @@
 
         void DeactivateAdmin(int adminId);
 
-        void ActivateAdmin(int adminId);
+        void ReactivateAdmin(int adminId);
 
         void ActivateDelegateUser(int delegateId);
 

--- a/DigitalLearningSolutions.Data/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Data/Services/RegistrationService.cs
@@ -170,7 +170,6 @@ namespace DigitalLearningSolutions.Data.Services
                     adminUser.Id
                 );
                 passwordDataService.SetPasswordByAdminId(adminUser.Id, delegateUser.Password);
-                // Set various roles - TODO do we want to force IsCentreManager to false like we do when registering?
                 userDataService.UpdateAdminUserPermissions(
                     adminUser.Id,
                     adminRoles.IsCentreAdmin,

--- a/DigitalLearningSolutions.Data/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Data/Services/RegistrationService.cs
@@ -159,7 +159,7 @@ namespace DigitalLearningSolutions.Data.Services
 
             var adminUser = userDataService.GetAdminUserByEmailAddress(delegateUser.EmailAddress);
 
-            if (adminUser?.Active is false && adminUser.CentreId == delegateUser.CentreId)
+            if (adminUser?.Active == false && adminUser.CentreId == delegateUser.CentreId)
             {
                 userDataService.ReactivateAdmin(adminUser.Id);
                 userDataService.UpdateAdminUser(

--- a/DigitalLearningSolutions.Data/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Data/Services/RegistrationService.cs
@@ -35,7 +35,6 @@ namespace DigitalLearningSolutions.Data.Services
         private readonly ICentresDataService centresDataService;
         private readonly IConfiguration config;
         private readonly IEmailService emailService;
-        private readonly IFrameworkNotificationService frameworkNotificationService;
         private readonly ILogger<RegistrationService> logger;
         private readonly IPasswordDataService passwordDataService;
         private readonly IPasswordResetService passwordResetService;
@@ -51,7 +50,6 @@ namespace DigitalLearningSolutions.Data.Services
             ICentresDataService centresDataService,
             IConfiguration config,
             ISupervisorDelegateService supervisorDelegateService,
-            IFrameworkNotificationService frameworkNotificationService,
             IUserDataService userDataService,
             ILogger<RegistrationService> logger
         )
@@ -64,7 +62,6 @@ namespace DigitalLearningSolutions.Data.Services
             this.userDataService = userDataService;
             this.config = config;
             this.supervisorDelegateService = supervisorDelegateService;
-            this.frameworkNotificationService = frameworkNotificationService;
             this.userDataService = userDataService;
             this.logger = logger;
         }
@@ -162,33 +159,59 @@ namespace DigitalLearningSolutions.Data.Services
 
             var adminUser = userDataService.GetAdminUserByEmailAddress(delegateUser.EmailAddress);
 
-            if (adminUser != null)
+            if (adminUser?.Active is false && adminUser.CentreId == delegateUser.CentreId)
+            {
+                userDataService.ActivateAdmin(adminUser.Id);
+                userDataService.UpdateAdminUser(
+                    delegateUser.FirstName,
+                    delegateUser.LastName,
+                    delegateUser.EmailAddress,
+                    delegateUser.ProfileImage,
+                    adminUser.Id
+                );
+                passwordDataService.SetPasswordByAdminId(adminUser.Id, delegateUser.Password);
+                // Set various roles - TODO do we want to force IsCentreManager to false like we do when registering?
+                userDataService.UpdateAdminUserPermissions(
+                    adminUser.Id,
+                    adminRoles.IsCentreAdmin,
+                    adminRoles.IsSupervisor,
+                    adminRoles.IsNominatedSupervisor,
+                    adminRoles.IsTrainer,
+                    adminRoles.IsContentCreator,
+                    adminRoles.IsContentManager,
+                    adminRoles.ImportOnly,
+                    categoryId
+                );
+            }
+            else if (adminUser == null)
+            {
+                var adminRegistrationModel = new AdminRegistrationModel(
+                    delegateUser.FirstName,
+                    delegateUser.LastName,
+                    delegateUser.EmailAddress,
+                    delegateUser.CentreId,
+                    delegateUser.Password,
+                    true,
+                    true,
+                    delegateUser.ProfessionalRegistrationNumber,
+                    categoryId,
+                    adminRoles.IsCentreAdmin,
+                    false,
+                    adminRoles.IsSupervisor,
+                    adminRoles.IsNominatedSupervisor,
+                    adminRoles.IsTrainer,
+                    adminRoles.IsContentCreator,
+                    adminRoles.IsCmsAdministrator,
+                    adminRoles.IsCmsManager,
+                    delegateUser.ProfileImage
+                );
+
+                registrationDataService.RegisterAdmin(adminRegistrationModel);
+            }
+            else
             {
                 throw new AdminCreationFailedException(AdminCreationError.EmailAlreadyInUse);
             }
-
-            var adminRegistrationModel = new AdminRegistrationModel(
-                delegateUser.FirstName,
-                delegateUser.LastName,
-                delegateUser.EmailAddress,
-                delegateUser.CentreId,
-                delegateUser.Password,
-                true,
-                true,
-                delegateUser.ProfessionalRegistrationNumber,
-                categoryId,
-                adminRoles.IsCentreAdmin,
-                false,
-                adminRoles.IsSupervisor,
-                adminRoles.IsNominatedSupervisor,
-                adminRoles.IsTrainer,
-                adminRoles.IsContentCreator,
-                adminRoles.IsCmsAdministrator,
-                adminRoles.IsCmsManager,
-                delegateUser.ProfileImage
-            );
-
-            registrationDataService.RegisterAdmin(adminRegistrationModel);
         }
 
         public string RegisterDelegateByCentre(DelegateRegistrationModel delegateRegistrationModel, string baseUrl)

--- a/DigitalLearningSolutions.Data/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Data/Services/RegistrationService.cs
@@ -161,7 +161,7 @@ namespace DigitalLearningSolutions.Data.Services
 
             if (adminUser?.Active is false && adminUser.CentreId == delegateUser.CentreId)
             {
-                userDataService.ActivateAdmin(adminUser.Id);
+                userDataService.ReactivateAdmin(adminUser.Id);
                 userDataService.UpdateAdminUser(
                     delegateUser.FirstName,
                     delegateUser.LastName,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -51,9 +51,9 @@
         public IActionResult Index(int delegateId)
         {
             var centreId = User.GetCentreId();
-            var delegateUser = userDataService.GetDelegateUserCardById(delegateId)!;
+            var delegateUser = userDataService.GetDelegateUserCardById(delegateId);
 
-            if (delegateUser.IsAdmin || !delegateUser.IsPasswordSet)
+            if (delegateUser!.IsAdmin || !delegateUser.IsPasswordSet)
             {
                 return NotFound();
             }


### PR DESCRIPTION
… at centre if it exists

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-958

### Description
Promote to Admin now reactivates the inactive admin account for that delegate at that centre (if it exists). It will also update the record with personal details (name, etc.) from the delegate record to make sure it is up to date, before setting the admin roles as the user specified on the form page.

### Screenshots
N/A, all backend changes.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
