### PR TITLE
HEEDLS-951 Fix incorrect property type in UserCentreDetails

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -198,7 +198,7 @@
             DateTime? detailsLastChecked = null,
             int? userCentreDetailsId = null,
             string? centreSpecificEmail = null,
-            bool? centreSpecificEmailVerified = null
+            DateTime? centreSpecificEmailVerified = null
         )
         {
             dateRegistered ??= DateTime.Parse("2010-09-22 06:52:09.080");

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -199,7 +199,7 @@
             int jobGroupId,
             DateTime detailsLastChecked,
             int userId,
-            bool shouldUpdateProfileImage = false
+            bool changeMadeBySameUser = false
         )
         {
             connection.Execute(
@@ -208,11 +208,11 @@
                             FirstName = @firstName,
                             LastName = @surname,
                             PrimaryEmail = @primaryEmail,
-                            ProfileImage = (CASE WHEN @shouldUpdateProfileImage = 1 THEN @profileImage ELSE ProfileImage END),
+                            ProfileImage = (CASE WHEN @changeMadeBySameUser = 1 THEN @profileImage ELSE ProfileImage END),
                             ProfessionalRegistrationNumber = @professionalRegNumber,
                             HasBeenPromptedForPrn = @hasBeenPromptedForPrn,
                             JobGroupId = @jobGroupId,
-                            DetailsLastChecked = @detailsLastChecked
+                            DetailsLastChecked = (CASE WHEN @changeMadeBySameUser = 1 THEN @detailsLastChecked ELSE DetailsLastChecked END)
                         WHERE ID = @userId",
                 new
                 {
@@ -225,7 +225,7 @@
                     hasBeenPromptedForPrn,
                     jobGroupId,
                     detailsLastChecked,
-                    shouldUpdateProfileImage,
+                    changeMadeBySameUser,
                 }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -54,7 +54,7 @@
             int jobGroupId,
             DateTime detailsLastChecked,
             int userId,
-            bool shouldUpdateProfileImage = false
+            bool changeMadeBySameUser = false
         );
 
         void UpdateDelegateAccount(

--- a/DigitalLearningSolutions.Data/Models/User/UserCentreDetails.cs
+++ b/DigitalLearningSolutions.Data/Models/User/UserCentreDetails.cs
@@ -1,11 +1,13 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.User
 {
+    using System;
+
     public class UserCentreDetails
     {
         public int Id { get; set; }
         public int UserId { get; set; }
         public int CentreId { get; set; }
         public string? Email { get; set; }
-        public bool? EmailVerified { get; set; }
+        public DateTime? EmailVerified { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -30,7 +30,7 @@ namespace DigitalLearningSolutions.Data.Services
             DelegateDetailsData? delegateDetailsData,
             string? centreEmail,
             int centreId,
-            bool shouldUpdateProfileImage
+            bool changeMadeBySameUser
         );
 
         bool NewEmailAddressIsValid(string emailAddress, int userId);
@@ -325,7 +325,7 @@ namespace DigitalLearningSolutions.Data.Services
             DelegateDetailsData? delegateDetailsData,
             string? centreEmail,
             int centreId,
-            bool shouldUpdateProfileImage
+            bool changeMadeBySameUser
         )
         {
             var detailsLastChecked = clockService.UtcNow;
@@ -360,7 +360,7 @@ namespace DigitalLearningSolutions.Data.Services
                 editAccountDetailsData.JobGroupId,
                 detailsLastChecked,
                 editAccountDetailsData.UserId,
-                shouldUpdateProfileImage
+                changeMadeBySameUser
             );
 
             userDataService.SetCentreEmail(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -103,11 +103,15 @@
         {
             // Given
             const string email = "test@email.com";
-            var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(DelegateId);
+            var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
+                DelegateId,
+                userCentreDetailsId: 1,
+                centreSpecificEmail: email
+            );
             var formData = new EditDelegateFormData
             {
                 JobGroupId = 1,
-                Email = email,
+                CentreSpecificEmail = email,
                 HasProfessionalRegistrationNumber = false,
             };
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -200,14 +200,15 @@
         }
 
         [Test]
-        public void Index_post_saves_centre_specific_email_as_null_if_same_as_primary_email()
+        public void Index_post_saves_centre_specific_email_as_null_if_same_as_primary_email_and_centre_email_is_null()
         {
             // Given
             const string primaryEmail = "primary@email";
             var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
                 DelegateId,
                 primaryEmail: primaryEmail,
-                centreSpecificEmail: "random@email"
+                userCentreDetailsId: 1,
+                centreSpecificEmail: null
             );
             A.CallTo(() => userService.GetDelegateById(DelegateId)).Returns(delegateEntity);
 
@@ -230,6 +231,88 @@
                         A<EditAccountDetailsData>._,
                         A<DelegateDetailsData>._,
                         null,
+                        delegateEntity.DelegateAccount.CentreId,
+                        false
+                    )
+                ).MustHaveHappened();
+                result.Should().BeRedirectToActionResult().WithControllerName("ViewDelegate").WithActionName("Index");
+            }
+        }
+
+        [Test]
+        public void
+            Index_post_saves_centre_specific_email_as_null_if_same_as_primary_email_and_user_has_no_centre_details()
+        {
+            // Given
+            const string primaryEmail = "primary@email";
+            var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
+                DelegateId,
+                primaryEmail: primaryEmail,
+                userCentreDetailsId: null,
+                centreSpecificEmail: null
+            );
+            A.CallTo(() => userService.GetDelegateById(DelegateId)).Returns(delegateEntity);
+
+            var formData = new EditDelegateFormData
+            {
+                JobGroupId = 1,
+                HasProfessionalRegistrationNumber = false,
+                CentreSpecificEmail = primaryEmail,
+            };
+            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int>._)).Returns(true);
+
+            // When
+            var result = controller.Index(formData, DelegateId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                A.CallTo(
+                    () => userService.UpdateUserDetailsAndCentreSpecificDetails(
+                        A<EditAccountDetailsData>._,
+                        A<DelegateDetailsData>._,
+                        null,
+                        delegateEntity.DelegateAccount.CentreId,
+                        false
+                    )
+                ).MustHaveHappened();
+                result.Should().BeRedirectToActionResult().WithControllerName("ViewDelegate").WithActionName("Index");
+            }
+        }
+
+        [Test]
+        public void
+            Index_post_saves_centre_specific_email_as_given_value_if_same_as_primary_email_and_user_has_centre_details()
+        {
+            // Given
+            const string primaryEmail = "primary@email";
+            var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
+                DelegateId,
+                primaryEmail: primaryEmail,
+                userCentreDetailsId: 1,
+                centreSpecificEmail: primaryEmail
+            );
+            A.CallTo(() => userService.GetDelegateById(DelegateId)).Returns(delegateEntity);
+
+            var formData = new EditDelegateFormData
+            {
+                JobGroupId = 1,
+                HasProfessionalRegistrationNumber = false,
+                CentreSpecificEmail = primaryEmail,
+            };
+            A.CallTo(() => userService.NewEmailAddressIsValid(A<string>._, A<int>._)).Returns(true);
+
+            // When
+            var result = controller.Index(formData, DelegateId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                A.CallTo(
+                    () => userService.UpdateUserDetailsAndCentreSpecificDetails(
+                        A<EditAccountDetailsData>._,
+                        A<DelegateDetailsData>._,
+                        primaryEmail,
                         delegateEntity.DelegateAccount.CentreId,
                         false
                     )

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -71,8 +71,7 @@
             var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
                 DelegateId,
                 userCentreDetailsId: 1,
-                centreSpecificEmail: centreSpecificEmail,
-                centreSpecificEmailVerified: false
+                centreSpecificEmail: centreSpecificEmail
             );
             A.CallTo(() => userService.GetDelegateById(DelegateId)).Returns(delegateEntity);
 
@@ -165,8 +164,7 @@
             var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
                 DelegateId,
                 userCentreDetailsId: 1,
-                centreSpecificEmail: centreSpecificEmail,
-                centreSpecificEmailVerified: false
+                centreSpecificEmail: centreSpecificEmail
             );
             var formData = new EditDelegateFormData
             {

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
@@ -55,8 +55,7 @@
             const string centreSpecificEmail = "centre@email.com";
             var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(
                 userCentreDetailsId: 1,
-                centreSpecificEmail: centreSpecificEmail,
-                centreSpecificEmailVerified: false
+                centreSpecificEmail: centreSpecificEmail
             );
             A.CallTo(() => userService.GetDelegateById(delegateId)).Returns(delegateEntity);
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EditDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EditDelegateController.cs
@@ -86,7 +86,10 @@
                 formData.CentreSpecificEmail = null;
             }
 
-            if (!userService.NewEmailAddressIsValid(formData.CentreSpecificEmail!, delegateEntity!.UserAccount.Id))
+            if (formData.CentreSpecificEmail != null && !userService.NewEmailAddressIsValid(
+                formData.CentreSpecificEmail,
+                delegateEntity!.UserAccount.Id
+            ))
             {
                 ModelState.AddModelError(
                     nameof(EditDetailsFormData.CentreSpecificEmail),

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EditDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EditDelegateController.cs
@@ -77,8 +77,11 @@
 
             var delegateEntity = userService.GetDelegateById(delegateId);
 
-            if (formData.CentreSpecificEmail == delegateEntity!.UserAccount.PrimaryEmail ||
-                string.IsNullOrWhiteSpace(formData.CentreSpecificEmail))
+            var centreEmailDefaultsToPrimary =
+                formData.CentreSpecificEmail == delegateEntity!.UserAccount.PrimaryEmail &&
+                delegateEntity.UserCentreDetails?.Email == null;
+
+            if (centreEmailDefaultsToPrimary || string.IsNullOrWhiteSpace(formData.CentreSpecificEmail))
             {
                 formData.CentreSpecificEmail = null;
             }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EditDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EditDelegate/Index.cshtml
@@ -14,19 +14,7 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred) {
-      <vc:error-summary order-of-property-names="@(new[] {
-                                                   nameof(Model.FirstName),
-                                                   nameof(Model.LastName),
-                                                   nameof(Model.CentreSpecificEmail),
-                                                   nameof(Model.HasProfessionalRegistrationNumber),
-                                                   nameof(Model.ProfessionalRegistrationNumber),
-                                                   nameof(Model.JobGroupId),
-                                                   nameof(Model.Answer1),
-                                                   nameof(Model.Answer2),
-                                                   nameof(Model.Answer3),
-                                                   nameof(Model.Answer4),
-                                                   nameof(Model.Answer5),
-                                                   nameof(Model.Answer6) })" />
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.FirstName), nameof(Model.LastName), nameof(Model.CentreSpecificEmail), nameof(Model.HasProfessionalRegistrationNumber), nameof(Model.ProfessionalRegistrationNumber), nameof(Model.JobGroupId), nameof(Model.Answer1), nameof(Model.Answer2), nameof(Model.Answer3), nameof(Model.Answer4), nameof(Model.Answer5), nameof(Model.Answer6) })" />
     }
 
     <h1 class="nhsuk-heading-xl">Edit delegate details</h1>
@@ -62,17 +50,17 @@
                        hint-text=""
                        css-class="nhsuk-u-width-one-half" />
 
+        <vc:select-list asp-for="@nameof(Model.JobGroupId)"
+                        label="Job group"
+                        value="@Model.JobGroupId.ToString()"
+                        hint-text=""
+                        deselectable="false"
+                        css-class="nhsuk-u-width-one-half"
+                        default-option="Select a job group"
+                        select-list-options="@Model.JobGroups" />
+
         <partial name="_EditRegistrationNumber" model="@Model" />
       </div>
-
-      <vc:select-list asp-for="@nameof(Model.JobGroupId)"
-                      label="Job group"
-                      value="@Model.JobGroupId.ToString()"
-                      hint-text=""
-                      deselectable="false"
-                      css-class="nhsuk-u-width-one-half"
-                      default-option="Select a job group"
-                      select-list-options="@Model.JobGroups" />
 
       @foreach (var customField in Model.CustomFields) {
         @if (customField.Options.Any()) {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EditDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EditDelegate/Index.cshtml
@@ -14,7 +14,19 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred) {
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.FirstName), nameof(Model.LastName), nameof(Model.CentreSpecificEmail), nameof(Model.HasProfessionalRegistrationNumber), nameof(Model.ProfessionalRegistrationNumber), nameof(Model.JobGroupId), nameof(Model.Answer1), nameof(Model.Answer2), nameof(Model.Answer3), nameof(Model.Answer4), nameof(Model.Answer5), nameof(Model.Answer6) })" />
+      <vc:error-summary order-of-property-names="@(new[] {
+                                                   nameof(Model.FirstName),
+                                                   nameof(Model.LastName),
+                                                   nameof(Model.CentreSpecificEmail),
+                                                   nameof(Model.JobGroupId),
+                                                   nameof(Model.HasProfessionalRegistrationNumber),
+                                                   nameof(Model.ProfessionalRegistrationNumber),
+                                                   nameof(Model.Answer1),
+                                                   nameof(Model.Answer2),
+                                                   nameof(Model.Answer3),
+                                                   nameof(Model.Answer4),
+                                                   nameof(Model.Answer5),
+                                                   nameof(Model.Answer6) })" />
     }
 
     <h1 class="nhsuk-heading-xl">Edit delegate details</h1>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-951

### Description

- Fix incorrect typing on UserCentreDetails.EmailVerified causing exception in Edit Delegate page
- Move Job group above PRN to match the Edit details page
- Change data service so Users.DetailsLastChecked is not updated in this journey
- Adjust email saving logic so if the admin does not edit the centre email from the primary email default, no new centre email is saved. But if the admin changes a delegate's centre email to match the primary email, this is saved as their centre email rather than clearing the value.

### Screenshots
![localhost_5001_TrackingSystem_Delegates_33463_Edit](https://user-images.githubusercontent.com/70278044/174784589-adc57365-6b35-4300-bcf2-07ea1f1398fd.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
