### PR TITLE
HEEDLS-961 Fixed adding new responses to existing registration prompts

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/EditRegistrationPrompt.cshtml
@@ -22,6 +22,7 @@
     <button name="action" class="nhsuk-button" value="@RegistrationPromptsController.AddPromptAction" aria-hidden="true" tabindex="-1">Add</button>
   </div>
 
+  <input type="hidden" asp-for="Prompt" />
   <input type="hidden" asp-for="OptionsString" />
 
   <vc:field-name-value-display display-name="Prompt" field-value="@Model.Prompt" />


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-961

### Description
Fixed the "Edit delegate registration prompt" page so that adding a new response does not result in an error

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
