### PR TITLE
DLSV2-560 Remove Staff member from my staff list results in error

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
@@ -46,6 +46,7 @@
       @Html.HiddenFor(m => m.LastName)
       @Html.HiddenFor(m => m.DelegateEmail)
       @Html.HiddenFor(m => m.CandidateAssessmentCount)
+      @Html.HiddenFor(m => m.ReturnPageQuery)
     </form>
 
     <vc:cancel-link-with-return-page-query asp-controller="Supervisor" asp-action="MyStaffList" return-page-query="@Model.ReturnPageQuery" />

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -71,16 +71,30 @@
         <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" view-data="@(new ViewDataDictionary(ViewData){{"isSupervisor", Model.IsUserSupervisor}})" />
       }
       </div>
-      <a class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4 button-small"
-         data-return-page-enabled="true"
-         asp-action="@(Model.SupervisorDelegateDetail.CandidateAssessmentCount == 0 ? "RemoveSupervisorDelegate" : "RemoveSupervisorDelegateConfirm")"
-         asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID"
-         asp-route-returnPageQuery="@Model.ReturnPageQuery">
-        Remove staff member
-      </a>
-
-  </div>
-
+      @if (Model.SupervisorDelegateDetail.CandidateAssessmentCount == 0)
+      {
+        <form method="post">
+          <button class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4 button-small" data-return-page-enabled="true"
+                  asp-action="RemoveSupervisorDelegate"
+                  asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+            Remove staff member
+          </button>
+          @Html.Hidden("Id", Model.SupervisorDelegateDetail.ID)
+          @Html.Hidden("DelegateEmail", Model.SupervisorDelegateDetail.DelegateEmail)
+          @Html.Hidden("ConfirmedRemove", true)
+          @Html.HiddenFor(m => m.ReturnPageQuery)
+        </form>
+      }
+      else
+      {
+        <a class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4 button-small" data-return-page-enabled="true"
+              asp-action="RemoveSupervisorDelegateConfirm"
+              asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID"
+              asp-route-returnPageQuery="@Model.ReturnPageQuery">
+            Remove staff member
+        </a>
+      }
+    </div>
   </details>
   @if (Model.SupervisorDelegateDetail.CandidateID != null)
   {
@@ -95,11 +109,11 @@
   else if (Model.SupervisorDelegateDetail.AddedByDelegate)
   {
         <a class="nhsuk-button nhsuk-u-margin-left-4 nhsuk-u-margin-top-0"
-           aria-describedby="@Model.SupervisorDelegateDetail.ID-name"
-           asp-controller="Supervisor"
-           asp-action="ConfirmSupervise"
-           asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+            aria-describedby="@Model.SupervisorDelegateDetail.ID-name"
+            asp-controller="Supervisor"
+            asp-action="ConfirmSupervise"
+            asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
           Confirm
         </a>
   }
-  </div>
+</div>


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-560

### Description
Fixing unsupported operation (http 405 error) caused by a mismatch of parameters being submitted to controller action `RemoveSupervisorDelegate()` method. Confirmation dialog is shown only when there are candidate assessments. So, depending on if there are candidate assessments, I am rendering a link to RemoveConfirm.cshtml or a post button for removing the delegate straightaway. 

![image](https://user-images.githubusercontent.com/94055251/180471759-3b37d600-3ef9-4b2f-a2fa-a0479bb66dc2.png)

Despite views _StaffMemberCard.cshtml and RemoveConfirm.cshtml are using different models, I can call the same post method, since `Hidden` helper in the view allows me to set the name of individual fields in the post  (unlike `HiddenFor` that takes the name from model).

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/180474358-0d9afc2c-76c4-498e-9ab0-3b6ea66b67ff.png)


-----
### Developer checks
Checked both scenarios: deleting a delegate straightaway or deleting with confirmation. 
(although all Remove buttons look the same, by hovering over Remove button, a url is shown by the browser if it is a link)
