### PR TITLE
DLSV2-563 Final adjustments to self assessment overview filters

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202206291720_AddIncludeRequirementsFiltersToSelfAssessmentsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202206291720_AddIncludeRequirementsFiltersToSelfAssessmentsTable.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202206291720)]
+    public class AddIncludeRequirementsFiltersToSelfAssessmentsTable : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments").AddColumn("IncludeRequirementsFilters").AsBoolean().NotNullable().WithDefaultValue(false);
+        }
+        public override void Down()
+        {
+            Delete.Column("IncludeRequirementsFilters").FromTable("SelfAssessments");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -16,6 +16,7 @@
                         SA.Name,
                         SA.Description,
                         SA.IncludesSignposting,
+                        SA.IncludeRequirementsFilters,
                         SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                         COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
                         COUNT(C.ID) AS NumberOfCompetencies,
@@ -37,7 +38,7 @@
                         ON SAS.CompetencyID = C.ID
                     WHERE CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
                     GROUP BY
-                        CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
+                        CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.IncludeRequirementsFilters, SA.SupervisorResultsReview,
                         COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID,
                         CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate",
@@ -55,6 +56,7 @@
                         SA.QuestionLabel,
                         SA.DescriptionLabel,
                         SA.IncludesSignposting,
+                        SA.IncludeRequirementsFilters,
                         SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
                         SA.SupervisorSelfAssessmentReview,
                         SA.EnforceRoleRequirementsForSignOff,
@@ -108,7 +110,7 @@
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description,
                         SA.DescriptionLabel, SA.QuestionLabel,
-                        SA.IncludesSignposting, SA.SignOffRequestorStatement, COALESCE(SA.Vocabulary, 'Capability'),
+                        SA.IncludesSignposting, SA.IncludeRequirementsFilters, SA.SignOffRequestorStatement, COALESCE(SA.Vocabulary, 'Capability'),
                         CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID, CA.UserBookmark, CA.UnprocessedUpdates,
                         CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders,

--- a/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
+++ b/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
@@ -2,12 +2,13 @@
 {
     public enum SelfAssessmentCompetencyFilter
     {
-        RequiresSelfAssessment = -1,
-        SelfAssessed = -2,
-        Verified = -3,
-        ConfirmationRequested = -4,
-        MeetingRequirements = -5,
-        PartiallyMeetingRequirements = -6,
-        NotMeetingRequirements = -7
+        RequiresSelfAssessment = -8,
+        SelfAssessed = -7,
+        ConfirmationRequested = -6,
+        Verified = -5, /* Confirmed */
+        ConfirmationRejected = -4,
+        MeetingRequirements = -3,
+        PartiallyMeetingRequirements = -2,
+        NotMeetingRequirements = -1
     }
 }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -10,6 +10,7 @@
         public DateTime? SubmittedDate { get; set; }
         public bool IsSupervised { get; set; }
         public bool IsSupervisorResultsReviewed { get; set; }
+        public bool IncludeRequirementsFilters { get; set; }
         public bool SupervisorSelfAssessmentReview { get; set; }
         public string? Vocabulary { get; set; }
         public string? VerificationRoleName { get; set; }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -300,7 +300,7 @@
                 CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup),
                 PreviousCompetencyNumber = 2,
                 SupervisorSignOffs = supervisorSignOffs,
-                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, null)
+                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null)
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
                 .Returns(selfAssessment);
@@ -362,7 +362,7 @@
                 CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup),
                 PreviousCompetencyNumber = 1,
                 SupervisorSignOffs = supervisorSignOffs,
-                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, null)
+                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null)
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
                 .Returns(selfAssessment);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -325,8 +325,8 @@
             }
 
             var searchViewModel = searchModel == null ?
-                new SearchSelfAssessmentOvervieviewViewModel(searchModel?.SearchText, assessment.Id, vocabulary, null, null)
-                : searchModel.Initialise(searchModel.AppliedFilters, competencyFlags.ToList());
+                new SearchSelfAssessmentOvervieviewViewModel(searchModel?.SearchText, assessment.Id, vocabulary, assessment.IsSupervisorResultsReviewed, assessment.IncludeRequirementsFilters, null, null)
+                : searchModel.Initialise(searchModel.AppliedFilters, competencyFlags.ToList(), assessment.IsSupervisorResultsReviewed, assessment.IncludeRequirementsFilters);
             var model = new SelfAssessmentOverviewViewModel
             {
                 SelfAssessment = assessment,
@@ -343,8 +343,6 @@
             ViewBag.SupervisorSelfAssessmentReview = assessment.SupervisorSelfAssessmentReview;
             return View("SelfAssessments/SelfAssessmentOverview", model);
         }
-
-        [HttpPost]
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/CompleteBy")]
         public IActionResult SetSelfAssessmentCompleteByDate(int selfAssessmentId, EditCompleteByDateFormData formData)

--- a/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
@@ -25,6 +25,8 @@ namespace DigitalLearningSolutions.Web.Extensions
                     return "Self-assessed" + (isSupervisorResultReview ? " (confirmation not yet requested)" : "");
                 case SelfAssessmentCompetencyFilter.ConfirmationRequested:
                     return "Confirmation requested";
+                case SelfAssessmentCompetencyFilter.ConfirmationRejected:
+                    return "Confirmation rejected";
                 case SelfAssessmentCompetencyFilter.Verified:
                     return "Confirmed";
                 case SelfAssessmentCompetencyFilter.MeetingRequirements:
@@ -34,7 +36,7 @@ namespace DigitalLearningSolutions.Web.Extensions
                 case SelfAssessmentCompetencyFilter.NotMeetingRequirements:
                     return "Not meeting requirements";
                 default:
-                    return null;
+                    return status.ToString();
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -46,6 +46,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                        (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
                     || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.Verified == null && q.ResultId != null))
                     || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
+                    || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
                     || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue))
                     where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
                         && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)
@@ -113,7 +114,8 @@ namespace DigitalLearningSolutions.Web.Helpers
                 (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment,
                 (int)SelfAssessmentCompetencyFilter.SelfAssessed,
                 (int)SelfAssessmentCompetencyFilter.Verified,
-                (int)SelfAssessmentCompetencyFilter.ConfirmationRequested
+                (int)SelfAssessmentCompetencyFilter.ConfirmationRequested,
+                (int)SelfAssessmentCompetencyFilter.ConfirmationRejected
             };
             return responseStatusFilters.Contains(filter);
         }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -86,10 +86,7 @@
           {
             <partial name="SelfAssessments/_MeanScores"
                      view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
-                    }
-
-
-
+          }
           <style>
             .nhsuk-expander[open] details.nhsuk-details[open] .nhsuk-details__summary-text::before {
               display: block;
@@ -132,7 +129,7 @@
             {
                 <div class="outer-score-container nhsuk-u-padding-bottom-4">
                     <partial name="SelfAssessments/_MeanScores"
-                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                             view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
                 </div>
             }
         </div>
@@ -147,20 +144,20 @@
     @if (Configuration.IsSignpostingUsed())
     {
         <a class="nhsuk-button finish-review-button trigger-loader"
-   asp-controller="RecommendedLearning"
-   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-   role="button">
+           asp-controller="RecommendedLearning"
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+           asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+           role="button">
             Submit results
         </a>
     }
     else
     {
         <a class="nhsuk-button finish-review-button trigger-loader"
-   asp-controller="RecommendedLearning"
-   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-   role="button">
+           asp-controller="RecommendedLearning"
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+           asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+           role="button">
             Submit self assessment
         </a>
     }
@@ -200,10 +197,10 @@
                 </div>
             }
             <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-       asp-action="RequestSignOff"
-       asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
-       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-       role="button">
+               asp-action="RequestSignOff"
+               asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
+               asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+               role="button">
                 Request @Model.SelfAssessment.SignOffRoleName sign-off
             </a>
         }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -41,6 +41,7 @@
   </div>
   @Html.HiddenFor(m => m.SelfAssessmentId)
   @Html.HiddenFor(m => m.IsSupervisorResultsReviewed)
+  @Html.HiddenFor(m => m.IncludeRequirementsFilters)
   @Html.HiddenFor(m => m.Vocabulary)
   @Html.Hidden(nameof(Model.SearchText), Model.SearchText)
   @for (int i = 0; i < Model.AppliedFilters.Count; i++)


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-563

### Description
Updated views, controller,  helper class and enums. Added migration for creating new column `IncludeRequirementsFilters` with default value `false`. Rebased against release branch 22.7.1.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/176845520-81ffcc23-c8b7-4889-b1e8-6033f07b3547.png)

-----
### Developer checks

I have checked that:

- Items on filter dropdown appear in the required order.
- When `IncludeRequirementsFilters` field is set to `true` in table SelfAssessments:
  - requirements filters are included in the filters dropdown.
- When `IncludeRequirementsFilters` field is set to `false` in table SelfAssessments:
  - requirements filters are not included in the filters dropdown.
- Filter functionality still works after rebasing above changes for [DLSV2-561] included in [PR 1234](https://github.com/TechnologyEnhancedLearning/DLSV2/pull/1243) coming from release-22.7.1 that includes.

