### PR TITLE
DLSV2-523 Fixes bug: flags not being added when creating new competency

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -148,6 +148,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             if (newCompetencyId > 0)
             {
                 var newFrameworkCompetencyId = frameworkService.InsertFrameworkCompetency(newCompetencyId, frameworkCompetencyGroupId, adminId, frameworkId);
+                frameworkService.UpdateCompetencyFlags(frameworkId, newCompetencyId, selectedFlagIds);
                 return new RedirectResult(Url.Action("ViewFramework", new { tabname = "Structure", frameworkId, frameworkCompetencyGroupId, frameworkCompetencyId }) + "#fc-" + newFrameworkCompetencyId.ToString());
             }
             logger.LogWarning($"Attempt to add framework competency failed for admin {adminId}.");


### PR DESCRIPTION
Fixes bug: when creating a new competency with flags, the flags are not added to the competency.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-523

### Description
Calling the method `UpdateCompetencyFlags` for updating/inserting flags, after inserting a new competency and newFrameworkCompetency in Competencies.cs.

-----
### Developer checks

Created new competency from scratch including flags.


