### PR TITLE
UAR-920 Unlock account via tracking system

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserDataServiceTests.cs
@@ -56,5 +56,15 @@
             // Then
             result.Should().BeEquivalentTo(UserTestHelper.GetDefaultUserAccount());
         }
+
+        [Test]
+        public void GetUserIdByAdminId_returns_expected_user_id()
+        {
+            // When
+            var result = userDataService.GetUserIdByAdminId(7);
+
+            // Then
+            result.Should().Be(2);
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -128,6 +128,8 @@
 
         UserAccount? GetUserAccountByEmailAddress(string emailAddress);
 
+        int? GetUserIdByAdminId(int adminId);
+
         IEnumerable<AdminAccount> GetAdminAccountsByUserId(int userId);
 
         IEnumerable<DelegateAccount> GetDelegateAccountsByUserId(int userId);
@@ -209,6 +211,14 @@
             return connection.Query<UserAccount>(
                 @$"{BaseSelectUserQuery} WHERE u.PrimaryEmail = @emailAddress",
                 new { emailAddress }
+            ).SingleOrDefault();
+        }
+
+        public int? GetUserIdByAdminId(int adminId)
+        {
+            return connection.Query<int>(
+                @"SELECT UserID FROM AdminAccounts WHERE ID = @adminId",
+                new { adminId }
             ).SingleOrDefault();
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
@@ -91,16 +91,18 @@
         public void UnlockAccount_unlocks_account_and_returns_to_page()
         {
             // Given
-            A.CallTo(() => userDataService.GetAdminUserById(A<int>._)).Returns(UserTestHelper.GetDefaultAdminUser());
-            A.CallTo(() => userDataService.UpdateUserFailedLoginCount(A<int>._, A<int>._)).DoesNothing();
+            var adminUser = UserTestHelper.GetDefaultAdminUser();
+            A.CallTo(() => userDataService.GetAdminUserById(A<int>._)).Returns(adminUser);
+            A.CallTo(() => userService.ResetFailedLoginCountByUserId(A<int>._)).DoesNothing();
+            A.CallTo(() => userDataService.GetUserIdByAdminId(adminUser.Id)).Returns(1);
 
             // When
-            var result = administratorController.UnlockAccount(1);
+            var result = administratorController.UnlockAccount(adminUser.Id);
 
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => userDataService.UpdateUserFailedLoginCount(1, 0)).MustHaveHappened();
+                A.CallTo(() => userService.ResetFailedLoginCountByUserId(1)).MustHaveHappened();
                 result.Should().BeRedirectToActionResult().WithActionName("Index");
             }
         }
@@ -113,7 +115,10 @@
             A.CallTo(() => userDataService.GetAdminUserById(adminUser.Id)).Returns(adminUser);
 
             // When
-            var result = administratorController.DeactivateOrDeleteAdmin(adminUser.Id, ReturnPageQueryHelper.GetDefaultReturnPageQuery());
+            var result = administratorController.DeactivateOrDeleteAdmin(
+                adminUser.Id,
+                ReturnPageQueryHelper.GetDefaultReturnPageQuery()
+            );
 
             // Then
             result.Should().BeNotFoundResult();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
@@ -91,18 +91,17 @@
         public void UnlockAccount_unlocks_account_and_returns_to_page()
         {
             // Given
-            var adminUser = UserTestHelper.GetDefaultAdminUser();
-            A.CallTo(() => userDataService.GetAdminUserById(A<int>._)).Returns(adminUser);
+            var adminAccount = UserTestHelper.GetDefaultAdminAccount();
             A.CallTo(() => userService.ResetFailedLoginCountByUserId(A<int>._)).DoesNothing();
-            A.CallTo(() => userDataService.GetUserIdByAdminId(adminUser.Id)).Returns(1);
+            A.CallTo(() => userDataService.GetUserIdByAdminId(adminAccount.Id)).Returns(adminAccount.UserId);
 
             // When
-            var result = administratorController.UnlockAccount(adminUser.Id);
+            var result = administratorController.UnlockAccount(adminAccount.Id);
 
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => userService.ResetFailedLoginCountByUserId(1)).MustHaveHappened();
+                A.CallTo(() => userService.ResetFailedLoginCountByUserId(adminAccount.UserId)).MustHaveHappened();
                 result.Should().BeRedirectToActionResult().WithActionName("Index");
             }
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -156,8 +156,7 @@
         [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
         public IActionResult UnlockAccount(int adminId)
         {
-            // TODO HEEDLS-920 - this needs to be userId for the admin
-            userDataService.UpdateUserFailedLoginCount(adminId, 0);
+            userService.ResetFailedLoginCountByUserId(userDataService.GetUserIdByAdminId(adminId)!.Value);
 
             return RedirectToAction("Index");
         }


### PR DESCRIPTION
### JIRA link
[HEEDLS-920](https://softwiretech.atlassian.net/jira/software/c/projects/HEEDLS/boards/753?modal=detail&selectedIssue=HEEDLS-920)

### Description
Changed the unlock account button from the tracking system to call the new method `ResetFailedLoginCountByUserId`

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
