### PR TITLE
Heedls 982 send email when password set

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -48,7 +48,6 @@
 
             controller = new RegisterDelegateByCentreController(
                     jobGroupsDataService,
-                    userService,
                     promptsService,
                     cryptoService,
                     userDataService,

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -38,11 +38,9 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         private readonly PromptsService promptsService;
         private readonly IRegistrationService registrationService;
         private readonly IUserDataService userDataService;
-        private readonly IUserService userService;
 
         public RegisterDelegateByCentreController(
             IJobGroupsDataService jobGroupsDataService,
-            IUserService userService,
             PromptsService promptsService,
             ICryptoService cryptoService,
             IUserDataService userDataService,
@@ -51,7 +49,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         )
         {
             this.jobGroupsDataService = jobGroupsDataService;
-            this.userService = userService;
             this.promptsService = promptsService;
             this.userDataService = userDataService;
             this.registrationService = registrationService;

--- a/DigitalLearningSolutions.Web/Services/PasswordResetService.cs
+++ b/DigitalLearningSolutions.Web/Services/PasswordResetService.cs
@@ -261,14 +261,14 @@
         )
         {
             var emailAddress = delegateEntity.EmailForCentreNotifications;
-            var setPasswordUrl = new UriBuilder(baseUrl);
-            if (!setPasswordUrl.Path.EndsWith('/'))
+            var completeRegistrationUrl = new UriBuilder(baseUrl);
+            if (!completeRegistrationUrl.Path.EndsWith('/'))
             {
-                setPasswordUrl.Path += '/';
+                completeRegistrationUrl.Path += '/';
             }
 
-            setPasswordUrl.Path += "CompleteRegistration"; // TODO: HEEDLS-974 Create controller for this link
-            setPasswordUrl.Query = $"code={registrationConfirmationHash}&email={emailAddress}";
+            completeRegistrationUrl.Path += "CompleteRegistration"; // TODO: HEEDLS-974 Create controller for this link
+            completeRegistrationUrl.Query = $"code={registrationConfirmationHash}&email={emailAddress}";
 
             const string emailSubject = "Welcome to Digital Learning Solutions - Verify your Registration";
 
@@ -277,14 +277,14 @@
                 TextBody = $@"Dear {delegateEntity.UserAccount.FullName},
                             An administrator has registered your details to give you access to the Digital Learning Solutions (DLS) platform under the centre {delegateEntity.DelegateAccount.CentreName}.
                             You have been assigned the unique DLS delegate number {delegateEntity.DelegateAccount.CandidateNumber}.
-                            To complete your registration and access your Digital Learning Solutions content, please click: {setPasswordUrl.Uri}
+                            To complete your registration and access your Digital Learning Solutions content, please click: {completeRegistrationUrl.Uri}
                             Note that this link can only be used once and it will expire in three days.
                             Please don't reply to this email as it has been automatically generated.",
                 HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'>
                                 <p>Dear {delegateEntity.UserAccount.FullName},</p>
                                 <p>An administrator has registered your details to give you access to the Digital Learning Solutions (DLS) platform under the centre {delegateEntity.DelegateAccount.CentreName}.</p>
                                 <p>You have been assigned the unique DLS delegate number {delegateEntity.DelegateAccount.CandidateNumber}.</p>
-                                <p><a href=""{setPasswordUrl.Uri}"">Click here to complete your registration and access your Digital Learning Solutions content</a></p>
+                                <p><a href=""{completeRegistrationUrl.Uri}"">Click here to complete your registration and access your Digital Learning Solutions content</a></p>
                                 <p>Note that this link can only be used once and it will expire in three days.</p>
                                 <p>Please don't reply to this email as it has been automatically generated.</p>
                             </body>",

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -260,7 +260,8 @@ namespace DigitalLearningSolutions.Web.Services
                     delegateRegistrationModel.PasswordHash
                 );
             }
-            else if (delegateRegistrationModel.NotifyDate.HasValue)
+
+            if (delegateRegistrationModel.NotifyDate.HasValue)
             {
                 passwordResetService.GenerateAndScheduleDelegateWelcomeEmail(
                     delegateId,


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-982

### Description
When an admin registers a new delegate at a centre, always send them a welcome email, regardless of whether the admin set a password or not.

Note: there was a bad unit test for this functionality: it only tested that an email is scheduled when a password is not set, despite the code in the service (both now and in the commit when the test was written) being 

```
if (password is set) { set password in the database } 
else if (notify date is set) { schedule welcome email }
```

Since I have changed this to two separate if statements, the test is no longer problematic, and doesn't need to be changed

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
