### PR TITLE
HEEDLS-959 Clear old ResetPasswordIDs on admins

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/RecurringSqlJobs/DeleteResetPasswordRecordsOlderThan4Days.sql
+++ b/DigitalLearningSolutions.Data.Migrations/RecurringSqlJobs/DeleteResetPasswordRecordsOlderThan4Days.sql
@@ -1,5 +1,11 @@
 ﻿-- Deletes ResetPassword records older than 4 days. Should be run every night at 3AM.
 BEGIN
+UPDATE au
+SET au.ResetPasswordID = NULL FROM AdminUsers AS au
+INNER JOIN ResetPassword AS r
+ON r.ID = au.ResetPasswordID
+WHERE r.PasswordResetDateTime < DATEADD(day, -4, GETDATE())
+
 UPDATE c
 SET c.ResetPasswordID = NULL FROM Candidates AS c
 INNER JOIN ResetPassword AS r


### PR DESCRIPTION
### JIRA link
[_HEEDLS-959_](https://softwiretech.atlassian.net/browse/HEEDLS-959)

### Description
Clear ResetPasswordIDs on AdminUsers as well as Candidates.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
