### PR TITLE
DLSV2-482 Custom self assessment reviewer comments label

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202202140841_AddReviewerCommentsFieldToSelfassessment.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202202140841_AddReviewerCommentsFieldToSelfassessment.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202202140841)]
+    public class AddReviewerCommentsFieldToSelfassessment : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments")
+                .AddColumn("ReviewerCommentsLabel").AsString(50).Nullable();
+        }
+
+        public override void Down()
+        {            
+            Delete.Column("ReviewerCommentsLabel").FromTable("SelfAssessments");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -17,6 +17,7 @@
                         SA.Description,
                         SA.IncludesSignposting,
                         SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
+                        SA.ReviewerCommentsLabel,
                         COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
                         COUNT(C.ID) AS NumberOfCompetencies,
                         CA.StartedDate,
@@ -38,6 +39,7 @@
                     WHERE CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
+                        SA.ReviewerCommentsLabel,
                         COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID,
                         CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate",
@@ -56,6 +58,7 @@
                         SA.DescriptionLabel,
                         SA.IncludesSignposting,
                         SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
+                        SA.ReviewerCommentsLabel,
                         SA.SupervisorSelfAssessmentReview,
                         SA.EnforceRoleRequirementsForSignOff,
                         COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
@@ -112,7 +115,8 @@
                         CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID, CA.UserBookmark, CA.UnprocessedUpdates,
                         CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders,
-                        SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview, SA.EnforceRoleRequirementsForSignOff, SA.ManageSupervisorsDescription",
+                        SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview,
+                        SA.ReviewerCommentsLabel, SA.EnforceRoleRequirementsForSignOff, SA.ManageSupervisorsDescription",
                 new { candidateId, selfAssessmentId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -200,7 +200,8 @@
                         sar.ID,
                         sstrc.CompetencyGroupID,
                         sea.Vocabulary,
-                        sasv.SignedOff
+                        sasv.SignedOff,
+                        sea.ReviewerCommentsLabel
                     FROM SelfAssessmentResultSupervisorVerifications AS sasv
                     INNER JOIN SelfAssessmentResults AS sar
                         ON sasv.SelfAssessmentResultId = sar.ID

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -17,5 +17,6 @@
         public string? SignOffRequestorStatement { get; set; }
         public bool EnforceRoleRequirementsForSignOff { get; set; }
         public string? ManageSupervisorsDescription { get; set; }
+        public string? ReviewerCommentsLabel { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SupervisorComment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SupervisorComment.cs
@@ -17,5 +17,6 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
         public int? CompetencyGroupID { get; set; }
         public string? Vocabulary { get; set; }
         public bool SignedOff { get; set; }
+        public string? ReviewerCommentsLabel { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
@@ -19,6 +19,7 @@
         public string? ProfessionalGroup { get; set; }
         public string? QuestionLabel { get; set; }
         public string? DescriptionLabel { get; set; }
+        public string? ReviewerCommentsLabel { get; set; }
         public string? SubGroup { get; set; }
         public string? RoleProfile { get; set; }
         public int SignOffRequested { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -276,7 +276,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
         public DelegateSelfAssessment GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId)
         {
             return connection.Query<DelegateSelfAssessment>(
-               @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.QuestionLabel, sa.DescriptionLabel,
+               @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.QuestionLabel, sa.DescriptionLabel, sa.ReviewerCommentsLabel,
                 sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, ca.StartedDate,
                 COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed,
                 ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate,
@@ -574,7 +574,7 @@ WHERE (ca.SelfAssessmentID = @selfAssessmentId) AND (cas.SupervisorDelegateId = 
             connection.Execute(@"UPDATE SelfAssessmentResultSupervisorVerifications SET Superceded = 1 WHERE CandidateAssessmentSupervisorID = @candidateAssessmentSupervisorId AND SelfAssessmentResultId = @resultId", new { candidateAssessmentSupervisorId, resultId });
             //Insert a new SelfAssessmentResultSupervisorVerifications record:
             var numberOfAffectedRows = connection.Execute(
-                     @"INSERT INTO SelfAssessmentResultSupervisorVerifications (CandidateAssessmentSupervisorID, SelfAssessmentResultId, EmailSent) VALUES (@candidateAssessmentSupervisorId, @resultId, GETUTCDATE())",  new { candidateAssessmentSupervisorId, resultId });
+                     @"INSERT INTO SelfAssessmentResultSupervisorVerifications (CandidateAssessmentSupervisorID, SelfAssessmentResultId, EmailSent) VALUES (@candidateAssessmentSupervisorId, @resultId, GETUTCDATE())", new { candidateAssessmentSupervisorId, resultId });
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
@@ -597,7 +597,7 @@ WHERE (ca.SelfAssessmentID = @selfAssessmentId) AND (cas.SupervisorDelegateId = 
         public SelfAssessmentResultSummary GetSelfAssessmentResultSummary(int candidateAssessmentId, int supervisorDelegateId)
         {
             return connection.Query<SelfAssessmentResultSummary>(
-                @"SELECT ca.ID, ca.SelfAssessmentID, sa.Name AS RoleName, COALESCE (sasr.SelfAssessmentReview, 1) AS SelfAssessmentReview, COALESCE (sasr.ResultsReview, 1) AS SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, 
+                @"SELECT ca.ID, ca.SelfAssessmentID, sa.Name AS RoleName, sa.ReviewerCommentsLabel, COALESCE (sasr.SelfAssessmentReview, 1) AS SelfAssessmentReview, COALESCE (sasr.ResultsReview, 1) AS SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, 
              ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, npg.ProfessionalGroup, nsg.SubGroup, nr.RoleProfile, casv.ID AS CandidateAssessmentSupervisorVerificationId,
                  (SELECT COUNT(sas1.CompetencyID) AS CompetencyAssessmentQuestionCount
                  FROM    SelfAssessmentStructure AS sas1 INNER JOIN

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -349,7 +349,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
         public DelegateSelfAssessment GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId)
         {
             return connection.Query<DelegateSelfAssessment>(
-                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup, sa.SupervisorResultsReview AS IsSupervisorResultsReviewed,
+                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, sa.ReviewerCommentsLabel, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup, sa.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -177,7 +177,8 @@
             }
         </p>
         <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
-        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
+        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
+        view-data="@(new ViewDataDictionary(ViewData) { { "reviewerCommentsLabel", (Model.SelfAssessment.ReviewerCommentsLabel == null ? "Comments": Model.SelfAssessment.ReviewerCommentsLabel) } })" />
         @if (Model.AllQuestionsVerifiedOrNotRequired())
         {
             @if (!Model.SupervisorSignOffs.Any())

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SignOffHistory.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SignOffHistory.cshtml
@@ -22,7 +22,8 @@
 }
   <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
   <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/pagination.css")" asp-append-version="true">
-  <partial name="../../Supervisor/Shared/_SignOffHistory.cshtml" model="@Model.SupervisorSignOffs" />
+  <partial name="../../Supervisor/Shared/_SignOffHistory.cshtml" model="@Model.SupervisorSignOffs"
+  view-data="@(new ViewDataDictionary(ViewData) { {"reviewerCommentsLabel", (Model.SelfAssessment.ReviewerCommentsLabel == null ? "Comments": Model.SelfAssessment.ReviewerCommentsLabel) } })" />
   <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="SelfAssessmentOverview" asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
       <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SupervisorComments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SupervisorComments.cshtml
@@ -78,7 +78,7 @@
       </div>
       <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
-          Confirmer comments
+          @(Model.SupervisorComment.ReviewerCommentsLabel == null ? "Reviewer comments": Model.SupervisorComment.ReviewerCommentsLabel.ToString())
         </dt>
         <dd class="nhsuk-summary-list__value">
           @Model.SupervisorComment.Comments

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -147,7 +147,7 @@
                     </legend>
                     <input name="ResultSupervisorVerificationId" type="hidden" asp-for="ResultSupervisorVerificationId" />
                     <nhs-form-group nhs-validation-for="SupervisorComments">
-                        <vc:text-area asp-for="SupervisorComments" character-count="null" label="Reviewer comments" rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
+                        <vc:text-area asp-for="SupervisorComments" character-count="null" label=@(Model.DelegateSelfAssessment.ReviewerCommentsLabel == null ? "Reviewer comments": Model.DelegateSelfAssessment.ReviewerCommentsLabel.ToString()) rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
                     </nhs-form-group>
 
                     <nhs-form-group nhs-validation-for="SignedOff">
@@ -228,7 +228,7 @@ else if (ViewContext.RouteData.Values["viewMode"].ToString() == "View" && Model.
             {
                 <div class="nhsuk-summary-list__row">
                 <dt class="nhsuk-summary-list__key">
-                    Reviewer comments
+                    @(Model.DelegateSelfAssessment.ReviewerCommentsLabel == null ? "Reviewer comments": Model.DelegateSelfAssessment.ReviewerCommentsLabel.ToString())
                 </dt>
                 <dd class="nhsuk-summary-list__value">
                         @Html.Raw(Model.SupervisorComments)

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -155,7 +155,8 @@
   {
     <div class="nhsuk-u-margin-top-4">
       <h3>Self Assessment Sign-off Status</h3>
-      <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
+      <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs"
+      view-data="@(new ViewDataDictionary(ViewData) { { "reviewerCommentsLabel", (Model.DelegateSelfAssessment.ReviewerCommentsLabel == null ? "Comments": Model.DelegateSelfAssessment.ReviewerCommentsLabel) } })" />
     </div>
   }
   @if (Model.CompetencyGroups.Any())

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SignOffHistory.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SignOffHistory.cshtml
@@ -14,7 +14,7 @@
           Status
         </th>
         <th role="columnheader" class="" scope="col">
-          Comments
+          @ViewData["reviewerCommentsLabel"]
         </th>
       </tr>
     </thead>
@@ -38,7 +38,7 @@
               <span class="nhsuk-tag nhsuk-tag--red">Rejected @supervisorSignOff.Verified.Value.ToShortDateString()</span>}
           </td>
           <td role="cell" class="nhsuk-table__cell">
-            <span class="nhsuk-table-responsive__heading">Comments </span>@supervisorSignOff.Comments
+            <span class="nhsuk-table-responsive__heading">@ViewData["reviewerCommentsLabel"]</span>@supervisorSignOff.Comments
           </td>
         </tr>
       }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -55,7 +55,7 @@
     </div>
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Comments
+      @ViewData["reviewerCommentsLabel"]
     </dt>
     <dd class="nhsuk-summary-list__value">
       @Model.FirstOrDefault().Comments

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffHistory.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffHistory.cshtml
@@ -1,53 +1,54 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor
 @{
-  ViewData["Title"] = "Review Profile Assessment";
-  ViewData["Application"] = "Supervisor";
+    ViewData["Title"] = "Review Profile Assessment";
+    ViewData["Application"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+<partial name="Shared/_NavMenuItems" />
 }
 @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+<nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-             asp-action="DelegateProfileAssessments"
-             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
-          </li>
-          <li class="nhsuk-breadcrumb__item">
-            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-               asp-action="ReviewDelegateSelfAssessment"
-               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-               asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-              @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
-            </a>
-          </li>
-          <li>
-            Sign-off History
-          </li>
+        <ol class="nhsuk-breadcrumb__list">
+            <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+            <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+            <li class="nhsuk-breadcrumb__item">
+                <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+            </li>
+            <li class="nhsuk-breadcrumb__item">
+                <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="ReviewDelegateSelfAssessment"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+                   asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+                    @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+                </a>
+            </li>
+            <li>
+                Sign-off History
+            </li>
         </ol>
-      </div>
-      <p class="nhsuk-breadcrumb__back">
+    </div>
+    <p class="nhsuk-breadcrumb__back">
         <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
            asp-action="ReviewDelegateSelfAssessment"
            asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
            asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-          Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
-      Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
+            Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
+            Model.DelegateSelfAssessment.RoleName.Substring(0,32) + "..." : Model.DelegateSelfAssessment.RoleName )
         </a>
-      </p>
-    </nav>
+    </p>
+</nav>
 }
-<partial name="Shared/_SignOffHistory" model="@Model.SupervisorSignOffs" />
+<partial name="Shared/_SignOffHistory" model="@Model.SupervisorSignOffs"
+         view-data="@(new ViewDataDictionary(ViewData) { {"reviewerCommentsLabel", (Model.DelegateSelfAssessment.ReviewerCommentsLabel == null ? "Comments": Model.DelegateSelfAssessment.ReviewerCommentsLabel) } })" />
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
-  </a>
+    <a class="nhsuk-back-link__link" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
@@ -165,7 +165,7 @@
         </legend>
         <input type="hidden" asp-for="CandidateAssessmentSupervisorVerificationId" />
         <nhs-form-group nhs-validation-for="SupervisorComments">
-          <vc:text-area asp-for="SupervisorComments" character-count="null" label="Reviewer comments" rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
+          <vc:text-area asp-for="SupervisorComments" character-count="null" label=@(Model.SelfAssessmentResultSummary.ReviewerCommentsLabel == null ? "Reviewer comments": Model.SelfAssessmentResultSummary.ReviewerCommentsLabel.ToString()) rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
         </nhs-form-group>
 
         <nhs-form-group nhs-validation-for="SignedOff">


### PR DESCRIPTION
### JIRA link
[DLSV2-482](https://hee-dls.atlassian.net/browse/DLSV2-482)

### Description
Adds a custom reviewer comments label field to self assessments. Displays custom label text in place of default "Reviewer comments" text when custom label field is populated throughout the supervisor and self assessment views. Excel export not updated because we plan to replace this with PDF export soon.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
