### PR TITLE
DLSV2-559 Tweaks view model to make non-form-posted content nullable

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/EnrolDelegateSupervisorRoleViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/EnrolDelegateSupervisorRoleViewModel.cs
@@ -8,10 +8,10 @@
 
     public class EnrolDelegateSupervisorRoleViewModel
     {
-        public SupervisorDelegateDetail SupervisorDelegateDetail { get; set; }
-        public RoleProfile RoleProfile { get; set; }
+        public SupervisorDelegateDetail? SupervisorDelegateDetail { get; set; }
+        public RoleProfile? RoleProfile { get; set; }
         [Required(ErrorMessage = "Please choose a supervisor role")]
         public int? SelfAssessmentSupervisorRoleId { get; set; }
-        public IEnumerable<SelfAssessmentSupervisorRole> SelfAssessmentSupervisorRoles { get; set; }
+        public IEnumerable<SelfAssessmentSupervisorRole>? SelfAssessmentSupervisorRoles { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
DLSV2-559

### Description
The supervisor, enrol staff member on self assessment choose role form was triggering validation errors even when a role had been chosen. This happened because the non-form elements of the view model were not nullable. This change makes them nullable so that they don't trigger validation errors.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
