### PR TITLE
HEEDLS-902 Fix registration of delegate when registering internal admin

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -1018,12 +1018,15 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentre(model.CentreSpecificEmail!, model.Centre)
+                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    model.CentreSpecificEmail!,
+                    model.Centre,
+                    userId
+                )
             ).MustHaveHappenedOnceExactly();
 
-            A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(A<string>._, A<int>._, A<int>._)
-            ).MustNotHaveHappened();
+            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre(A<string>._, A<int>._))
+                .MustNotHaveHappened();
 
             A.CallTo(
                     () =>
@@ -1066,12 +1069,15 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentre(model.CentreSpecificEmail!, model.Centre)
+                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    model.CentreSpecificEmail!,
+                    model.Centre,
+                    userId
+                )
             ).MustHaveHappenedOnceExactly();
 
-            A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(A<string>._, A<int>._, A<int>._)
-            ).MustNotHaveHappened();
+            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre(A<string>._, A<int>._))
+                .MustNotHaveHappened();
 
             A.CallTo(
                     () =>
@@ -1113,12 +1119,15 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentre(model.CentreSpecificEmail!, model.Centre)
+                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    model.CentreSpecificEmail!,
+                    model.Centre,
+                    userId
+                )
             ).MustHaveHappenedOnceExactly();
 
-            A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(A<string>._, A<int>._, A<int>._)
-            ).MustNotHaveHappened();
+            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre(A<string>._, A<int>._))
+                .MustNotHaveHappened();
 
             A.CallTo(
                     () =>

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
@@ -101,7 +101,6 @@
 
             if (delegateAccount == null)
             {
-                // We can have the centreSpecificEmail = null here because we already set it for the admin account
                 registrationService.CreateDelegateAccountForExistingUser(
                     new InternalDelegateRegistrationModel(
                         model.Centre!.Value,

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -466,7 +466,7 @@ namespace DigitalLearningSolutions.Web.Services
                 ValidateCentreEmail(
                     delegateRegistrationModel.CentreSpecificEmail,
                     delegateRegistrationModel.Centre,
-                    null
+                    userId
                 );
             }
 


### PR DESCRIPTION
### JIRA link
[HEEDLS-902](https://softwiretech.atlassian.net/browse/HEEDLS-902)

### Description
I fixed the exception that was being thrown when creating the delegate account during the internal admin self registration journey.

I am a bit unsure if I should change `RegistrationService.ValidateCentreEmail` to have the `idOfRegistrantIfAlreadyExisting
` non nullable. Currently, both uses of this function provide an id, but I am inclined to leave it as it is to be more general for future use.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
