### PR TITLE
HEELDS-940 If a user is logged in but doesn't have a UserId claim, re…

### DIFF
--- a/DigitalLearningSolutions.Data/Enums/ButtonType.cs
+++ b/DigitalLearningSolutions.Data/Enums/ButtonType.cs
@@ -1,0 +1,34 @@
+﻿namespace DigitalLearningSolutions.Data.Enums
+{
+    public class ButtonType : Enumeration
+    {
+        public static readonly ButtonType Primary = new ButtonType(
+            0,
+            nameof(Primary),
+            "nhsuk-button"
+        );
+
+        public static readonly ButtonType Secondary = new ButtonType(
+            1,
+            nameof(Secondary),
+            "nhsuk-button nhsuk-button--secondary"
+        );
+
+        public static readonly ButtonType Reverse = new ButtonType(
+            2,
+            nameof(Reverse),
+            "nhsuk-button nhsuk-button--reverse"
+        );
+
+        public readonly string CssClass;
+
+        private ButtonType(
+            int id,
+            string name,
+            string cssClass
+        ) : base(id, name)
+        {
+            CssClass = cssClass;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.IntegrationTests/AuthenticatedTests/OnRedirectToAccessDeniedTests.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/AuthenticatedTests/OnRedirectToAccessDeniedTests.cs
@@ -1,0 +1,48 @@
+﻿namespace DigitalLearningSolutions.Web.IntegrationTests.AuthenticatedTests
+{
+    using System.Threading.Tasks;
+    using DigitalLearningSolutions.Web.IntegrationTests.TestHelpers;
+    using FluentAssertions;
+    using Microsoft.Extensions.DependencyInjection;
+    using Xunit;
+
+    public class OnRedirectToAccessDeniedTests : IClassFixture<AuthenticationWebApplicationFactory<Startup>>
+    {
+        private readonly AuthenticationWebApplicationFactory<Startup> _factory;
+
+        public OnRedirectToAccessDeniedTests(AuthenticationWebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task redirect_to_PleaseLogout_occurs_when_user_is_authenticated_without_UserId_claim()
+        {
+            // Given
+            using var scope = _factory.Services.CreateScope();
+
+            var client = await HttpClientHelper.SetDelegateSessionWithoutUserIdClaimAndGetClient(_factory, 1);
+
+            // When
+            var response = await client.GetAsync("/SuperAdmin/Admins");
+
+            // Then
+            response.Headers.Location.AbsolutePath.Should().Be("/PleaseLogout");
+        }
+
+        [Fact]
+        public async Task redirect_to_AccessDenied_occurs_when_user_is_authenticated_without_sufficient_privileges()
+        {
+            // Given
+            using var scope = _factory.Services.CreateScope();
+
+            var client = await HttpClientHelper.SetDelegateSessionAndGetClient(_factory, 1);
+
+            // When
+            var response = await client.GetAsync("/SuperAdmin/Admins");
+
+            // Then
+            response.Headers.Location.AbsolutePath.Should().Be("/AccessDenied");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.IntegrationTests/TestHelpers/HttpClientHelper.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/TestHelpers/HttpClientHelper.cs
@@ -17,6 +17,15 @@
             return await GetClient(factory).GetAsyncAndSetCookie($"/SetDelegateTestSession?delegateId={delegateId}");
         }
 
+        public static async Task<HttpClient> SetDelegateSessionWithoutUserIdClaimAndGetClient(
+            AuthenticationWebApplicationFactory<Startup> factory,
+            int delegateId
+        )
+        {
+            return await GetClient(factory)
+                .GetAsyncAndSetCookie($"/SetDelegateTestSession?delegateId={delegateId}&withoutUserIdClaim=1");
+        }
+
         private static HttpClient GetClient(AuthenticationWebApplicationFactory<Startup> factory)
         {
             var client = factory.CreateClient(

--- a/DigitalLearningSolutions.Web.IntegrationTests/TestHelpers/TestUserAppStartupFilter.cs
+++ b/DigitalLearningSolutions.Web.IntegrationTests/TestHelpers/TestUserAppStartupFilter.cs
@@ -27,6 +27,7 @@
                             async context =>
                             {
                                 var delegateId = int.Parse(context.Request.Query["delegateId"]);
+                                var withoutUserIdClaim = context.Request.Query["withoutUserIdClaim"].Count > 0;
                                 var userAccount = TestUserDataService.GetUserAccount(delegateId);
                                 var delegateUser = TestUserDataService.GetDelegate(delegateId);
                                 var userEntity = new UserEntity(
@@ -34,8 +35,16 @@
                                     new List<AdminAccount>(),
                                     new List<DelegateAccount> { delegateUser }
                                 );
+
                                 var claims = LoginClaimsHelper.GetClaimsForSignIntoCentre(userEntity, 1);
+
+                                if (withoutUserIdClaim)
+                                {
+                                    claims = claims.Where(claim => claim.Type != CustomClaimTypes.UserId).ToList();
+                                }
+
                                 var claimsIdentity = new ClaimsIdentity(claims, "Identity.Application");
+
                                 var authProperties = new AuthenticationProperties
                                 {
                                     AllowRefresh = true,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningSolutions/LearningSolutionsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningSolutions/LearningSolutionsControllerTests.cs
@@ -183,5 +183,15 @@
             result.Should().BeRedirectToActionResult().WithControllerName("LearningPortal")
                 .WithActionName("AccessDenied");
         }
+
+        [Test]
+        public void PleaseLogout_returns_default_view()
+        {
+            // When
+            var result = controller.PleaseLogout();
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName();
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningSolutions/LearningSolutionsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningSolutions/LearningSolutionsController.cs
@@ -50,6 +50,7 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningSolutions
             var model = new TermsViewModel(termsText);
             return View(model);
         }
+
         public IActionResult Contact()
         {
             var contactText = configDataService.GetConfigValue(ConfigDataService.ContactText);
@@ -95,6 +96,13 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningSolutions
             }
 
             return View("Error/AccessDenied");
+        }
+
+        [Route("/PleaseLogout")]
+        [SetDlsSubApplication(nameof(DlsSubApplication.Main))]
+        public IActionResult PleaseLogout()
+        {
+            return View();
         }
 
         private ErrorViewModel GetErrorModel()

--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -17,7 +17,7 @@
 
         public static bool IsMissingUserId(this ClaimsPrincipal user)
         {
-            return user.GetUserPrimaryEmail() != null && user.GetUserId() == null;
+            return user.Identity.IsAuthenticated && user.GetUserId() == null;
         }
 
         public static int? GetAdminId(this ClaimsPrincipal user)

--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -15,6 +15,11 @@
             return user.GetCustomClaimAsRequiredInt(CustomClaimTypes.UserId);
         }
 
+        public static bool IsMissingUserId(this ClaimsPrincipal user)
+        {
+            return user.GetUserPrimaryEmail() != null && user.GetUserId() == null;
+        }
+
         public static int? GetAdminId(this ClaimsPrincipal user)
         {
             return user.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId);

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -62,7 +62,7 @@ namespace DigitalLearningSolutions.Web
                         options.Cookie.Name = ".AspNet.SharedCookie";
                         options.Cookie.Path = "/";
                         options.Events.OnRedirectToLogin = RedirectToLogin;
-                        options.Events.OnRedirectToAccessDenied = RedirectToAccessDenied;
+                        options.Events.OnRedirectToAccessDenied = RedirectToAccessDeniedOrLogout;
                     }
                 );
 
@@ -355,9 +355,10 @@ namespace DigitalLearningSolutions.Web
             return Task.CompletedTask;
         }
 
-        private Task RedirectToAccessDenied(RedirectContext<CookieAuthenticationOptions> context)
+        private Task RedirectToAccessDeniedOrLogout(RedirectContext<CookieAuthenticationOptions> context)
         {
-            context.HttpContext.Response.Redirect(config.GetAppRootPath() + "/AccessDenied");
+            var redirectTo = context.HttpContext.User.IsMissingUserId() ? "/PleaseLogout" : "/AccessDenied";
+            context.HttpContext.Response.Redirect(config.GetAppRootPath() + redirectTo);
             return Task.CompletedTask;
         }
     }

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/PleaseLogout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/PleaseLogout.cshtml
@@ -1,4 +1,5 @@
-﻿@{
+﻿@using DigitalLearningSolutions.Data.Enums
+@{
   ViewData["Title"] = "Please log out";
 }
 
@@ -7,6 +8,6 @@
     <h1>@ViewData["Title"]</h1>
     <p>We recently changed how we store user accounts, so that you can switch between accounts while logged in.</p>
     <p>Because of these changes, you must log out and in again in order to continue using DLS.</p>
-    <partial name="_LogoutForm" model="@("nhsuk-button--primary")" />
+    <partial name="_LogoutForm" model="@ButtonType.Primary" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/PleaseLogout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/PleaseLogout.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+  ViewData["Title"] = "Please log out";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds nhsuk-u-reading-width">
+    <h1>@ViewData["Title"]</h1>
+    <p>We recently changed how we store user accounts, so that you can switch between accounts while logged in.</p>
+    <p>Because of these changes, you must log out and in again in order to continue using DLS.</p>
+    <partial name="_LogoutForm" />
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/LearningSolutions/PleaseLogout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningSolutions/PleaseLogout.cshtml
@@ -7,6 +7,6 @@
     <h1>@ViewData["Title"]</h1>
     <p>We recently changed how we store user accounts, so that you can switch between accounts while logged in.</p>
     <p>Because of these changes, you must log out and in again in order to continue using DLS.</p>
-    <partial name="_LogoutForm" />
+    <partial name="_LogoutForm" model="@("nhsuk-button--primary")" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -1,3 +1,4 @@
+@using DigitalLearningSolutions.Data.Enums
 @using DigitalLearningSolutions.Web.ViewModels.MyAccount
 @model MyAccountViewModel
 
@@ -25,7 +26,7 @@
       @{ var switchCentreButtonText = Model.CentreId == null ? "Choose centre" : "Switch centre"; }
       <div class="nhsuk-grid-column-one-half heading-button-group">
         <a
-          class="nhsuk-button nhsuk-button--secondary heading-button"
+          class="@($"{ButtonType.Secondary.CssClass} heading-button")"
           asp-controller="Login"
           asp-action="ChooseACentre"
           asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment"
@@ -51,14 +52,14 @@
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2" asp-controller="MyAccount" asp-action="EditDetails" asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment" role="button">
+    <a class="@($"{ButtonType.Primary.CssClass} left-button-mobile-margin-bottom nhsuk-u-margin-right-2")" asp-controller="MyAccount" asp-action="EditDetails" asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment" role="button">
       Edit details
     </a>
-    <a class="nhsuk-button nhsuk-button--secondary left-button-mobile-margin-bottom nhsuk-u-margin-right-2" asp-controller="ChangePassword" asp-action="Index" asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment" role="button">
+    <a class="@($"{ButtonType.Secondary.CssClass} left-button-mobile-margin-bottom nhsuk-u-margin-right-2")" asp-controller="ChangePassword" asp-action="Index" asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment" role="button">
       Change password
     </a>
     @if (Model.CentreId != null) {
-      <a class="nhsuk-button nhsuk-button--secondary" asp-controller="NotificationPreferences" asp-action="Index" asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment" role="button">
+      <a class="@ButtonType.Secondary.CssClass" asp-controller="NotificationPreferences" asp-action="Index" asp-route-dlsSubApplication="@Model.DlsSubApplication.UrlSegment" role="button">
         View notification preferences
       </a>
     }
@@ -66,6 +67,6 @@
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <partial name="_LogoutForm" model="@("nhsuk-button--secondary")" />
+    <partial name="_LogoutForm" model="@ButtonType.Secondary" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/MyAccount/Index.cshtml
@@ -66,6 +66,6 @@
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <partial name="_LogoutForm" />
+    <partial name="_LogoutForm" model="@("nhsuk-button--secondary")" />
   </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/Confirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/Confirmation.cshtml
@@ -1,4 +1,5 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.Register
+﻿@using DigitalLearningSolutions.Data.Enums
+@using DigitalLearningSolutions.Web.ViewModels.Register
 @model InternalConfirmationViewModel
 
 @{
@@ -24,13 +25,13 @@
       <p>
         You will need to log out and in again before you can access the Learning Portal.
       </p>
-      <partial name="_LogoutForm" model="@("nhsuk-button--secondary")" />
+      <partial name="_LogoutForm" model="@ButtonType.Secondary" />
     } else if (Model.Approved) {
       <p>
         You can now log into your new account.
       </p>
       <a
-        class="nhsuk-button nhsuk-button--secondary"
+        class="@ButtonType.Secondary.CssClass"
         asp-controller="Login"
         asp-action="ChooseACentre"
         role="button">

--- a/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/Confirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/Confirmation.cshtml
@@ -19,11 +19,12 @@
       <span class="nhsuk-u-visually-hidden">Information: </span>
       <p>Your delegate number is <span class="nhsuk-u-font-weight-bold">@Model.CandidateNumber</span></p>
     </div>
+
     @if (Model.HasAdminAccountAtCentre) {
       <p>
         You will need to log out and in again before you can access the Learning Portal.
       </p>
-      <partial name="_LogoutForm" />
+      <partial name="_LogoutForm" model="@("nhsuk-button--secondary")" />
     } else if (Model.Approved) {
       <p>
         You can now log into your new account.
@@ -35,9 +36,7 @@
         role="button">
         Switch centre
       </a>
-    }
-
-    @if (!Model.Approved) {
+    } else {
       <div class="nhsuk-warning-callout">
         <h2 class="nhsuk-warning-callout__label">
           <span role="text">

--- a/DigitalLearningSolutions.Web/Views/Shared/_LogoutForm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_LogoutForm.cshtml
@@ -1,7 +1,8 @@
-﻿@model string
+﻿@using DigitalLearningSolutions.Data.Enums
+@model ButtonType
 
 <form asp-controller="Logout" asp-action="Index" method="post">
-  <button type="submit" class="@($"nhsuk-button {Model}")">
+  <button type="submit" class="@Model.CssClass">
     Log out
   </button>
 </form>

--- a/DigitalLearningSolutions.Web/Views/Shared/_LogoutForm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_LogoutForm.cshtml
@@ -1,5 +1,7 @@
-﻿<form asp-controller="Logout" asp-action="Index" method="post">
-  <button type="submit" class="nhsuk-button nhsuk-button--secondary">
+﻿@model string
+
+<form asp-controller="Logout" asp-action="Index" method="post">
+  <button type="submit" class="@($"nhsuk-button {Model}")">
     Log out
   </button>
 </form>


### PR DESCRIPTION
…direct them to a page telling them to log out if they try to access authenticated content

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-940

### Description
* Added a new claim to CustomClaimHelper: `IsMissingUserId`, true when the user has a PrimaryEmail but no UserId (checking PrimaryEmail is not null ensures that the user is definitely logged in, since it is present on both master and uar-test)
* Changed the `OnRedirectToAccessDenied` handler so that it redirects to `/PleaseLogout` if the user is `IsMissingUserId`
* Added the `/PleaseLogout` page as shown in the wireframe in Jira

### Screenshots
![please_logout](https://user-images.githubusercontent.com/1258014/181288188-5598dad2-09b3-4de9-b8ea-2c3880a49d58.png)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
