### PR TITLE
DLSV2-561 Filter self assessment competencies by flag

### DIFF
--- a/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
+++ b/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
@@ -2,12 +2,12 @@
 {
     public enum SelfAssessmentCompetencyFilter
     {
-        RequiresSelfAssessment,
-        SelfAssessed,
-        Verified,
-        ConfirmationRequested,
-        MeetingRequirements,
-        PartiallyMeetingRequirements,
-        NotMeetingRequirements
+        RequiresSelfAssessment = -1,
+        SelfAssessed = -2,
+        Verified = -3,
+        ConfirmationRequested = -4,
+        MeetingRequirements = -5,
+        PartiallyMeetingRequirements = -6,
+        NotMeetingRequirements = -7
     }
 }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -32,7 +32,7 @@
         IEnumerable<CompetencyFlag> GetSelectedCompetencyFlagsByCompetecyIds(int[] ids);
         IEnumerable<CompetencyFlag> GetSelectedCompetencyFlagsByCompetecyId(int competencyId);
         IEnumerable<CompetencyFlag> GetCompetencyFlagsByFrameworkId(int frameworkId, int? competencyId, bool? selected = null);
-        IEnumerable<Flag> GetCustomFlagsByFrameworkId(int frameworkId, int? flagId);
+        IEnumerable<Flag> GetCustomFlagsByFrameworkId(int? frameworkId, int? flagId);
 
         IEnumerable<BrandedFramework> GetFrameworkByFrameworkName(string frameworkName, int adminId);
 
@@ -383,7 +383,8 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
 
         public IEnumerable<CompetencyFlag> GetSelectedCompetencyFlagsByCompetecyIds(int[] ids)
         {
-            var competencyIdFilter = ids.Count() > 0 ? $"cf.CompetencyID IN ({String.Join(',', ids)})" : "1=1";
+            var commaSeparatedIds = String.Join(',', ids.Distinct());
+            var competencyIdFilter = ids.Count() > 0 ? $"cf.CompetencyID IN ({commaSeparatedIds})" : "1=1";
             return connection.Query<CompetencyFlag>(
                 $@"SELECT CompetencyId, Selected, {FlagFields}
 	                FROM CompetencyFlags AS cf
@@ -397,13 +398,14 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
             return GetSelectedCompetencyFlagsByCompetecyIds(new int[1] { competencyId });
         }
 
-        public IEnumerable<Flag> GetCustomFlagsByFrameworkId(int frameworkId, int? flagId = null)
+        public IEnumerable<Flag> GetCustomFlagsByFrameworkId(int? frameworkId, int? flagId = null)
         {
             var flagIdFilter = flagId.HasValue ? "fl.ID = @flagId" : "1=1";
+            var frameworkFilter = frameworkId.HasValue ? "FrameworkId = @frameworkId" : "1=1";
             return connection.Query<Flag>(
                 $@"SELECT {FlagFields}
 	                FROM Flags fl
-                    WHERE FrameworkId = @frameworkId AND {flagIdFilter}",
+                    WHERE {frameworkFilter} AND {flagIdFilter}",
                 new { frameworkId, flagId });
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -262,6 +262,7 @@
             {
 
                 string description;
+                string tagClass = string.Empty;
                 if (model.SelectedFilter < 0)
                 {
                     description = ((SelfAssessmentCompetencyFilter)model.SelectedFilter).GetDescription(model.IsSupervisorResultsReviewed);
@@ -270,8 +271,9 @@
                 {
                     var flag = frameworkService.GetCustomFlagsByFrameworkId(null, model.SelectedFilter).First();
                     description = $"{flag.FlagGroup}: {flag.FlagName}";
+                    tagClass = flag.FlagTagClass;
                 }
-                model.AppliedFilters.Add(new AppliedFilterViewModel(description, null, model.SelectedFilter.ToString()));
+                model.AppliedFilters.Add(new AppliedFilterViewModel(description, null, model.SelectedFilter.ToString(), tagClass));
             }
             TempData.Clear();
             TempData.Set<List<AppliedFilterViewModel>>(model.AppliedFilters);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -258,10 +258,20 @@
 
         public IActionResult AddSelfAssessmentOverviewFilter(SearchSelfAssessmentOvervieviewViewModel model)
         {
-            string filterName = Enum.GetName(model.ResponseStatus.GetType(), model.ResponseStatus);
-            if (!model.AppliedFilters.Any(f => f.FilterValue == model.ResponseStatus.ToString()))
+            if (!model.AppliedFilters.Any(f => f.FilterValue == model.SelectedFilter.ToString()))
             {
-                model.AppliedFilters.Add(new AppliedFilterViewModel(model.ResponseStatus?.GetDescription(model.IsSupervisorResultsReviewed), null, model.ResponseStatus.ToString()));
+
+                string description;
+                if (model.SelectedFilter < 0)
+                {
+                    description = ((SelfAssessmentCompetencyFilter)model.SelectedFilter).GetDescription(model.IsSupervisorResultsReviewed);
+                }
+                else
+                {
+                    var flag = frameworkService.GetCustomFlagsByFrameworkId(null, model.SelectedFilter).First();
+                    description = $"{flag.FlagGroup}: {flag.FlagName}";
+                }
+                model.AppliedFilters.Add(new AppliedFilterViewModel(description, null, model.SelectedFilter.ToString()));
             }
             TempData.Clear();
             TempData.Set<List<AppliedFilterViewModel>>(model.AppliedFilters);
@@ -288,13 +298,15 @@
             var optionalCompetencies = selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, candidateId);
             selfAssessmentService.UpdateLastAccessed(assessment.Id, candidateId);
             var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(selfAssessmentId, candidateId);
-            var competencies = FilterCompetencies(selfAssessmentService.GetMostRecentResults(assessment.Id, candidateId).ToList(), searchModel);
-            var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencies.Select(c => c.Id).ToArray());
+
+            var recentResults = selfAssessmentService.GetMostRecentResults(assessment.Id, candidateId).ToList();
+            var competencyIds = recentResults.Select(c => c.Id).ToArray();
+            var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds).DistinctBy(f => f.FlagId);
+            var competencies = FilterCompetencies(recentResults, competencyFlags, searchModel);
 
             foreach (var competency in competencies)
             {
                 competency.QuestionLabel = assessment.QuestionLabel;
-                competency.CompetencyFlags = competencyFlags.Where(f => f.CompetencyId == competency.Id);
                 foreach (var assessmentQuestion in competency.AssessmentQuestions)
                 {
                     if (assessmentQuestion.AssessmentQuestionInputTypeID != 2)
@@ -311,8 +323,8 @@
             }
 
             var searchViewModel = searchModel == null ?
-                new SearchSelfAssessmentOvervieviewViewModel(searchModel?.SearchText, assessment.Id, vocabulary, null)
-                : searchModel.Initialise(searchModel.AppliedFilters);
+                new SearchSelfAssessmentOvervieviewViewModel(searchModel?.SearchText, assessment.Id, vocabulary, null, null)
+                : searchModel.Initialise(searchModel.AppliedFilters, competencyFlags.ToList());
             var model = new SelfAssessmentOverviewViewModel
             {
                 SelfAssessment = assessment,
@@ -330,52 +342,20 @@
             return View("SelfAssessments/SelfAssessmentOverview", model);
         }
 
-        private List<Competency> FilterCompetencies(List<Competency> competencies, SearchSelfAssessmentOvervieviewViewModel search)
+        private IEnumerable<Competency> FilterCompetencies(IEnumerable<Competency> competencies, IEnumerable<Data.Models.Frameworks.CompetencyFlag> competencyFlags, SearchSelfAssessmentOvervieviewViewModel search)
         {
-            var searchText = search?.SearchText?.Trim() ?? string.Empty;
-            IEnumerable<Competency> filteredCompetencies = competencies;
-            var filters = search?.AppliedFilters?.Select(f => Enum.Parse<SelfAssessmentCompetencyFilter>(f.FilterValue)) ?? Enumerable.Empty<SelfAssessmentCompetencyFilter>();
-            var appliedResponseStatusFilters = filters.Where(f => f.IsResponseStatusFilter());
-            var appliedRequirementsFilters = filters.Where(f => f.IsRequirementsFilter());
-
-            if (appliedResponseStatusFilters.Any() || searchText.Length > 0)
-            {
-                var wordsInSearchText = searchText.Split().Where(w => w != string.Empty);
-                filteredCompetencies = (
-                    from c in competencies
-                    let searchTextMatchesGroup = wordsInSearchText.Any(w => c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                    let searchTextMatchesCompetencyDescription = wordsInSearchText.Any(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                    let searchTextMatchesCompetencyName = wordsInSearchText.Any(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                    let responseStatusFilterMatchesAnyQuestion =
-                           (filters.Contains(SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
-                        || (filters.Contains(SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.Verified == null && q.ResultId != null))
-                        || (filters.Contains(SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
-                        || (filters.Contains(SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue))
-                    where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
-                        && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)
-                    select c);
-            }
-
-            var filteredQuestions = filteredCompetencies.SelectMany(c => c.AssessmentQuestions);
+            var filteredCompetencies = competencies;
             if (search != null)
             {
-                search.AnyQuestionMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 3);
-                search.AnyQuestionPartiallyMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 2);
-                search.AnyQuestionNotMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 1);
+                var searchText = search.SearchText?.Trim() ?? string.Empty;
+                var filters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)) ?? Enumerable.Empty<int>();
+                search.CompetencyFlags = competencyFlags.ToList();
+                filteredCompetencies = CompetencyFilterHelper.ApplyResponseStatusFilters(filteredCompetencies, filters, searchText);
+                CompetencyFilterHelper.UpdateRequirementsFilterDropdownOptionsVisibility(search, filteredCompetencies);
+                filteredCompetencies = CompetencyFilterHelper.ApplyRequirementsFilters(filteredCompetencies, filters);
+                filteredCompetencies = CompetencyFilterHelper.ApplyCompetencyGroupFilters(filteredCompetencies, search);
             }
-
-            if (appliedRequirementsFilters.Any())
-            {
-                filteredCompetencies = (
-                    from c in filteredCompetencies
-                    let requirementsFilterMatchesAnyQuestion =
-                           (filters.Contains(SelfAssessmentCompetencyFilter.MeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 3))
-                        || (filters.Contains(SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 2))
-                        || (filters.Contains(SelfAssessmentCompetencyFilter.NotMeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 1))
-                    where requirementsFilterMatchesAnyQuestion
-                    select c);
-            }
-            return (filteredCompetencies.ToList());
+            return filteredCompetencies;
         }
 
         [HttpPost]

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -301,8 +301,8 @@
 
             var recentResults = selfAssessmentService.GetMostRecentResults(assessment.Id, candidateId).ToList();
             var competencyIds = recentResults.Select(c => c.Id).ToArray();
-            var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds).DistinctBy(f => f.FlagId);
-            var competencies = FilterCompetencies(recentResults, competencyFlags, searchModel);
+            var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
+            var competencies = CompetencyFilterHelper.FilterCompetencies(recentResults, competencyFlags, searchModel);
 
             foreach (var competency in competencies)
             {
@@ -340,22 +340,6 @@
             }
             ViewBag.SupervisorSelfAssessmentReview = assessment.SupervisorSelfAssessmentReview;
             return View("SelfAssessments/SelfAssessmentOverview", model);
-        }
-
-        private IEnumerable<Competency> FilterCompetencies(IEnumerable<Competency> competencies, IEnumerable<Data.Models.Frameworks.CompetencyFlag> competencyFlags, SearchSelfAssessmentOvervieviewViewModel search)
-        {
-            var filteredCompetencies = competencies;
-            if (search != null)
-            {
-                var searchText = search.SearchText?.Trim() ?? string.Empty;
-                var filters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)) ?? Enumerable.Empty<int>();
-                search.CompetencyFlags = competencyFlags.ToList();
-                filteredCompetencies = CompetencyFilterHelper.ApplyResponseStatusFilters(filteredCompetencies, filters, searchText);
-                CompetencyFilterHelper.UpdateRequirementsFilterDropdownOptionsVisibility(search, filteredCompetencies);
-                filteredCompetencies = CompetencyFilterHelper.ApplyRequirementsFilters(filteredCompetencies, filters);
-                filteredCompetencies = CompetencyFilterHelper.ApplyCompetencyGroupFilters(filteredCompetencies, search);
-            }
-            return filteredCompetencies;
         }
 
         [HttpPost]

--- a/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
@@ -37,20 +37,5 @@ namespace DigitalLearningSolutions.Web.Extensions
                     return null;
             }
         }
-
-        public static bool IsRequirementsFilter(this SelfAssessmentCompetencyFilter filter)
-        {
-            return filter == SelfAssessmentCompetencyFilter.MeetingRequirements
-                || filter == SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements
-                || filter == SelfAssessmentCompetencyFilter.NotMeetingRequirements;
-        }
-
-        public static bool IsResponseStatusFilter(this SelfAssessmentCompetencyFilter filter)
-        {
-            return filter == SelfAssessmentCompetencyFilter.RequiresSelfAssessment
-                || filter == SelfAssessmentCompetencyFilter.SelfAssessed
-                || filter == SelfAssessmentCompetencyFilter.Verified
-                || filter == SelfAssessmentCompetencyFilter.ConfirmationRequested;
-        }
     }
 }

--- a/DigitalLearningSolutions.Web/Extensions/EnumerableExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace DigitalLearningSolutions.Web.Extensions
+{
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<T> DistinctBy<T, TKey>(this IEnumerable<T> enumerable, Func<T, TKey> key)
+        {
+            return enumerable.GroupBy(key).Select(g => g.First());
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DigitalLearningSolutions.Data.Enums;
+using DigitalLearningSolutions.Data.Models.SelfAssessments;
+using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments;
+
+namespace DigitalLearningSolutions.Web.Helpers
+{
+    public class CompetencyFilterHelper
+    {
+        public static IEnumerable<Competency> ApplyResponseStatusFilters(IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
+        {
+            var filteredCompetencies = competencies;
+            var appliedResponseStatusFilters = filters.Where(f => IsResponseStatusFilter(f));
+            if (appliedResponseStatusFilters.Any() || searchText.Length > 0)
+            {
+                var wordsInSearchText = searchText.Split().Where(w => w != string.Empty);
+                filters = appliedResponseStatusFilters;
+                filteredCompetencies = from c in competencies
+                    let searchTextMatchesGroup = wordsInSearchText.Any(w => c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                    let searchTextMatchesCompetencyDescription = wordsInSearchText.Any(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                    let searchTextMatchesCompetencyName = wordsInSearchText.Any(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                    let responseStatusFilterMatchesAnyQuestion =
+                       (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
+                    || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.Verified == null && q.ResultId != null))
+                    || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
+                    || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue))
+                    where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
+                        && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)
+                    select c;
+            }
+            return filteredCompetencies;
+        }
+
+        public static IEnumerable<Competency> ApplyRequirementsFilters(IEnumerable<Competency> competencies, IEnumerable<int> filters)
+        {
+            var filteredCompetencies = competencies;
+            var appliedRequirementsFilters = filters.Where(f => IsRequirementsFilter(f));
+            if (appliedRequirementsFilters.Any())
+            {
+                filters = appliedRequirementsFilters;
+                filteredCompetencies = from c in competencies
+                    let requirementsFilterMatchesAnyQuestion =
+                           (filters.Contains((int)SelfAssessmentCompetencyFilter.MeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 3))
+                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 2))
+                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.NotMeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 1))
+                    where requirementsFilterMatchesAnyQuestion
+                    select c;
+            }
+            return filteredCompetencies;
+        }
+
+        public static IEnumerable<Competency> ApplyCompetencyGroupFilters(IEnumerable<Competency> competencies, SearchSelfAssessmentOvervieviewViewModel search)
+        {
+            var filteredCompetencies = competencies;
+            var appliedCompetencyGroupFilters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)).Where(f => IsCompetencyGroupFilter(f)) ?? Enumerable.Empty<int>();
+            if (appliedCompetencyGroupFilters.Any())
+            {
+                foreach(var competency in filteredCompetencies)
+                {
+                    competency.CompetencyFlags = search.CompetencyFlags.Where(f => f.CompetencyId == competency.Id);
+                }
+                filteredCompetencies = competencies.Where(c => c.CompetencyFlags.Any(f => appliedCompetencyGroupFilters.Contains(f.FlagId)));
+            }
+            return filteredCompetencies;
+        }
+
+        public static void UpdateRequirementsFilterDropdownOptionsVisibility(SearchSelfAssessmentOvervieviewViewModel search, IEnumerable<Competency> competencies)
+        {
+            var filteredQuestions = competencies.SelectMany(c => c.AssessmentQuestions);
+            if (search != null)
+            {
+                search.AnyQuestionMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 3);
+                search.AnyQuestionPartiallyMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 2);
+                search.AnyQuestionNotMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 1);
+            }
+        }
+
+        public static bool IsRequirementsFilter(int filter)
+        {
+            var requirementFilters = new int[]
+            {
+                (int)SelfAssessmentCompetencyFilter.MeetingRequirements,
+                (int)SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements,
+                (int)SelfAssessmentCompetencyFilter.NotMeetingRequirements
+
+            };
+            return requirementFilters.Contains(filter);
+        }
+
+        public static bool IsResponseStatusFilter(int filter)
+        {
+            var responseStatusFilters = new int[]
+            {
+                (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment,
+                (int)SelfAssessmentCompetencyFilter.SelfAssessed,
+                (int)SelfAssessmentCompetencyFilter.Verified,
+                (int)SelfAssessmentCompetencyFilter.ConfirmationRequested
+            };
+            return responseStatusFilters.Contains(filter);
+        }
+
+        public static bool IsCompetencyGroupFilter(string filter)
+        {
+            int filterAsInteger;
+            return int.TryParse(filter, out filterAsInteger) && IsCompetencyGroupFilter(filterAsInteger);
+        }
+
+        public static bool IsCompetencyGroupFilter(int filter)
+        {
+            return filter > 0;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -75,7 +75,7 @@ namespace DigitalLearningSolutions.Web.Helpers
         private static void ApplyCompetencyGroupFilters(ref IEnumerable<Competency> competencies, SearchSelfAssessmentOvervieviewViewModel search)
         {
             var filteredCompetencies = competencies;
-            var appliedCompetencyGroupFilters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)).Where(f => IsCompetencyGroupFilter(f)) ?? Enumerable.Empty<int>();
+            var appliedCompetencyGroupFilters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)).Where(f => IsCompetencyFlagFilter(f)) ?? Enumerable.Empty<int>();
             if (appliedCompetencyGroupFilters.Any())
             {
                 filteredCompetencies = competencies.Where(c => c.CompetencyFlags.Any(f => appliedCompetencyGroupFilters.Contains(f.FlagId)));
@@ -118,7 +118,7 @@ namespace DigitalLearningSolutions.Web.Helpers
             return responseStatusFilters.Contains(filter);
         }
 
-        public static bool IsCompetencyGroupFilter(int filter)
+        public static bool IsCompetencyFlagFilter(int filter)
         {
             return filter > 0;
         }

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/AppliedFilterViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/AppliedFilterViewModel.cs
@@ -2,11 +2,12 @@
 {
     public class AppliedFilterViewModel
     {
-        public AppliedFilterViewModel(string displayText, string filterCategory, string filterValue)
+        public AppliedFilterViewModel(string displayText, string filterCategory, string filterValue, string tagClass = "")
         {
             DisplayText = displayText;
             FilterCategory = filterCategory;
             FilterValue = filterValue;
+            TagClass = tagClass;
         }
         public AppliedFilterViewModel()
         {
@@ -18,5 +19,7 @@
         public string FilterCategory { get; set; }
 
         public string FilterValue { get; set; }
+
+        public string TagClass { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SearchSelfAssessmentOvervieviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SearchSelfAssessmentOvervieviewViewModel.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using DigitalLearningSolutions.Data.Enums;
-using DigitalLearningSolutions.Web.Models.Enums;
 using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 using DigitalLearningSolutions.Web.Extensions;
 
 namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 {
+    using DigitalLearningSolutions.Data.Models.Frameworks;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+    using DigitalLearningSolutions.Web.Helpers;
 
     public class SearchSelfAssessmentOvervieviewViewModel
     {
@@ -17,10 +18,11 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
         public bool IsSupervisorResultsReviewed { get; set; }
         public string Vocabulary { get; set; }
         public string SearchText { get; set; }
-        public SelfAssessmentCompetencyFilter? ResponseStatus { get; set; }
+        public int SelectedFilter { get; set; }
         public int Page { get; set; }
         public List<FilterModel> Filters { get; set; }
         public List<AppliedFilterViewModel> AppliedFilters { get; set; }
+        public List<CompetencyFlag> CompetencyFlags { get; set; }
         public bool AnyQuestionMeetingRequirements { get; set; }
         public bool AnyQuestionPartiallyMeetingRequirements { get; set; }
         public bool AnyQuestionNotMeetingRequirements { get; set; }
@@ -41,33 +43,44 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
             }
         }
 
-        public SearchSelfAssessmentOvervieviewViewModel Initialise(List<AppliedFilterViewModel> appliedFilters)
+        public SearchSelfAssessmentOvervieviewViewModel Initialise(List<AppliedFilterViewModel> appliedFilters, List<CompetencyFlag> competencyFlags = null)
         {
             var allFilters = Enum.GetValues(typeof(SelfAssessmentCompetencyFilter)).Cast<SelfAssessmentCompetencyFilter>();
-            var filterOptions = allFilters.Where(f => f.IsResponseStatusFilter()).ToList();
+            var filterOptions = allFilters.Where(f => CompetencyFilterHelper.IsResponseStatusFilter((int)f)).ToList();
             if (AnyQuestionMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.MeetingRequirements);
             if (AnyQuestionNotMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.NotMeetingRequirements);
             if (AnyQuestionPartiallyMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements);
 
             var dropdownFilterOptions = filterOptions.Select(
                 f => new FilterOptionModel(f.GetDescription(IsSupervisorResultsReviewed),
-                f.ToString(),
-                FilterStatus.Default));
+                ((int)f).ToString(),
+                FilterStatus.Default)).ToList();
+
+            if (competencyFlags?.Count() > 0)
+            {
+                var competencyFlagOptions = competencyFlags.DistinctBy(f => f.FlagId)
+                    .Select(c =>
+                        new FilterOptionModel(
+                                $"{c.FlagGroup}: {c.FlagName}",
+                                c.FlagId.ToString(),
+                                FilterStatus.Default));
+                dropdownFilterOptions.AddRange(competencyFlagOptions);
+            }
 
             Filters = new List<FilterModel>()
             {
                 new FilterModel(
-                        filterProperty: FilterBy,
-                        filterName: FilterBy,
-                        filterOptions: dropdownFilterOptions)
+                    filterProperty: FilterBy,
+                    filterName: FilterBy,
+                    filterOptions: dropdownFilterOptions)
             };
             AppliedFilters = appliedFilters ?? new List<AppliedFilterViewModel>();
             return this;
         }
 
-        public SearchSelfAssessmentOvervieviewViewModel(string searchText, int selfAssessmentId, string vocabulary, List<AppliedFilterViewModel> appliedFilters)
+        public SearchSelfAssessmentOvervieviewViewModel(string searchText, int selfAssessmentId, string vocabulary, List<AppliedFilterViewModel> appliedFilters, List<CompetencyFlag> competencyFlags = null)
         {
-            FilterBy = nameof(ResponseStatus);
+            FilterBy = nameof(SelectedFilter);
             SearchText = searchText ?? string.Empty;
             SelfAssessmentId = selfAssessmentId;   
             Vocabulary = vocabulary;

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -47,6 +47,7 @@
   {
     @Html.HiddenFor(m => m.AppliedFilters[i].DisplayText)
     @Html.HiddenFor(m => m.AppliedFilters[i].FilterValue)
+    @Html.HiddenFor(m => m.AppliedFilters[i].TagClass)
   }
 </form>
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -20,18 +20,18 @@
     </div>
   </div>
   <div class="filter-value-container">
-    @Html.DropDownListFor(m => m.ResponseStatus,
+    @Html.DropDownListFor(m => m.SelectedFilter,
       Model.Filters.First().FilterOptions
         .Where(f => parent.SelfAssessment.IsSupervisorResultsReviewed
                     || f.FilterValue == SelfAssessmentCompetencyFilter.RequiresSelfAssessment.ToString()
                     || f.FilterValue == SelfAssessmentCompetencyFilter.SelfAssessed.ToString())
         .Select(f => new SelectListItem(
           text: f.DisplayText,
-          value: f.FilterValue.ToString(),
+          value: f.FilterValue,
           selected: f.FilterValue == SelfAssessmentCompetencyFilter.RequiresSelfAssessment.ToString())
         ),
       new
-          {
+      {
         @class = "nhsuk-select filter-dropdown",
         aria_label = "ResponseStatus filter"
       })

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_AppliedFilterTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_AppliedFilterTag.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage
 @model AppliedFilterViewModel
 
-<div class="nhsuk-tag nhsuk-tag--blue filter-tag word-break" data-filter-value="@Model.FilterValue">
+<div class="nhsuk-tag @(String.IsNullOrEmpty(Model.TagClass) ? "nhsuk-tag--blue" : Model.TagClass) filter-tag word-break" data-filter-value="@Model.FilterValue">
   @if(!string.IsNullOrEmpty(Model.FilterCategory))
   {
     @Model.FilterCategory<text>:</text>

--- a/DigitalLearningSolutions.Web/Views/Shared/_ComperencyFlags.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_ComperencyFlags.cshtml
@@ -5,7 +5,7 @@
   <div class="nhsuk-u-margin-bottom-3">
     @foreach (var flag in Model)
     {
-      <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
+      <span class="nhsuk-u-padding-right-2 @(flag == Model.First() ? ViewData["cssClass"]?.ToString() : String.Empty)">
         <strong class="nhsuk-tag @flag.FlagTagClass">
           @flag.FlagName
         </strong>


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-561

### Description
The dropdown of filters was reworked to allow any integer value instead of being restricted to values in the enum `SelfAssessmentCompetencyFilter`. The enum is still being used in the code to identify requirement filters and response filters by their negative values. If positive, the flag filter represents a flagId on table CompetencyFilters. This change only affects the dropdown, as the view itself still uses `AppliedFilterViewModel` object. Also created helper class `CompetencyFilterHelper` to organise the code.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/176416494-c1050f43-8499-4c42-82c5-a61b46b5c59b.png)

-----
### Developer checks
Tried multiple combinations of searches for texts with requirements filters, response filters and competency flag filters. Ran searches from Learning Portal application while edit the items from the Framework application.

https://localhost:44363/LearningPortal/SelfAssessment/1/Capabilities
https://localhost:44363/Framework/2/Details
![image](https://user-images.githubusercontent.com/94055251/176418146-8ac82b98-75b3-4072-a5f0-b39684586317.png)
