### PR TITLE
DLSV2-558 Fixes reading of supervisor details for supervisor comment VM

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -187,30 +187,32 @@
         {
             return connection.Query<SupervisorComment>(
                 @"SELECT
-                        sar.AssessmentQuestionID,
-                        sea.Name,
-                        sasv.Comments,
-                        sar.CandidateID,
-                        sar.CompetencyID,
-                        com.Name as CompetencyName,
-                        sar.SelfAssessmentID,
-                        sasv.CandidateAssessmentSupervisorID,
-                        sasv.SelfAssessmentResultId,
-                        sasv.Verified,
-                        sar.ID,
-                        sstrc.CompetencyGroupID,
-                        sea.Vocabulary,
-                        sasv.SignedOff,
-                        sea.ReviewerCommentsLabel
-                    FROM SelfAssessmentResultSupervisorVerifications AS sasv
-                    INNER JOIN SelfAssessmentResults AS sar
-                        ON sasv.SelfAssessmentResultId = sar.ID
-                    INNER JOIN SelfAssessments AS sea
-                        ON sar.SelfAssessmentID = sea.ID
-                    INNER JOIN SelfAssessmentStructure AS sstrc
-                        ON sar.CompetencyID = sstrc.CompetencyID 
-                    INNER JOIN Competencies AS com
-                        ON sar.CompetencyID = com.ID
+                    sar.AssessmentQuestionID,
+                    sea.Name,
+                    au.Forename + ' ' + au.Surname As SupervisorName,
+                    sasr.RoleName,
+                    sasv.Comments,
+                    sar.CandidateID,
+                    sar.CompetencyID,
+                    com.Name AS CompetencyName,
+                    sar.SelfAssessmentID,
+                    sasv.CandidateAssessmentSupervisorID,
+                    sasv.SelfAssessmentResultId,
+                    sasv.Verified,
+                    sar.ID,
+                    sstrc.CompetencyGroupID, 
+                    sea.Vocabulary,
+                    sasv.SignedOff,
+                    sea.ReviewerCommentsLabel
+                    FROM   SelfAssessmentResultSupervisorVerifications AS sasv INNER JOIN
+                    SelfAssessmentResults AS sar ON sasv.SelfAssessmentResultId = sar.ID INNER JOIN
+                    SelfAssessments AS sea ON sar.SelfAssessmentID = sea.ID INNER JOIN
+                    SelfAssessmentStructure AS sstrc ON sar.CompetencyID = sstrc.CompetencyID INNER JOIN
+                    Competencies AS com ON sar.CompetencyID = com.ID INNER JOIN
+                    CandidateAssessmentSupervisors AS cas ON sasv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
+                    SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
+                    AdminUsers AS au ON sd.SupervisorAdminID = au.AdminID INNER JOIN
+                    SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
                     WHERE (sar.CandidateID = @candidateId) AND (sasv.SelfAssessmentResultId = @resultId)",
                 new { candidateId, resultId }
             ).FirstOrDefault();

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SupervisorComment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SupervisorComment.cs
@@ -5,9 +5,11 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
     public class SupervisorComment
     {
         public int? AssessmentQuestionID { get; set; }
-        public string? Name { get; set; }        
+        public string? Name { get; set; }
+        public string? SupervisorName { get; set; }
+        public string? RoleName { get; set; }
         public string? Comments { get; set; }
-        public int? CandidateID { get; set; }        
+        public int? CandidateID { get; set; }
         public int? CompetencyID { get; set; }
         public string? CompetencyName { get; set; }
         public int? SelfAssessmentID { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentService.cs
@@ -71,8 +71,6 @@
         // Supervisor
         IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int candidateId);
 
-        SelfAssessmentSupervisor? GetSupervisorForSelfAssessmentId(int selfAssessmentId, int candidateId);
-
         IEnumerable<SupervisorSignOff> GetSupervisorSignOffsForCandidateAssessment(
             int selfAssessmentId,
             int candidateId
@@ -209,11 +207,6 @@
         public SupervisorComment? GetSupervisorComments(int candidateId, int resultId)
         {
             return selfAssessmentDataService.GetSupervisorComments(candidateId, resultId);
-        }
-
-        public SelfAssessmentSupervisor? GetSupervisorForSelfAssessmentId(int selfAssessmentId, int candidateId)
-        {
-            return selfAssessmentDataService.GetSupervisorForSelfAssessmentId(selfAssessmentId, candidateId);
         }
 
         public IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -227,8 +227,6 @@
             var model = new SupervisorCommentsViewModel
             {
                 SupervisorComment = supervisorComment,
-                SelfAssessmentSupervisor =
-                    selfAssessmentService.GetSupervisorForSelfAssessmentId(selfAssessmentId, candidateId),
                 AssessmentQuestion = new AssessmentQuestion
                 {
                     Verified = supervisorComment.Verified,
@@ -336,7 +334,7 @@
                 SupervisorSignOffs = supervisorSignOffs,
                 SearchViewModel = searchViewModel
             };
-            if(searchModel != null)
+            if (searchModel != null)
             {
                 searchModel.IsSupervisorResultsReviewed = assessment.IsSupervisorResultsReviewed;
             }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SupervisorCommentsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SupervisorCommentsViewModel.cs
@@ -5,7 +5,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 {
     public class SupervisorCommentsViewModel
     {
-        public SelfAssessmentSupervisor? SelfAssessmentSupervisor { get; set; }
         public SupervisorComment? SupervisorComment { get; set; }
         public AssessmentQuestion AssessmentQuestion { get; set; }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SupervisorComments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SupervisorComments.cshtml
@@ -2,101 +2,101 @@
 @model SupervisorCommentsViewModel
 
 @{
-  Layout = "SelfAssessments/_Layout";
-  ViewData["Title"] = "Supervisor comments";
-  ViewData["Application"] = "Supervisor notes";
-  var supervisorName = string.IsNullOrWhiteSpace(Model.SelfAssessmentSupervisor?.SupervisorName) ?
-    "Supervisor" : Model.SelfAssessmentSupervisor.SupervisorName;
+    Layout = "SelfAssessments/_Layout";
+    ViewData["Title"] = "Supervisor comments";
+    ViewData["Application"] = "Supervisor notes";
+    var supervisorName = string.IsNullOrWhiteSpace(Model.SupervisorComment.SupervisorName) ?
+      "Supervisor" : Model.SupervisorComment.SupervisorName;
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 @section breadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment"
-             asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID">
-            @(Model.SupervisorComment != null ? $"{Model.SupervisorComment.Name} introduction" : "")
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview"
-             asp-route-vocabulary="@Model.VocabPlural()"
-             asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID"
-             asp-route-competencyGroupId="@Model.SupervisorComment.CompetencyGroupID"
-             asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">
-            @(Model.VocabPlural()) menu
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">@Model.SelfAssessmentSupervisor.RoleName notes</li>
-      </ol>
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment"
+                   asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID">
+                        @(Model.SupervisorComment != null ? $"{Model.SupervisorComment.Name} introduction" : "")
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview"
+                   asp-route-vocabulary="@Model.VocabPlural()"
+                   asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID"
+                   asp-route-competencyGroupId="@Model.SupervisorComment.CompetencyGroupID"
+                   asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">
+                        @(Model.VocabPlural()) menu
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">@Model.SupervisorComment.RoleName notes</li>
+            </ol>
 
-    </div>
-  </nav>
+        </div>
+    </nav>
 }
-@section mobilebacklink
-{
-  <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessmentOverview"
+    @section mobilebacklink
+    {
+    <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessmentOverview"
        asp-route-vocabulary="@Model.VocabPlural()"
        asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID"
        asp-route-competencyGroupId="@Model.SupervisorComment.CompetencyGroupID"
        asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">
-      Back to @Model.VocabPlural()
-    </a>
-  </p>
+            Back to @Model.VocabPlural()
+        </a>
+    </p>
 }
-  <div>
-    <h1>@Model.SupervisorComment?.CompetencyName</h1>
-    <div class="nhsuk-care-card nhsuk-care-card--non-urgent">
-      <div class="nhsuk-care-card__heading-container">
-        <h2 class="nhsuk-care-card__heading">
-          <span role="text">
-            Reviewer: @supervisorName
-          </span>
-        </h2>
-        <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
-      </div>
-      <div class="nhsuk-care-card__content">
-        <dl class="nhsuk-summary-list nhsuk-summary-list--no-border">
-          <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Date of review
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            @Model.SupervisorComment.Verified?.ToShortDateString()
-          </dd>
-      </div>
-      <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          Status
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.AssessmentQuestion" />
-        </dd>
-      </div>
-      <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          @(Model.SupervisorComment.ReviewerCommentsLabel == null ? "Reviewer comments": Model.SupervisorComment.ReviewerCommentsLabel.ToString())
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          @Model.SupervisorComment.Comments
-        </dd>
-      </div>
-      </dl>
-    </div>
-  </div>
+    <div>
+        <h1>@Model.SupervisorComment?.CompetencyName</h1>
+        <div class="nhsuk-care-card nhsuk-care-card--non-urgent">
+            <div class="nhsuk-care-card__heading-container">
+                <h2 class="nhsuk-care-card__heading">
+                    <span role="text">
+                        Reviewer: @supervisorName
+                    </span>
+                </h2>
+                <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
+            </div>
+            <div class="nhsuk-care-card__content">
+                <dl class="nhsuk-summary-list nhsuk-summary-list--no-border">
+                    <div class="nhsuk-summary-list__row">
+                        <dt class="nhsuk-summary-list__key">
+                            Date of review
+                        </dt>
+                        <dd class="nhsuk-summary-list__value">
+                            @Model.SupervisorComment.Verified?.ToShortDateString()
+                        </dd>
+                    </div>
+                    <div class="nhsuk-summary-list__row">
+                        <dt class="nhsuk-summary-list__key">
+                            Status
+                        </dt>
+                        <dd class="nhsuk-summary-list__value">
+                            <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.AssessmentQuestion" />
+                        </dd>
+                    </div>
+                    <div class="nhsuk-summary-list__row">
+                        <dt class="nhsuk-summary-list__key">
+                            @(Model.SupervisorComment.ReviewerCommentsLabel == null ? "Reviewer comments": Model.SupervisorComment.ReviewerCommentsLabel.ToString())
+                        </dt>
+                        <dd class="nhsuk-summary-list__value">
+                            @Model.SupervisorComment.Comments
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+        </div>
 
-  <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()"
-       asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID"
-       asp-route-competencyGroupId="@Model.SupervisorComment.CompetencyGroupID"
-       asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="24" width="24">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Back
-    </a>
-  </div>
-  </div>
+        <div class="nhsuk-back-link">
+            <a class="nhsuk-back-link__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()"
+           asp-route-selfAssessmentId="@Model.SupervisorComment.SelfAssessmentID"
+           asp-route-competencyGroupId="@Model.SupervisorComment.CompetencyGroupID"
+           asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">
+                <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="24" width="24">
+                    <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+                </svg>
+                Back
+            </a>
+        </div>
+    </div>


### PR DESCRIPTION
### JIRA link
[DLSV2-558](https://hee-dls.atlassian.net/browse/DLSV2-558)

### Description
Removes get supervisor for self assessment service and reference to it in supervisor comments view model. Adds supervisor name and role to the SupervisorComments model and adds them to the query in the existing data service. Updates the view to use the name and role from the supervisor comments model.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
