### PR TITLE
DLSV2-559 Fixes validation on choose supervisor

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -560,18 +560,22 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Supervisors/Add")]
         public IActionResult SetSupervisorName(AddSupervisorViewModel model)
         {
+            var sessionAddSupervisor = TempData.Peek<SessionAddSupervisor>();
             if (!ModelState.IsValid)
             {
+                var supervisors = selfAssessmentService.GetValidSupervisorsForActivity(
+               User.GetCentreId(),
+               sessionAddSupervisor.SelfAssessmentID,
+               User.GetCandidateIdKnownNotNull()
+           );
+                model.Supervisors = supervisors;
                 return View("SelfAssessments/AddSupervisor", model);
             }
-
             var supervisor = selfAssessmentService.GetSupervisorByAdminId(model.SupervisorAdminID);
-            var sessionAddSupervisor = TempData.Peek<SessionAddSupervisor>();
             if (sessionAddSupervisor == null)
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-
             sessionAddSupervisor.SupervisorAdminId = model.SupervisorAdminID;
             sessionAddSupervisor.SupervisorEmail = supervisor.Email;
             var roles = supervisorService.GetDelegateNominatableSupervisorRolesForSelfAssessment(model.SelfAssessmentID)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
@@ -43,6 +43,7 @@
 
             <input type="hidden" asp-for="SelfAssessmentID" value="@Model.SelfAssessmentID" />
             <input type="hidden" asp-for="SelfAssessmentName" value="@Model.SelfAssessmentName" />
+            <input type="hidden" asp-for="Supervisors" value="@Model.Supervisors" />
             <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
               <h2 class="nhsuk-fieldset__heading">
                 Choose a supervisor


### PR DESCRIPTION
### JIRA link
[DLSV2-559](https://info.hl7.org/orientation-station)

### Description
Fixes bug validating first step pf the add supervisor flow in self assessment manage supervisors. The model being passed back to the view on error was incomplete.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/174298190-9e8f6371-e806-4769-9e11-1cd60ee38034.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
