### PR TITLE
DLSV2-573 Add catalogue filtering to signposting

### DIFF
--- a/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
+++ b/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
@@ -16,6 +16,7 @@
     {
         Task<ResourceSearchResult> SearchResource(
             string text,
+            int? catalogueId,
             int? offset = null,
             int? limit = null,
             IEnumerable<string>? resourceTypes = null
@@ -26,6 +27,8 @@
         Task<BulkResourceReferences> GetBulkResourcesByReferenceIds(
             IEnumerable<int> resourceReferenceIds
         );
+
+        Task<CataloguesResult> GetCatalogues();
     }
 
     public class LearningHubApiClient : ILearningHubApiClient
@@ -48,12 +51,13 @@
 
         public async Task<ResourceSearchResult> SearchResource(
             string text,
+            int? catalogueId = null,
             int? offset = null,
             int? limit = null,
             IEnumerable<string>? resourceTypes = null
         )
         {
-            var queryString = GetSearchQueryString(text, offset, limit, resourceTypes);
+            var queryString = GetSearchQueryString(text, catalogueId, offset, limit, resourceTypes);
 
             var response = await GetStringAsync($"/Resource/Search?{queryString}");
             var result = JsonConvert.DeserializeObject<ResourceSearchResult>(response);
@@ -80,22 +84,32 @@
             return result;
         }
 
+        public async Task<CataloguesResult> GetCatalogues()
+        {
+            var response = await GetStringAsync($"/Catalogues");
+            var result = JsonConvert.DeserializeObject<CataloguesResult>(response);
+            return result;
+        }
+
         private static string GetSearchQueryString(
             string text,
+            int? catalogueId = null,
             int? offset = null,
             int? limit = null,
             IEnumerable<string>? resourceTypes = null
         )
         {
             var textQueryString = GetQueryString("text", text);
+            var catalogueIdString = GetQueryString("catalogueId", catalogueId.ToString());
             var offSetQueryString = GetQueryString("offset", offset.ToString());
             var limitQueryString = GetQueryString("limit", limit.ToString());
 
-            var queryStrings = new List<string> { textQueryString, offSetQueryString, limitQueryString };
+            var queryStrings = new List<string> { textQueryString, catalogueIdString, offSetQueryString, limitQueryString };
 
             if (resourceTypes != null)
             {
-                var resourceTypesQueryStrings = resourceTypes.Where(x => !string.IsNullOrEmpty(x))
+                var resourceTypesQueryStrings = resourceTypes
+                    .Where(x => !string.IsNullOrEmpty(x))
                     .Select(r => GetQueryString("resourceTypes", r.ToString()));
                 queryStrings.AddRange(resourceTypesQueryStrings);
             }

--- a/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
+++ b/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
@@ -100,9 +100,9 @@
         )
         {
             var textQueryString = GetQueryString("text", text);
-            var catalogueIdString = GetQueryString("catalogueId", catalogueId.ToString());
-            var offSetQueryString = GetQueryString("offset", offset.ToString());
-            var limitQueryString = GetQueryString("limit", limit.ToString());
+            var catalogueIdString = GetQueryString("catalogueId", catalogueId?.ToString());
+            var offSetQueryString = GetQueryString("offset", offset?.ToString());
+            var limitQueryString = GetQueryString("limit", limit?.ToString());
 
             var queryStrings = new List<string> { textQueryString, catalogueIdString, offSetQueryString, limitQueryString };
 

--- a/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/CataloguesResult.cs
+++ b/DigitalLearningSolutions.Data/Models/External/LearningHubApiClient/CataloguesResult.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DigitalLearningSolutions.Data.Models.External.LearningHubApiClient
+{
+    public class CataloguesResult
+    {
+        public List<Catalogue> Catalogues { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -20,6 +20,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
 {
     public partial class FrameworksController
     {
+        private static List<Catalogue> Catalogues { get; set; }
+
         [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/CompetencyGroup/{frameworkCompetencyGroupId}/Signposting")]
         public IActionResult EditCompetencyLearningResources(int frameworkId, int frameworkCompetencyGroupId, int frameworkCompetencyId)
         {
@@ -29,9 +31,12 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         }
 
         [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/CompetencyGroup/{frameworkCompetencyGroupId}/Signposting/AddResource/{page=1:int}")]
-        public async Task<IActionResult> SearchLearningResourcesAsync(int frameworkId, int frameworkCompetencyId, int? frameworkCompetencyGroupId, string searchText, int page)
+        public async Task<IActionResult> SearchLearningResourcesAsync(int frameworkId, int frameworkCompetencyId, int? frameworkCompetencyGroupId, int? catalogueId, string searchText, int page)
         {
             var model = new CompetencyResourceSignpostingViewModel(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId);
+            Catalogues = Catalogues ?? (await this.learningHubApiClient.GetCatalogues())?.Catalogues;
+            model.Catalogues = Catalogues;
+            model.CatalogueId = catalogueId;
             if (frameworkCompetencyGroupId.HasValue)
             {
                 var competency = frameworkService.GetFrameworkCompetencyById(frameworkCompetencyId);
@@ -44,7 +49,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 try
                 {
                     var offset = (int?)((model.Page - 1) * CompetencyResourceSignpostingViewModel.ItemsPerPage);
-                    model.SearchResult = await this.learningHubApiClient.SearchResource(model.SearchText ?? String.Empty, offset, CompetencyResourceSignpostingViewModel.ItemsPerPage);
+                    model.SearchResult = await this.learningHubApiClient.SearchResource(model.SearchText ?? String.Empty, catalogueId, offset, CompetencyResourceSignpostingViewModel.ItemsPerPage);
                     model.LearningHubApiError = model.SearchResult == null;
                 }
                 catch (Exception)

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -37,6 +37,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             Catalogues = Catalogues ?? (await this.learningHubApiClient.GetCatalogues())?.Catalogues;
             model.Catalogues = Catalogues;
             model.CatalogueId = catalogueId;
+            model.Page = Math.Max(page, 1);
             if (frameworkCompetencyGroupId.HasValue)
             {
                 var competency = frameworkService.GetFrameworkCompetencyById(frameworkCompetencyId);
@@ -44,7 +45,6 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             }
             if (searchText?.Trim().Length > 1)
             {
-                model.Page = Math.Max(page, 1);
                 model.SearchText = searchText;
                 try
                 {

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSignpostingViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSignpostingViewModel.cs
@@ -11,6 +11,8 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
         public string Title { get; set; }
         public List<SignpostingCardViewModel> CompetencyResourceLinks { get; set; }
         public IEnumerable<SearchableCompetencyViewModel> Delegates { get; set; }
+        public List<Catalogue> Catalogues { get; set; }
+        public int? CatalogueId { get; set; }
         public string SearchText { get; set; }
         public override int Page { get; set; }
         public bool LearningHubApiError { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
@@ -11,7 +11,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
     public class CompetencyResourceSummaryViewModel : BaseSignpostingViewModel
     {
         private string _Link;
-        private string _Catalog;
         private int _ReferenceId;
         public int ReferenceId
         {
@@ -47,6 +46,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
             }
         }
         public string SelectedCatalogue { get; set; }
+        public int? CatalogueId { get; set; }
         public decimal? Rating { get; set; }
         public string NameOfCompetency { get; set; }
         public string SearchText { get; set; }
@@ -60,8 +60,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
             Resource = resource;
         }
 
-        public CompetencyResourceSummaryViewModel(int frameworkId, int frameworkCompetencyId, int frameworkCompetencyGroupId) : base(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId)
+        public CompetencyResourceSummaryViewModel(int frameworkId, int frameworkCompetencyId, int frameworkCompetencyGroupId, int? catalogueId = null) : base(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId)
         {
+            CatalogueId = catalogueId;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/CompetencyResourceSummaryViewModel.cs
@@ -60,9 +60,8 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
             Resource = resource;
         }
 
-        public CompetencyResourceSummaryViewModel(int frameworkId, int frameworkCompetencyId, int frameworkCompetencyGroupId, int? catalogueId = null) : base(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId)
+        public CompetencyResourceSummaryViewModel(int frameworkId, int frameworkCompetencyId, int frameworkCompetencyGroupId) : base(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId)
         {
-            CatalogueId = catalogueId;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
@@ -84,6 +84,7 @@
      asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
      asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
      asp-route-searchText="@Model.SearchText"
+     asp-route-catalogueId="@parent?.CatalogueId"
      asp-route-page="1">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
@@ -4,7 +4,6 @@
 @{
   ViewData["Title"] = "Add Competency Learning Resource Summary";
   ViewData["Application"] = "Framework Service";
-  var parent = (CompetencyResourceSignpostingViewModel)ViewData["parent"];
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 
@@ -76,15 +75,17 @@
   @Html.HiddenFor(m => m.Resource.Description)
   @Html.HiddenFor(m => m.Link)
   @Html.HiddenFor(m => m.SelectedCatalogue)
+  @Html.HiddenFor(m => m.CatalogueId)
   @Html.HiddenFor(m => m.Rating)
 </form>
 <div class="nhsuk-back-link nhsuk-u-margin-left-1">
-  <a class="nhsuk-back-link__link" asp-action="SearchLearningResources"
+  <a class="nhsuk-back-link__link"
+     asp-action="SearchLearningResources"
      asp-route-frameworkId="@Model.FrameworkId"
      asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
      asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
      asp-route-searchText="@Model.SearchText"
-     asp-route-catalogueId="@parent?.CatalogueId"
+     asp-route-catalogueId="@Model.CatalogueId"
      asp-route-page="1">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
@@ -57,7 +57,10 @@
                 asp-action="SearchLearningResources"
                 asp-route-frameworkId="@Model.FrameworkId"
                 asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
-                asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">
+                asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
+                asp-route-searchText=""
+                asp-route-catalogueId="null"
+                asp-route-page="1">
           Restart search
         </button>
       </div>
@@ -69,14 +72,11 @@
   @Html.HiddenFor(m => m.FrameworkCompetencyGroupId)
   @Html.HiddenFor(m => m.FrameworkCompetencyId)
   @Html.HiddenFor(m => m.ReferenceId)
-  @Html.HiddenFor(m => m.SearchText)
   @Html.HiddenFor(m => m.Resource.Title)
   @Html.HiddenFor(m => m.Resource.ResourceType)
   @Html.HiddenFor(m => m.Resource.Description)
   @Html.HiddenFor(m => m.Link)
   @Html.HiddenFor(m => m.SelectedCatalogue)
-  @Html.HiddenFor(m => m.CatalogueId)
-  @Html.HiddenFor(m => m.Page)
   @Html.HiddenFor(m => m.Rating)
 </form>
 <div class="nhsuk-back-link nhsuk-u-margin-left-1">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResourceSummary.cshtml
@@ -76,6 +76,7 @@
   @Html.HiddenFor(m => m.Link)
   @Html.HiddenFor(m => m.SelectedCatalogue)
   @Html.HiddenFor(m => m.CatalogueId)
+  @Html.HiddenFor(m => m.Page)
   @Html.HiddenFor(m => m.Rating)
 </form>
 <div class="nhsuk-back-link nhsuk-u-margin-left-1">
@@ -86,7 +87,7 @@
      asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
      asp-route-searchText="@Model.SearchText"
      asp-route-catalogueId="@Model.CatalogueId"
-     asp-route-page="1">
+     asp-route-page="@Model.Page">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
     </svg>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -46,10 +46,25 @@
     <div class="nhsuk-grid-column-three-quarters">
       <div class="search-box-container" id="search">
         @Html.LabelFor(m => m.SearchText, "Search", new { @class = "nhsuk-u-visually-hidden", @for = "search-field" })
-        @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
+        @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box nhsuk-input", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
         <button class="nhsuk-button sort-submit" type="submit" asp-route-page="1" asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">
           Search
         </button>
+      </div>
+      <div class="filter-value-container">
+        @Html.DropDownListFor(c => c.CatalogueId,
+          Model.Catalogues
+            .Select(c => new SelectListItem(
+              text: c.Name,
+              value: c.Id.ToString(),
+              selected: c.Id == (Model.CatalogueId ?? Model.Catalogues?.FirstOrDefault()?.Id))
+            ),
+          new
+          {
+            @class = "nhsuk-select nhsuk-u-margin-bottom-4",
+            aria_label = "Catalogue filter",
+            style = "border-radius: 4px;"
+          })
       </div>
     </div>
   </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -1,8 +1,15 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks;
 @model CompetencyResourceSignpostingViewModel
 @{
-  ViewData["Title"] = "Add Competency Learning Resource";
-  ViewData["Application"] = "Framework Service";
+    ViewData["Title"] = "Add Competency Learning Resource";
+    ViewData["Application"] = "Framework Service";
+    var dropdownItems = Model.Catalogues
+          .Select(c => new SelectListItem(
+            text: c.Name,
+            value: c.Id.ToString(),
+            selected: c.Id == Model.CatalogueId)
+          ).ToList();
+    dropdownItems.Insert(0, new SelectListItem("Any", "null", !Model.CatalogueId.HasValue));
 }
 
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
@@ -16,18 +23,31 @@
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
         <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a>
+          <a class="nhsuk-breadcrumb__link trigger-loader"
+             asp-action="ViewFrameworks"
+             asp-route-tabname="Mine">Frameworks</a>
         </li>
         <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-fragment="fc-@Model.FrameworkCompetencyId" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Framework Structure</a>
+          <a class="nhsuk-breadcrumb__link trigger-loader"
+             asp-action="ViewFramework" asp-fragment="fc-@Model.FrameworkCompetencyId"
+             asp-route-frameworkId="@Model.FrameworkId"
+             asp-route-tabname="Structure">Framework Structure</a>
         </li>
         <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-action="EditCompetencyLearningResources" asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">Signposting</a>
+          <a class="nhsuk-breadcrumb__link trigger-loader"
+             asp-action="EditCompetencyLearningResources"
+             asp-route-frameworkId="@Model.FrameworkId"
+             asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
+             asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">Signposting</a>
         </li>
         <li class="nhsuk-breadcrumb__item">Add Resource</li>
       </ol>
       <p class="nhsuk-breadcrumb__back">
-        <a class="nhsuk-breadcrumb__backlink" asp-action="EditCompetencyLearningResources" asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">Back to Signposting</a>
+        <a class="nhsuk-breadcrumb__backlink"
+           asp-action="EditCompetencyLearningResources"
+           asp-route-frameworkId="@Model.FrameworkId"
+           asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
+           asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">Back to Signposting</a>
       </p>
     </div>
   </nav>
@@ -52,13 +72,7 @@
         </button>
       </div>
       <div class="filter-value-container">
-        @Html.DropDownListFor(c => c.CatalogueId,
-          Model.Catalogues
-            .Select(c => new SelectListItem(
-              text: c.Name,
-              value: c.Id.ToString(),
-              selected: c.Id == (Model.CatalogueId ?? Model.Catalogues?.FirstOrDefault()?.Id))
-            ),
+        @Html.DropDownListFor(c => c.CatalogueId, dropdownItems,
           new
           {
             @class = "nhsuk-select nhsuk-u-margin-bottom-4",
@@ -81,6 +95,7 @@
 <form method="get">
   <partial name="PaginatedPage/_BottomPaginationNavWithAlert" model="Model" />
   @Html.Hidden("SearchText", Model.SearchText)
+  @Html.Hidden("CatalogueId", Model.CatalogueId)
 </form>
 <div class="nhsuk-back-link nhsuk-u-margin-left-1 nhsuk-u-margin-top-6">
   <a class="nhsuk-back-link__link" asp-action="EditCompetencyLearningResources" asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -67,7 +67,12 @@
       <div class="search-box-container" id="search">
         @Html.LabelFor(m => m.SearchText, "Search", new { @class = "nhsuk-u-visually-hidden", @for = "search-field" })
         @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box nhsuk-input", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
-        <button class="nhsuk-button sort-submit" type="submit" asp-route-page="1" asp-route-frameworkId="@Model.FrameworkId" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId">
+        <button class="nhsuk-button sort-submit" type="submit"
+                asp-route-page="1"
+                asp-route-frameworkId="@Model.FrameworkId"
+                asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
+                asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
+                asp-route-catalogueId="@Model.CatalogueId">
           Search
         </button>
       </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -68,7 +68,7 @@
         @Html.LabelFor(m => m.SearchText, "Search", new { @class = "nhsuk-u-visually-hidden", @for = "search-field" })
         @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box nhsuk-input", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
         <button class="nhsuk-button sort-submit" type="submit"
-                asp-route-page="1"
+                asp-route-page="@Model.Page"
                 asp-route-frameworkId="@Model.FrameworkId"
                 asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId"
                 asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -42,7 +42,6 @@
                       asp-route-resourceReferenceId="@Model.ReferenceId">Preview</a>
                   <button class="nhsuk-button small-edit-button"
                       asp-action="AddCompetencyLearningResourceSummary"
-                      asp-route-catalogueId="@parent.CatalogueId"
                       asp-route-SelectedCatalogue="@catalogue">
                     Select
                   </button>
@@ -55,6 +54,7 @@
         @Html.HiddenFor(m => m.FrameworkCompetencyGroupId)
         @Html.HiddenFor(m => m.FrameworkCompetencyId)
         @Html.Hidden("ReferenceId", Model.ReferenceId)
+        @Html.Hidden("CatalogueId", parent.CatalogueId)
         @Html.Hidden("Resource.Title", Model.Resource?.Title)
         @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
         @Html.HiddenFor(m => m.Resource.Description)

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -58,6 +58,7 @@
         @Html.HiddenFor(m => m.FrameworkCompetencyId)
         @Html.Hidden("ReferenceId", Model.ReferenceId)
         @Html.Hidden("CatalogueId", parent.CatalogueId)
+        @Html.Hidden("Page", parent.Page)
         @Html.Hidden("Resource.Title", Model.Resource?.Title)
         @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
         @Html.HiddenFor(m => m.Resource.Description)

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -40,7 +40,10 @@
                       asp-controller="SignpostingSso"
                       asp-action="ViewResource"
                       asp-route-resourceReferenceId="@Model.ReferenceId">Preview</a>
-                  <button class="nhsuk-button small-edit-button" asp-action="AddCompetencyLearningResourceSummary" asp-route-SelectedCatalogue="@catalogue">
+                  <button class="nhsuk-button small-edit-button"
+                      asp-action="AddCompetencyLearningResourceSummary"
+                      asp-route-catalogueId="@parent.CatalogueId"
+                      asp-route-SelectedCatalogue="@catalogue">
                     Select
                   </button>
                 </dd>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -23,12 +23,15 @@
     </div>
     @if (Model.Catalogues.Count() > 0)
     {
-      <div class="nhsuk-u-font-weight-bold nhsuk-u-margin-left-1 nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2">
-        Catalogues
-      </div>
       <form method="post" role="search" asp-controller="Frameworks">
         <div class="nhsuk-card__content nhsuk-u-margin-1 nhsuk-u-padding-0">
           <dl class="nhsuk-summary-list">
+            <div class="nhsuk-summary-list__row">
+              <dt class="nhsuk-summary-list__key">
+                Catalogues
+              </dt>
+              <dd class="nhsuk-summary-list__value"></dd>
+            </div>
             @foreach(var catalogue in Model.Catalogues)
             {
               <div class="nhsuk-summary-list__row">


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-573

### Description
Making a request to learning hub for retrieving catalogues. When user selects a resource, catalogue id is passed as parameter in order to return to the original search when needed.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/178004966-ecf78c22-c5e9-4dfb-a0a2-ff9f8574bd86.png)

-----
### Developer checks

I have:

Checked that it works for searches returning multiple pages and it returns to the original search and page when cancel button is clicked.

