### PR TITLE
UAR-879 - fix return url encoding when switching centres

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -68,7 +68,7 @@
             var result = myAccountController.Index(DlsSubApplication.Default);
 
             // Then
-            const string expectedReturnUrl = "%2fHome%2fWelcome";
+            const string expectedReturnUrl = "/Home/Welcome";
             result.As<ViewResult>().Model.As<MyAccountViewModel>().SwitchCentreReturnUrl.Should()
                 .BeEquivalentTo(expectedReturnUrl);
         }

--- a/DigitalLearningSolutions.Web.Tests/Helpers/StringHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/StringHelperTests.cs
@@ -10,8 +10,8 @@
     {
         private readonly IConfiguration config = A.Fake<IConfiguration>();
 
-        [TestCase("https://hee-dls-test.softwire.com", "%2fMyAccount")]
-        [TestCase("https://hee-dls-test.softwire.com/uar-test", "%2fuar-test%2fMyAccount")]
+        [TestCase("https://hee-dls-test.softwire.com", "/MyAccount")]
+        [TestCase("https://hee-dls-test.softwire.com/uar-test", "/uar-test/MyAccount")]
         public void GetLocalRedirectUrl_returns_correctly_formatted_url(string appRootPath, string expectedReturnValue)
         {
             // Given

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -23,6 +23,7 @@
     [Authorize]
     public class MyAccountController : Controller
     {
+        private const string SwitchCentreReturnUrl = "/Home/Welcome";
         private readonly ICentreRegistrationPromptsService centreRegistrationPromptsService;
         private readonly IConfiguration config;
         private readonly IImageResizeService imageResizeService;
@@ -68,8 +69,7 @@
                     delegateAccount
                 );
 
-            var switchCentreReturnUrl =
-                StringHelper.GetLocalRedirectUrl(config, "/Home/Welcome");
+            var switchCentreReturnUrl = StringHelper.GetLocalRedirectUrl(config, SwitchCentreReturnUrl);
 
             var model = new MyAccountViewModel(
                 userEntity.UserAccount,

--- a/DigitalLearningSolutions.Web/Helpers/StringHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/StringHelper.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
     using System;
-    using System.Web;
     using DigitalLearningSolutions.Data.Extensions;
     using Microsoft.Extensions.Configuration;
 
@@ -15,7 +14,7 @@
         public static string GetLocalRedirectUrl(IConfiguration config, string basicUrl)
         {
             var applicationPath = new Uri(config.GetAppRootPath()).AbsolutePath.TrimEnd('/');
-            return HttpUtility.UrlEncode(applicationPath + basicUrl);
+            return applicationPath + basicUrl;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -1,6 +1,5 @@
 namespace DigitalLearningSolutions.Web
 {
-    using System;
     using System.Collections.Generic;
     using System.Data;
     using System.IO;
@@ -346,7 +345,7 @@ namespace DigitalLearningSolutions.Web
 
         private Task RedirectToLogin(RedirectContext<CookieAuthenticationOptions> context)
         {
-            var url = StringHelper.GetLocalRedirectUrl(config, context.Request.Path);
+            var url = HttpUtility.UrlEncode(StringHelper.GetLocalRedirectUrl(config, context.Request.Path));
             var queryString = HttpUtility.UrlEncode(context.Request.QueryString.Value);
             context.HttpContext.Response.Redirect(config.GetAppRootPath() + $"/Login?returnUrl={url}{queryString}");
             return Task.CompletedTask;


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-879

### Description
Fixed crash when switch centres to an account that would force a details check. 

The returnUrl to /Home/Welcome when switching centres would be UrlEncoded when it didn't need to be. So when the forced details check occurred and tried to grab the sub application from the return URL, it could not find any forward slashes (as they were encoded), and therefore crashed. We no longer needed the encoding here, so I've moved that logic out of the common helper method.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
