### PR TITLE
HEEDLS-891 Update bulk upload PRN logic

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -256,6 +256,13 @@ namespace DigitalLearningSolutions.Data.Tests.Services
         }
 
         [Test]
+        public void ProcessDelegateTable_has_false_HasPRN_error_for_PRN_with_value_and_false_HasPRN()
+        {
+            var row = GetSampleDelegateDataRow(hasPrn: false, prn: "PRN1234");
+            Test_ProcessDelegateTable_row_has_error(row, BulkUploadResult.ErrorReason.PrnButHasPrnIsFalse);
+        }
+
+        [Test]
         public void ProcessDelegateTable_has_invalid_PRN_characters_error_for_PRN_with_invalid_characters()
         {
             var row = GetSampleDelegateDataRow(hasPrn: true, prn: "^%£PRN");
@@ -511,6 +518,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
 
             // When
             var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId);
@@ -531,6 +541,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
 
             // When
             var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId);
@@ -635,7 +648,37 @@ namespace DigitalLearningSolutions.Data.Tests.Services
         }
 
         [Test]
-        public void ProcessDelegateTable_update_resets_delegate_PRN_if_HasPRN_is_empty()
+        public void ProcessDelegateTable_update_updates_delegate_PRN_if_HasPRN_is_null_and_PRN_has_value()
+        {
+            // Given
+            const string delegateId = "DELEGATE";
+            const string prn = "PRN1234";
+            var row = GetSampleDelegateDataRow(candidateNumber: delegateId, hasPrn: null, prn: prn);
+            var table = CreateTableFromData(new[] { row });
+            var candidateNumberDelegate = UserTestHelper.GetDefaultDelegateUser(candidateNumber: delegateId);
+
+            A.CallTo(() => userDataService.GetDelegateUserByCandidateNumber(delegateId, CentreId))
+                .Returns(candidateNumberDelegate);
+            A.CallTo(
+                () =>
+                    userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
+            ACallToUserDataServiceUpdatesDoNothing();
+
+            // When
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId);
+
+            // Then
+            A.CallTo(
+                () =>
+                    userDataService.UpdateDelegateProfessionalRegistrationNumber(candidateNumberDelegate.Id, prn, true)
+            ).MustHaveHappened();
+            result.ProcessedCount.Should().Be(1);
+            result.UpdatedCount.Should().Be(1);
+        }
+
+        [Test]
+        public void ProcessDelegateTable_update_updates_delegate_PRN_if_HasPRN_is_empty_and_PRN_does_not_have_value()
         {
             // Given
             const string delegateId = "DELEGATE";
@@ -657,8 +700,8 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             // Then
             A.CallTo(
                 () =>
-                    userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, null, false)
-            ).MustHaveHappenedOnceExactly();
+                    userDataService.UpdateDelegateProfessionalRegistrationNumber(candidateNumberDelegate.Id, null, false)
+            ).MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
             result.UpdatedCount.Should().Be(1);
         }
@@ -676,6 +719,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
 
             // When
             var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId);
@@ -719,6 +765,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
 
             // When
             var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, welcomeEmailDate);
@@ -763,6 +812,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
             A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
+            A.CallTo(
                 () => passwordResetService.GenerateAndScheduleDelegateWelcomeEmail(
                     A<string>._,
                     A<string>._,
@@ -803,6 +855,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
             A.CallTo(
                 () => passwordResetService.GenerateAndScheduleDelegateWelcomeEmail(
                     A<string>._,
@@ -900,6 +955,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(candidateNumber);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
             A.CallTo(() => userDataService.GetDelegateUserByCandidateNumber(candidateNumber, CentreId))
                 .Returns(UserTestHelper.GetDefaultDelegateUser(newDelegateRecordId));
             A.CallTo(
@@ -995,33 +1053,6 @@ namespace DigitalLearningSolutions.Data.Tests.Services
         }
 
         [Test]
-        public void ProcessDelegateTable_successful_register_does_not_update_delegate_PRN_if_HasPRN_is_empty()
-        {
-            // Given
-            const string candidateNumber = "DELEGATE";
-            const int newDelegateRecordId = 5;
-            var row = GetSampleDelegateDataRow(candidateNumber: string.Empty);
-            var table = CreateTableFromData(new[] { row });
-
-            A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
-            A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
-                .Returns(candidateNumber);
-            A.CallTo(() => userDataService.GetDelegateUserByCandidateNumber(candidateNumber, CentreId))
-                .Returns(UserTestHelper.GetDefaultDelegateUser(newDelegateRecordId));
-
-            // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId);
-
-            // Then
-            A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
-                .MustHaveHappened();
-            A.CallTo(
-                () =>
-                    userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
-            ).MustNotHaveHappened();
-        }
-
-        [Test]
         public void ProcessDelegateTable_counts_updated_correctly()
         {
             // Given
@@ -1083,6 +1114,9 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             A.CallTo(() => userService.IsDelegateEmailValidForCentre("email@test.com", CentreId)).Returns(true);
             A.CallTo(() => registrationDataService.RegisterDelegate(A<DelegateRegistrationModel>._))
                 .Returns(delegateId);
+            A.CallTo(
+                () => userDataService.UpdateDelegateProfessionalRegistrationNumber(A<int>._, A<string?>._, A<bool>._)
+            ).DoesNothing();
 
             // When
             var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId);

--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/BulkUploadResult.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/BulkUploadResult.cs
@@ -31,6 +31,7 @@
             BadFormatEmail,
             WhitespaceInEmail,
             HasPrnButMissingPrnValue,
+            PrnButHasPrnIsFalse,
             InvalidPrnLength,
             InvalidPrnCharacters,
         }

--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
@@ -147,6 +147,10 @@
             {
                 Error = BulkUploadResult.ErrorReason.HasPrnButMissingPrnValue;
             }
+            else if (HasPrn.HasValue && !HasPrn.Value && !string.IsNullOrEmpty(Prn))
+            {
+                Error = BulkUploadResult.ErrorReason.PrnButHasPrnIsFalse;
+            }
             else if (!string.IsNullOrEmpty(Prn) && (Prn.Length < 5 || Prn.Length > 20))
             {
                 Error = BulkUploadResult.ErrorReason.InvalidPrnLength;

--- a/DigitalLearningSolutions.Data/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/DelegateUploadFileService.cs
@@ -187,8 +187,7 @@ namespace DigitalLearningSolutions.Data.Services
                 UpdateUserProfessionalRegistrationNumberIfNecessary(
                     delegateRow.HasPrn,
                     delegateRow.Prn,
-                    delegateUser.Id,
-                    true
+                    delegateUser.Id
                 );
 
                 delegateRow.RowStatus = RowStatus.Updated;
@@ -221,8 +220,7 @@ namespace DigitalLearningSolutions.Data.Services
                     UpdateUserProfessionalRegistrationNumberIfNecessary(
                         delegateRow.HasPrn,
                         delegateRow.Prn,
-                        newDelegateRecord.Id,
-                        false
+                        newDelegateRecord.Id
                     );
                     SetUpSupervisorDelegateRelations(delegateRow.Email!, centreId, newDelegateRecord.Id);
                     if (welcomeEmailDate.HasValue)
@@ -240,22 +238,22 @@ namespace DigitalLearningSolutions.Data.Services
             }
         }
 
-        private void UpdateUserProfessionalRegistrationNumberIfNecessary(bool? delegateRowHasPrn, string? delegateRowPrn, int delegateId, bool isUpdate)
+        private void UpdateUserProfessionalRegistrationNumberIfNecessary(bool? delegateRowHasPrn, string? delegateRowPrn, int delegateId)
         {
-            if (delegateRowHasPrn.HasValue)
+            if (delegateRowPrn != null)
             {
                 userDataService.UpdateDelegateProfessionalRegistrationNumber(
                     delegateId,
-                    delegateRowHasPrn.Value ? delegateRowPrn : null,
+                    delegateRowPrn,
                     true
                 );
             }
-            else if (isUpdate)
+            else
             {
                 userDataService.UpdateDelegateProfessionalRegistrationNumber(
                     delegateId,
                     null,
-                    false
+                    delegateRowHasPrn.HasValue
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUploadResultsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUploadResultsViewModel.cs
@@ -63,6 +63,8 @@
                     "EmailAddress must not contain any whitespace characters",
                 BulkUploadResult.ErrorReason.HasPrnButMissingPrnValue =>
                     "HasPRN was set to true, but PRN was not provided. When HasPRN is set to true, PRN is a required field",
+                BulkUploadResult.ErrorReason.PrnButHasPrnIsFalse =>
+                    "HasPRN was set to false, but PRN was provided. When HasPRN is set to false, PRN is required to be empty",
                 BulkUploadResult.ErrorReason.InvalidPrnLength => "PRN must be between 5 and 20 characters",
                 BulkUploadResult.ErrorReason.InvalidPrnCharacters =>
                     "Invalid PRN format - Only alphanumeric characters (a-z, A-Z and 0-9) and hyphens (-) allowed",


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-891

### Description
Changed the HasPRN and PRN logic so that it still sets a PRN when one is provided and there is no value in HasPRN. Added a new validation failure for PRN provided and HasPRN false.

### Screenshots
![image](https://user-images.githubusercontent.com/59561751/174103763-c534ba73-825d-4aac-9ac1-f274d4a6e8df.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
