### PR TITLE
HEEDLS-1007 Add parameterless constructor to AdminEntity

### DIFF
--- a/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
+++ b/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
@@ -5,6 +5,13 @@
 
     public class AdminEntity : BaseSearchableItem
     {
+        // This type needs a parameterless constructor when it replaces the type T in GenericSearchHelper.SearchItems
+        public AdminEntity()
+        {
+            AdminAccount = new AdminAccount();
+            UserAccount = new UserAccount();
+        }
+
         public AdminEntity(
             AdminAccount adminAccount,
             UserAccount userAccount,


### PR DESCRIPTION
### JIRA link
[HEEDLS-1007](https://softwiretech.atlassian.net/browse/HEEDLS-1007)

### Description
There was a bug on the admins page, when the user was writing some text in the search bar and then refreshing. An exception was being thrown in `GenericSearchHelper.SearchItems`, on line 65: `var query = Activator.CreateInstance(typeof(T)) as BaseSearchableItem;`. The exception was saying that `AdminEntity` (which was the type `T` in this case) has no parameterless constructor.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
