### PR TITLE
Heedls 970 myaccount not show inactive delegates

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
@@ -414,7 +414,9 @@
             var testDelegates = new List<DelegateUserCard>
             {
                 new DelegateUserCard
-                    { FirstName = "include", Approved = true, SelfReg = false, Password = null, EmailAddress = "email" },
+                {
+                    FirstName = "include", Approved = true, SelfReg = false, Password = null, EmailAddress = "email"
+                },
                 new DelegateUserCard
                     { FirstName = "include", Approved = true, SelfReg = false, Password = "", EmailAddress = "email" },
                 new DelegateUserCard
@@ -785,6 +787,30 @@
             A.CallTo(() => clockService.UtcNow).Returns(now);
             var userEntity = new UserEntity(
                 UserTestHelper.GetDefaultUserAccount(detailsLastChecked: yesterday),
+                new List<AdminAccount>(),
+                new List<DelegateAccount>
+                    { UserTestHelper.GetDefaultDelegateAccount(centreSpecificDetailsLastChecked: sevenMonthsAgo) }
+            );
+
+            // When
+            var result = userService.ShouldForceDetailsCheck(userEntity, 2);
+
+            // Then
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void
+            ShouldForceDetailsCheck_returns_false_when_delegate_account_details_last_checked_is_beyond_threshold_but_inactive()
+        {
+            // Given
+            var now = new DateTime(2022, 5, 5);
+            var yesterday = now.AddDays(-1);
+            var sevenMonthsAgo = now.AddMonths(-7);
+            A.CallTo(() => configuration["MonthsToPromptUserDetailsCheck"]).Returns("6");
+            A.CallTo(() => clockService.UtcNow).Returns(now);
+            var userEntity = new UserEntity(
+                UserTestHelper.GetDefaultUserAccount(detailsLastChecked: yesterday, active: false),
                 new List<AdminAccount>(),
                 new List<DelegateAccount>
                     { UserTestHelper.GetDefaultDelegateAccount(centreSpecificDetailsLastChecked: sevenMonthsAgo) }

--- a/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/UserServiceTests.cs
@@ -810,17 +810,17 @@
             A.CallTo(() => configuration["MonthsToPromptUserDetailsCheck"]).Returns("6");
             A.CallTo(() => clockService.UtcNow).Returns(now);
             var userEntity = new UserEntity(
-                UserTestHelper.GetDefaultUserAccount(detailsLastChecked: yesterday, active: false),
+                UserTestHelper.GetDefaultUserAccount(detailsLastChecked: yesterday),
                 new List<AdminAccount>(),
                 new List<DelegateAccount>
-                    { UserTestHelper.GetDefaultDelegateAccount(centreSpecificDetailsLastChecked: sevenMonthsAgo) }
+                    { UserTestHelper.GetDefaultDelegateAccount(centreSpecificDetailsLastChecked: sevenMonthsAgo, active: false) }
             );
 
             // When
             var result = userService.ShouldForceDetailsCheck(userEntity, 2);
 
             // Then
-            result.Should().BeTrue();
+            result.Should().BeFalse();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/Services/UserService.cs
+++ b/DigitalLearningSolutions.Data/Services/UserService.cs
@@ -315,7 +315,7 @@ namespace DigitalLearningSolutions.Data.Services
                 return true;
             }
 
-            return delegateAccount != null &&
+            return delegateAccount is { Active: true } &&
                    (delegateAccount.CentreSpecificDetailsLastChecked == null ||
                     delegateAccount.CentreSpecificDetailsLastChecked.Value.AddMonths(monthThresholdToForceCheck) < now);
         }

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
@@ -62,7 +63,7 @@
             var userEntity = userService.GetUserById(userId);
 
             var adminAccount = userEntity!.GetCentreAccountSet(centreId)?.AdminAccount;
-            var delegateAccount = userEntity.GetCentreAccountSet(centreId)?.DelegateAccount;
+            var delegateAccount = GetDelegateAccountIfActive(userEntity, centreId);
 
             var customPrompts =
                 centreRegistrationPromptsService.GetCentreRegistrationPromptsWithAnswersByCentreIdAndDelegateAccount(
@@ -97,10 +98,10 @@
             var centreId = User.GetCentreId();
             var userId = User.GetUserIdKnownNotNull();
             var userEntity = userService.GetUserById(userId);
-            var delegateAccount = userEntity!.GetCentreAccountSet(centreId)?.DelegateAccount;
+            var delegateAccount = GetDelegateAccountIfActive(userEntity, centreId);
 
             var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical().ToList();
-            
+
             var customPrompts =
                 centreId != null
                     ? promptsService.GetEditDelegateRegistrationPromptViewModelsForCentre(
@@ -291,6 +292,13 @@
 
             var model = new MyAccountEditDetailsViewModel(formData, jobGroups, customPrompts, dlsSubApplication);
             return View(model);
+        }
+
+        private static DelegateAccount? GetDelegateAccountIfActive(UserEntity? user, int? centreId)
+        {
+            var delegateAccount = user?.GetCentreAccountSet(centreId)?.DelegateAccount;
+
+            return delegateAccount is { Active: true } ? delegateAccount : null;
         }
     }
 }


### PR DESCRIPTION
### JIRA link
_[HEEDLS-970](https://softwiretech.atlassian.net/browse/HEEDLS-970)_

### Description
Added checks for delegate account activity to MyAccountController methods and ShouldForceDetailsCheck

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
