### PR TITLE
Heedls 982 update welcome emails

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/PasswordResetDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/PasswordResetDataServiceTests.cs
@@ -1,13 +1,10 @@
 namespace DigitalLearningSolutions.Data.Tests.DataServices
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
-    using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.Auth;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;

--- a/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationConfirmationDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationConfirmationDataServiceTests.cs
@@ -1,0 +1,61 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.DataServices
+{
+    using System;
+    using System.Transactions;
+    using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Models.Auth;
+    using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using Microsoft.Data.SqlClient;
+    using NUnit.Framework;
+
+    public class RegistrationConfirmationDataServiceTests
+    {
+        private SqlConnection connection = null!;
+        private RegistrationConfirmationDataService service = null!;
+        private UserDataService userDataService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            connection = ServiceTestHelper.GetDatabaseConnection();
+            userDataService = new UserDataService(connection);
+            service = new RegistrationConfirmationDataService(connection);
+        }
+
+        [Test]
+        public void
+            SetRegistrationConfirmation_sets_DelegateAccount_RegistrationConfirmationHash_and_RegistrationConfirmationHashCreationDateTime()
+        {
+            using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            // Given
+            var createTime = new DateTime(2021, 1, 1);
+            const int delegateAccountId = 2;
+            var delegateAccount = userDataService.GetDelegateAccountById(delegateAccountId);
+            var registrationConfirmationModel = new RegistrationConfirmationModel(
+                createTime,
+                "RegistrationConfirmationHash",
+                delegateAccountId
+            );
+
+            // When
+            service.SetRegistrationConfirmation(registrationConfirmationModel);
+
+            var updated = userDataService.GetDelegateAccountById(delegateAccountId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                delegateAccount!.RegistrationConfirmationHash.Should().BeNull();
+                delegateAccount.RegistrationConfirmationHashCreationDateTime.Should().BeNull();
+
+                updated!.RegistrationConfirmationHash.Should().Be(registrationConfirmationModel.Hash);
+                updated.RegistrationConfirmationHashCreationDateTime.Should()
+                    .Be(registrationConfirmationModel.CreateTime);
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -28,7 +28,7 @@
     public class DelegateUploadFileServiceTests
     {
         private const int CentreId = 101;
-        private static DateTime Today = DateTime.Today;
+        private static readonly DateTime WelcomeEmailDate = new DateTime(3000, 1, 1);
         public const string TestDelegateUploadRelativeFilePath = "\\TestData\\DelegateUploadTest.xlsx";
         private IConfiguration configuration = null!;
         private static readonly (int, string) NewDelegateIdAndCandidateNumber = (5, "DELEGATE");
@@ -291,7 +291,7 @@
             A.CallTo(() => userDataService.GetDelegateByCandidateNumber(delegateId)).Returns(null);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             AssertBulkUploadResultHasOnlyOneError(result);
@@ -318,7 +318,7 @@
                 .Returns(true);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             AssertBulkUploadResultHasOnlyOneError(result);
@@ -346,7 +346,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -385,7 +385,7 @@
                 .Returns(candidateNumberDelegate);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             AssertCreateOrUpdateDelegateWereNotCalled();
@@ -414,7 +414,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             result.ProcessedCount.Should().Be(1);
@@ -438,7 +438,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -482,7 +482,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -517,7 +517,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -553,7 +553,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -588,7 +588,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -625,7 +625,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -644,7 +644,7 @@
                                 model.ProfessionalRegistrationNumber == row.PRN &&
                                 model.CentreSpecificEmail == row.EmailAddress &&
                                 Guid.TryParse(model.PrimaryEmail, out primaryEmailIsGuid) &&
-                                model.NotifyDate == Today &&
+                                model.NotifyDate == WelcomeEmailDate &&
                                 model.IsSelfRegistered == false &&
                                 model.UserIsActive == false &&
                                 model.CentreAccountIsActive == true &&
@@ -666,7 +666,6 @@
         public void ProcessDelegateTable_calls_register_with_expected_values_when_welcomeEmailDate_is_populated()
         {
             // Given
-            var welcomeEmailDate = new DateTime(3000, 01, 01);
             var row = GetSampleDelegateDataRow(candidateNumber: string.Empty);
             var table = CreateTableFromData(new[] { row });
             Guid primaryEmailIsGuid;
@@ -685,7 +684,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, welcomeEmailDate);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -704,7 +703,7 @@
                                 model.ProfessionalRegistrationNumber == row.PRN &&
                                 model.CentreSpecificEmail == row.EmailAddress &&
                                 Guid.TryParse(model.PrimaryEmail, out primaryEmailIsGuid) &&
-                                model.NotifyDate == welcomeEmailDate
+                                model.NotifyDate == WelcomeEmailDate
                         ),
                         false
                     )
@@ -796,7 +795,7 @@
             ).DoesNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -847,7 +846,7 @@
             ).DoesNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -890,7 +889,7 @@
             ).DoesNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             A.CallTo(
@@ -922,7 +921,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             result.ProcessedCount.Should().Be(5);
@@ -950,7 +949,7 @@
                 .Returns(candidateNumberDelegate);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             result.ProcessedCount.Should().Be(5);
@@ -978,7 +977,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             result.ProcessedCount.Should().Be(5);
@@ -1031,7 +1030,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             using (new AssertionScope())
@@ -1053,7 +1052,7 @@
             var table = CreateTableFromData(new[] { row });
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, Today);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
 
             // Then
             AssertBulkUploadResultHasOnlyOneError(result);

--- a/DigitalLearningSolutions.Data.Tests/Services/LearningHubSsoSecurityServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LearningHubSsoSecurityServiceTests.cs
@@ -202,6 +202,7 @@
             private bool Called { get; set; }
 
             public DateTime UtcNow => GetNow();
+            public DateTime UtcToday => GetNow().Date;
 
             private DateTime GetNow()
             {

--- a/DigitalLearningSolutions.Data.Tests/Services/PasswordResetServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/PasswordResetServiceTests.cs
@@ -24,6 +24,7 @@
         private IEmailService emailService = null!;
         private IPasswordResetDataService passwordResetDataService = null!;
         private PasswordResetService passwordResetService = null!;
+        private IRegistrationConfirmationDataService registrationConfirmationDataService = null!;
         private IPasswordService passwordService = null!;
         private IUserService userService = null!;
 
@@ -34,6 +35,7 @@
             emailService = A.Fake<IEmailService>();
             clockService = A.Fake<IClockService>();
             passwordResetDataService = A.Fake<IPasswordResetDataService>();
+            registrationConfirmationDataService = A.Fake<IRegistrationConfirmationDataService>();
             passwordService = A.Fake<IPasswordService>();
 
             A.CallTo(() => userService.GetUserByEmailAddress(A<string>._))
@@ -42,6 +44,7 @@
             passwordResetService = new PasswordResetService(
                 userService,
                 passwordResetDataService,
+                registrationConfirmationDataService,
                 passwordService,
                 emailService,
                 clockService

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationConfirmationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationConfirmationDataService.cs
@@ -1,0 +1,41 @@
+﻿namespace DigitalLearningSolutions.Data.DataServices
+{
+    using System.Data;
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models.Auth;
+
+    public interface IRegistrationConfirmationDataService
+    {
+        void SetRegistrationConfirmation(RegistrationConfirmationModel model);
+    }
+
+    public class RegistrationConfirmationDataService : IRegistrationConfirmationDataService
+    {
+        private readonly IDbConnection connection;
+
+        public RegistrationConfirmationDataService(
+            IDbConnection connection
+        )
+        {
+            this.connection = connection;
+        }
+
+        public void SetRegistrationConfirmation(RegistrationConfirmationModel model)
+        {
+            connection.Execute(
+                @"
+                    UPDATE DelegateAccounts
+                    SET RegistrationConfirmationHash = @Hash,
+                        RegistrationConfirmationHashCreationDateTime = @CreateTime
+                    WHERE ID = @DelegateId
+                ",
+                new
+                {
+                    model.Hash,
+                    model.CreateTime,
+                    model.DelegateId,
+                }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -60,7 +60,9 @@
                 da.SelfReg,
                 da.OldPassword,
                 da.UserID,
-                da.CentreSpecificDetailsLastChecked
+                da.CentreSpecificDetailsLastChecked,
+                da.RegistrationConfirmationHash,
+                da.RegistrationConfirmationHashCreationDateTime
             FROM DelegateAccounts AS da
             INNER JOIN Centres AS ce ON ce.CentreId = da.CentreId";
 

--- a/DigitalLearningSolutions.Data/Models/Auth/RegistrationConfirmationModel.cs
+++ b/DigitalLearningSolutions.Data/Models/Auth/RegistrationConfirmationModel.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Models.Auth
+{
+    using System;
+
+    public class RegistrationConfirmationModel
+    {
+        public RegistrationConfirmationModel(DateTime createTime, string hash, int delegateId)
+        {
+            CreateTime = createTime;
+            Hash = hash;
+            DelegateId = delegateId;
+        }
+
+        public readonly DateTime CreateTime;
+        public readonly string Hash;
+        public readonly int DelegateId;
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/Auth/ResetPasswordCreateModel.cs
+++ b/DigitalLearningSolutions.Data/Models/Auth/ResetPasswordCreateModel.cs
@@ -1,7 +1,6 @@
 namespace DigitalLearningSolutions.Data.Models.Auth
 {
     using System;
-    using DigitalLearningSolutions.Data.Enums;
 
     public class ResetPasswordCreateModel
     {

--- a/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
@@ -23,5 +23,7 @@
         public bool SelfReg { get; set; }
         public string? OldPassword { get; set; }
         public DateTime? CentreSpecificDetailsLastChecked { get; set; }
+        public string? RegistrationConfirmationHash { get; set; }
+        public DateTime? RegistrationConfirmationHashCreationDateTime { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/ClockService.cs
+++ b/DigitalLearningSolutions.Data/Services/ClockService.cs
@@ -5,10 +5,12 @@ namespace DigitalLearningSolutions.Data.Services
     public interface IClockService
     {
         public DateTime UtcNow { get; }
+        public DateTime UtcToday { get; }
     }
 
     public class ClockService : IClockService
     {
         public DateTime UtcNow => DateTime.UtcNow;
+        public DateTime UtcToday => UtcNow.Date;
     }
 }

--- a/DigitalLearningSolutions.Data/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/DelegateUploadFileService.cs
@@ -20,7 +20,7 @@ namespace DigitalLearningSolutions.Data.Services
 
     public interface IDelegateUploadFileService
     {
-        public BulkUploadResult ProcessDelegatesFile(IFormFile file, int centreId, DateTime? welcomeEmailDate = null);
+        public BulkUploadResult ProcessDelegatesFile(IFormFile file, int centreId, DateTime welcomeEmailDate);
     }
 
     public class DelegateUploadFileService : IDelegateUploadFileService
@@ -49,7 +49,7 @@ namespace DigitalLearningSolutions.Data.Services
             this.configuration = configuration;
         }
 
-        public BulkUploadResult ProcessDelegatesFile(IFormFile file, int centreId, DateTime? welcomeEmailDate)
+        public BulkUploadResult ProcessDelegatesFile(IFormFile file, int centreId, DateTime welcomeEmailDate)
         {
             var table = OpenDelegatesTable(file);
             return ProcessDelegatesTable(table, centreId, welcomeEmailDate);
@@ -69,7 +69,7 @@ namespace DigitalLearningSolutions.Data.Services
             return table;
         }
 
-        internal BulkUploadResult ProcessDelegatesTable(IXLTable table, int centreId, DateTime? welcomeEmailDate = null)
+        internal BulkUploadResult ProcessDelegatesTable(IXLTable table, int centreId, DateTime welcomeEmailDate)
         {
             var jobGroupIds = jobGroupsDataService.GetJobGroupsAlphabetical().Select(item => item.id).ToList();
             var delegateRows = table.Rows().Skip(1).Select(row => new DelegateTableRow(table, row)).ToList();
@@ -84,7 +84,7 @@ namespace DigitalLearningSolutions.Data.Services
 
         private void ProcessDelegateRow(
             int centreId,
-            DateTime? welcomeEmailDate,
+            DateTime welcomeEmailDate,
             DelegateTableRow delegateRow,
             IEnumerable<int> jobGroupIds
         )
@@ -179,7 +179,7 @@ namespace DigitalLearningSolutions.Data.Services
             }
         }
 
-        private void RegisterDelegate(DelegateTableRow delegateRow, DateTime? welcomeEmailDate, int centreId)
+        private void RegisterDelegate(DelegateTableRow delegateRow, DateTime welcomeEmailDate, int centreId)
         {
             var model = new DelegateRegistrationModel(delegateRow, centreId, welcomeEmailDate);
 
@@ -193,15 +193,12 @@ namespace DigitalLearningSolutions.Data.Services
 
             SetUpSupervisorDelegateRelations(delegateRow.Email!, centreId, delegateId);
 
-            if (welcomeEmailDate.HasValue)
-            {
-                passwordResetService.GenerateAndScheduleDelegateWelcomeEmail(
-                    delegateId,
-                    configuration.GetAppRootPath(),
-                    welcomeEmailDate.Value,
-                    "DelegateBulkUpload_Refactor"
-                );
-            }
+            passwordResetService.GenerateAndScheduleDelegateWelcomeEmail(
+                delegateId,
+                configuration.GetAppRootPath(),
+                welcomeEmailDate,
+                "DelegateBulkUpload_Refactor"
+            );
 
             delegateRow.RowStatus = RowStatus.Registered;
         }

--- a/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
+++ b/DigitalLearningSolutions.Data/Services/PasswordResetService.cs
@@ -266,7 +266,7 @@
                 setPasswordUrl.Path += '/';
             }
 
-            setPasswordUrl.Path += "SetPassword"; // TODO: HEEDLS-901 The controller for this link has been deleted
+            setPasswordUrl.Path += "CompleteRegistration"; // TODO: HEEDLS-974 Create controller for this link
             setPasswordUrl.Query = $"code={registrationConfirmationHash}&email={emailAddress}";
 
             const string emailSubject = "Welcome to Digital Learning Solutions - Verify your Registration";

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
 {
-    using System;
     using DigitalLearningSolutions.Web.AutomatedUiTests.TestFixtures;
     using DigitalLearningSolutions.Web.AutomatedUiTests.TestHelpers;
-    using DocumentFormat.OpenXml.ExtendedProperties;
     using FluentAssertions;
     using Selenium.Axe;
     using Xunit;
@@ -72,10 +70,10 @@
             Driver.SubmitForm();
 
             var welcomeEmailResult = new AxeBuilder(Driver).Analyze();
-            var today = DateTime.Today;
-            Driver.FillTextInput("Day", today.Day.ToString());
-            Driver.FillTextInput("Month", today.Month.ToString());
-            Driver.FillTextInput("Year", today.Year.ToString());
+
+            Driver.FillTextInput("Day", "1");
+            Driver.FillTextInput("Month", "1");
+            Driver.FillTextInput("Year", "3000"); // The date must be in the future for the form to submit successfully
             Driver.SubmitForm();
 
             var passwordResult = new AxeBuilder(Driver).Analyze();

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/RegistrationJourneyAccessibilityTests.cs
@@ -1,7 +1,9 @@
 ﻿namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
 {
+    using System;
     using DigitalLearningSolutions.Web.AutomatedUiTests.TestFixtures;
     using DigitalLearningSolutions.Web.AutomatedUiTests.TestHelpers;
+    using DocumentFormat.OpenXml.ExtendedProperties;
     using FluentAssertions;
     using Selenium.Axe;
     using Xunit;
@@ -70,7 +72,10 @@
             Driver.SubmitForm();
 
             var welcomeEmailResult = new AxeBuilder(Driver).Analyze();
-            Driver.SetCheckboxState("ShouldSendEmail", false);
+            var today = DateTime.Today;
+            Driver.FillTextInput("Day", today.Day.ToString());
+            Driver.FillTextInput("Month", today.Month.ToString());
+            Driver.FillTextInput("Year", today.Year.ToString());
             Driver.SubmitForm();
 
             var passwordResult = new AxeBuilder(Driver).Analyze();
@@ -83,7 +88,7 @@
             // then
             registerResult.Violations.Should().BeEmpty();
             learnerInformationResult.Violations.Should().BeEmpty();
-            CheckWelcomeEmailViolations(welcomeEmailResult);
+            welcomeEmailResult.Violations.Should().BeEmpty();
             passwordResult.Violations.Should().BeEmpty();
             summaryResult.Violations.Should().BeEmpty();
         }
@@ -111,19 +116,6 @@
             registerResult.Violations.Should().BeEmpty();
             learnerInformationResult.Violations.Should().BeEmpty();
             summaryResult.Violations.Should().BeEmpty();
-        }
-
-        private static void CheckWelcomeEmailViolations(AxeResult welcomeEmailResult)
-        {
-            // Expect an axe violation caused by having an aria-expanded attribute on an input
-            // The target #ShouldSendEmail is an nhs-tested component so ignore this violation
-            welcomeEmailResult.Violations.Should().HaveCount(1);
-            var violation = welcomeEmailResult.Violations[0];
-
-            violation.Id.Should().Be("aria-allowed-attr");
-            violation.Nodes.Should().HaveCount(1);
-            violation.Nodes[0].Target.Should().HaveCount(1);
-            violation.Nodes[0].Target[0].Selector.Should().Be("#ShouldSendEmail");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -213,36 +213,23 @@
         }
 
         [Test]
-        public void WelcomeEmailPost_with_ShouldSendEmail_false_updates_tempdata_correctly()
-        {
-            // Given
-            controller.TempData.Set(new DelegateRegistrationByCentreData());
-            var model = new WelcomeEmailViewModel { ShouldSendEmail = false, Day = 7, Month = 7, Year = 2200 };
-
-            // When
-            controller.WelcomeEmail(model);
-
-            // Then
-            var data = controller.TempData.Peek<DelegateRegistrationByCentreData>()!;
-            data.ShouldSendEmail.Should().BeFalse();
-            data.WelcomeEmailDate.Should().BeNull();
-        }
-
-        [Test]
-        public void WelcomeEmailPost_with_ShouldSendEmail_true_updates_tempdata_correctly()
+        public void WelcomeEmailPost_updates_tempdata_correctly()
         {
             // Given
             controller.TempData.Set(new DelegateRegistrationByCentreData { PasswordHash = "hash" });
             var date = new DateTime(2200, 7, 7);
             var model = new WelcomeEmailViewModel
-            { ShouldSendEmail = true, Day = date.Day, Month = date.Month, Year = date.Year };
+            {
+                Day = date.Day,
+                Month = date.Month,
+                Year = date.Year,
+            };
 
             // When
             controller.WelcomeEmail(model);
 
             // Then
             var data = controller.TempData.Peek<DelegateRegistrationByCentreData>()!;
-            data.ShouldSendEmail.Should().BeTrue();
             data.WelcomeEmailDate.Should().Be(date);
             data.IsPasswordSet.Should().BeFalse();
             data.PasswordHash.Should().BeNull();
@@ -313,10 +300,8 @@
 
             // Then
             var delegateNumber = (string?)controller.TempData.Peek("delegateNumber");
-            var emailSent = (bool)controller.TempData.Peek("emailSent");
             var passwordSet = (bool)controller.TempData.Peek("passwordSet");
             delegateNumber.Should().Be(sampleDelegateNumber);
-            emailSent.Should().Be(data.ShouldSendEmail);
             passwordSet.Should().Be(data.IsPasswordSet);
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -1,13 +1,11 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.Register
 {
     using System;
-    using System.Collections.Generic;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.Register;
-    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.Controllers.Register;

--- a/DigitalLearningSolutions.Web.Tests/Models/DelegateRegistrationByCentreDataTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Models/DelegateRegistrationByCentreDataTests.cs
@@ -38,34 +38,22 @@
         }
 
         [Test]
-        public void SetWelcomeEmail_with_ShouldSendEmail_false_sets_data_correctly()
-        {
-            // Given
-            var model = new WelcomeEmailViewModel { ShouldSendEmail = false, Day = 7, Month = 7, Year = 2200 };
-            var data = new DelegateRegistrationByCentreData();
-
-            // When
-            data.SetWelcomeEmail(model);
-
-            // Then
-            data.ShouldSendEmail.Should().BeFalse();
-            data.WelcomeEmailDate.Should().BeNull();
-        }
-
-        [Test]
-        public void SetWelcomeEmail_with_ShouldSendEmail_true_sets_data_correctly()
+        public void SetWelcomeEmail_sets_data_correctly()
         {
             // Given
             var date = new DateTime(2200, 7, 7);
             var model = new WelcomeEmailViewModel
-                { ShouldSendEmail = true, Day = date.Day, Month = date.Month, Year = date.Year };
+            {
+                Day = date.Day,
+                Month = date.Month,
+                Year = date.Year,
+            };
             var data = new DelegateRegistrationByCentreData();
 
             // When
             data.SetWelcomeEmail(model);
 
             // Then
-            data.ShouldSendEmail.Should().BeTrue();
             data.WelcomeEmailDate.Should().Be(date);
             data.IsPasswordSet.Should().BeFalse();
             data.PasswordHash.Should().BeNull();

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -2,7 +2,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -169,8 +169,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         {
             var data = TempData.Peek<DelegateRegistrationByCentreData>()!;
 
-            model.ClearDateIfNotSendEmail();
-
             if (!ModelState.IsValid)
             {
                 return View(model);
@@ -238,7 +236,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
                 TempData.Clear();
                 TempData.Add("delegateNumber", candidateNumber);
-                TempData.Add("emailSent", data.ShouldSendEmail);
                 TempData.Add("passwordSet", data.IsPasswordSet);
                 return RedirectToAction("Confirmation");
             }
@@ -264,8 +261,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         public IActionResult Confirmation()
         {
             var delegateNumber = (string?)TempData.Peek("delegateNumber");
-            var emailSent = (bool)TempData.Peek("emailSent");
-            var passwordSet = (bool)TempData.Peek("passwordSet");
             TempData.Clear();
 
             if (delegateNumber == null)
@@ -273,7 +268,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
                 return RedirectToAction("Index");
             }
 
-            var viewModel = new ConfirmationViewModel(delegateNumber, emailSent, passwordSet);
+            var viewModel = new ConfirmationViewModel(delegateNumber);
             return View(viewModel);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -21,14 +21,17 @@
     {
         private readonly IDelegateDownloadFileService delegateDownloadFileService;
         private readonly IDelegateUploadFileService delegateUploadFileService;
+        private readonly IClockService clockService;
 
         public BulkUploadController(
             IDelegateDownloadFileService delegateDownloadFileService,
-            IDelegateUploadFileService delegateUploadFileService
+            IDelegateUploadFileService delegateUploadFileService,
+            IClockService clockService
         )
         {
             this.delegateDownloadFileService = delegateDownloadFileService;
             this.delegateUploadFileService = delegateUploadFileService;
+            this.clockService = clockService;
         }
 
         public IActionResult Index()
@@ -43,7 +46,7 @@
                 delegateDownloadFileService.GetDelegatesAndJobGroupDownloadFileForCentre(
                     User.GetCentreIdKnownNotNull()
                 );
-            var fileName = $"DLS Delegates for Bulk Update {DateTime.Today:yyyy-MM-dd}.xlsx";
+            var fileName = $"DLS Delegates for Bulk Update {clockService.UtcToday:yyyy-MM-dd}.xlsx";
             return File(
                 content,
                 FileHelper.GetContentTypeFromFileName(fileName),

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -39,7 +39,10 @@
         [Route("DownloadDelegates")]
         public IActionResult DownloadDelegates()
         {
-            var content = delegateDownloadFileService.GetDelegatesAndJobGroupDownloadFileForCentre(User.GetCentreIdKnownNotNull());
+            var content =
+                delegateDownloadFileService.GetDelegatesAndJobGroupDownloadFileForCentre(
+                    User.GetCentreIdKnownNotNull()
+                );
             var fileName = $"DLS Delegates for Bulk Update {DateTime.Today:yyyy-MM-dd}.xlsx";
             return File(
                 content,
@@ -65,8 +68,6 @@
             {
                 return View("StartUpload", model);
             }
-
-            model.ClearDateIfNotSendEmail();
 
             try
             {

--- a/DigitalLearningSolutions.Web/Models/DelegateRegistrationByCentreData.cs
+++ b/DigitalLearningSolutions.Web/Models/DelegateRegistrationByCentreData.cs
@@ -14,20 +14,12 @@
 
         public DateTime? WelcomeEmailDate { get; set; }
 
-        public bool ShouldSendEmail => WelcomeEmailDate.HasValue;
         public bool IsPasswordSet => PasswordHash != null;
 
         public void SetWelcomeEmail(WelcomeEmailViewModel model)
         {
-            if (model.ShouldSendEmail)
-            {
-                WelcomeEmailDate = new DateTime(model.Year!.Value, model.Month!.Value, model.Day!.Value);
-                PasswordHash = null;
-            }
-            else
-            {
-                WelcomeEmailDate = null;
-            }
+            WelcomeEmailDate = new DateTime(model.Year!.Value, model.Month!.Value, model.Day!.Value);
+            PasswordHash = null;
         }
 
         public void SetPersonalInformation(RegisterDelegatePersonalInformationViewModel model)

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -262,6 +262,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<ICentreContractAdminUsageService, CentreContractAdminUsageService>();
             services.AddScoped<IPasswordDataService, PasswordDataService>();
             services.AddScoped<IPasswordResetDataService, PasswordResetDataService>();
+            services.AddScoped<IRegistrationConfirmationDataService, RegistrationConfirmationDataService>();
             services.AddScoped<IProgressDataService, ProgressDataService>();
             services.AddScoped<IRegionDataService, RegionDataService>();
             services.AddScoped<IRegistrationDataService, RegistrationDataService>();

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -14,11 +14,6 @@ namespace DigitalLearningSolutions.Web
     using DigitalLearningSolutions.Data.Mappers;
     using DigitalLearningSolutions.Data.ModelBinders;
     using DigitalLearningSolutions.Data.Models.DelegateUpload;
-    using DigitalLearningSolutions.Data.Models.MultiPageFormData.AddAdminField;
-    using DigitalLearningSolutions.Data.Models.MultiPageFormData.AddNewCentreCourse;
-    using DigitalLearningSolutions.Data.Models.MultiPageFormData.AddRegistrationPrompt;
-    using DigitalLearningSolutions.Data.Models.MultiPageFormData.EditAdminField;
-    using DigitalLearningSolutions.Data.Models.MultiPageFormData.EditRegistrationPrompt;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;

--- a/DigitalLearningSolutions.Web/ViewModels/Register/RegisterDelegateByCentre/ConfirmationViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/RegisterDelegateByCentre/ConfirmationViewModel.cs
@@ -2,15 +2,11 @@
 {
     public class ConfirmationViewModel
     {
-        public ConfirmationViewModel(string delegateNumber, bool emailWillBeSent, bool passwordSet)
+        public ConfirmationViewModel(string delegateNumber)
         {
             DelegateNumber = delegateNumber;
-            EmailWillBeSent = emailWillBeSent;
-            PasswordSet = passwordSet;
         }
 
         public string DelegateNumber { get; set; }
-        public bool EmailWillBeSent { get; set; }
-        public bool PasswordSet { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Register/RegisterDelegateByCentre/SummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/RegisterDelegateByCentre/SummaryViewModel.cs
@@ -15,11 +15,7 @@
             LastName = data.LastName;
             CentreSpecificEmail = data.CentreSpecificEmail;
             IsPasswordSet = data.IsPasswordSet;
-            if (data.ShouldSendEmail)
-            {
-                WelcomeEmailDate = data.WelcomeEmailDate!.Value.ToString(DateHelper.StandardDateFormat);
-            }
-
+            WelcomeEmailDate = data.WelcomeEmailDate!.Value.ToString(DateHelper.StandardDateFormat);
             ProfessionalRegistrationNumber = data.ProfessionalRegistrationNumber ?? "Not professionally registered";
             HasProfessionalRegistrationNumber = data.HasProfessionalRegistrationNumber;
         }
@@ -29,7 +25,6 @@
         public string? CentreSpecificEmail { get; set; }
         public bool IsPasswordSet { get; set; }
         public string? WelcomeEmailDate { get; set; }
-        public bool ShouldSendEmail => WelcomeEmailDate != null;
         public string? JobGroup { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
         public bool? HasProfessionalRegistrationNumber { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/Register/RegisterDelegateByCentre/WelcomeEmailViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/RegisterDelegateByCentre/WelcomeEmailViewModel.cs
@@ -11,39 +11,19 @@
 
         public WelcomeEmailViewModel(DelegateRegistrationByCentreData data)
         {
-            ShouldSendEmail = data.ShouldSendEmail;
-            if (ShouldSendEmail)
-            {
-                Day = data.WelcomeEmailDate!.Value.Day;
-                Month = data.WelcomeEmailDate!.Value.Month;
-                Year = data.WelcomeEmailDate!.Value.Year;
-            }
+            Day = data.WelcomeEmailDate!.Value.Day;
+            Month = data.WelcomeEmailDate!.Value.Month;
+            Year = data.WelcomeEmailDate!.Value.Year;
         }
 
         public int? Day { get; set; }
         public int? Month { get; set; }
         public int? Year { get; set; }
-        public bool ShouldSendEmail { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (!ShouldSendEmail)
-            {
-                return new List<ValidationResult>();
-            }
-
             return DateValidator.ValidateDate(Day, Month, Year, "Email delivery date", true)
                 .ToValidationResultList(nameof(Day), nameof(Month), nameof(Year));
-        }
-
-        public void ClearDateIfNotSendEmail()
-        {
-            if (!ShouldSendEmail)
-            {
-                Day = null;
-                Month = null;
-                Year = null;
-            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
@@ -19,12 +19,12 @@
 
         [Required(ErrorMessage = "Delegates update file is required")]
         [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format")]
-        [MaxFileSize(5*1024*1024, "Maximum allowed file size is 5MB")]
+        [MaxFileSize(5 * 1024 * 1024, "Maximum allowed file size is 5MB")]
         public IFormFile? DelegatesFile { get; set; }
 
-        public DateTime? GetWelcomeEmailDate()
+        public DateTime GetWelcomeEmailDate()
         {
-            return ShouldSendEmail ? new DateTime(Year!.Value, Month!.Value, Day!.Value) : (DateTime?)null;
+            return new DateTime(Year!.Value, Month!.Value, Day!.Value);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/Confirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/Confirmation.cshtml
@@ -14,21 +14,9 @@
     <h1 id="page-heading" class="nhsuk-heading-xl">
       Delegate registration complete
     </h1>
-    @if (Model.EmailWillBeSent) {
-      <p class="nhsuk-body-l">
-        A welcome message will be sent to the email provided, on the date specified, inviting the delegate to set their password and confirm their registration.
-      </p>
-    } else {
-      if (Model.PasswordSet) {
-        <p class="nhsuk-body-l">
-          You should contact the delegate to inform them of their login details and recommend that they change their password using the My account interface after login.
-        </p>
-      } else {
-        <p class="nhsuk-body-l">
-          The delegate has been registered but no welcome email has been sent. You can send the welcome email at a later date from the All Delegates interface using the Send Welcome Emails button.
-        </p>
-      }
-    }
+    <p class="nhsuk-body-l">
+      A welcome message will be sent to the email provided, on the date specified, inviting the delegate to confirm their registration.
+    </p>
     <div class="nhsuk-inset-text">
       <span class="nhsuk-u-visually-hidden">Information: </span>
       <p>Delegate number <span class="nhsuk-u-font-weight-bold">@Model.DelegateNumber</span></p>

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/Summary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/Summary.cshtml
@@ -96,10 +96,10 @@
       }
       <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
-          @(Model.ShouldSendEmail ? "Welcome email date" : "Send welcome email")
+          Welcome email date
         </dt>
         <dd class="nhsuk-summary-list__value">
-          @(Model.ShouldSendEmail ? Model.WelcomeEmailDate : "No")
+          @Model.WelcomeEmailDate
         </dd>
         <dd class="nhsuk-summary-list__actions">
           <a asp-action="WelcomeEmail">
@@ -107,21 +107,19 @@
           </a>
         </dd>
       </div>
-      @if (!Model.ShouldSendEmail) {
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Password set
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            @(Model.IsPasswordSet ? "Yes" : "No")
-          </dd>
-          <dd class="nhsuk-summary-list__actions">
-            <a asp-action="Password">
-              Change<span class="nhsuk-u-visually-hidden"> password settings</span>
-            </a>
-          </dd>
-        </div>
-      }
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Password set
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          @(Model.IsPasswordSet ? "Yes" : "No")
+        </dd>
+        <dd class="nhsuk-summary-list__actions">
+          <a asp-action="Password">
+            Change<span class="nhsuk-u-visually-hidden"> password settings</span>
+          </a>
+        </dd>
+      </div>
     </dl>
 
     <form method="post" asp-action="Summary">

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
@@ -1,11 +1,13 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Register.RegisterDelegateByCentre
+﻿@using DigitalLearningSolutions.Data.Services
+@using DigitalLearningSolutions.Web.ViewModels.Register.RegisterDelegateByCentre
 @model WelcomeEmailViewModel
+@inject IClockService ClockService
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? "Error: Register delegate - Welcome email" : "Register delegate - Welcome email";
   const string dateInputId = "welcome-email-date";
-  var exampleDate = DateTime.Today;
+  var exampleDate = ClockService.UtcToday;
   var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}" };
 }
 

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
@@ -29,7 +29,7 @@
                      day-id="Day"
                      month-id="Month"
                      year-id="Year"
-                     css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5" : "")"
+                     css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5 nhsuk-u-margin-bottom-3" : "")"
                      hint-text-lines="@hintTextLines" />
 
       <a class="nhsuk-button nhsuk-button--secondary" asp-controller="RegisterDelegateByCentre" asp-action="LearnerInformation" role="button">Back</a>

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/WelcomeEmail.cshtml
@@ -6,9 +6,6 @@
   ViewData["Title"] = errorHasOccurred ? "Error: Register delegate - Welcome email" : "Register delegate - Welcome email";
   const string dateInputId = "welcome-email-date";
   var exampleDate = DateTime.Today;
-  var emailDateCss = "nhsuk-checkboxes__conditional"
-                     + (Model.ShouldSendEmail ? "" : " nhsuk-checkboxes__conditional--hidden")
-                     + (errorHasOccurred ? " nhsuk-u-padding-left-5" : "");
   var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}" };
 }
 
@@ -25,29 +22,13 @@
     <h1 class="nhsuk-heading-xl">Welcome email</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="WelcomeEmail">
-      <div class="nhsuk-checkboxes nhsuk-checkboxes--conditional nhsuk-u-margin-bottom-4">
-        <div class="nhsuk-checkboxes__item">
-          <input class="nhsuk-checkboxes__input"
-                 id="ShouldSendEmail"
-                 name="ShouldSendEmail"
-                 asp-for="ShouldSendEmail"
-                 type="checkbox"
-                 value="true"
-                 aria-controls="@dateInputId"
-                 aria-expanded="@(Model.ShouldSendEmail ? "true" : "false")">
-          <label class="nhsuk-label nhsuk-checkboxes__label" for="ShouldSendEmail">
-            Send welcome email to registered delegate
-          </label>
-        </div>
-
-        <vc:date-input id="@dateInputId"
-                       label="Deliver email on or after"
-                       day-id="Day"
-                       month-id="Month"
-                       year-id="Year"
-                       css-class="@emailDateCss"
-                       hint-text-lines="@hintTextLines" />
-      </div>
+      <vc:date-input id="@dateInputId"
+                     label="Send welcome email to registered delegate, to be delivered on or after"
+                     day-id="Day"
+                     month-id="Month"
+                     year-id="Year"
+                     css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5" : "")"
+                     hint-text-lines="@hintTextLines" />
 
       <a class="nhsuk-button nhsuk-button--secondary" asp-controller="RegisterDelegateByCentre" asp-action="LearnerInformation" role="button">Back</a>
       <button class="nhsuk-button" type="submit">Next</button>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
@@ -25,7 +25,7 @@
                      day-id="Day"
                      month-id="Month"
                      year-id="Year"
-                     css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5" : "")"
+                     css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5 nhsuk-u-margin-bottom-3" : "")"
                      hint-text-lines="@hintTextLines" />
 
       <vc:file-input asp-for="@nameof(Model.DelegatesFile)" label="File with updated information" hint-text="" css-class="nhsuk-u-width-one-half" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
@@ -6,9 +6,6 @@
   ViewData["Title"] = errorHasOccurred ? "Error: Bulk upload/update delegates" : "Bulk upload/update delegates";
   const string dateInputId = "welcome-email-date";
   var exampleDate = DateTime.Today;
-  var emailDateCss = "nhsuk-checkboxes__conditional"
-                     + (Model.ShouldSendEmail ? "" : " nhsuk-checkboxes__conditional--hidden")
-                     + (errorHasOccurred ? " nhsuk-u-padding-left-5" : "");
   var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}" };
 }
 
@@ -21,27 +18,13 @@
     <h1 class="nhsuk-heading-xl">Bulk upload/update delegates</h1>
 
     <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="StartUpload" enctype="multipart/form-data">
-      <div class="nhsuk-checkboxes nhsuk-checkboxes--conditional nhsuk-u-margin-bottom-4">
-        <div class="nhsuk-checkboxes__item">
-          <input class="nhsuk-checkboxes__input"
-                 asp-for="ShouldSendEmail"
-                 type="checkbox"
-                 value="true"
-                 aria-controls="@dateInputId"
-                 aria-expanded="@Model.ShouldSendEmail">
-          <label class="nhsuk-label nhsuk-checkboxes__label" asp-for="ShouldSendEmail">
-            Send welcome email to registered delegates
-          </label>
-        </div>
-
-        <vc:date-input id="@dateInputId"
-                       label="Deliver email on or after"
-                       day-id="Day"
-                       month-id="Month"
-                       year-id="Year"
-                       css-class="@emailDateCss"
-                       hint-text-lines="@hintTextLines" />
-      </div>
+      <vc:date-input id="@dateInputId"
+                     label="Send welcome email to registered delegates, to be delivered on or after"
+                     day-id="Day"
+                     month-id="Month"
+                     year-id="Year"
+                     css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5" : "")"
+                     hint-text-lines="@hintTextLines" />
 
       <vc:file-input asp-for="@nameof(Model.DelegatesFile)" label="File with updated information" hint-text="" css-class="nhsuk-u-width-one-half" />
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
@@ -1,11 +1,13 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates
+﻿@using DigitalLearningSolutions.Data.Services
+@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates
 @model UploadDelegatesViewModel
+@inject IClockService ClockService
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? "Error: Bulk upload/update delegates" : "Bulk upload/update delegates";
   const string dateInputId = "welcome-email-date";
-  var exampleDate = DateTime.Today;
+  var exampleDate = ClockService.UtcToday;
   var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}" };
 }
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-982

### Description
* It is now mandatory to send welcome emails to delegates created by the bulk upload and register-by-admin journeys
  * The label for email delivery date in the UI has been changed so that it makes sense now that the optional checkbox has been removed
* The welcome email will link to /CompleteRegistration, which is currently not implemented
* RegistrationConfirmationHash and RegistrationConfirmationHashCreationDateTime are populated in the database for new DelegateAccounts during these journeys, and for other journeys where welcome emails are sent, rather than creating a reset password record
* The register-by-admin summary page now always shows whether a password has been set

### Screenshots
Bulk upload journey - start upload step
![bulk upload](https://user-images.githubusercontent.com/1258014/178000340-374c2cfe-5716-48d0-82f8-b5c3ae67444c.png)

Register by admin journey - welcome email step
![register by admin](https://user-images.githubusercontent.com/1258014/178000344-be2a887f-4818-41e8-8e00-3bf0af458278.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [x] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
