### PR TITLE
Heedls 970b fix validation missing delegate

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -133,6 +133,13 @@
                 (() => centreRegistrationPromptsService.GetCentreRegistrationPromptsByCentreId(2)).Returns(
                 PromptsTestHelper.GetDefaultCentreRegistrationPrompts(customPromptLists, 2)
             );
+            var testUserEntity = new UserEntity(
+                UserTestHelper.GetDefaultUserAccount(),
+                new AdminAccount[] { },
+                new[] { UserTestHelper.GetDefaultDelegateAccount() }
+            );
+            A.CallTo
+                (() => userService.GetUserById(A<int>._)).Returns(testUserEntity);
             var formData = new MyAccountEditDetailsFormData();
             var expectedPrompt = new EditDelegateRegistrationPromptViewModel(
                 1,
@@ -163,7 +170,7 @@
         }
 
         [Test]
-        public void EditDetailsPostSave_for_admin_user_with_missing_delegate_answers_doesnt_fail_validation()
+        public void EditDetailsPostSave_for_admin_only_user_with_missing_delegate_answers_doesnt_fail_validation_or_update_delegate()
         {
             // Given
             var myAccountController = new MyAccountController(
@@ -188,6 +195,13 @@
                     )
                 )
                 .DoesNothing();
+            var testUserEntity = new UserEntity(
+                UserTestHelper.GetDefaultUserAccount(),
+                new[] { UserTestHelper.GetDefaultAdminAccount() },
+                new DelegateAccount[] {  }
+            );
+            A.CallTo
+                (() => userService.GetUserById(A<int>._)).Returns(testUserEntity);
             const string centreSpecificEmail = "centre@email.com";
             var model = new MyAccountEditDetailsFormData
             {
@@ -217,7 +231,7 @@
             A.CallTo(
                     () => userService.UpdateUserDetailsAndCentreSpecificDetails(
                         A<EditAccountDetailsData>._,
-                        A<DelegateDetailsData>._,
+                        null,
                         A<string?>._,
                         A<int>._,
                         true

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -164,7 +164,7 @@
 
             if (delegateAccount != null)
             {
-                promptsService.ValidateCentreRegistrationPrompts(formData, User.GetCentreIdKnownNotNull(), ModelState);
+                promptsService.ValidateCentreRegistrationPrompts(formData, centreId, ModelState);
             }
 
             if (formData.ProfileImageFile != null)
@@ -225,7 +225,7 @@
                 accountDetailsData,
                 delegateDetailsData,
                 formData.CentreSpecificEmail,
-                User.GetCentreIdKnownNotNull(),
+                centreId,
                 true
             );
 

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -156,11 +156,13 @@
             DlsSubApplication dlsSubApplication
         )
         {
-            var userDelegateId = User.GetCandidateId();
             var centreId = User.GetCentreIdKnownNotNull();
             var userId = User.GetUserIdKnownNotNull();
+            var userEntity = userService.GetUserById(userId);
 
-            if (userDelegateId.HasValue)
+            var delegateAccount = GetDelegateAccountIfActive(userEntity, centreId);
+
+            if (delegateAccount != null)
             {
                 promptsService.ValidateCentreRegistrationPrompts(formData, User.GetCentreIdKnownNotNull(), ModelState);
             }
@@ -217,7 +219,7 @@
             var (accountDetailsData, delegateDetailsData) = AccountDetailsDataHelper.MapToEditAccountDetailsData(
                 formData,
                 userId,
-                userDelegateId
+                delegateAccount?.Id
             );
             userService.UpdateUserDetailsAndCentreSpecificDetails(
                 accountDetailsData,


### PR DESCRIPTION
### JIRA link
_[HEEDLS-970](https://softwiretech.atlassian.net/browse/HEEDLS-970)_

### Description
The centre-specific details are no longer validated if the delegate account is inactive. 

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
