### PR TITLE
Develop/features/dlsv2 563 final adjustments self assessment overview filters

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SearchSelfAssessmentOvervieviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SearchSelfAssessmentOvervieviewViewModel.cs
@@ -50,7 +50,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
             var filterOptions = (from f in allFilters
                                 let includeRejectedWhenSupervisorReviewed = f != SelfAssessmentCompetencyFilter.ConfirmationRejected || isSupervisorResultsReviewed
                                 where CompetencyFilterHelper.IsResponseStatusFilter((int)f) && includeRejectedWhenSupervisorReviewed
-                                select f).ToList();
+                                select f).ToList();           
             if (includeRequirementsFilters)
             {
                 if (AnyQuestionMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.MeetingRequirements);
@@ -59,7 +59,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
             }
 
             var dropdownFilterOptions = filterOptions.Select(
-                f => new FilterOptionModel(f.GetDescription(IsSupervisorResultsReviewed),
+                f => new FilterOptionModel(f.GetDescription(isSupervisorResultsReviewed),
                 ((int)f).ToString(),
                 FilterStatus.Default)).ToList();
 
@@ -81,6 +81,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
                     filterName: FilterBy,
                     filterOptions: dropdownFilterOptions)
             };
+            IsSupervisorResultsReviewed = isSupervisorResultsReviewed;
             AppliedFilters = appliedFilters ?? new List<AppliedFilterViewModel>();
             return this;
         }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -23,8 +23,8 @@
     @Html.DropDownListFor(m => m.SelectedFilter,
       Model.Filters.First().FilterOptions
         .Where(f => parent.SelfAssessment.IsSupervisorResultsReviewed
-                    || f.FilterValue == SelfAssessmentCompetencyFilter.RequiresSelfAssessment.ToString()
-                    || f.FilterValue == SelfAssessmentCompetencyFilter.SelfAssessed.ToString())
+                    || f.FilterValue == ((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment).ToString()
+                    || f.FilterValue == ((int)SelfAssessmentCompetencyFilter.SelfAssessed).ToString())
         .Select(f => new SelectListItem(
           text: f.DisplayText,
           value: f.FilterValue,


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-563

### Description
Since filter dropdown selected option is now an integer not restricted by enum `SelfAssessmentCompetencyFilter`, converting a enum value to string in order to compare would result into "RequiresSelfAssessment", "SelfAssessed", etc; while the expected result would be "-8", "-7", etc. Solution is to cast the enum as `int` before calling `ToString()`; so that it can be compared to selected value.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/177102974-893e5907-4e20-4092-8bbe-3bd594e6779b.png)
![image](https://user-images.githubusercontent.com/94055251/177103097-f754b602-94b4-46ed-b5a9-641cacc3f2eb.png)

-----
### Developer checks
Edited the value of `SupervisorResultsReview` on table `SelfAssessments` for the self assessment id I was working on.
