### PR TITLE
UAR-906 - Implemented Reregistering functionality

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
@@ -51,7 +51,7 @@
                 delegateRegistrationModel,
                 false
             );
-            
+
             // Then
             var delegateEntity = userDataService.GetDelegateByCandidateNumber(candidateNumber);
             using (new AssertionScope())
@@ -89,7 +89,7 @@
                 delegateRegistrationModel,
                 true
             );
-           
+
             // Then
             var delegateEntity = userDataService.GetDelegateByCandidateNumber(candidateNumber);
             using (new AssertionScope())
@@ -193,6 +193,181 @@
             userCentreDetailsCount.Should().Be(0);
             candidateNumber.Should().Be("FS352");
             user.CandidateNumber.Should().Be("FS352");
+        }
+
+        [Test]
+        public void ReregisterDelegateAccountAndCentreDetailForExistingUser_sets_all_fields_correctly_on_registration()
+        {
+            using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            // Given
+            var delegateRegistrationModel =
+                RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel(
+                    "forename",
+                    "surname",
+                    "test@gmail.com",
+                    active: true,
+                    approved: false
+                );
+            var currentTime = new DateTime(2022, 06, 27, 11, 03, 12);
+            const int userId = 281052;
+            const int existingDelegateId = 142559;
+
+            // When
+            var userBeforeUpdate = userDataService.GetUserAccountById(userId);
+            var delegateBeforeUpdate = userDataService.GetDelegateAccountById(existingDelegateId);
+            service.ReregisterDelegateAccountAndCentreDetailForExistingUser(
+                delegateRegistrationModel,
+                userId,
+                existingDelegateId,
+                currentTime
+            );
+
+            // Then
+            var userAfterUpdate = userDataService.GetUserAccountById(userId);
+            var delegateAfterUpdate = userDataService.GetDelegateAccountById(existingDelegateId);
+            using (new AssertionScope())
+            {
+                var oldDateRegistered = new DateTime(2014, 12, 24, 10, 44, 53, 257);
+                var oldCentreSpecificDetailsLastChecked = new DateTime(2022, 04, 27, 16, 31, 29, 897);
+                userBeforeUpdate.Should().NotBeNull();
+                delegateBeforeUpdate.Should().NotBeNull();
+                userAfterUpdate.Should().NotBeNull();
+                delegateAfterUpdate.Should().NotBeNull();
+                userBeforeUpdate!.Id.Should().Be(userId);
+                userBeforeUpdate.FirstName.Should().Be("xxxx");
+                userBeforeUpdate.LastName.Should().Be("xxxx");
+                userBeforeUpdate.PrimaryEmail.Should().Be("noe");
+                userBeforeUpdate.DetailsLastChecked.Should().BeNull();
+                userBeforeUpdate.JobGroupId.Should().Be(4);
+                userBeforeUpdate.PasswordHash.Should().BeEmpty();
+                userBeforeUpdate.ProfessionalRegistrationNumber.Should().BeNull();
+
+                userAfterUpdate!.Id.Should().Be(userBeforeUpdate.Id);
+                userAfterUpdate.FirstName.Should().Be(userBeforeUpdate.FirstName);
+                userAfterUpdate.LastName.Should().Be(userBeforeUpdate.LastName);
+                userAfterUpdate.PrimaryEmail.Should().Be(userBeforeUpdate.PrimaryEmail);
+                userAfterUpdate.DetailsLastChecked.Should().Be(userBeforeUpdate.DetailsLastChecked);
+                userAfterUpdate.JobGroupId.Should().Be(userBeforeUpdate.JobGroupId);
+                userAfterUpdate.PasswordHash.Should().Be(userBeforeUpdate.PasswordHash);
+                userAfterUpdate.ProfessionalRegistrationNumber.Should()
+                    .Be(userBeforeUpdate.ProfessionalRegistrationNumber);
+
+                delegateBeforeUpdate!.CentreId.Should().Be(121);
+                delegateBeforeUpdate.Id.Should().Be(existingDelegateId);
+                delegateBeforeUpdate.CandidateNumber.Should().Be("LP497");
+                delegateBeforeUpdate.OldPassword.Should().BeNull();
+                delegateBeforeUpdate.UserId.Should().Be(userId);
+                delegateBeforeUpdate.Answer1.Should().BeNull();
+                delegateBeforeUpdate.Answer2.Should().Be("xxxxxxxxxxxx");
+                delegateBeforeUpdate.Answer3.Should().BeNull();
+                delegateBeforeUpdate.Answer4.Should().BeNull();
+                delegateBeforeUpdate.Answer5.Should().BeNull();
+                delegateBeforeUpdate.Answer6.Should().BeNull();
+                delegateBeforeUpdate.Active.Should().BeFalse();
+                delegateBeforeUpdate.Approved.Should().BeTrue();
+                delegateBeforeUpdate.ExternalReg.Should().BeFalse();
+                delegateBeforeUpdate.SelfReg.Should().BeFalse();
+                delegateBeforeUpdate.DateRegistered.Should().Be(oldDateRegistered);
+                delegateBeforeUpdate.CentreSpecificDetailsLastChecked.Should().Be(oldCentreSpecificDetailsLastChecked);
+
+                delegateAfterUpdate!.CentreId.Should().Be(delegateBeforeUpdate.CentreId);
+                delegateAfterUpdate.Id.Should().Be(existingDelegateId);
+                delegateAfterUpdate.CandidateNumber.Should().Be(delegateBeforeUpdate.CandidateNumber);
+                delegateAfterUpdate.OldPassword.Should().Be(delegateBeforeUpdate.OldPassword);
+                delegateAfterUpdate.UserId.Should().Be(userId);
+                delegateAfterUpdate.Answer1.Should().Be(delegateRegistrationModel.Answer1);
+                delegateAfterUpdate.Answer2.Should().Be(delegateRegistrationModel.Answer2);
+                delegateAfterUpdate.Answer3.Should().Be(delegateRegistrationModel.Answer3);
+                delegateAfterUpdate.Answer4.Should().Be(delegateRegistrationModel.Answer4);
+                delegateAfterUpdate.Answer5.Should().Be(delegateRegistrationModel.Answer5);
+                delegateAfterUpdate.Answer6.Should().Be(delegateRegistrationModel.Answer6);
+                delegateAfterUpdate.Active.Should().Be(delegateRegistrationModel.Active);
+                delegateAfterUpdate.Approved.Should().Be(delegateRegistrationModel.Approved);
+                delegateAfterUpdate.ExternalReg.Should().Be(delegateBeforeUpdate.ExternalReg);
+                delegateAfterUpdate.SelfReg.Should().Be(delegateBeforeUpdate.SelfReg);
+                delegateAfterUpdate.DateRegistered.Should().Be(delegateBeforeUpdate.DateRegistered);
+                delegateAfterUpdate.CentreSpecificDetailsLastChecked.Should().Be(currentTime);
+            }
+        }
+
+        [Test]
+        public void
+            ReregisterDelegateAccountAndCentreDetailForExistingUser_does_create_UserCentreDetails_with_non_null_centre_specific_email()
+        {
+            using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            // Given
+            var currentTime = new DateTime(2022, 06, 27, 11, 03, 12);
+            const int userId = 281052;
+            const int existingDelegateId = 142559;
+            const int centreId = 121;
+            var newCentreEmail = "newCentreEmailTest@test.com";
+            var delegateRegistrationModel =
+                RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel(
+                    "forename",
+                    "surname",
+                    "test@gmail.com",
+                    centreId,
+                    centreSpecificEmail: newCentreEmail
+                );
+
+            // When
+            service.ReregisterDelegateAccountAndCentreDetailForExistingUser(
+                delegateRegistrationModel,
+                userId,
+                existingDelegateId,
+                currentTime
+            );
+
+            // Then
+            var userCentreDetails = connection.GetEmailAndVerifiedDateFromUserCentreDetails(userId, centreId);
+            userCentreDetails.email.Should().Be(newCentreEmail);
+            userCentreDetails.emailVerified.Should().BeNull();
+        }
+
+        [Test]
+        public async Task
+            ReregisterDelegateAccountAndCentreDetailForExistingUser_sets_existing_UserCentreDetails_email_to_null_when_input_email_is_null()
+        {
+            using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            // Given
+            var currentTime = new DateTime(2022, 06, 27, 11, 03, 12);
+            const int userId = 281052;
+            const int existingDelegateId = 142559;
+            const int centreId = 121;
+            const string existingEmail = "existingEmail@test.com";
+            var existingEmailVerified = new DateTime(2022, 10, 4, 12, 12, 12);
+            var delegateRegistrationModel =
+                RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel(
+                    "forename",
+                    "surname",
+                    "test@gmail.com",
+                    centreId,
+                    centreSpecificEmail: null
+                );
+
+            // When
+            await connection.InsertUserCentreDetails(userId, centreId, existingEmail, existingEmailVerified);
+            var existingUserCentreDetails = connection.GetEmailAndVerifiedDateFromUserCentreDetails(userId, centreId);
+
+            service.ReregisterDelegateAccountAndCentreDetailForExistingUser(
+                delegateRegistrationModel,
+                userId,
+                existingDelegateId,
+                currentTime
+            );
+            var userCentreDetails = connection.GetEmailAndVerifiedDateFromUserCentreDetails(userId, centreId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                existingUserCentreDetails.email.Should().Be(existingEmail);
+                existingUserCentreDetails.emailVerified.Should().Be(existingEmailVerified);
+                userCentreDetails.email.Should().BeNull();
+                userCentreDetails.emailVerified.Should().BeNull();
+            }
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/UserTestHelper.cs
@@ -478,7 +478,10 @@
             );
         }
 
-        public static void SetAdminToInactiveWithCentreManagerAndSuperAdminPermissions(this DbConnection connection, int adminId)
+        public static void SetAdminToInactiveWithCentreManagerAndSuperAdminPermissions(
+            this DbConnection connection,
+            int adminId
+        )
         {
             connection.Execute(
                 @"UPDATE AdminUsers SET
@@ -568,6 +571,32 @@
             await connection.ExecuteAsync(
                 @"UPDATE DelegateAccounts SET OldPassword = @oldPassword WHERE UserID = @userId;",
                 new { oldPassword = "old password", userId = user.Id }
+            );
+        }
+
+        public static async Task InsertUserCentreDetails(
+            this DbConnection connection,
+            int userId,
+            int centreId,
+            string? email,
+            DateTime? emailVerified = null
+        )
+        {
+            await connection.ExecuteAsync(
+                @"INSERT INTO UserCentreDetails (UserID, CentreID, Email, EmailVerified)
+                    VALUES (@userId, @centreId, @email, @emailVerified)",
+                new { userId, centreId, email, emailVerified }
+            );
+        }
+
+        public static (string? email, DateTime? emailVerified) GetEmailAndVerifiedDateFromUserCentreDetails(
+            this DbConnection connection,
+            int userId,
+            int centreId
+        )
+        {
+            return connection.QuerySingle<(string? email, DateTime? emailVerified)>(
+                $"SELECT Email, EmailVerified FROM UserCentreDetails WHERE CentreID = {centreId} AND UserID = {userId}"
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -23,6 +23,13 @@
             IDbTransaction? transaction = null
         );
 
+        void ReregisterDelegateAccountAndCentreDetailForExistingUser(
+            DelegateRegistrationModel delegateRegistrationModel,
+            int userId,
+            int delegateId,
+            DateTime currentTime
+        );
+
         int RegisterAdmin(AdminRegistrationModel registrationModel, int userId);
     }
 
@@ -30,8 +37,8 @@
     {
         private readonly IClockService clockService;
         private readonly IDbConnection connection;
-        private readonly IUserDataService userDataService;
         private readonly ILogger<IRegistrationDataService> logger;
+        private readonly IUserDataService userDataService;
 
         public RegistrationDataService(
             IDbConnection connection,
@@ -112,6 +119,35 @@
             }
 
             return (delegateId, candidateNumber);
+        }
+
+        public void ReregisterDelegateAccountAndCentreDetailForExistingUser(
+            DelegateRegistrationModel delegateRegistrationModel,
+            int userId,
+            int delegateId,
+            DateTime currentTime
+        )
+        {
+            connection.EnsureOpen();
+            var transaction = connection.BeginTransaction();
+
+            userDataService.SetCentreEmail(
+                userId,
+                delegateRegistrationModel.Centre,
+                delegateRegistrationModel.CentreSpecificEmail,
+                transaction
+            );
+
+            ReregisterDelegateAccount(
+                delegateRegistrationModel,
+                delegateId,
+                currentTime,
+                transaction
+            );
+
+            // TODO HEEDLS-874 deal with group assignment
+
+            transaction.Commit();
         }
 
         public int RegisterAdmin(AdminRegistrationModel registrationModel, int userId)
@@ -359,6 +395,44 @@
             }
 
             return (delegateId, candidateNumber);
+        }
+
+        private void ReregisterDelegateAccount(
+            DelegateRegistrationModel delegateRegistrationModel,
+            int delegateId,
+            DateTime currentTime,
+            IDbTransaction transaction
+        )
+        {
+            var newDelegateValues = new
+            {
+                delegateId,
+                delegateRegistrationModel.Answer1,
+                delegateRegistrationModel.Answer2,
+                delegateRegistrationModel.Answer3,
+                delegateRegistrationModel.Answer4,
+                delegateRegistrationModel.Answer5,
+                delegateRegistrationModel.Answer6,
+                delegateRegistrationModel.Approved,
+                delegateRegistrationModel.Active,
+                CentreSpecificDetailsLastChecked = currentTime,
+            };
+
+            connection.Execute(
+                @"UPDATE DelegateAccounts SET
+                            Answer1 = @answer1,
+                            Answer2 = @answer2,
+                            Answer3 = @answer3,
+                            Answer4 = @answer4,
+                            Answer5 = @answer5,
+                            Answer6 = @answer6,
+                            Approved = @approved,
+                            Active = @active,
+                            CentreSpecificDetailsLastChecked = @centreSpecificDetailsLastChecked
+                        WHERE ID = @delegateId",
+                newDelegateValues,
+                transaction
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/DelegateCreationError.cs
+++ b/DigitalLearningSolutions.Data/Enums/DelegateCreationError.cs
@@ -4,16 +4,19 @@
     {
         public static DelegateCreationError UnexpectedError = new DelegateCreationError(
             1,
-            nameof(UnexpectedError),
-            "-1"
+            nameof(UnexpectedError)
         );
 
         public static DelegateCreationError EmailAlreadyInUse = new DelegateCreationError(
             2,
-            nameof(EmailAlreadyInUse),
-            "-4"
+            nameof(EmailAlreadyInUse)
         );
 
-        private DelegateCreationError(int id, string name, string storedProcedureErrorCode) : base(id, name) { }
+        public static DelegateCreationError ActiveAccountAlreadyExists = new DelegateCreationError(
+            3,
+            nameof(ActiveAccountAlreadyExists)
+        );
+
+        private DelegateCreationError(int id, string name) : base(id, name) { }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAtNewCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAtNewCentreController.cs
@@ -102,13 +102,11 @@
             {
                 var delegateAccount = userService.GetUserById(User.GetUserIdKnownNotNull())!.DelegateAccounts
                     .SingleOrDefault(da => da.CentreId == model.Centre);
-                if (delegateAccount != null)
+                if (delegateAccount?.Active == true)
                 {
                     ModelState.AddModelError(
                         nameof(InternalPersonalInformationViewModel.Centre),
-                        delegateAccount.Active
-                            ? "You are already registered at this centre"
-                            : "You already have an inactive account at this centre - you can reactivate it via the Switch centre page"
+                        "You are already registered at this centre"
                     );
                 }
             }
@@ -299,9 +297,9 @@
         private void ValidateEmailAddress(InternalPersonalInformationViewModel model)
         {
             if (model.CentreSpecificEmail != null && !userService.NewEmailAddressIsValid(
-                    model.CentreSpecificEmail,
-                    User.GetUserIdKnownNotNull()
-                ))
+                model.CentreSpecificEmail,
+                User.GetUserIdKnownNotNull()
+            ))
             {
                 ModelState.AddModelError(
                     nameof(PersonalInformationViewModel.CentreSpecificEmail),

--- a/DigitalLearningSolutions.Web/Views/Login/ChooseACentre.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/ChooseACentre.cshtml
@@ -72,10 +72,10 @@
                   </button>
                 </form>
               } else if (centreRow.Status.ActionButton == ChooseACentreButton.Reactivate) {
-                @* TODO HEEDLS-906: Link to Reactivate centre account page *@
-                <button class="nhsuk-button nhsuk-u-margin-bottom-3 nhsuk-u-padding-bottom-0 nhsuk-u-padding-top-0 nhsuk-u-margin-top-0">
-                  Reactivate <span class="nhsuk-u-visually-hidden">@centreRow.CentreName</span>
-                </button>
+                var reactivateRouteData = new Dictionary<string, string> {{"centreId", centreRow.CentreId.ToString()}};
+                <a asp-controller="RegisterAtNewCentre" asp-action="Index" asp-all-route-data="@reactivateRouteData" class="nhsuk-button nhsuk-u-margin-bottom-3 nhsuk-u-padding-bottom-0 nhsuk-u-padding-top-0 nhsuk-u-margin-top-0">
+                  Reregister <span class="nhsuk-u-visually-hidden">@centreRow.CentreName</span>
+                </a>
               } else {
                 <span class="nhsuk-u-visually-hidden">You cannot log in to this centre.</span>
               }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-906

### Description
Modified the Internal Registration journey to allow users with inactive delegate accounts to reregister. Changed the "Reactivate" button to read "Reregister" and hooked it up to that journey.

### Screenshots
![image](https://user-images.githubusercontent.com/80777689/175950931-fb342dab-c39e-4127-8f36-bad4c1ca5a56.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
