### PR TITLE
DLSV2-557 - DLSV2-557-crash-when-cancelling-import-competencies-to-framework

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
@@ -6,8 +6,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
 {
     public partial class FrameworksController
     {
-        [Route("/Framework/{frameworkId}/Structure/Import")]
-        public IActionResult ImportCompetencies(int frameworkId)
+        [Route("/Framework/{frameworkId}/{tabname}/Import")]
+        public IActionResult ImportCompetencies(int frameworkId, string tabname)
         {
             var adminId = GetAdminId();
             var userRole = frameworkService.GetAdminUserRoleForFrameworkId(adminId, frameworkId);

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Structure.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Structure.cshtml
@@ -58,7 +58,7 @@ else
       <div class="nhsuk-grid-column-full">
         <a class="nhsuk-button" asp-action="AddEditFrameworkCompetencyGroup" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Add @Model.VocabSingular().ToLower() group</a>
         <a class="nhsuk-button nhsuk-button--secondary" asp-action="AddEditFrameworkCompetency" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Add ungrouped @Model.VocabSingular().ToLower()</a>
-        <a class="nhsuk-button nhsuk-button--secondary" asp-action="ImportCompetencies" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Import @Model.VocabPlural().ToLower() from Excel</a>
+        <a class="nhsuk-button nhsuk-button--secondary" asp-action="ImportCompetencies" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-tabname="@(ViewContext.RouteData.Values["tabname"])">Import @Model.VocabPlural().ToLower() from Excel</a>
       </div>
     </div>
   }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-XXXX_](https://hee-dls.atlassian.net/browse/DLSV2-557)

### Description
tabname parameter added to FrameworksController and cancel link in View

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
