### PR TITLE
HEEDLS-943 Pagination - redirect out-of-bounds pages to page 1

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/searchSortFilterAndPaginate.ts
@@ -143,6 +143,12 @@ export class SearchSortFilterAndPaginate {
     const sortedUniqueElements = _.uniqBy(sortedElements, 'parentIndex');
 
     const resultCount = sortedUniqueElements.length;
+    const itemsPerPage = getItemsPerPageValue();
+    const totalPages = Math.ceil(resultCount / itemsPerPage);
+
+    if (this.page < 1 || this.page > totalPages) {
+      this.updatePageNumberIfPaginated(1, searchableData);
+    }
 
     const paginatedElements = this.paginationEnabled
       ? paginateResults(sortedUniqueElements, this.page)


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-943

### Description
In the pagination interface, when javascript is enabled, manually changing the page number in the URL to be either < 1 or > the maximum number of pages leads to bad results (see Jira for screenshots).

This PR causes the browser to change the URL to `/1` in these scenarios, so the first page of results is displayed.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
