### PR TITLE
HEEDLS-960 Escape double quotes in data-filter-value selector

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/filter.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/filter.ts
@@ -182,8 +182,11 @@ function doesElementMatchFilterValue(
   searchableElement: ISearchableElement,
   filter: string,
 ): boolean {
-  const filterElement = searchableElement.element
-    .querySelector(`[data-filter-value="${filter}"]`);
+  const filterElement = searchableElement.element.querySelector(
+    // Escape " in `filter` because `[attr=""value""]` is not a valid selector.
+    // The `g` flag on the regex means "greedy", i.e. match multiple times (with every match being replaced).
+    `[data-filter-value="${filter.replace(/"/g, '\\"')}"]`,
+  );
   const filterValue = filterElement?.getAttribute('data-filter-value')?.trim() ?? '';
   return filterValue === filter;
 }

--- a/DigitalLearningSolutions.Web/Scripts/spec/filter.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/filter.spec.ts
@@ -51,7 +51,7 @@ describe('filter', () => {
 
   it('should return expected results with 2 filters in the same group', () => {
     // Given
-    createFilterableElements(`Name|Name|a${filterSeparator}Name|Name|c`);
+    createFilterableElements(`Name|Name|a${filterSeparator}Name|Name|"c"`);
 
     // When
     const filteredElements = filterSearchableElements(
@@ -67,7 +67,7 @@ describe('filter', () => {
   it('should return expected results with a mix of grouped and ungrouped filters', () => {
     // Given
     createFilterableElements(
-      `Name|Name|a${filterSeparator}Name|Name|c${filterSeparator}Number|Number|1`,
+      `Name|Name|a${filterSeparator}Name|Name|"c"${filterSeparator}Number|Number|1`,
     );
 
     // When
@@ -112,7 +112,7 @@ describe('applied filter container', () => {
   it('should have the same number of children as there are filters', () => {
     // Given
     createFilterableElements(
-      `Name|Name|a${filterSeparator}Name|Name|c${filterSeparator}Number|Number|1`,
+      `Name|Name|a${filterSeparator}Name|Name|"c"${filterSeparator}Number|Number|1`,
     );
 
     // When
@@ -137,7 +137,7 @@ function createFilterableElements(existingFilterString: string) {
       <html>
       <head></head>
       <body>
-        <input type="text" id="existing-filter-string" value="${existingFilterString}"/>
+        <input type="text" id="existing-filter-string" value='${existingFilterString}' />
         <div id="applied-filters" hidden>
             <div class="applied-filter-container" id="applied-filter-container"></div>
         </div>
@@ -163,8 +163,8 @@ function createFilterableElements(existingFilterString: string) {
           </div>
           <div class="searchable-element" id="course-c">
             <span name="name" class="searchable-element-title">c: Course</span>
-            <div class="card-filter-tag" data-filter-value="Name|Name|c">
-              <strong>Name: c</strong>
+            <div class="card-filter-tag" data-filter-value='Name|Name|"c"'>
+              <strong>Name: "c"</strong>
             </div>
             <div class="card-filter-tag" data-filter-value="Number|Number|1">
               <strong>Number: 1</strong>
@@ -173,7 +173,7 @@ function createFilterableElements(existingFilterString: string) {
         </div>
         <div class="filter-tag" data-filter-value="Name|Name|a">Name: a</div>
         <div class="filter-tag" data-filter-value="Name|Name|b">Name: b</div>
-        <div class="filter-tag" data-filter-value="Name|Name|c">Name: c</div>
+        <div class="filter-tag" data-filter-value='Name|Name|"c"'>Name: "c"</div>
         <div class="filter-tag" data-filter-value="Number|Number|1">Number: 1</div>
         <div class="filter-tag" data-filter-value="Number|Number|2">Number: 2</div>
         <div class="nhsuk-pagination-item--previous"></div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-960

### Description
Escape double quotes in data-filter-value selector

### Screenshots
![filters](https://user-images.githubusercontent.com/1258014/173091507-c682f730-3474-40eb-a144-513bb179fd63.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
