### PR TITLE
DLSV2-575 contact us page

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202206291527_AddContactUsConfigRecord.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202206291527_AddContactUsConfigRecord.cs
@@ -1,0 +1,21 @@
+﻿using FluentMigrator;
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    [Migration(202206291527)]
+    public class AddContactUsConfigRecord : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(@"INSERT [dbo].[Config] ([ConfigName], [ConfigText], [IsHtml])
+                            VALUES (
+                                    N'ContactUsHtml',
+                                    N'<p>If you are interested in accessing learning content, please&nbsp;<strong><a href=""https://www.dls.nhs.uk/v2/findyourcentre"">Find Your Centre</a></strong>&nbsp;and contact them for more information.</p><p>If you represent a centre using or interested in using Digital Learning Solutions, please contact us at <a href=""mailto:dls@hee.nhs.uk"">dls@hee.nhs.uk</a></p><p>Digital Learning Solutions is provided by Health Education England Technology Enhanced Learning:</p><p>Health Education England<br />Stewart House<br />32 Russell Square<br />London<br />WC1B 5DN</p>',
+                                    1)");
+        }
+        public override void Down()
+        {
+            Execute.Sql(@"DELETE FROM Config
+`                           WHERE ConfigName = N'ContactUsHtml'");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/ConfigDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ConfigDataService.cs
@@ -22,6 +22,7 @@
         public const string TrackingSystemBaseUrl = "TrackingSystemBaseURL";
         public const string AccessibilityHelpText = "AccessibilityNotice";
         public const string TermsText = "TermsAndConditions";
+        public const string ContactText = "ContactUsHtml";
         public const string AppBaseUrl = "V2AppBaseUrl";
 
         private readonly IDbConnection connection;

--- a/DigitalLearningSolutions.Web/Controllers/LearningSolutions/LearningSolutionsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningSolutions/LearningSolutionsController.cs
@@ -50,6 +50,18 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningSolutions
             var model = new TermsViewModel(termsText);
             return View(model);
         }
+        public IActionResult Contact()
+        {
+            var contactText = configDataService.GetConfigValue(ConfigDataService.ContactText);
+            if (contactText == null)
+            {
+                logger.LogError("Contact text from Config table is null");
+                return StatusCode(500);
+            }
+
+            var model = new ContactViewModel(contactText);
+            return View(model);
+        }
 
         public IActionResult Error()
         {

--- a/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/ContactViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningSolutions/ContactViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningSolutions
+{
+    using Microsoft.AspNetCore.Html;
+
+    public class ContactViewModel
+    {
+        public HtmlString ContactText { get; }
+
+        public ContactViewModel(string contactText)
+        {
+            ContactText = new HtmlString(contactText);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/Contact.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/Contact.cshtml
@@ -1,0 +1,13 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningSolutions
+@model ContactViewModel
+@{
+  ViewData["Title"] = "Digital Learning Solutions - Contact us";
+  ViewData["DoNotDisplayNavBar"] = true;
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1>Contact us</h1>
+    @Model.ContactText
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -152,13 +152,16 @@
         <h2 class="nhsuk-u-visually-hidden">Support links</h2>
         <ul class="nhsuk-footer__list">
           <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use</a>
+            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Contact">Contact us <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
           </li>
           <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility</a>
+            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
           </li>
           <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy</a>
+            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
+          </li>
+          <li class="nhsuk-footer__list-item">
+            <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
           </li>
         </ul>
         <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @DateTime.Now.Year</p>


### PR DESCRIPTION
### JIRA link
[DLSV2-575](https://hee-dls.atlassian.net/browse/DLSV2-575)

### Description
Adds a contact us page linked to from the site layout template footer. The text for the contact us page is stored as a HTML string to the config table in the database and a migration is used to populate a starter config string.

Also adds visually hidden text to footer links to tell screenreader users that the links will open in new browser windows.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/176470590-003bdc3c-5540-422b-a7ce-9deff369a2b9.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
