### PR TITLE
DLSV2-544 Handles competency groups when checking for use in other frameworks

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -542,8 +542,8 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
             }
 
             var existingId = (int)connection.ExecuteScalar(
-                @"SELECT COALESCE ((SELECT ID FROM CompetencyGroups WHERE [Name] = @groupName), 0) AS CompetencyGroupID",
-                new { groupName }
+                @"SELECT COALESCE ((SELECT ID FROM CompetencyGroups WHERE [Name] = @groupName AND Description = @groupDescription), 0) AS CompetencyGroupID",
+                new { groupName, groupDescription }
             );
             if (existingId > 0)
             {
@@ -565,8 +565,8 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
             }
 
             existingId = (int)connection.ExecuteScalar(
-                @"SELECT COALESCE ((SELECT ID FROM CompetencyGroups WHERE [Name] = @groupName), 0) AS CompetencyGroupID",
-                new { groupName }
+                @"SELECT COALESCE ((SELECT TOP(1) ID FROM CompetencyGroups WHERE [Name] = @groupName AND Description = @groupDescription), 0) AS CompetencyGroupID",
+                new { groupName, groupDescription }
             );
             return existingId;
         }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -850,7 +850,7 @@ LEFT OUTER JOIN FrameworkReviews AS fwr ON fwc.ID = fwr.FrameworkCollaboratorID 
         public void RemoveCustomFlag(int flagId)
         {
             connection.Execute(
-                @"DELETE FROM CompetencyFlags WHERE FlagID = @flagId", new { flagId}
+                @"DELETE FROM CompetencyFlags WHERE FlagID = @flagId", new { flagId }
             );
             connection.Execute(
                 @"DELETE FROM Flags WHERE ID = @flagId", new { flagId }


### PR DESCRIPTION
### JIRA link
[DLSV2-544](https://hee-dls.atlassian.net/browse/DLSV2-544)

### Description
The code which checks for the use of the competency group in other frameworks before updating has been tweaked to handle the new competency group description field.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
