### PR TITLE
DLSV2-602 Adds nominated supervisor to custom claim helper

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -131,7 +131,8 @@
 
         public static bool HasSupervisorAdminPermissions(this ClaimsPrincipal user)
         {
-            return user.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) == true;
+            return user.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) == true ||
+                   user.GetCustomClaimAsBool(CustomClaimTypes.IsNominatedSupervisor) == true;
         }
 
         public static string GetCandidateNumberKnownNotNull(this ClaimsPrincipal user)


### PR DESCRIPTION
### JIRA link
[DLSV2-602](https://hee-dls.atlassian.net/browse/DLSV2-602)

### Description
Fixes bug with My Account being unavailable for users with nominated supervisor role accessing the supervisor interface by adding nominated supervisor to the CustomClaimHelper class HasSupervisorAdminPermissions method.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
