### PR TITLE
DLSV2-544 Fixes relating to failed service test and reverts changes to appsettings

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1207,7 +1207,7 @@ GROUP BY fc.ID, c.ID, c.Name, c.Description, fc.Ordering
                 {
                     logger.LogWarning(
                         "Not deleting competency group as db update failed. " +
-                        $"competencyGroupId: { competencyGroupId }, adminId: { adminId }"
+                        $"competencyGroupId: {competencyGroupId}, adminId: {adminId}"
                     );
                 }
             }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -540,9 +540,8 @@
                 );
                 return -2;
             }
-
             var existingId = (int)connection.ExecuteScalar(
-                @"SELECT COALESCE ((SELECT ID FROM CompetencyGroups WHERE [Name] = @groupName AND Description = @groupDescription), 0) AS CompetencyGroupID",
+                @"SELECT COALESCE ((SELECT TOP(1)ID FROM CompetencyGroups WHERE [Name] = @groupName AND (@groupDescription IS NULL OR Description = @groupDescription)), 0) AS CompetencyGroupID",
                 new { groupName, groupDescription }
             );
             if (existingId > 0)
@@ -565,7 +564,7 @@
             }
 
             existingId = (int)connection.ExecuteScalar(
-                @"SELECT COALESCE ((SELECT TOP(1) ID FROM CompetencyGroups WHERE [Name] = @groupName AND Description = @groupDescription), 0) AS CompetencyGroupID",
+                @"SELECT COALESCE ((SELECT TOP(1)ID FROM CompetencyGroups WHERE [Name] = @groupName AND (@groupDescription IS NULL OR Description = @groupDescription)), 0) AS CompetencyGroupID",
                 new { groupName, groupDescription }
             );
             return existingId;

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -1,8 +1,8 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=DESKTOP-KKQ5HSL\\SQLEXPRESS;Initial Catalog=mbdbx101;Integrated Security=True;",
-    "UnitTestConnection": "Data Source=DESKTOP-KKQ5HSL\\SQLEXPRESS;Initial Catalog=mbdbx101_test;Integrated Security=True;"
+    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True;",
+    "UnitTestConnection": "Data Source=localhost;Initial Catalog=mbdbx101_test;Integrated Security=True;"
   },
   "CurrentSystemBaseUrl": "https://www.dls.nhs.uk",
   "AppRootPath": "https://localhost:44363",


### PR DESCRIPTION
### JIRA link
[DLSV2-544](https://hee-dls.atlassian.net/browse/DLSV2-544)

### Description
Fixes problem with null propagation in SQL script that resulted in failing to match a competency group if the competency group description was null.

Also, resets appsettings Unit test connection string inadvertently checked in after being changed by another dev on this branch.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
