### PR TITLE
HEEDLS-939 remove category filter options for users with a category

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
@@ -131,7 +131,26 @@
                     expectedTopicsFilterViewModel,
                     expectedStatusFilterViewModel,
                     expectedVisibilityFilterViewModel,
-                    expectedHasAdminFieldsFilterViewModel
+                    expectedHasAdminFieldsFilterViewModel,
+                }
+            );
+        }
+
+        [Test]
+        public void GetFilterOptions_excludes_category_option_if_passed_no_categories()
+        {
+            // When
+            var result =
+                CourseStatisticsViewModelFilterOptions.GetFilterOptions(new string[] { }, filterableTopics);
+
+            // Then
+            result.Should().BeEquivalentTo(
+                new List<FilterModel>
+                {
+                    expectedTopicsFilterViewModel,
+                    expectedStatusFilterViewModel,
+                    expectedVisibilityFilterViewModel,
+                    expectedHasAdminFieldsFilterViewModel,
                 }
             );
         }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesStatisticsViewModelFilterOptionsTests.cs
@@ -114,5 +114,23 @@
                 }
             );
         }
+
+        [Test]
+        public void GetFilterOptions_excludes_category_option_if_passed_no_categories()
+        {
+            // When
+            var result =
+                DelegateCourseStatisticsViewModelFilterOptions.GetFilterOptions(new string[] { }, filterableTopics);
+
+            // Then
+            result.Should().BeEquivalentTo(
+                new List<FilterModel>
+                {
+                    expectedTopicsFilterViewModel,
+                    expectedStatusFilterViewModel,
+                    expectedHasAdminFieldsFilterViewModel,
+                }
+            );
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -82,7 +82,7 @@
             var details = courseService.GetCentreCourseDetails(centreId, categoryId);
 
             var availableFilters = CourseStatisticsViewModelFilterOptions
-                .GetFilterOptions(details.Categories, details.Topics).ToList();
+                .GetFilterOptions(categoryId.HasValue ? new string[] { } : details.Categories, details.Topics).ToList();
 
             var searchSortPaginationOptions = new SearchSortFilterAndPaginateOptions(
                 new SearchOptions(searchString),

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -65,7 +65,7 @@
             var details = courseService.GetCentreCourseDetailsWithAllCentreCourses(centreId, categoryId);
 
             var availableFilters = DelegateCourseStatisticsViewModelFilterOptions
-                .GetFilterOptions(details.Categories, details.Topics).ToList();
+                .GetFilterOptions(categoryId.HasValue ? new string[] { } : details.Categories, details.Topics).ToList();
 
             var searchSortPaginationOptions = new SearchSortFilterAndPaginateOptions(
                 new SearchOptions(searchString),

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptions.cs
@@ -33,13 +33,8 @@
             IEnumerable<string> topics
         )
         {
-            return new[]
+            var filterOptions = new[]
             {
-                new FilterModel(
-                    nameof(CourseStatistics.CategoryName),
-                    "Category",
-                    GetCategoryOptions(categories)
-                ),
                 new FilterModel(
                     nameof(CourseStatistics.CourseTopic),
                     "Topic",
@@ -57,6 +52,16 @@
                     CourseHasAdminFieldOptions
                 ),
             };
+
+            return categories.Any()
+                ? filterOptions.Prepend(
+                    new FilterModel(
+                        nameof(CourseStatistics.CategoryName),
+                        "Category",
+                        GetCategoryOptions(categories)
+                    )
+                )
+                : filterOptions;
         }
 
         private static IEnumerable<FilterOptionModel> GetCategoryOptions(IEnumerable<string> categories)

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCourseStatisticsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCourseStatisticsViewModelFilterOptions.cs
@@ -29,13 +29,8 @@
             IEnumerable<string> topics
         )
         {
-            return new[]
+            var filterOptions = new[]
             {
-                new FilterModel(
-                    nameof(CourseStatistics.CategoryName),
-                    "Category",
-                    GetCategoryOptions(categories)
-                ),
                 new FilterModel(
                     nameof(CourseStatistics.CourseTopic),
                     "Topic",
@@ -48,6 +43,16 @@
                     CourseHasAdminFieldOptions
                 ),
             };
+
+            return categories.Any()
+                ? filterOptions.Prepend(
+                    new FilterModel(
+                        nameof(CourseStatistics.CategoryName),
+                        "Category",
+                        GetCategoryOptions(categories)
+                    )
+                )
+                : filterOptions;
         }
 
         private static IEnumerable<FilterOptionModel> GetCategoryOptions(IEnumerable<string> categories)


### PR DESCRIPTION
### JIRA link
_[HEEDLS-939](https://softwiretech.atlassian.net/browse/HEEDLS-939)_

### Description
The filter options for Course Setup and Delegate Courses do not include a category filter if the user has a specific category specified on their account.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
