### PR TITLE
HEEDLS-1005 Remove usages of DateTime functions on uar

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/CompletedCourseHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/CompletedCourseHelper.cs
@@ -2,9 +2,12 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public static class CompletedCourseHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public static CompletedCourse CreateDefaultCompletedCourse(
             int customisationId = 1,
             string courseName = "Course 1",
@@ -34,9 +37,9 @@
                 Sections = sections,
                 ProgressID = progressId,
                 Evaluated = evaluated,
-                StartedDate = startedDate ?? DateTime.UtcNow,
-                LastAccessed = lastAccessed ?? DateTime.UtcNow,
-                Completed = completed ?? DateTime.UtcNow,
+                StartedDate = startedDate ?? ClockUtility.UtcNow,
+                LastAccessed = lastAccessed ?? ClockUtility.UtcNow,
+                Completed = completed ?? ClockUtility.UtcNow,
                 ArchivedDate = archivedDate,
             };
         }

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/CourseDetailsTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/CourseDetailsTestHelper.cs
@@ -2,9 +2,12 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public static class CourseDetailsTestHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public static CourseDetails GetDefaultCourseDetails(
             int customisationId = 100,
             int centreId = 101,
@@ -47,8 +50,8 @@
                 ApplicationName = applicationName,
                 CustomisationName = customisationName,
                 CurrentVersion = currentVersion,
-                CreatedDate = createdDate ?? DateTime.UtcNow,
-                LastAccessed = lastAccessed ?? DateTime.UtcNow,
+                CreatedDate = createdDate ?? ClockUtility.UtcNow,
+                LastAccessed = lastAccessed ?? ClockUtility.UtcNow,
                 Password = password,
                 NotificationEmails = notificationEmails,
                 PostLearningAssessment = postLearningAssessment,

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/CurrentCourseHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/CurrentCourseHelper.cs
@@ -2,9 +2,12 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public static class CurrentCourseHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public static CurrentCourse CreateDefaultCurrentCourse(
             int customisationId = 1,
             string courseName = "Course 1",
@@ -37,8 +40,8 @@
                 SupervisorAdminId = supervisorAdminId,
                 GroupCustomisationId = groupCustomisationId,
                 CompleteByDate = completeByDate,
-                StartedDate = startedDate ?? DateTime.UtcNow,
-                LastAccessed = lastAccessed ?? DateTime.UtcNow,
+                StartedDate = startedDate ?? ClockUtility.UtcNow,
+                LastAccessed = lastAccessed ?? ClockUtility.UtcNow,
                 ProgressID = progressId,
                 EnrollmentMethodID = enrollmentMethodId,
                 PLLocked = locked,

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/GroupTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/GroupTestHelper.cs
@@ -7,9 +7,12 @@
     using System.Threading.Tasks;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public static class GroupTestHelper
     {
+        private static ClockUtility clockUtility = new ClockUtility();
+
         public static GroupDelegate GetDefaultGroupDelegate(
             int groupDelegateId = 62,
             int groupId = 5,
@@ -71,7 +74,7 @@
                 CustomisationName = customisationName,
                 IsMandatory = isMandatory,
                 IsAssessed = isAssessed,
-                AddedToGroup = addedToGroup ?? DateTime.Now,
+                AddedToGroup = addedToGroup ?? clockUtility.UtcNow,
                 CurrentVersion = currentVersion,
                 SupervisorAdminId = supervisorAdminId,
                 SupervisorFirstName = supervisorFirstName,

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/SelfAssessmentHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/SelfAssessmentHelper.cs
@@ -4,9 +4,12 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public static class SelfAssessmentHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public static CurrentSelfAssessment CreateDefaultSelfAssessment(
             int id = 1,
             string name = "name",
@@ -31,7 +34,7 @@
                 Description = description,
                 Name = name,
                 NumberOfCompetencies = numberOfCompetencies,
-                StartedDate = startedDate ?? DateTime.UtcNow,
+                StartedDate = startedDate ?? ClockUtility.UtcNow,
                 LastAccessed = lastAccessed,
                 CompleteByDate = completeByDate,
                 IncludesSignposting = includesSignposting,

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/SessionTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/SessionTestHelper.cs
@@ -4,12 +4,14 @@
     using System.Collections.Generic;
     using Dapper;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Utilities;
     using FluentAssertions;
     using Microsoft.Data.SqlClient;
 
     public class SessionTestHelper
     {
         private readonly SqlConnection connection;
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
 
         public SessionTestHelper(SqlConnection connection)
         {
@@ -58,7 +60,7 @@
             bool active = true
         )
         {
-            loginTime ??= DateTime.UtcNow;
+            loginTime ??= ClockUtility.UtcNow;
             return new Session(sessionId, candidateId, customisationId, loginTime.Value, duration, active);
         }
 

--- a/DigitalLearningSolutions.Data.Tests/TestHelpers/SystemNotificationTestHelper.cs
+++ b/DigitalLearningSolutions.Data.Tests/TestHelpers/SystemNotificationTestHelper.cs
@@ -4,11 +4,13 @@
     using System.Collections.Generic;
     using Dapper;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Utilities;
     using Microsoft.Data.SqlClient;
 
     public class SystemNotificationTestHelper
     {
         private readonly SqlConnection connection;
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
 
         public SystemNotificationTestHelper(SqlConnection connection)
         {
@@ -58,7 +60,7 @@
                 subject,
                 bodyHtml,
                 expiryDate,
-                dateAdded ?? DateTime.UtcNow,
+                dateAdded ?? ClockUtility.UtcNow,
                 targetUserRoleId
             );
         }

--- a/DigitalLearningSolutions.Data.Tests/Utilities/ClockUtilityTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Utilities/ClockUtilityTests.cs
@@ -14,7 +14,9 @@
 
         private readonly string[] directoriesToTest =
         {
-            "DigitalLearningSolutions.Data", "DigitalLearningSolutions.Data.Migrations", "DigitalLearningSolutions.Web",
+            "DigitalLearningSolutions.Data",
+            "DigitalLearningSolutions.Data.Migrations",
+            "DigitalLearningSolutions.Web",
         };
 
         [Test]
@@ -24,7 +26,7 @@
         public void ClockUtility_should_be_used_instead_of_DateTime_functions(string disallowed, string useInstead)
         {
             var filenames = RunCommandAndReturnOutput(
-                $"/C git grep -l {disallowed} {string.Join("", directoriesToTest)}",
+                $"/C git grep -l {disallowed} {string.Join(" ", directoriesToTest)}",
                 repoRootDir
             ).Trim().Split("\n");
 

--- a/DigitalLearningSolutions.Data.Tests/Utilities/ClockUtilityTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Utilities/ClockUtilityTests.cs
@@ -1,0 +1,66 @@
+﻿namespace DigitalLearningSolutions.Data.Tests.Utilities
+{
+    using System.IO;
+    using System.Linq;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class ClockUtilityTests
+    {
+        private readonly string repoRootDir = RunCommandAndReturnOutput(
+            "/C git rev-parse --show-toplevel",
+            Directory.GetCurrentDirectory()
+        ).Trim();
+
+        private readonly string[] directoriesToTest =
+        {
+            "DigitalLearningSolutions.Data", "DigitalLearningSolutions.Data.Migrations", "DigitalLearningSolutions.Web",
+        };
+
+        [Test]
+        [TestCase("DateTime.UtcNow", "ClockUtility.UtcNow")]
+        [TestCase("DateTime.Now", "ClockUtility.UtcNow")]
+        [TestCase("DateTime.Today", "ClockUtility.UtcToday")]
+        public void ClockUtility_should_be_used_instead_of_DateTime_functions(string disallowed, string useInstead)
+        {
+            var filenames = RunCommandAndReturnOutput(
+                $"/C git grep -l {disallowed} {string.Join("", directoriesToTest)}",
+                repoRootDir
+            ).Trim().Split("\n");
+
+            filenames
+                .Where(
+                    filename =>
+                        filename != string.Empty &&
+                        filename != "DigitalLearningSolutions.Data/Utilities/ClockUtility.cs" &&
+                        filename != "DigitalLearningSolutions.Data.Tests/Utilities/ClockUtilityTests.cs"
+                )
+                .Should().BeEmpty($"Use {useInstead} instead");
+        }
+
+        private static string RunCommandAndReturnOutput(string args, string workingDirectory)
+        {
+            var process = new System.Diagnostics.Process();
+
+            process.StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
+                FileName = "cmd.exe",
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                Arguments = args,
+                WorkingDirectory = workingDirectory,
+            };
+
+            process.Start();
+
+            var output = process.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+
+            return output;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityFilterData.cs
+++ b/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityFilterData.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public class ActivityFilterData
     {
@@ -31,11 +32,12 @@
         public DateTime? EndDate { get; set; }
         public ReportInterval ReportInterval { get; set; }
         public CourseFilterType FilterType { get; set; }
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
 
         public static ActivityFilterData GetDefaultFilterData(int? categoryIdFilter)
         {
             return new ActivityFilterData(
-                DateTime.UtcNow.Date.AddYears(-1),
+                ClockUtility.UtcNow.Date.AddYears(-1),
                 null,
                 null,
                 categoryIdFilter,

--- a/DigitalLearningSolutions.Web.IntegrationTests/TestHelpers/TestUserAppStartupFilter.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/TestHelpers/TestUserAppStartupFilter.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Security.Claims;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Helpers;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Builder;
@@ -13,6 +14,8 @@
 
     public class TestUserAppStartupFilter : IStartupFilter
     {
+        private readonly IClockUtility clockUtility = new ClockUtility();
+
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
         {
             return builder =>
@@ -40,7 +43,7 @@
                                 {
                                     AllowRefresh = true,
                                     IsPersistent = false,
-                                    IssuedUtc = DateTime.UtcNow,
+                                    IssuedUtc = clockUtility.UtcNow,
                                 };
 
                                 await context.SignInAsync(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
@@ -3,6 +3,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
     using System.Security.Claims;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -33,6 +34,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
         private ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService = null!;
         private ISearchSortFilterPaginateService searchSortFilterPaginateService = null!;
         private IUserDataService userDataService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void SetUp()
@@ -50,6 +52,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
             var logger = A.Fake<ILogger<LearningPortalController>>();
             config = A.Fake<IConfiguration>();
             searchSortFilterPaginateService = A.Fake<ISearchSortFilterPaginateService>();
+            clockUtility = A.Fake<IClockUtility>();
 
             A.CallTo(() => config["CurrentSystemBaseUrl"]).Returns(BaseUrl);
 
@@ -76,7 +79,8 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
                 config,
                 actionPlanService,
                 candidateAssessmentDownloadFileService,
-                searchSortFilterPaginateService
+                searchSortFilterPaginateService,
+                clockUtility
             );
             controller.ControllerContext = new ControllerContext
                 { HttpContext = new DefaultHttpContext { User = user } };

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
@@ -4,6 +4,7 @@
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Models.External.Filtered;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
     using DigitalLearningSolutions.Web.Helpers.ExternalApis;
     using DigitalLearningSolutions.Web.Services;
@@ -26,6 +27,7 @@
         private IRecommendedLearningService recommendedLearningService = null!;
         private ISearchSortFilterPaginateService searchSortFilterPaginateService = null!;
         private ISelfAssessmentService selfAssessmentService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void Setup()
@@ -36,6 +38,7 @@
             recommendedLearningService = A.Fake<IRecommendedLearningService>();
             actionPlanService = A.Fake<IActionPlanService>();
             searchSortFilterPaginateService = A.Fake<ISearchSortFilterPaginateService>();
+            clockUtility = A.Fake<IClockUtility>();
 
             controller = new RecommendedLearningController(
                     filteredApiHelperService,
@@ -43,7 +46,8 @@
                     configuration,
                     recommendedLearningService,
                     actionPlanService,
-                    searchSortFilterPaginateService
+                    searchSortFilterPaginateService,
+                    clockUtility
                 )
                 .WithDefaultContext()
                 .WithMockUser(true, delegateId: DelegateId);

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -9,6 +9,7 @@
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers;
     using DigitalLearningSolutions.Web.Models.Enums;
     using DigitalLearningSolutions.Web.Services;
@@ -36,6 +37,7 @@
         private ISessionService sessionService = null!;
         private IUserService userService = null!;
         private IUrlHelper urlHelper = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void SetUp()
@@ -45,8 +47,11 @@
             logger = A.Fake<ILogger<LoginController>>();
             userService = A.Fake<IUserService>();
             urlHelper = A.Fake<IUrlHelper>();
+            clockUtility = A.Fake<IClockUtility>();
 
-            controller = new LoginController(loginService, sessionService, logger, userService)
+            A.CallTo(() => clockUtility.UtcNow).Returns(DateTime.UtcNow);
+
+            controller = new LoginController(loginService, sessionService, logger, userService, clockUtility)
                 .WithDefaultContext()
                 .WithMockUser(false)
                 .WithMockTempData()
@@ -58,7 +63,13 @@
                     typeof(IAuthenticationService)
                 );
 
-            controllerWithAuthenticatedUser = new LoginController(loginService, sessionService, logger, userService)
+            controllerWithAuthenticatedUser = new LoginController(
+                    loginService,
+                    sessionService,
+                    logger,
+                    userService,
+                    clockUtility
+                )
                 .WithDefaultContext()
                 .WithMockUser(true)
                 .WithMockTempData()

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -7,6 +7,7 @@
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.Register;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.Register;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
@@ -33,6 +34,7 @@
         private PromptsService promptsService = null!;
         private IRegistrationService registrationService = null!;
         private IUserDataService userDataService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void Setup()
@@ -43,6 +45,7 @@
             cryptoService = A.Fake<ICryptoService>();
             registrationService = A.Fake<IRegistrationService>();
             config = A.Fake<IConfiguration>();
+            clockUtility = A.Fake<IClockUtility>();
 
             controller = new RegisterDelegateByCentreController(
                     jobGroupsDataService,
@@ -50,7 +53,8 @@
                     cryptoService,
                     userDataService,
                     registrationService,
-                    config
+                    config,
+                    clockUtility
                 )
                 .WithDefaultContext()
                 .WithMockTempData();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/ReportsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/ReportsControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Centre
 {
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Reports;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -16,19 +17,21 @@
         private HttpResponse httpResponse = null!;
         private IActivityService activityService = null!;
         private IEvaluationSummaryService evaluationSummaryService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void Setup()
         {
             activityService = A.Fake<IActivityService>();
             evaluationSummaryService = A.Fake<IEvaluationSummaryService>();
+            clockUtility = A.Fake<IClockUtility>();
 
             httpRequest = A.Fake<HttpRequest>();
             httpResponse = A.Fake<HttpResponse>();
             const string cookieName = "ReportsFilterCookie";
             const string cookieValue = "";
 
-            reportsController = new ReportsController(activityService, evaluationSummaryService)
+            reportsController = new ReportsController(activityService, evaluationSummaryService, clockUtility)
                 .WithMockHttpContext(httpRequest, cookieName, cookieValue, httpResponse)
                 .WithMockUser(true)
                 .WithMockServices()

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EmailDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EmailDelegatesControllerTests.cs
@@ -30,6 +30,7 @@
         private ISearchSortFilterPaginateService searchSortFilterPaginateService = null!;
         private IUserService userService = null!;
         private ICentreRegistrationPromptsService centreRegistrationPromptsService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void Setup()
@@ -41,6 +42,7 @@
             passwordResetService = A.Fake<IPasswordResetService>();
             searchSortFilterPaginateService = A.Fake<ISearchSortFilterPaginateService>();
             config = A.Fake<IConfiguration>();
+            clockUtility = A.Fake<IClockUtility>();
 
             httpRequest = A.Fake<HttpRequest>();
             httpResponse = A.Fake<HttpResponse>();
@@ -53,7 +55,8 @@
                     passwordResetService,
                     userService,
                     searchSortFilterPaginateService,
-                    config
+                    config,
+                    clockUtility
                 )
                 .WithMockHttpContext(httpRequest, CookieName, cookieValue, httpResponse)
                 .WithMockUser(true)

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyDelegateUserCanAccessSelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyDelegateUserCanAccessSelfAssessmentTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
 {
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
     using DigitalLearningSolutions.Web.Helpers.ExternalApis;
     using DigitalLearningSolutions.Web.ServiceFilter;
@@ -20,12 +21,14 @@
         private const int SelfAssessmentId = 1;
         private ILogger<VerifyDelegateUserCanAccessSelfAssessment> logger = null!;
         private ISelfAssessmentService selfAssessmentService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void Setup()
         {
             selfAssessmentService = A.Fake<ISelfAssessmentService>();
             logger = A.Fake<ILogger<VerifyDelegateUserCanAccessSelfAssessment>>();
+            clockUtility = A.Fake<IClockUtility>();
         }
 
         [Test]
@@ -68,7 +71,8 @@
                 A.Fake<IConfiguration>(),
                 A.Fake<IRecommendedLearningService>(),
                 A.Fake<IActionPlanService>(),
-                A.Fake<ISearchSortFilterPaginateService>()
+                A.Fake<ISearchSortFilterPaginateService>(),
+                clockUtility
             ).WithDefaultContext().WithMockUser(true, delegateId: DelegateId);
             var context = ContextHelper.GetDefaultActionExecutingContext(delegateGroupsController);
             context.RouteData.Values["selfAssessmentId"] = SelfAssessmentId;

--- a/DigitalLearningSolutions.Web.Tests/Services/ActivityServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ActivityServiceTests.cs
@@ -11,6 +11,7 @@
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.TrackingSystem;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Services;
     using FakeItEasy;
     using FluentAssertions;
@@ -25,6 +26,7 @@
         private ICourseCategoriesDataService courseCategoriesDataService = null!;
         private ICourseDataService courseDataService = null!;
         private IJobGroupsDataService jobGroupsDataService = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void SetUp()
@@ -33,11 +35,13 @@
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
             courseCategoriesDataService = A.Fake<ICourseCategoriesDataService>();
             courseDataService = A.Fake<ICourseDataService>();
+            clockUtility = A.Fake<IClockUtility>();
             activityService = new ActivityService(
                 activityDataService,
                 jobGroupsDataService,
                 courseCategoriesDataService,
-                courseDataService
+                courseDataService,
+                clockUtility
             );
         }
 
@@ -465,6 +469,7 @@
             var endDateString = "2021-06-06";
             A.CallTo(() => activityDataService.GetStartOfActivityForCentre(101, A<int?>._))
                 .Returns(DateTime.Parse("2000-06-07"));
+            A.CallTo(() => clockUtility.UtcNow).Returns(DateTime.UtcNow);
 
             // when
             var dateRange = activityService.GetValidatedUsageStatsDateRange(startDateString, endDateString, 101);

--- a/DigitalLearningSolutions.Web.Tests/Services/EmailServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/EmailServiceTests.cs
@@ -6,6 +6,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
     using DigitalLearningSolutions.Data.Factories;
     using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Services;
     using FakeItEasy;
     using MailKit.Net.Smtp;
@@ -20,6 +21,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
         private IEmailDataService emailDataService = null!;
         private EmailService emailService = null!;
         private ISmtpClient smtpClient = null!;
+        private IClockUtility clockUtility = null!;
 
         [SetUp]
         public void Setup()
@@ -28,6 +30,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             configDataService = A.Fake<IConfigDataService>();
             var smtpClientFactory = A.Fake<ISmtpClientFactory>();
             smtpClient = A.Fake<ISmtpClient>();
+            clockUtility = A.Fake<IClockUtility>();
             A.CallTo(() => smtpClientFactory.GetSmtpClient()).Returns(smtpClient);
 
             A.CallTo(() => configDataService.GetConfigValue(ConfigDataService.MailPort)).Returns("25");
@@ -38,7 +41,13 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                 .Returns("test@example.com");
 
             var logger = A.Fake<ILogger<EmailService>>();
-            emailService = new EmailService(emailDataService, configDataService, smtpClientFactory, logger);
+            emailService = new EmailService(
+                emailDataService,
+                configDataService,
+                smtpClientFactory,
+                logger,
+                clockUtility
+            );
         }
 
         [TestCase(ConfigDataService.MailPort)]
@@ -341,6 +350,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             var emails = new List<Email> { EmailTestHelper.GetDefaultEmailToSingleRecipient("to@example.com") };
             var deliveryDate = DateTime.Today;
             const string addedByProcess = "some process";
+            A.CallTo(() => clockUtility.UtcToday).Returns(deliveryDate);
 
             // When
             emailService.ScheduleEmails(emails, addedByProcess, deliveryDate);

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CompletedCourseHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CompletedCourseHelper.cs
@@ -3,12 +3,15 @@
     using System;
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Completed;
     using Microsoft.AspNetCore.Mvc;
 
     public static class CompletedCourseHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public static CompletedCourse CreateDefaultCompletedCourse(
             int customisationId = 1,
             string courseName = "Course 1",
@@ -38,9 +41,9 @@
                 Sections = sections,
                 ProgressID = progressId,
                 Evaluated = evaluated,
-                StartedDate = startedDate ?? DateTime.UtcNow,
-                LastAccessed = lastAccessed ?? DateTime.UtcNow,
-                Completed = completed ?? DateTime.UtcNow,
+                StartedDate = startedDate ?? ClockUtility.UtcNow,
+                LastAccessed = lastAccessed ?? ClockUtility.UtcNow,
+                Completed = completed ?? ClockUtility.UtcNow,
                 ArchivedDate = archivedDate
             };
         }

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/CurrentCourseHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/CurrentCourseHelper.cs
@@ -3,12 +3,14 @@
     using System;
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.LearningPortalController;
     using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current;
     using Microsoft.AspNetCore.Mvc;
 
     public static class CurrentCourseHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
 
         public static CurrentCourse CreateDefaultCurrentCourse(
             int customisationId = 1,
@@ -41,8 +43,8 @@
                 SupervisorAdminId = supervisorAdminId,
                 GroupCustomisationId = groupCustomisationId,
                 CompleteByDate = completeByDate,
-                StartedDate = startedDate ?? DateTime.UtcNow,
-                LastAccessed = lastAccessed ?? DateTime.UtcNow,
+                StartedDate = startedDate ?? ClockUtility.UtcNow,
+                LastAccessed = lastAccessed ?? ClockUtility.UtcNow,
                 ProgressID = progressId,
                 EnrollmentMethodID = enrollmentMethodId,
                 PLLocked = locked

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModelTests.cs
@@ -39,8 +39,11 @@
         };
 
         [Test]
-        public void EmailDelegatesViewModel_sets_delivery_date_today_by_default()
+        public void EmailDelegatesViewModel_sets_delivery_date()
         {
+            // Given
+            var date = new DateTime(2022, 1, 1);
+
             // When
             var model = new EmailDelegatesViewModel(
                 new SearchSortFilterPaginationResult<DelegateUserCard>(
@@ -50,13 +53,14 @@
                     null,
                     null
                 ),
-                availableFilters
+                availableFilters,
+                emailDate: date
             );
 
             // Then
-            model.Day.Should().Be(DateTime.Today.Day);
-            model.Month.Should().Be(DateTime.Today.Month);
-            model.Year.Should().Be(DateTime.Today.Year);
+            model.Day.Should().Be(date.Day);
+            model.Month.Should().Be(date.Month);
+            model.Year.Should().Be(date.Year);
         }
 
         [Test]
@@ -74,7 +78,8 @@
                         null,
                         null
                     ),
-                    availableFilters
+                    availableFilters,
+                    new DateTime(2022, 1, 1)
                 )
                 { SelectedDelegateIds = selectedDelegateIds };
 
@@ -98,6 +103,7 @@
                     null
                 ),
                 availableFilters,
+                new DateTime(2022, 1, 1),
                 true
             );
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/LearningPortalController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/LearningPortalController.cs
@@ -2,6 +2,7 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningPortalController
 {
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
@@ -28,6 +29,7 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningPortalController
         private readonly IFrameworkService frameworkService;
         private readonly ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
+        private readonly IClockUtility clockUtility;
 
         public LearningPortalController(
             ICentresDataService centresDataService,
@@ -42,7 +44,8 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningPortalController
             IConfiguration config,
             IActionPlanService actionPlanService,
             ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService,
-            ISearchSortFilterPaginateService searchSortFilterPaginateService
+            ISearchSortFilterPaginateService searchSortFilterPaginateService,
+            IClockUtility clockUtility
         )
         {
             this.centresDataService = centresDataService;
@@ -58,6 +61,7 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningPortalController
             this.actionPlanService = actionPlanService;
             this.candidateAssessmentDownloadFileService = candidateAssessmentDownloadFileService;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
+            this.clockUtility = clockUtility;
         }
 
         [SetDlsSubApplication(nameof(DlsSubApplication.LearningPortal))]

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
@@ -10,6 +10,7 @@
     using DigitalLearningSolutions.Data.Models.External.Filtered;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Helpers.ExternalApis;
@@ -33,6 +34,7 @@
         private readonly IRecommendedLearningService recommendedLearningService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
         private readonly ISelfAssessmentService selfAssessmentService;
+        private readonly IClockUtility clockUtility;
 
         public RecommendedLearningController(
             IFilteredApiHelperService filteredApiHelperService,
@@ -40,7 +42,8 @@
             IConfiguration configuration,
             IRecommendedLearningService recommendedLearningService,
             IActionPlanService actionPlanService,
-            ISearchSortFilterPaginateService searchSortFilterPaginateService
+            ISearchSortFilterPaginateService searchSortFilterPaginateService,
+            IClockUtility clockUtility
         )
         {
             this.filteredApiHelperService = filteredApiHelperService;
@@ -49,6 +52,7 @@
             this.recommendedLearningService = recommendedLearningService;
             this.actionPlanService = actionPlanService;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
+            this.clockUtility = clockUtility;
         }
 
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Results")]
@@ -258,7 +262,7 @@
                 var accessToken = await filteredApiHelperService.GetUserAccessToken<AccessToken>(candidateNum);
                 filteredToken = accessToken.Jwt_access_token;
                 var cookieOptions = new CookieOptions();
-                cookieOptions.Expires = new DateTimeOffset(DateTime.Now.AddMinutes(15));
+                cookieOptions.Expires = new DateTimeOffset(clockUtility.UtcNow.AddMinutes(15));
                 Response.Cookies.Append("filtered-" + candidateNum, filteredToken, cookieOptions);
             }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -7,6 +7,7 @@
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Data.Models.SessionData.SelfAssessments;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
@@ -1137,7 +1138,7 @@
         public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string vocabulary)
         {
             var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, GetCandidateId());
-            var fileName = $"DLS {vocabulary} Assessment Export {DateTime.Today:yyyy-MM-dd}.xlsx";
+            var fileName = $"DLS {vocabulary} Assessment Export {clockUtility.UtcToday:yyyy-MM-dd}.xlsx";
             return File(
                 content,
                 FileHelper.GetContentTypeFromFileName(fileName),

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
@@ -26,18 +27,21 @@
         private readonly ILoginService loginService;
         private readonly ISessionService sessionService;
         private readonly IUserService userService;
+        private readonly IClockUtility clockUtility;
 
         public LoginController(
             ILoginService loginService,
             ISessionService sessionService,
             ILogger<LoginController> logger,
-            IUserService userService
+            IUserService userService,
+            IClockUtility clockUtility
         )
         {
             this.loginService = loginService;
             this.sessionService = sessionService;
             this.logger = logger;
             this.userService = userService;
+            this.clockUtility = clockUtility;
         }
 
         public IActionResult Index(string? returnUrl = null)
@@ -138,7 +142,7 @@
             {
                 AllowRefresh = true,
                 IsPersistent = rememberMe,
-                IssuedUtc = DateTime.UtcNow,
+                IssuedUtc = clockUtility.UtcNow,
             };
 
             var adminAccount = userEntity!.GetCentreAccountSet(centreIdToLogInto)?.AdminAccount;
@@ -178,7 +182,7 @@
             {
                 AllowRefresh = true,
                 IsPersistent = rememberMe,
-                IssuedUtc = DateTime.UtcNow,
+                IssuedUtc = clockUtility.UtcNow,
             };
 
             await HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -7,6 +7,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Extensions;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
@@ -38,6 +39,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         private readonly PromptsService promptsService;
         private readonly IRegistrationService registrationService;
         private readonly IUserDataService userDataService;
+        private readonly IClockUtility clockUtility;
 
         public RegisterDelegateByCentreController(
             IJobGroupsDataService jobGroupsDataService,
@@ -45,7 +47,8 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             ICryptoService cryptoService,
             IUserDataService userDataService,
             IRegistrationService registrationService,
-            IConfiguration config
+            IConfiguration config,
+            IClockUtility clockUtility
         )
         {
             this.jobGroupsDataService = jobGroupsDataService;
@@ -54,6 +57,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             this.registrationService = registrationService;
             this.cryptoService = cryptoService;
             this.config = config;
+            this.clockUtility = clockUtility;
         }
 
         [Route("/TrackingSystem/Delegates/Register")]
@@ -270,7 +274,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void SetCentreDelegateRegistrationData(int centreId)
         {
-            var centreDelegateRegistrationData = new DelegateRegistrationByCentreData(centreId, DateTime.Today);
+            var centreDelegateRegistrationData = new DelegateRegistrationByCentreData(centreId, clockUtility.UtcToday);
             TempData.Set(centreDelegateRegistrationData);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.TrackingSystem;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
@@ -23,14 +24,17 @@
     {
         private readonly IActivityService activityService;
         private readonly IEvaluationSummaryService evaluationSummaryService;
+        private readonly IClockUtility clockUtility;
 
         public ReportsController(
             IActivityService activityService,
-            IEvaluationSummaryService evaluationSummaryService
+            IEvaluationSummaryService evaluationSummaryService,
+            IClockUtility clockUtility
         )
         {
             this.activityService = activityService;
             this.evaluationSummaryService = evaluationSummaryService;
+            this.clockUtility = clockUtility;
         }
 
         public IActionResult Index()
@@ -40,7 +44,7 @@
 
             var filterData = Request.Cookies.RetrieveFilterDataFromCookie(categoryIdFilter);
 
-            Response.Cookies.SetReportsFilterCookie(filterData, DateTime.UtcNow);
+            Response.Cookies.SetReportsFilterCookie(filterData, clockUtility.UtcNow);
 
             var activity = activityService.GetFilteredActivity(centreId, filterData);
 
@@ -61,7 +65,7 @@
                 filterModel,
                 evaluationResponseBreakdowns,
                 filterData.StartDate,
-                filterData.EndDate ?? DateTime.Today,
+                filterData.EndDate ?? clockUtility.UtcToday,
                 activityService.GetActivityStartDateForCentre(centreId, categoryIdFilter) != null,
                 activityService.GetCourseCategoryNameForActivityFilter(categoryIdFilter)
             );
@@ -128,7 +132,7 @@
                 model.ReportInterval
             );
 
-            Response.Cookies.SetReportsFilterCookie(filterData, DateTime.UtcNow);
+            Response.Cookies.SetReportsFilterCookie(filterData, clockUtility.UtcNow);
 
             return RedirectToAction("Index");
         }
@@ -167,7 +171,7 @@
 
             var dataFile = activityService.GetActivityDataFileForCentre(centreId, filterData);
 
-            var fileName = $"Activity data for centre {centreId} downloaded {DateTime.Today:yyyy-MM-dd}.xlsx";
+            var fileName = $"Activity data for centre {centreId} downloaded {clockUtility.UtcToday:yyyy-MM-dd}.xlsx";
             return File(
                 dataFile,
                 FileHelper.GetContentTypeFromFileName(fileName),
@@ -208,7 +212,7 @@
             );
 
             var content = evaluationSummaryService.GetEvaluationSummaryFileForCentre(centreId, filterData);
-            var fileName = $"DLS Evaluation Stats {DateTime.Today:yyyy-MM-dd}.xlsx";
+            var fileName = $"DLS Evaluation Stats {clockUtility.UtcToday:yyyy-MM-dd}.xlsx";
             return File(
                 content,
                 FileHelper.GetContentTypeFromFileName(fileName),

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -60,7 +60,7 @@
         public IActionResult StartUpload()
         {
             TempData.Clear();
-            var model = new UploadDelegatesViewModel(DateTime.Today);
+            var model = new UploadDelegatesViewModel(clockUtility.UtcToday);
             return View("StartUpload", model);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EmailDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EmailDelegatesController.cs
@@ -9,6 +9,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
@@ -33,6 +34,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         private readonly IUserService userService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
         private readonly IConfiguration config;
+        private readonly IClockUtility clockUtility;
 
         public EmailDelegatesController(
             PromptsService promptsService,
@@ -40,7 +42,8 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             IPasswordResetService passwordResetService,
             IUserService userService,
             ISearchSortFilterPaginateService searchSortFilterPaginateService,
-            IConfiguration config
+            IConfiguration config,
+            IClockUtility clockUtility
         )
         {
             this.promptsService = promptsService;
@@ -49,6 +52,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             this.userService = userService;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
             this.config = config;
+            this.clockUtility = clockUtility;
         }
 
         [HttpGet]
@@ -91,6 +95,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             var model = new EmailDelegatesViewModel(
                 result,
                 availableFilters,
+                clockUtility.UtcToday,
                 selectAll
             );
 

--- a/DigitalLearningSolutions.Web/Helpers/DateValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/DateValidator.cs
@@ -7,7 +7,7 @@
 
     public static class DateValidator
     {
-        private static ClockUtility clockUtility = new ClockUtility();
+        private static readonly ClockUtility ClockUtility = new ClockUtility();
 
         public static DateValidationResult ValidateDate(
             int? day,
@@ -63,12 +63,12 @@
             try
             {
                 var date = new DateTime(year, month, day);
-                if (dateMustNotBeInPast && date < clockUtility.UtcToday)
+                if (dateMustNotBeInPast && date < ClockUtility.UtcToday)
                 {
                     return new DateValidationResult("Enter " + NameWithIndefiniteArticle(name) + " not in the past");
                 }
 
-                if (dateMustNotBeInFuture && date > clockUtility.UtcToday)
+                if (dateMustNotBeInFuture && date > ClockUtility.UtcToday)
                 {
                     return new DateValidationResult("Enter " + NameWithIndefiniteArticle(name) + " not in the future");
                 }

--- a/DigitalLearningSolutions.Web/Helpers/DateValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/DateValidator.cs
@@ -3,9 +3,12 @@
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public static class DateValidator
     {
+        private static ClockUtility clockUtility = new ClockUtility();
+
         public static DateValidationResult ValidateDate(
             int? day,
             int? month,
@@ -60,12 +63,12 @@
             try
             {
                 var date = new DateTime(year, month, day);
-                if (dateMustNotBeInPast && date < DateTime.Today)
+                if (dateMustNotBeInPast && date < clockUtility.UtcToday)
                 {
                     return new DateValidationResult("Enter " + NameWithIndefiniteArticle(name) + " not in the past");
                 }
 
-                if (dateMustNotBeInFuture && date > DateTime.Today)
+                if (dateMustNotBeInFuture && date > clockUtility.UtcToday)
                 {
                     return new DateValidationResult("Enter " + NameWithIndefiniteArticle(name) + " not in the future");
                 }

--- a/DigitalLearningSolutions.Web/Helpers/ExternalApis/FilteredApiHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ExternalApis/FilteredApiHelper.cs
@@ -14,6 +14,7 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public interface IFilteredApiHelperService
     {
@@ -28,6 +29,7 @@
     public class FilteredApiHelper : IFilteredApiHelperService
     {
         private static readonly HttpClient client = new HttpClient();
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
         public async Task<AccessToken> GetUserAccessToken<T>(string candidateNumber)
         {
             string token = GenerateUserJwt(candidateNumber);
@@ -102,7 +104,7 @@
             new Claim("userID", "DLS-" + candidateNumber),
                 }),
                 //Issuer = myIssuer,
-                Expires = DateTime.UtcNow.AddDays(7),
+                Expires = ClockUtility.UtcNow.AddDays(7),
                 SigningCredentials = new SigningCredentials(mySecurityKey, SecurityAlgorithms.HmacSha256)
             };
 

--- a/DigitalLearningSolutions.Web/Helpers/OldDateValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/OldDateValidator.cs
@@ -3,12 +3,15 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using DigitalLearningSolutions.Data.Utilities;
 
     // This helper class is currently used in LearningPortal pages
     // Switch over to the new DateValidator class in HEEDLS-560
 
     public static class OldDateValidator
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public class ValidationResult
         {
             public ValidationResult()
@@ -58,7 +61,7 @@
                 }
 
                 var newDate = new DateTime(year, month, day);
-                if (newDate <= DateTime.Today)
+                if (newDate <= ClockUtility.UtcToday)
                 {
                     return new ValidationResult(day, month, year)
                     {

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationMappingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationMappingHelper.cs
@@ -2,10 +2,13 @@
 {
     using System;
     using DigitalLearningSolutions.Data.Models.Register;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Models;
 
     public static class RegistrationMappingHelper
     {
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
+
         public static AdminRegistrationModel MapToCentreManagerAdminRegistrationModel(RegistrationData data)
         {
             return new AdminRegistrationModel(
@@ -53,7 +56,7 @@
                 true,
                 true,
                 data.ProfessionalRegistrationNumber,
-                notifyDate: DateTime.Now
+                notifyDate: ClockUtility.UtcNow
             );
         }
 

--- a/DigitalLearningSolutions.Web/Helpers/SignpostingCookieHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SignpostingCookieHelper.cs
@@ -5,10 +5,13 @@ using System;
 
 namespace DigitalLearningSolutions.Web.Helpers
 {
+    using DigitalLearningSolutions.Data.Utilities;
+
     public static class SignpostingCookieHelper
     {
         public static readonly string CookieName = "SignpostingCookie";
         public static readonly int CookieExpiryDays = 30;
+        private static readonly IClockUtility ClockUtility = new ClockUtility();
 
         public static void SetSignpostingCookie(
             this IResponseCookies cookies,
@@ -16,7 +19,7 @@ namespace DigitalLearningSolutions.Web.Helpers
             DateTime? currentDateTime = null
         )
         {
-            var expiry = (currentDateTime ?? DateTime.UtcNow).AddDays(CookieExpiryDays);
+            var expiry = (currentDateTime ?? ClockUtility.UtcNow).AddDays(CookieExpiryDays);
             var settings = new JsonSerializerSettings
             {
                 DefaultValueHandling = DefaultValueHandling.Ignore,

--- a/DigitalLearningSolutions.Web/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Web/Services/ActivityService.cs
@@ -10,6 +10,7 @@
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.TrackingSystem;
+    using DigitalLearningSolutions.Data.Utilities;
 
     public interface IActivityService
     {
@@ -42,18 +43,21 @@
         private readonly ICourseCategoriesDataService courseCategoriesDataService;
         private readonly ICourseDataService courseDataService;
         private readonly IJobGroupsDataService jobGroupsDataService;
+        private readonly IClockUtility clockUtility;
 
         public ActivityService(
             IActivityDataService activityDataService,
             IJobGroupsDataService jobGroupsDataService,
             ICourseCategoriesDataService courseCategoriesDataService,
-            ICourseDataService courseDataService
+            ICourseDataService courseDataService,
+            IClockUtility clockUtility
         )
         {
             this.activityDataService = activityDataService;
             this.jobGroupsDataService = jobGroupsDataService;
             this.courseCategoriesDataService = courseCategoriesDataService;
             this.courseDataService = courseDataService;
+            this.clockUtility = clockUtility;
         }
 
         public IEnumerable<PeriodOfActivity> GetFilteredActivity(int centreId, ActivityFilterData filterData)
@@ -73,7 +77,7 @@
 
             var dateSlots = DateHelper.GetPeriodsBetweenDates(
                 filterData.StartDate,
-                filterData.EndDate ?? DateTime.UtcNow,
+                filterData.EndDate ?? clockUtility.UtcNow,
                 filterData.ReportInterval
             );
 
@@ -139,7 +143,7 @@
                         DateInformation.GetDateRangeLabel(
                             DateHelper.StandardDateFormat,
                             filterData.StartDate,
-                            filterData.EndDate ?? DateTime.Now
+                            filterData.EndDate ?? clockUtility.UtcNow
                         ),
                         p.Registrations,
                         p.Completions,
@@ -161,7 +165,7 @@
                 var lastRow = new WorkbookRow(
                     last.DateInformation.GetDateRangeLabel(
                         DateHelper.StandardDateFormat,
-                        filterData.EndDate ?? DateTime.Now,
+                        filterData.EndDate ?? clockUtility.UtcNow,
                         true
                     ),
                     last.Registrations,
@@ -205,7 +209,7 @@
 
             var endDateIsSet = DateTime.TryParse(endDateString, out var endDate);
 
-            if (endDateIsSet && (endDate < startDate || endDate > DateTime.Now))
+            if (endDateIsSet && (endDate < startDate || endDate > clockUtility.UtcNow))
             {
                 return null;
             }

--- a/DigitalLearningSolutions.Web/Services/EmailService.cs
+++ b/DigitalLearningSolutions.Web/Services/EmailService.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Factories;
     using DigitalLearningSolutions.Data.Models.Email;
+    using DigitalLearningSolutions.Data.Utilities;
     using MailKit.Net.Smtp;
     using Microsoft.Extensions.Logging;
     using MimeKit;
@@ -25,18 +26,21 @@
         private readonly IEmailDataService emailDataService;
         private readonly ILogger<EmailService> logger;
         private readonly ISmtpClientFactory smtpClientFactory;
+        private readonly IClockUtility clockUtility;
 
         public EmailService(
             IEmailDataService emailDataService,
             IConfigDataService configDataService,
             ISmtpClientFactory smtpClientFactory,
-            ILogger<EmailService> logger
+            ILogger<EmailService> logger,
+            IClockUtility clockUtility
         )
         {
             this.emailDataService = emailDataService;
             this.configDataService = configDataService;
             this.smtpClientFactory = smtpClientFactory;
             this.logger = logger;
+            this.clockUtility = clockUtility;
         }
 
         public void SendEmail(Email email)
@@ -76,7 +80,7 @@
         public void ScheduleEmails(IEnumerable<Email> emails, string addedByProcess, DateTime? deliveryDate = null)
         {
             var senderAddress = GetMailConfig().MailSenderAddress;
-            var urgent = deliveryDate?.Date.Equals(DateTime.Today) ?? false;
+            var urgent = deliveryDate?.Date.Equals(clockUtility.UtcToday) ?? false;
             emailDataService.ScheduleEmails(emails, senderAddress, addedByProcess, urgent, deliveryDate);
         }
 

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -205,7 +205,7 @@
             var completionStatus = progressDataService.GetCompletionStatusForProgress(progress.ProgressId);
             if (completionStatus > 0)
             {
-                progressDataService.SetCompletionDate(progress.ProgressId, DateTime.UtcNow);
+                progressDataService.SetCompletionDate(progress.ProgressId, clockUtility.UtcNow);
                 var numLearningLogItemsAffected =
                     learningLogItemsDataService.MarkLearningLogItemsCompleteByProgressId(progress.ProgressId);
                 notificationService.SendProgressCompletionNotificationEmail(

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Current/CurrentLearningItemViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Current/CurrentLearningItemViewModel.cs
@@ -24,12 +24,14 @@
 
         public string DateStyle()
         {
-            if (CompleteByDate < clockUtility.UtcToday)
+            var utcToday = clockUtility.UtcToday;
+
+            if (CompleteByDate < utcToday)
             {
                 return "overdue";
             }
 
-            if (CompleteByDate < clockUtility.UtcToday + TimeSpan.FromDays(30))
+            if (CompleteByDate < utcToday + TimeSpan.FromDays(30))
             {
                 return "due-soon";
             }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Current/CurrentLearningItemViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Current/CurrentLearningItemViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Helpers;
 
     public class CurrentLearningItemViewModel : StartedLearningItemViewModel
@@ -19,15 +20,16 @@
         public DateTime? CompleteByDate { get; }
         public OldDateValidator.ValidationResult? CompleteByValidationResult { get; set; }
         public ReturnPageQuery ReturnPageQuery { get; }
+        private readonly IClockUtility clockUtility = new ClockUtility();
 
         public string DateStyle()
         {
-            if (CompleteByDate < DateTime.Today)
+            if (CompleteByDate < clockUtility.UtcToday)
             {
                 return "overdue";
             }
 
-            if (CompleteByDate < DateTime.Today + TimeSpan.FromDays(30))
+            if (CompleteByDate < clockUtility.UtcToday + TimeSpan.FromDays(30))
             {
                 return "due-soon";
             }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModel.cs
@@ -1,23 +1,20 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.EmailDelegates
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.User;
-    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public class EmailDelegatesViewModel : BaseSearchablePageViewModel<DelegateUserCard>
     {
-        public EmailDelegatesViewModel(
+        private EmailDelegatesViewModel(
             SearchSortFilterPaginationResult<DelegateUserCard> result,
             IEnumerable<FilterModel> availableFilters,
-            bool selectAll = false
+            bool selectAll
         ) : base(result, true, availableFilters)
         {
-            Day = clockUtility.UtcToday.Day;
-            Month = clockUtility.UtcToday.Month;
-            Year = clockUtility.UtcToday.Year;
             Delegates = result.ItemsToDisplay.Select(
                 delegateUser =>
                 {
@@ -31,8 +28,20 @@
         public EmailDelegatesViewModel(
             SearchSortFilterPaginationResult<DelegateUserCard> result,
             IEnumerable<FilterModel> availableFilters,
+            DateTime emailDate,
+            bool selectAll = false
+        ) : this(result, availableFilters, selectAll)
+        {
+            Day = emailDate.Day;
+            Month = emailDate.Month;
+            Year = emailDate.Year;
+        }
+
+        public EmailDelegatesViewModel(
+            SearchSortFilterPaginationResult<DelegateUserCard> result,
+            IEnumerable<FilterModel> availableFilters,
             EmailDelegatesFormData formData
-        ) : this(result, availableFilters)
+        ) : this(result, availableFilters, false)
         {
             SelectedDelegateIds = formData.SelectedDelegateIds;
             Day = formData.Day;
@@ -46,7 +55,6 @@
         public int? Day { get; set; }
         public int? Month { get; set; }
         public int? Year { get; set; }
-        private readonly IClockUtility clockUtility = new ClockUtility();
 
         public override IEnumerable<(string, string)> SortOptions { get; } = new List<(string, string)>();
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/EmailDelegates/EmailDelegatesViewModel.cs
@@ -1,10 +1,10 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.EmailDelegates
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public class EmailDelegatesViewModel : BaseSearchablePageViewModel<DelegateUserCard>
@@ -15,9 +15,9 @@
             bool selectAll = false
         ) : base(result, true, availableFilters)
         {
-            Day = DateTime.Today.Day;
-            Month = DateTime.Today.Month;
-            Year = DateTime.Today.Year;
+            Day = clockUtility.UtcToday.Day;
+            Month = clockUtility.UtcToday.Month;
+            Year = clockUtility.UtcToday.Year;
             Delegates = result.ItemsToDisplay.Select(
                 delegateUser =>
                 {
@@ -46,6 +46,7 @@
         public int? Day { get; set; }
         public int? Month { get; set; }
         public int? Year { get; set; }
+        private readonly IClockUtility clockUtility = new ClockUtility();
 
         public override IEnumerable<(string, string)> SortOptions { get; } = new List<(string, string)>();
 

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Publish.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Publish.cshtml
@@ -1,8 +1,10 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks;
+﻿@using DigitalLearningSolutions.Data.Utilities
+@using DigitalLearningSolutions.Web.ViewModels.Frameworks;
 @model PublishViewModel;
 @{
   ViewData["Title"] = Model.DetailFramework.FrameworkName;
   ViewData["Application"] = "Framework Service";
+  var clockUtility = new ClockUtility();
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
@@ -50,7 +52,7 @@
             <span class="nhsuk-table-responsive__heading">Reviewer </span>@review.UserEmail
           </td>
           <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-            <span class="nhsuk-table-responsive__heading">Requested </span>@(review.ReviewRequested.ToShortDateString() != DateTime.UtcNow.ToShortDateString() ? review.ReviewRequested.ToShortDateString() : "Today")
+            <span class="nhsuk-table-responsive__heading">Requested </span>@(review.ReviewRequested.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? review.ReviewRequested.ToShortDateString() : "Today")
           </td>
           <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
             <span class="nhsuk-table-responsive__heading">Status </span>
@@ -72,7 +74,7 @@
             }
             @if (review.ReviewComplete == null)
             {
-              @if (review.ReviewRequested.ToShortDateString() != DateTime.UtcNow.ToShortDateString())
+              @if (review.ReviewRequested.ToShortDateString() != clockUtility.UtcNow.ToShortDateString())
               {
                 <a asp-action="ResendRequest" asp-route-reviewId="@review.ID" asp-route-frameworkId="@review.FrameworkID" asp-route-frameworkCollaboratorId="@review.FrameworkCollaboratorID">
                   Send reminder

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Publish.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Publish.cshtml
@@ -1,10 +1,10 @@
 ﻿@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.ViewModels.Frameworks;
+@inject IClockUtility ClockUtility
 @model PublishViewModel;
 @{
   ViewData["Title"] = Model.DetailFramework.FrameworkName;
   ViewData["Application"] = "Framework Service";
-  var clockUtility = new ClockUtility();
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
@@ -52,7 +52,7 @@
             <span class="nhsuk-table-responsive__heading">Reviewer </span>@review.UserEmail
           </td>
           <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-            <span class="nhsuk-table-responsive__heading">Requested </span>@(review.ReviewRequested.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? review.ReviewRequested.ToShortDateString() : "Today")
+            <span class="nhsuk-table-responsive__heading">Requested </span>@(review.ReviewRequested.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString() ? review.ReviewRequested.ToShortDateString() : "Today")
           </td>
           <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
             <span class="nhsuk-table-responsive__heading">Status </span>
@@ -74,7 +74,7 @@
             }
             @if (review.ReviewComplete == null)
             {
-              @if (review.ReviewRequested.ToShortDateString() != clockUtility.UtcNow.ToShortDateString())
+              @if (review.ReviewRequested.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString())
               {
                 <a asp-action="ResendRequest" asp-route-reviewId="@review.ID" asp-route-frameworkId="@review.FrameworkID" asp-route-frameworkCollaboratorId="@review.FrameworkCollaboratorID">
                   Send reminder

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/MarkActionPlanResourceAsComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/MarkActionPlanResourceAsComplete.cshtml
@@ -1,11 +1,13 @@
-﻿@using DigitalLearningSolutions.Web.Helpers
+﻿@using DigitalLearningSolutions.Data.Utilities
+@using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
 @model MarkActionPlanResourceAsCompleteViewModel
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? $"Error: Mark {Model.ResourceName} as complete" : $"Mark {Model.ResourceName} as complete";
-  var exampleDate = DateTime.Today;
+  var clockUtility = new ClockUtility();
+  var exampleDate = clockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}",
   };

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/MarkActionPlanResourceAsComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/MarkActionPlanResourceAsComplete.cshtml
@@ -1,13 +1,13 @@
 ﻿@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
+@inject IClockUtility ClockUtility
 @model MarkActionPlanResourceAsCompleteViewModel
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? $"Error: Mark {Model.ResourceName} as complete" : $"Mark {Model.ResourceName} as complete";
-  var clockUtility = new ClockUtility();
-  var exampleDate = clockUtility.UtcToday;
+  var exampleDate = ClockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}",
   };

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -3,13 +3,13 @@
 @using DigitalLearningSolutions.Web.Controllers.LearningPortalController
 @using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
+@inject IClockUtility ClockUtility
 @model EditCompleteByDateViewModel
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? $"Error: Learning Portal - {Model.Name} - Set complete by date" : $"Learning Portal - {Model.Name} - Set complete by date";
-  var clockUtility = new ClockUtility();
-  var exampleDate = clockUtility.UtcToday + TimeSpan.FromDays(7);
+  var exampleDate = ClockUtility.UtcToday + TimeSpan.FromDays(7);
   var standardHintText = $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the complete by date.";
   var courseHintText = Model.Type.Equals(LearningItemType.Course) ? "Activities with a complete by date will remain on your 'Current courses' list until completed. Activities with no complete by date will be removed after 6 months of inactivity." : "";
   var hintTextLines = new List<string> { standardHintText, courseHintText };

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/SetCompleteByDate.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Data.Enums
+@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Controllers.LearningPortalController
 @using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
@@ -7,7 +8,8 @@
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? $"Error: Learning Portal - {Model.Name} - Set complete by date" : $"Learning Portal - {Model.Name} - Set complete by date";
-  var exampleDate = DateTime.Today + TimeSpan.FromDays(7);
+  var clockUtility = new ClockUtility();
+  var exampleDate = clockUtility.UtcToday + TimeSpan.FromDays(7);
   var standardHintText = $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the complete by date.";
   var courseHintText = Model.Type.Equals(LearningItemType.Course) ? "Activities with a complete by date will remain on your 'Current courses' list until completed. Activities with no complete by date will be removed after 6 months of inactivity." : "";
   var hintTextLines = new List<string> { standardHintText, courseHintText };

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -1,4 +1,9 @@
-﻿@using Microsoft.AspNetCore.Http.Extensions
+﻿@using DigitalLearningSolutions.Data.Utilities
+@using Microsoft.AspNetCore.Http.Extensions
+
+@{
+  var clockUtility = new ClockUtility();
+}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -91,7 +96,7 @@
                             <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
                         </li>
                     </ul>
-                    <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @DateTime.Now.Year</p>
+                    <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @clockUtility.UtcNow.Year</p>
                 </div>
             </div>
         </footer>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -1,9 +1,6 @@
 ﻿@using DigitalLearningSolutions.Data.Utilities
 @using Microsoft.AspNetCore.Http.Extensions
-
-@{
-  var clockUtility = new ClockUtility();
-}
+@inject IClockUtility ClockUtility
 
 <!DOCTYPE html>
 <html lang="en">
@@ -96,7 +93,7 @@
                             <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
                         </li>
                     </ul>
-                    <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @clockUtility.UtcNow.Year</p>
+                    <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @ClockUtility.UtcNow.Year</p>
                 </div>
             </div>
         </footer>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Data.Enums
+@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Extensions
 @using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.Models.Enums
@@ -14,6 +15,7 @@
   }
   var headerExtension = (string)ViewData[LayoutViewDataKeys.Application];
   var shouldDisplayHelpMenuItem = dlsSubApplication?.DisplayHelpMenuItem ?? headerExtension != DlsSubApplication.TrackingSystem.HeaderExtension;
+  var clockUtility = new ClockUtility();
 }
 
 <!DOCTYPE html>
@@ -164,7 +166,7 @@
             <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
           </li>
         </ul>
-        <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @DateTime.Now.Year</p>
+        <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @clockUtility.UtcNow.Year</p>
       </div>
     </div>
   </footer>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -5,6 +5,7 @@
 @using DigitalLearningSolutions.Web.Models.Enums
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
+@inject IClockUtility ClockUtility
 
 @{
   var dlsSubApplication = (DlsSubApplication?)ViewData[LayoutViewDataKeys.DlsSubApplication];
@@ -15,7 +16,6 @@
   }
   var headerExtension = (string)ViewData[LayoutViewDataKeys.Application];
   var shouldDisplayHelpMenuItem = dlsSubApplication?.DisplayHelpMenuItem ?? headerExtension != DlsSubApplication.TrackingSystem.HeaderExtension;
-  var clockUtility = new ClockUtility();
 }
 
 <!DOCTYPE html>
@@ -166,7 +166,7 @@
             <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
           </li>
         </ul>
-        <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @clockUtility.UtcNow.Year</p>
+        <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @ClockUtility.UtcNow.Year</p>
       </div>
     </div>
   </footer>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
@@ -1,6 +1,8 @@
 ﻿@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+@inject IClockUtility ClockUtility
 @model EnrolDelegateSetCompletByDateViewModel;
+
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = "Enrol on Profile Assessment";
@@ -39,8 +41,7 @@
   </nav>
 }
 @{
-  var clockUtility = new ClockUtility();
-  var exampleDate = clockUtility.UtcToday + TimeSpan.FromDays(7);
+  var exampleDate = ClockUtility.UtcToday + TimeSpan.FromDays(7);
   string prefillDay;
   string prefillMonth;
   string prefillYear;

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
@@ -1,4 +1,5 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+﻿@using DigitalLearningSolutions.Data.Utilities
+@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model EnrolDelegateSetCompletByDateViewModel;
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
@@ -38,7 +39,8 @@
   </nav>
 }
 @{
-  var exampleDate = @DateTime.Today + TimeSpan.FromDays(7);
+  var clockUtility = new ClockUtility();
+  var exampleDate = clockUtility.UtcToday + TimeSpan.FromDays(7);
   string prefillDay;
   string prefillMonth;
   string prefillYear;

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
@@ -1,5 +1,10 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Supervisor;
+@using DigitalLearningSolutions.Data.Utilities
 @model IEnumerable<DelegateSelfAssessment>;
+
+@{
+  var clockUtility = new ClockUtility();
+}
 
 <table role="table" class="nhsuk-table-responsive">
   <caption class="nhsuk-table__caption"><h2>Self assessments</h2></caption>
@@ -42,14 +47,14 @@
       </td>
       <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
         <span class="nhsuk-table-responsive__heading">Actions </span>
-        @if (delegateSelfAssessment.SignOffRequested == 0 && delegateSelfAssessment.LastAccessed < DateTime.Now.AddDays(-7))
+        @if (delegateSelfAssessment.SignOffRequested == 0 && delegateSelfAssessment.LastAccessed < clockUtility.UtcNow.AddDays(-7))
         {
           <a class="status-tag" asp-action="SendReminderDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Send reminder</a>
-        } 
+        }
         @if (delegateSelfAssessment.LaunchCount > 0)
         {
           <a asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">@(delegateSelfAssessment.SignOffRequested > 0 | delegateSelfAssessment.ResultsVerificationRequests > 0 ? "Review" : "View")</a>
-        } 
+        }
         @if (delegateSelfAssessment.CompletedDate != null | delegateSelfAssessment.LaunchCount == 0)
         {
           <a asp-action="RemoveDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Remove</a>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
@@ -1,10 +1,7 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Supervisor;
 @using DigitalLearningSolutions.Data.Utilities
 @model IEnumerable<DelegateSelfAssessment>;
-
-@{
-  var clockUtility = new ClockUtility();
-}
+@inject IClockUtility ClockUtility
 
 <table role="table" class="nhsuk-table-responsive">
   <caption class="nhsuk-table__caption"><h2>Self assessments</h2></caption>
@@ -47,7 +44,7 @@
       </td>
       <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
         <span class="nhsuk-table-responsive__heading">Actions </span>
-        @if (delegateSelfAssessment.SignOffRequested == 0 && delegateSelfAssessment.LastAccessed < clockUtility.UtcNow.AddDays(-7))
+        @if (delegateSelfAssessment.SignOffRequested == 0 && delegateSelfAssessment.LastAccessed < ClockUtility.UtcNow.AddDays(-7))
         {
           <a class="status-tag" asp-action="SendReminderDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Send reminder</a>
         }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
@@ -1,8 +1,10 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Supervisor
+@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Extensions
 @model SupervisorDelegateDetail
 @{
-    bool IsSupervisor = (bool)(ViewData["isSupervisor"] ?? false);   
+  bool IsSupervisor = (bool)(ViewData["isSupervisor"] ?? false);
+  var clockUtility = new ClockUtility();
 }
 
 <dl class="nhsuk-summary-list">
@@ -11,7 +13,7 @@
     Added
   </dt>
   <dd class="nhsuk-summary-list__value">
-    @(Model.Added.ToShortDateString() != DateTime.UtcNow.ToShortDateString() ? Model.Added.ToShortDateString() : "Today")
+    @(Model.Added.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? Model.Added.ToShortDateString() : "Today")
   </dd>
   <dd class="nhsuk-summary-list__actions">
   </dd>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
@@ -1,10 +1,11 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Supervisor
 @using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Extensions
+@inject IClockUtility ClockUtility
 @model SupervisorDelegateDetail
+
 @{
-  bool IsSupervisor = (bool)(ViewData["isSupervisor"] ?? false);
-  var clockUtility = new ClockUtility();
+  bool isSupervisor = (bool)(ViewData["isSupervisor"] ?? false);
 }
 
 <dl class="nhsuk-summary-list">
@@ -13,12 +14,12 @@
     Added
   </dt>
   <dd class="nhsuk-summary-list__value">
-    @(Model.Added.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? Model.Added.ToShortDateString() : "Today")
+    @(Model.Added.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString() ? Model.Added.ToShortDateString() : "Today")
   </dd>
   <dd class="nhsuk-summary-list__actions">
   </dd>
   </div>
-  @if (IsSupervisor)
+  @if (isSupervisor)
   {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -1,10 +1,7 @@
 ﻿@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.ViewModels.Supervisor
+@inject IClockUtility ClockUtility
 @model SupervisorDelegateDetailViewModel;
-
-@{
-  var clockUtility = new ClockUtility();
-}
 
 <div class="searchable-element nhsuk-panel" id="@Model.SupervisorDelegateDetail.ID-card">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
@@ -49,7 +46,7 @@
               Added
             </dt>
             <dd class="nhsuk-summary-list__value">
-              @(Model.SupervisorDelegateDetail.Added.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.Added.ToShortDateString() : "Today")
+              @(Model.SupervisorDelegateDetail.Added.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.Added.ToShortDateString() : "Today")
             </dd>
             <dd class="nhsuk-summary-list__actions">
             </dd>
@@ -59,10 +56,10 @@
             Notification Sent
           </dt>
           <dd class="nhsuk-summary-list__value">
-            @(Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() : "Today")
+            @(Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() : "Today")
           </dd>
           <dd class="nhsuk-summary-list__actions">
-            @if (Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != clockUtility.UtcNow.ToShortDateString())
+            @if (Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString())
             {
               <a asp-action="ResendInvite" asp-route-reviewId="@Model.SupervisorDelegateDetail.ID">
                 Send reminder

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -1,5 +1,11 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor
+﻿@using DigitalLearningSolutions.Data.Utilities
+@using DigitalLearningSolutions.Web.ViewModels.Supervisor
 @model SupervisorDelegateDetailViewModel;
+
+@{
+  var clockUtility = new ClockUtility();
+}
+
 <div class="searchable-element nhsuk-panel" id="@Model.SupervisorDelegateDetail.ID-card">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
     <summary class="nhsuk-details__summary">
@@ -43,7 +49,7 @@
               Added
             </dt>
             <dd class="nhsuk-summary-list__value">
-              @(Model.SupervisorDelegateDetail.Added.ToShortDateString() != DateTime.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.Added.ToShortDateString() : "Today")
+              @(Model.SupervisorDelegateDetail.Added.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.Added.ToShortDateString() : "Today")
             </dd>
             <dd class="nhsuk-summary-list__actions">
             </dd>
@@ -53,10 +59,10 @@
             Notification Sent
           </dt>
           <dd class="nhsuk-summary-list__value">
-            @(Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != DateTime.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() : "Today")
+            @(Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != clockUtility.UtcNow.ToShortDateString() ? Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() : "Today")
           </dd>
           <dd class="nhsuk-summary-list__actions">
-            @if (Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != DateTime.UtcNow.ToShortDateString())
+            @if (Model.SupervisorDelegateDetail.NotificationSent.ToShortDateString() != clockUtility.UtcNow.ToShortDateString())
             {
               <a asp-action="ResendInvite" asp-route-reviewId="@Model.SupervisorDelegateDetail.ID">
                 Send reminder

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -1,11 +1,7 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments
 @using DigitalLearningSolutions.Data.Utilities
-
+@inject IClockUtility ClockUtility
 @model IEnumerable<SupervisorSignOff>
-
-@{
-  var clockUtility = new ClockUtility();
-}
 
 @if (Model.Any())
 {
@@ -46,7 +42,7 @@
     @if ((Model.Count() - 1) > 0)
     {
   <dd class="nhsuk-summary-list__actions">
-    @if ((Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != clockUtility.UtcNow.ToShortDateString()))
+    @if ((Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString()))
     {
       if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
       {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -1,6 +1,11 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments
+@using DigitalLearningSolutions.Data.Utilities
 
 @model IEnumerable<SupervisorSignOff>
+
+@{
+  var clockUtility = new ClockUtility();
+}
 
 @if (Model.Any())
 {
@@ -41,7 +46,7 @@
     @if ((Model.Count() - 1) > 0)
     {
   <dd class="nhsuk-summary-list__actions">
-    @if ((Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != DateTime.UtcNow.ToShortDateString()))
+    @if ((Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != clockUtility.UtcNow.ToShortDateString()))
     {
       if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
       {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompleteByDate.cshtml
@@ -1,6 +1,7 @@
 ﻿@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
+@inject IClockUtility ClockUtility
 @model EditCompleteByDateViewModel
 
 @{
@@ -14,8 +15,7 @@
     routeParamsForBackLink.Add("delegateId", Model.DelegateId.ToString());
   }
 
-  var clockUtility = new ClockUtility();
-  var exampleDate = clockUtility.UtcToday;
+  var exampleDate = ClockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the complete by date.",
     "Activities with no complete by date will be removed after 6 months of inactivity.",

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompleteByDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompleteByDate.cshtml
@@ -1,4 +1,5 @@
-﻿@using DigitalLearningSolutions.Web.Models.Enums
+﻿@using DigitalLearningSolutions.Data.Utilities
+@using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
 @model EditCompleteByDateViewModel
 
@@ -13,7 +14,8 @@
     routeParamsForBackLink.Add("delegateId", Model.DelegateId.ToString());
   }
 
-  var exampleDate = DateTime.Today;
+  var clockUtility = new ClockUtility();
+  var exampleDate = clockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the complete by date.",
     "Activities with no complete by date will be removed after 6 months of inactivity.",

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
@@ -1,6 +1,7 @@
 @using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
+@inject IClockUtility ClockUtility
 @model EditCompletionDateViewModel
 
 @{
@@ -15,8 +16,7 @@
     routeParamsForBackLink.Add("delegateId", Model.DelegateId.ToString());
   }
 
-  var clockUtility = new ClockUtility();
-  var exampleDate = clockUtility.UtcToday;
+  var exampleDate = ClockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the completed date",
   };

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/EditCompletionDate.cshtml
@@ -1,3 +1,4 @@
+@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateProgress
 @model EditCompletionDateViewModel
@@ -14,7 +15,8 @@
     routeParamsForBackLink.Add("delegateId", Model.DelegateId.ToString());
   }
 
-  var exampleDate = DateTime.Today;
+  var clockUtility = new ClockUtility();
+  var exampleDate = clockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}. Leave the boxes blank to clear the completed date",
   };

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/Index.cshtml
@@ -1,3 +1,4 @@
+@using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.EmailDelegates
 @model EmailDelegatesViewModel
 
@@ -6,7 +7,8 @@
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? "Error: Send welcome messages" : "Send welcome messages";
-  var exampleDate = DateTime.Today;
+  var clockUtility = new ClockUtility();
+  var exampleDate = clockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}",
   };

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EmailDelegates/Index.cshtml
@@ -1,5 +1,6 @@
 @using DigitalLearningSolutions.Data.Utilities
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.EmailDelegates
+@inject IClockUtility ClockUtility
 @model EmailDelegatesViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/delegates/emailDelegates.css")" asp-append-version="true">
@@ -7,8 +8,7 @@
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = errorHasOccurred ? "Error: Send welcome messages" : "Send welcome messages";
-  var clockUtility = new ClockUtility();
-  var exampleDate = clockUtility.UtcToday;
+  var exampleDate = ClockUtility.UtcToday;
   var hintTextLines = new List<string> {
     $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}",
   };


### PR DESCRIPTION
### JIRA link
[HEEDLS-1005](https://softwiretech.atlassian.net/browse/HEEDLS-1005)

### Description
I replaced the usages of DateTime.Now and DateTime.UtcNow with ClockUtility.UtcNow and those of DateTime.Today with ClockUtility.UtcToday.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
