### PR TITLE
HEEDLS-962 Add prompt name on ConfigureAnswers page

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -277,11 +277,11 @@
             }
 
             if (centreRegistrationPromptsService.AddCentreRegistrationPrompt(
-                User.GetCentreId(),
-                data.SelectPromptViewModel.CustomPromptId!.Value,
-                data.SelectPromptViewModel.Mandatory,
-                data.ConfigureAnswersViewModel.OptionsString
-            ))
+                    User.GetCentreId(),
+                    data.SelectPromptViewModel.CustomPromptId!.Value,
+                    data.SelectPromptViewModel.Mandatory,
+                    data.ConfigureAnswersViewModel.OptionsString
+                ))
             {
                 TempData.Clear();
                 return RedirectToAction("Index");

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
-    using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
@@ -189,6 +188,8 @@
         {
             var data = TempData.Peek<AddRegistrationPromptData>()!;
             var viewModel = data.ConfigureAnswersViewModel;
+            viewModel.PromptName = centreRegistrationPromptsService.GetCentreRegistrationPromptsAlphabeticalList()
+                .Single(c => c.id == data.SelectPromptViewModel.CustomPromptId).value;
 
             return View(viewModel);
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswersViewModel.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Configuration.RegistrationPrompts
 {
-    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
@@ -28,6 +27,8 @@
         public string? Answer { get; set; }
 
         public bool IncludeAnswersTableCaption { get; set; }
+
+        public string? PromptName { get; set; }
 
         private IEnumerable<string> ComparableOptions => NewlineSeparatedStringListHelper
             .SplitNewlineSeparatedList(OptionsString)

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -14,7 +14,7 @@
     }
 
     <h1 class="nhsuk-heading-xl">Configure responses</h1>
-    <vc:field-name-value-display display-name="Prompt" field-value="@Model.PromptName"/>
+    <vc:field-name-value-display display-name="Prompt" field-value="@Model.PromptName" />
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
       <div class="hidden-submit">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Configuration/RegistrationPrompts/AddRegistrationPromptConfigureAnswers.cshtml
@@ -14,6 +14,7 @@
     }
 
     <h1 class="nhsuk-heading-xl">Configure responses</h1>
+    <vc:field-name-value-display display-name="Prompt" field-value="@Model.PromptName"/>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddRegistrationPromptConfigureAnswers">
       <div class="hidden-submit">


### PR DESCRIPTION
### JIRA link
[HEEDLS-962](https://softwiretech.atlassian.net/browse/HEEDLS-962)

### Description
I added the prompt name on the ConfigureAnswers page in the add registration prompt journey.

### Screenshots
![image](https://user-images.githubusercontent.com/105208326/174745876-ef638934-5cce-427c-b02c-38b8dba6a093.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
