### PR TITLE
DLSV2-598 Fixes get recipient query and data tests

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/RegistrationServiceTests.cs
@@ -16,6 +16,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FakeItEasy;
+    using FizzWare.NBuilder;
     using FluentAssertions;
     using FluentAssertions.Execution;
     using Microsoft.Extensions.Configuration;
@@ -51,7 +52,7 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             centresDataService = A.Fake<ICentresDataService>();
             config = A.Fake<IConfiguration>();
             supervisorDelegateService = A.Fake<ISupervisorDelegateService>();
-            notificationDataService = A.Fake<NotificationDataService>();
+            notificationDataService = A.Fake<INotificationDataService>();
             userDataService = A.Fake<IUserDataService>();
 
             A.CallTo(() => config["CurrentSystemBaseUrl"]).Returns(OldSystemBaseUrl);
@@ -154,17 +155,11 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             // Then
             A.CallTo(
                 () =>
-                    emailService.SendEmail(
-                        A<Email>.That.Matches(
-                            e =>
-                                e.To[0] == ApproverEmail &&
-                                e.Cc.IsNullOrEmpty() &&
-                                e.Bcc.IsNullOrEmpty() &&
-                                e.Subject == "Digital Learning Solutions Registration Requires Approval" &&
-                                e.Body.TextBody.Contains(OldSystemBaseUrl + "/tracking/approvedelegates")
-                        )
+                notificationDataService.GetAdminRecipientsForCentreNotification(
+                    model.Centre,
+                    4
                     )
-            ).MustHaveHappened();
+                ).MustHaveHappened();
         }
 
         [Test]
@@ -179,17 +174,11 @@ namespace DigitalLearningSolutions.Data.Tests.Services
             // Then
             A.CallTo(
                 () =>
-                    emailService.SendEmail(
-                        A<Email>.That.Matches(
-                            e =>
-                                e.To[0] == ApproverEmail &&
-                                e.Cc.IsNullOrEmpty() &&
-                                e.Bcc.IsNullOrEmpty() &&
-                                e.Subject == "Digital Learning Solutions Registration Requires Approval" &&
-                                e.Body.TextBody.Contains(RefactoredSystemBaseUrl + "/TrackingSystem/Delegates/Approve")
-                        )
+                notificationDataService.GetAdminRecipientsForCentreNotification(
+                    model.Centre,
+                    4
                     )
-            ).MustHaveHappened();
+                ).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/DataServices/NotificationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/NotificationDataService.cs
@@ -84,14 +84,15 @@
         }
         public IEnumerable<Recipient> GetAdminRecipientsForCentreNotification(int centreId, int notificationId)
         {
-            return connection.Query<Recipient>(
+            var recipients = connection.Query<Recipient>(
 
                 @"SELECT au.Forename as FirstName, au.Surname as LastName, au.Email
                     FROM     NotificationUsers AS nu INNER JOIN
                          AdminUsers AS au ON nu.AdminUserID = au.AdminID AND au.Active = 1 
-                    WHERE  (nu.NotificationID = @notificationId) AND (au.CentreID = @centreId OR c.CentreID = @centreId)",
+                    WHERE  (nu.NotificationID = @notificationId) AND (au.CentreID = @centreId)",
                 new { notificationId, centreId }
                 );
+            return recipients;
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[DLSV2-598](https://hee-dls.atlassian.net/browse/DLSV2-598)

### Description
Fixes the notification service, get recipients for notification query and related data tests.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
