### PR TITLE
HEEDLS-966 Mark centre email verified if set by admin

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserCentreDetailsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserCentreDetailsDataServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Tests.DataServices.UserDataServiceTests
 {
+    using System;
     using System.Linq;
     using System.Transactions;
     using Dapper;
@@ -34,6 +35,40 @@
 
             // Then
             result.Should().BeEquivalentTo(email);
+            count.Should().Equal(entriesCount);
+        }
+
+        [Test]
+        [TestCase(true, null, 1)]
+        [TestCase(true, "new@admin.email", 1)]
+        [TestCase(false, null, 0)]
+        [TestCase(false, "new@admin.email", 1)]
+        public void SetCentreEmail_sets_emailVerified_if_provided_and_email_not_empty(
+            bool detailsExist,
+            string? email,
+            int entriesCount
+        )
+        {
+            using var transaction = new TransactionScope();
+
+            // Given
+            var emailVerified = new DateTime(2022, 2, 2);
+            if (detailsExist)
+            {
+                connection.Execute(
+                    @"INSERT INTO UserCentreDetails (UserID, CentreID, Email)
+                        VALUES (8, 374, 'sample@admin.email')"
+                );
+            }
+
+            // When
+            userDataService.SetCentreEmail(8, 374, email, emailVerified);
+            var result = connection.Query<DateTime?>(@"SELECT EmailVerified FROM UserCentreDetails WHERE UserID = 8")
+                .SingleOrDefault();
+            var count = connection.Query<int>(@"SELECT COUNT(*) FROM UserCentreDetails WHERE UserID = 8");
+
+            // Then
+            result.Should().Be(email == null ? (DateTime?)null : emailVerified);
             count.Should().Equal(entriesCount);
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -135,6 +135,7 @@
                 userId,
                 delegateRegistrationModel.Centre,
                 delegateRegistrationModel.CentreSpecificEmail,
+                null,
                 transaction
             );
 
@@ -293,6 +294,7 @@
                     userId,
                     centreId,
                     centreSpecificEmail,
+                    null,
                     transaction
                 );
             }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.DataServices.UserDataService
 {
+    using System;
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
@@ -12,6 +13,7 @@
             int userId,
             int centreId,
             string? email,
+            DateTime? emailVerified,
             IDbTransaction? transaction = null
         )
         {
@@ -28,6 +30,7 @@
                 userId,
                 centreId,
                 email,
+                emailVerified,
             };
 
             var detailsAlreadyExist = connection.QuerySingle<bool>(
@@ -50,7 +53,7 @@
                             EmailVerified = NULL
                         WHERE userID = @userId AND centreID = @centreId"
                         : @"UPDATE UserCentreDetails
-                        SET Email = @email
+                        SET Email = @email, EmailVerified = @emailVerified
                         WHERE userID = @userId AND centreID = @centreId",
                     userCentreDetailsValues,
                     transaction
@@ -63,13 +66,15 @@
                     (
                         UserId,
                         CentreId,
-                        Email
+                        Email,
+                        EmailVerified
                     )
                     VALUES
                     (
                         @userId,
                         @centreId,
-                        @email
+                        @email,
+                        @emailVerified
                     )",
                     userCentreDetailsValues,
                     transaction

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -155,6 +155,7 @@
             int userId,
             int centreId,
             string? email,
+            DateTime? emailVerified = null,
             IDbTransaction? transaction = null
         );
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterInternalAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterInternalAdminControllerTests.cs
@@ -202,6 +202,7 @@
                         DefaultUserId,
                         DefaultCentreId,
                         centreSpecificEmail,
+                        null,
                         A<IDbTransaction?>._
                     )
                 )
@@ -262,7 +263,15 @@
                     )
                 ).MustHaveHappenedOnceExactly();
                 A.CallTo(() => delegateApprovalsService.ApproveDelegate(A<int>._, A<int>._)).MustNotHaveHappened();
-                A.CallTo(() => userDataService.SetCentreEmail(A<int>._, A<int>._, A<string?>._, A<IDbTransaction?>._))
+                A.CallTo(
+                        () => userDataService.SetCentreEmail(
+                            A<int>._,
+                            A<int>._,
+                            A<string?>._,
+                            null,
+                            A<IDbTransaction?>._
+                        )
+                    )
                     .MustNotHaveHappened();
             }
 

--- a/DigitalLearningSolutions.Web.Tests/Services/ClaimAccountServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ClaimAccountServiceTests.cs
@@ -95,7 +95,15 @@
             // Then
             A.CallTo(() => userDataService.SetPrimaryEmailAndActivate(DefaultUserId, DefaultEmail))
                 .MustHaveHappenedOnceExactly();
-            A.CallTo(() => userDataService.SetCentreEmail(DefaultUserId, DefaultCentreId, null, A<IDbTransaction?>._))
+            A.CallTo(
+                    () => userDataService.SetCentreEmail(
+                        DefaultUserId,
+                        DefaultCentreId,
+                        null,
+                        null,
+                        A<IDbTransaction?>._
+                    )
+                )
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => userDataService.SetRegistrationConfirmationHash(DefaultUserId, DefaultCentreId, null))
                 .MustHaveHappenedOnceExactly();

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -1191,6 +1191,7 @@
                     A<int>._,
                     A<int>._,
                     A<string>._,
+                    null,
                     A<IDbTransaction?>._
                 )
             ).DoesNothing();

--- a/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
@@ -197,6 +197,7 @@
                         accountDetailsData.UserId,
                         centreId,
                         centreEmail,
+                        null,
                         A<IDbTransaction?>._
                     )
                 )
@@ -287,6 +288,71 @@
         }
 
         [Test]
+        public void
+            UpdateUserDetailsAndCentreSpecificDetails_with_changeMadeBySameUser_true_does_not_set_emailVerified()
+        {
+            // Given
+            const int centreId = 1;
+            const string centreEmail = "test@email.com";
+            const bool changeMadeBySameUser = true;
+            var accountDetailsData = UserTestHelper.GetDefaultAccountDetailsData();
+            var detailsLastChecked = new DateTime(2022, 1, 1);
+            A.CallTo(() => clockUtility.UtcNow).Returns(detailsLastChecked);
+
+            // When
+            userService.UpdateUserDetailsAndCentreSpecificDetails(
+                accountDetailsData,
+                null,
+                centreEmail,
+                centreId,
+                changeMadeBySameUser
+            );
+
+            // Then
+            A.CallTo(
+                () => userDataService.SetCentreEmail(
+                    accountDetailsData.UserId,
+                    centreId,
+                    centreEmail,
+                    null,
+                    A<IDbTransaction?>._
+                )
+            ).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void UpdateUserDetailsAndCentreSpecificDetails_with_changeMadeBySameUser_false_sets_emailVerified()
+        {
+            // Given
+            const int centreId = 1;
+            const string centreEmail = "test@email.com";
+            const bool changeMadeBySameUser = false;
+            var accountDetailsData = UserTestHelper.GetDefaultAccountDetailsData();
+            var detailsLastChecked = new DateTime(2022, 1, 1);
+            A.CallTo(() => clockUtility.UtcNow).Returns(detailsLastChecked);
+
+            // When
+            userService.UpdateUserDetailsAndCentreSpecificDetails(
+                accountDetailsData,
+                null,
+                centreEmail,
+                centreId,
+                changeMadeBySameUser
+            );
+
+            // Then
+            A.CallTo(
+                () => userDataService.SetCentreEmail(
+                    accountDetailsData.UserId,
+                    centreId,
+                    centreEmail,
+                    detailsLastChecked,
+                    A<IDbTransaction?>._
+                )
+            ).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
         public void UpdateUserDetails_updates_user()
         {
             // Given
@@ -369,7 +435,7 @@
             };
 
             A.CallTo(
-                () => userDataService.SetCentreEmail(A<int>._, A<int>._, A<string?>._, A<IDbTransaction?>._)
+                () => userDataService.SetCentreEmail(A<int>._, A<int>._, A<string?>._, null, A<IDbTransaction?>._)
             ).DoesNothing();
 
             // When
@@ -377,13 +443,13 @@
 
             // Then
             A.CallTo(
-                () => userDataService.SetCentreEmail(userId, 1, "email@centre1.com", A<IDbTransaction?>._)
+                () => userDataService.SetCentreEmail(userId, 1, "email@centre1.com", null, A<IDbTransaction?>._)
             ).MustHaveHappenedOnceExactly();
             A.CallTo(
-                () => userDataService.SetCentreEmail(userId, 2, "email@centre2.com", A<IDbTransaction?>._)
+                () => userDataService.SetCentreEmail(userId, 2, "email@centre2.com", null, A<IDbTransaction?>._)
             ).MustHaveHappenedOnceExactly();
             A.CallTo(
-                () => userDataService.SetCentreEmail(userId, 3, null, A<IDbTransaction?>._)
+                () => userDataService.SetCentreEmail(userId, 3, null, null, A<IDbTransaction?>._)
             ).MustHaveHappenedOnceExactly();
         }
 
@@ -398,7 +464,7 @@
 
             // Then
             A.CallTo(
-                () => userDataService.SetCentreEmail(A<int>._, A<int>._, A<string?>._, A<IDbTransaction?>._)
+                () => userDataService.SetCentreEmail(A<int>._, A<int>._, A<string?>._, null, A<IDbTransaction?>._)
             ).MustNotHaveHappened();
         }
 

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -396,7 +396,8 @@ namespace DigitalLearningSolutions.Web.Services
             userDataService.SetCentreEmail(
                 editAccountDetailsData.UserId,
                 centreId,
-                centreEmail
+                centreEmail,
+                changeMadeBySameUser ? (DateTime?)null : clockUtility.UtcNow
             );
         }
 


### PR DESCRIPTION
### JIRA link
[HEEDLS-966](https://softwiretech.atlassian.net/browse/HEEDLS-966)

### Description
I added a new parameter for the `emailVerified` date to `UserCentreDetailsDataService.SetCentreEmail`.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
