### PR TITLE
HEEDLS-1006 Fixed being unable to edit delegate details when primary email is a GUID

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/PromptsService.cs
+++ b/DigitalLearningSolutions.Web/Helpers/PromptsService.cs
@@ -70,23 +70,7 @@
         }
 
         public List<EditDelegateRegistrationPromptViewModel> GetEditDelegateRegistrationPromptViewModelsForCentre(
-            MyAccountEditDetailsFormData formData,
-            int centreId
-        )
-        {
-            return GetEditDelegateRegistrationPromptViewModelsForCentre(
-                centreId,
-                formData.Answer1,
-                formData.Answer2,
-                formData.Answer3,
-                formData.Answer4,
-                formData.Answer5,
-                formData.Answer6
-            );
-        }
-
-        public List<EditDelegateRegistrationPromptViewModel> GetEditDelegateRegistrationPromptViewModelsForCentre(
-            EditDelegateFormData formData,
+            EditAccountDetailsFormDataBase formData,
             int centreId
         )
         {

--- a/DigitalLearningSolutions.Web/Helpers/PromptsService.cs
+++ b/DigitalLearningSolutions.Web/Helpers/PromptsService.cs
@@ -8,6 +8,7 @@
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.ViewModels.Common;
     using DigitalLearningSolutions.Web.ViewModels.MyAccount;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.EditDelegate;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
 
     public class PromptsService
@@ -85,7 +86,7 @@
         }
 
         public List<EditDelegateRegistrationPromptViewModel> GetEditDelegateRegistrationPromptViewModelsForCentre(
-            EditDetailsFormData formData,
+            EditDelegateFormData formData,
             int centreId
         )
         {
@@ -192,6 +193,24 @@
 
         public void ValidateCentreRegistrationPrompts(
             EditDetailsFormData formData,
+            int centreId,
+            ModelStateDictionary modelState
+        )
+        {
+            ValidateCentreRegistrationPrompts(
+                centreId,
+                formData.Answer1,
+                formData.Answer2,
+                formData.Answer3,
+                formData.Answer4,
+                formData.Answer5,
+                formData.Answer6,
+                modelState
+            );
+        }
+
+        public void ValidateCentreRegistrationPrompts(
+            EditDelegateFormData formData,
             int centreId,
             ModelStateDictionary modelState
         )

--- a/DigitalLearningSolutions.Web/ViewModels/Common/EditAccountDetailsFormDataBase.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/EditAccountDetailsFormDataBase.cs
@@ -1,0 +1,51 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using DigitalLearningSolutions.Web.Attributes;
+    using DigitalLearningSolutions.Web.Helpers;
+
+    public abstract class EditAccountDetailsFormDataBase
+    {
+        [Required(ErrorMessage = "Enter your first name")]
+        [MaxLength(250, ErrorMessage = CommonValidationErrorMessages.TooLongFirstName)]
+        public string? FirstName { get; set; }
+
+        [Required(ErrorMessage = "Enter your last name")]
+        [MaxLength(250, ErrorMessage = CommonValidationErrorMessages.TooLongLastName)]
+        public string? LastName { get; set; }
+
+        [MaxLength(255, ErrorMessage = CommonValidationErrorMessages.TooLongEmail)]
+        [EmailAddress(ErrorMessage = CommonValidationErrorMessages.InvalidEmail)]
+        [NoWhitespace(CommonValidationErrorMessages.WhitespaceInEmail)]
+        public string? CentreSpecificEmail { get; set; }
+
+        public int? JobGroupId { get; set; }
+
+        public string? Answer1 { get; set; }
+
+        public string? Answer2 { get; set; }
+
+        public string? Answer3 { get; set; }
+
+        public string? Answer4 { get; set; }
+
+        public string? Answer5 { get; set; }
+
+        public string? Answer6 { get; set; }
+
+        public string? ProfessionalRegistrationNumber { get; set; }
+
+        public bool? HasProfessionalRegistrationNumber { get; set; }
+
+        public bool IsSelfRegistrationOrEdit { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (!JobGroupId.HasValue)
+            {
+                yield return new ValidationResult("Select a job group", new[] { nameof(JobGroupId) });
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/EditDetailsFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/EditDetailsFormData.cs
@@ -1,57 +1,15 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.Common
 {
-    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
 
-    public class EditDetailsFormData
+    public class EditDetailsFormData : EditAccountDetailsFormDataBase
     {
-        [Required(ErrorMessage = "Enter your first name")]
-        [MaxLength(250, ErrorMessage = CommonValidationErrorMessages.TooLongFirstName)]
-        public string? FirstName { get; set; }
-
-        [Required(ErrorMessage = "Enter your last name")]
-        [MaxLength(250, ErrorMessage = CommonValidationErrorMessages.TooLongLastName)]
-        public string? LastName { get; set; }
-
         [Required(ErrorMessage = "Enter your email")]
         [MaxLength(255, ErrorMessage = CommonValidationErrorMessages.TooLongEmail)]
         [EmailAddress(ErrorMessage = CommonValidationErrorMessages.InvalidEmail)]
         [NoWhitespace(CommonValidationErrorMessages.WhitespaceInEmail)]
         public string? Email { get; set; }
-
-        [MaxLength(255, ErrorMessage = CommonValidationErrorMessages.TooLongEmail)]
-        [EmailAddress(ErrorMessage = CommonValidationErrorMessages.InvalidEmail)]
-        [NoWhitespace(CommonValidationErrorMessages.WhitespaceInEmail)]
-        public string? CentreSpecificEmail { get; set; }
-
-        public int? JobGroupId { get; set; }
-
-        public string? Answer1 { get; set; }
-
-        public string? Answer2 { get; set; }
-
-        public string? Answer3 { get; set; }
-
-        public string? Answer4 { get; set; }
-
-        public string? Answer5 { get; set; }
-
-        public string? Answer6 { get; set; }
-
-        public string? ProfessionalRegistrationNumber { get; set; }
-
-        public bool? HasProfessionalRegistrationNumber { get; set; }
-
-        public bool IsSelfRegistrationOrEdit { get; set; }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            if (!JobGroupId.HasValue)
-            {
-                yield return new ValidationResult("Select a job group", new[] { nameof(JobGroupId) });
-            }
-        }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EditDelegate/EditDelegateFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EditDelegate/EditDelegateFormData.cs
@@ -7,7 +7,8 @@
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common;
 
-    public class EditDelegateFormData : EditDetailsFormData, IEditProfessionalRegistrationNumbers, IValidatableObject
+    public class EditDelegateFormData : EditAccountDetailsFormDataBase, IEditProfessionalRegistrationNumbers,
+        IValidatableObject
     {
         public EditDelegateFormData() { }
 
@@ -54,5 +55,7 @@
             HasProfessionalRegistrationNumber = formData.HasProfessionalRegistrationNumber;
             IsSelfRegistrationOrEdit = false;
         }
+
+        public string? Email { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-1006

### Description
This bug was caused by changes made in https://softwiretech.atlassian.net/browse/HEEDLS-973: the new user is created with a primary email which is a GUID, which is present in a hidden field on the edit delegate page. Validation then takes place on this field, which fails because the format of the email address is incorrect.

To fix this, I have changed the `EditDelegateFormData` ViewModel so that it no longer inherits from the `EditDetailsFormData`, ViewModel which is where the primary email validation was taking place. As these two ViewModels are very similar, I have created a new abstract base class (`EditAccountDetailsFormDataBase`), which they now both inherit from

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
