### PR TITLE
DLSV2-578 Competency tags missing on the Self Assessment Results page

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -378,6 +378,7 @@
             var delegateSelfAssessment =
                 supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
             var assessmentQuestion = GetLevelDescriptorsForAssessmentQuestion(competency.AssessmentQuestions.First());
+            competency.CompetencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyId(competency.Id);
             var model = new ReviewCompetencySelfAsessmentViewModel()
             {
                 DelegateSelfAssessment = delegateSelfAssessment,

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -58,75 +58,81 @@
 <dl class="nhsuk-summary-list">
 
     <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-            @Model.Competency.Vocabulary
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-            @Model.Competency.Name
-    </dd>
-
+      <dt class="nhsuk-summary-list__key">
+          @Model.Competency.Vocabulary
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+          @Model.Competency.Name
+      </dd>
     </div>
+    @if (Model.Competency.CompetencyFlags.Any())
+    {
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Flags
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          <partial name="_CompetencyFlags" model="Model.Competency.CompetencyFlags" />
+        </dd>
+      </div>
+    }
     @if (Model.Competency.Description != null)
     {
         <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-            Description
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-                @Html.Raw(Model.Competency.Description)
-        </dd>
+          <dt class="nhsuk-summary-list__key">
+              Description
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+              @Html.Raw(Model.Competency.Description)
+          </dd>
         </div>
     }
     <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-        Question
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-            @Model.Competency.AssessmentQuestions.First().Question
-    </dd>
-
+      <dt class="nhsuk-summary-list__key">
+          Question
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+          @Model.Competency.AssessmentQuestions.First().Question
+      </dd>
     </div>
 
     <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-        Learner response
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-        <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
-    </dd>
-
+      <dt class="nhsuk-summary-list__key">
+          Learner response
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+          <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
+      </dd>
     </div>
     @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
     {
         <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-            Role expectations
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-                @(Model.Competency.AssessmentQuestions.First().ResultRAG == 1 ? "Not meeting" : Model.Competency.AssessmentQuestions.First().ResultRAG == 2 ? "Partially meeting" : "Fully meeting"  )
-        </dd>
-
+          <dt class="nhsuk-summary-list__key">
+              Role expectations
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+                  @(Model.Competency.AssessmentQuestions.First().ResultRAG == 1 ? "Not meeting" : Model.Competency.AssessmentQuestions.First().ResultRAG == 2 ? "Partially meeting" : "Fully meeting"  )
+          </dd>
         </div>
     }
     @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
     {
         <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-            Comments
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-                @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)
-        </dd>
+          <dt class="nhsuk-summary-list__key">
+              Comments
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+                  @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)
+          </dd>
         </div>
     }
     <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-        Status
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-        <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
-    </dd>
-
+      <dt class="nhsuk-summary-list__key">
+          Status
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+          <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
+      </dd>
     </div>
 </dl>
 @if (errorHasOccurred)


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-578

### Description
Retrieved the competency flags for a self assessment result and displayed them using existent shared partial view for rendering flags on a view.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/178024464-d27b5bde-c57a-474e-9a8b-6764df59264e.png)

-----
### Developer checks

I have:
Tested cases when there are no flags, one flag and multiple flags for a self assessment result.
