### PR TITLE
HEEDLS-1009 Tell registrants to swiych centre rather than log out

### DIFF
--- a/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/Confirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/Confirmation.cshtml
@@ -26,9 +26,15 @@
       <partial name="_LogoutForm" />
     } else if (Model.Approved) {
       <p>
-        You will need to log out and in again before you can access your new account.
+        You can now log into your new account.
       </p>
-      <partial name="_LogoutForm" />
+      <a
+        class="nhsuk-button nhsuk-button--secondary"
+        asp-controller="Login"
+        asp-action="ChooseACentre"
+        role="button">
+        Switch centre
+      </a>
     }
 
     @if (!Model.Approved) {


### PR DESCRIPTION
### JIRA link
[HEEDLS-1009](https://softwiretech.atlassian.net/browse/HEEDLS-1009)

### Description
Changed text and button on the confirmation page after registration at a new centre.

### Screenshots
![image](https://user-images.githubusercontent.com/105208326/180368571-c2dbc48b-bcd6-4dc5-9f69-3ee43c2c3012.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
