### PR TITLE
HEEDLS-998 Fixed My account > edit details UI when user has active ad…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -73,9 +73,9 @@
         public void EditDetailsPostSave_with_invalid_model_doesnt_call_services()
         {
             // Given
-            var myAccountController = GetMyAccountController().WithMockUser(true);
+            var myAccountController = GetMyAccountController().WithMockUser(true, null);
             var formData = new MyAccountEditDetailsFormData();
-            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData);
+            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData, null);
 
             myAccountController.ModelState.AddModelError(nameof(MyAccountEditDetailsFormData.Email), "Required");
 
@@ -112,7 +112,8 @@
         public void EditDetailsPostSave_with_missing_delegate_answers_fails_validation()
         {
             // Given
-            var myAccountController = GetMyAccountController().WithMockUser(true, adminId: null);
+            const int centreId = 2;
+            var myAccountController = GetMyAccountController().WithMockUser(true, centreId, adminId: null);
 
             var customPromptLists = new List<CentreRegistrationPrompt>
             {
@@ -134,7 +135,7 @@
                 null
             );
 
-            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData);
+            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData, centreId);
             expectedModel.DelegateRegistrationPrompts.Add(expectedPrompt);
 
             A.CallTo(() => userService.GetUserById(A<int>._)).Returns(testUserEntity);
@@ -218,7 +219,7 @@
                 HasProfessionalRegistrationNumber = false,
             };
 
-            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData);
+            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData, centreId);
 
             // When
             var result = myAccountController.EditDetails(formData, "save", DlsSubApplication.Default);
@@ -393,7 +394,8 @@
         public void EditDetailsPostSave_without_previewing_profile_image_fails_validation()
         {
             // Given
-            var myAccountController = GetMyAccountController().WithMockUser(true, adminId: null);
+            const int centreId = 2;
+            var myAccountController = GetMyAccountController().WithMockUser(true, centreId, adminId: null);
 
             var customPromptLists = new List<CentreRegistrationPrompt>
             {
@@ -413,11 +415,11 @@
                 null
             );
 
-            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData);
+            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData, centreId);
             expectedModel.DelegateRegistrationPrompts.Add(expectedPrompt);
 
             A.CallTo(() => centreRegistrationPromptsService.GetCentreRegistrationPromptsByCentreId(2)).Returns(
-                PromptsTestHelper.GetDefaultCentreRegistrationPrompts(customPromptLists, 2)
+                PromptsTestHelper.GetDefaultCentreRegistrationPrompts(customPromptLists, centreId)
             );
 
             // When
@@ -528,7 +530,7 @@
 
             var (myAccountController, formData) =
                 GetCentrelessControllerAndFormData(userId, centreSpecificEmailsByCentreId);
-            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData);
+            var expectedModel = GetBasicMyAccountEditDetailsViewModel(formData, null);
 
             myAccountController.ModelState.AddModelError(nameof(MyAccountEditDetailsFormData.Email), "Required");
 
@@ -606,11 +608,13 @@
         }
 
         private static MyAccountEditDetailsViewModel GetBasicMyAccountEditDetailsViewModel(
-            MyAccountEditDetailsFormData formData
+            MyAccountEditDetailsFormData formData,
+            int? centreId
         )
         {
             return new MyAccountEditDetailsViewModel(
                 formData,
+                centreId,
                 new List<(int id, string name)>(),
                 new List<EditDelegateRegistrationPromptViewModel>(),
                 new List<(int, string, string?)>(),

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -126,6 +126,7 @@
             var model = new MyAccountEditDetailsViewModel(
                 userEntity!.UserAccount,
                 delegateAccount,
+                centreId,
                 jobGroups,
                 centreId != null ? userService.GetCentreEmail(userId, centreId.Value) : null,
                 customPrompts,
@@ -297,6 +298,7 @@
 
             var model = new MyAccountEditDetailsViewModel(
                 formData,
+                centreId,
                 jobGroups,
                 customPrompts,
                 allCentreSpecificEmails,
@@ -337,6 +339,7 @@
 
             var model = new MyAccountEditDetailsViewModel(
                 formData,
+                centreId,
                 jobGroups,
                 customPrompts,
                 allCentreSpecificEmails,
@@ -373,6 +376,7 @@
 
             var model = new MyAccountEditDetailsViewModel(
                 formData,
+                centreId,
                 jobGroups,
                 customPrompts,
                 allCentreSpecificEmails,

--- a/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/MyAccount/MyAccountEditDetailsViewModel.cs
@@ -13,6 +13,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
         public MyAccountEditDetailsViewModel(
             UserAccount userAccount,
             DelegateAccount? delegateAccount,
+            int? centreId,
             List<(int id, string name)> jobGroups,
             string? centreSpecificEmail,
             List<EditDelegateRegistrationPromptViewModel> editDelegateRegistrationPromptViewModels,
@@ -30,6 +31,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
             isCheckDetailRedirect
         )
         {
+            IsLoggedInToCentre = centreId != null;
             DlsSubApplication = dlsSubApplication;
             JobGroups = SelectListHelper.MapOptionsToSelectListItemsWithSelectedText(
                 jobGroups,
@@ -41,20 +43,24 @@ namespace DigitalLearningSolutions.Web.ViewModels.MyAccount
 
         public MyAccountEditDetailsViewModel(
             MyAccountEditDetailsFormData formData,
+            int? centreId,
             IReadOnlyCollection<(int id, string name)> jobGroups,
             List<EditDelegateRegistrationPromptViewModel> editDelegateRegistrationPromptViewModels,
             List<(int, string, string?)> allCentreSpecificEmails,
             DlsSubApplication dlsSubApplication
         ) : base(formData)
         {
-            DlsSubApplication = dlsSubApplication;
             var jobGroupName = jobGroups.Where(jg => jg.id == formData.JobGroupId).Select(jg => jg.name)
                 .SingleOrDefault();
+
+            IsLoggedInToCentre = centreId != null;
             JobGroups = SelectListHelper.MapOptionsToSelectListItemsWithSelectedText(jobGroups, jobGroupName);
             DelegateRegistrationPrompts = editDelegateRegistrationPromptViewModels;
             AllCentreSpecificEmails = allCentreSpecificEmails;
+            DlsSubApplication = dlsSubApplication;
         }
 
+        public bool IsLoggedInToCentre { get; set; }
         public DlsSubApplication DlsSubApplication { get; set; }
 
         public IEnumerable<SelectListItem> JobGroups { get; }

--- a/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/EditDetails.cshtml
@@ -130,7 +130,7 @@
   <div class="nhsuk-grid-row divider">
     <div class="nhsuk-grid-column-full">
 
-      @if (Model.IsDelegateUser) {
+      @if (Model.IsLoggedInToCentre) {
         const string centreEmailHintText = @"If you supply a centre email, all notifications relating to your activity at this centre will be sent to this email address.
                                               Your primary email address will still be used for logging in and notifications for managing your account.";
 
@@ -143,7 +143,22 @@
           autocomplete="email"
           hint-text="@centreEmailHintText"
           css-class="nhsuk-u-width-one-half" />
+      } else {
+        const string centreEmailHintText = @"If you supply a centre email for an account, all notifications relating to your activity at that centre will be sent to this email address.
+                                              Your primary email address will still be used for logging in and notifications for managing your account.";
 
+        <h2>Centre emails</h2>
+
+        <vc:dictionary-text-input
+          asp-for="AllCentreSpecificEmailsDictionary"
+          spell-check="false"
+          autocomplete="email"
+          hint-text="@centreEmailHintText"
+          css-class="nhsuk-u-width-one-half" />
+      }
+
+
+      @if (Model.IsDelegateUser) {
         @foreach (var customField in Model.DelegateRegistrationPrompts) {
           @if (customField.Options.Any()) {
             <vc:select-list asp-for="@("Answer" + customField.PromptNumber)"
@@ -165,18 +180,6 @@
                            css-class="nhsuk-u-width-one-half" />
           }
         }
-      } else {
-        const string centreEmailHintText = @"If you supply a centre email for an account, all notifications relating to your activity at that centre will be sent to this email address.
-                                              Your primary email address will still be used for logging in and notifications for managing your account.";
-
-        <h2>Centre emails</h2>
-
-        <vc:dictionary-text-input
-          asp-for="AllCentreSpecificEmailsDictionary"
-          spell-check="false"
-          autocomplete="email"
-          hint-text="@centreEmailHintText"
-          css-class="nhsuk-u-width-one-half" />
       }
     </div>
   </div>


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-998

### Description
Fixed edit details UI when user has active admin account + inactive delegate account and is not logged in to the centre
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
