### PR TITLE
HEEDLS-996 add authorisation policies to bare authorised pages

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ApplicationSelectorController.cs
@@ -10,7 +10,7 @@
 
     public class ApplicationSelectorController : Controller
     {
-        [Authorize]
+        [Authorize(Policy = CustomPolicies.UserAdmin)]
         [RedirectDelegateOnlyToLearningPortal]
         [SetDlsSubApplication(nameof(DlsSubApplication.Main))]
         [SetSelectedTab(nameof(NavMenuTab.SwitchApplication))]

--- a/DigitalLearningSolutions.Web/Controllers/VerifyEmailController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/VerifyEmailController.cs
@@ -7,7 +7,7 @@
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
-    [Authorize]
+    [Authorize(Policy = CustomPolicies.BasicUser)]
     public class VerifyEmailController : Controller
     {
         private readonly IUserService userService;

--- a/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomClaimHelper.cs
@@ -127,6 +127,11 @@
             return user.GetCustomClaimAsBool(CustomClaimTypes.LearnUserAuthenticated) ?? false;
         }
 
+        public static bool IsAdminAccount(this ClaimsPrincipal user)
+        {
+            return user.GetUserId() != null && user.GetAdminId() != null;
+        }
+
         public static bool HasCentreAdminPermissions(this ClaimsPrincipal user)
         {
             return (user.GetCustomClaimAsBool(CustomClaimTypes.UserCentreAdmin) ?? false) ||

--- a/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
-    using System.Security.Claims;
     using Microsoft.AspNetCore.Authorization;
 
     public class CustomPolicies
@@ -38,13 +37,13 @@
 
         public static AuthorizationPolicyBuilder ConfigurePolicyUserAdmin(AuthorizationPolicyBuilder policy)
         {
-            return policy.RequireAssertion(context => UserIsAdmin(context.User));
+            return policy.RequireAssertion(context => context.User.IsAdminAccount());
         }
 
         public static AuthorizationPolicyBuilder ConfigurePolicyUserCentreAdmin(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => UserIsAdmin(context.User) &&
+                context => context.User.IsAdminAccount() &&
                            context.User.HasCentreAdminPermissions()
             );
         }
@@ -54,10 +53,10 @@
         )
         {
             return policy.RequireAssertion(
-                context => UserIsAdmin(context.User) &&
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) == true) |
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor) == true) |
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) == true) |
+                context => context.User.IsAdminAccount() &&
+                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) == true) ||
+                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor) == true) ||
+                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) == true) ||
                            (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceContributor) == true)
             );
         }
@@ -67,7 +66,7 @@
         )
         {
             return policy.RequireAssertion(
-                context => UserIsAdmin(context.User) &&
+                context => context.User.IsAdminAccount() &&
                            context.User.HasCentreManagerPermissions()
             );
         }
@@ -77,7 +76,7 @@
         )
         {
             return policy.RequireAssertion(
-                context => UserIsAdmin(context.User) &&
+                context => context.User.IsAdminAccount() &&
                            (context.User.HasCentreAdminPermissions() || context.User.HasFrameworksAdminPermissions())
             );
         }
@@ -85,7 +84,7 @@
         public static AuthorizationPolicyBuilder ConfigurePolicyUserSupervisor(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => UserIsAdmin(context.User) &&
+                context => context.User.IsAdminAccount() &&
                            (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) == true ||
                             context.User.GetCustomClaimAsBool(CustomClaimTypes.IsNominatedSupervisor) == true)
             );
@@ -94,14 +93,9 @@
         public static AuthorizationPolicyBuilder ConfigurePolicyUserSuperAdmin(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => UserIsAdmin(context.User) &&
+                context => context.User.IsAdminAccount() &&
                            context.User.HasSuperAdminPermissions()
             );
-        }
-
-        private static bool UserIsAdmin(ClaimsPrincipal user)
-        {
-            return user.GetUserId() != null && user.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
+    using System.Security.Claims;
     using Microsoft.AspNetCore.Authorization;
 
     public class CustomPolicies
@@ -7,6 +8,7 @@
         public const string BasicUser = "BasicUser";
         public const string CentreUser = "CentreUser";
         public const string UserDelegateOnly = "UserDelegateOnly";
+        public const string UserAdmin = "UserAdmin";
         public const string UserCentreAdmin = "UserCentreAdmin";
         public const string UserFrameworksAdminOnly = "UserFrameworksAdminOnly";
         public const string UserCentreManager = "UserCentreManager";
@@ -34,11 +36,15 @@
             );
         }
 
+        public static AuthorizationPolicyBuilder ConfigurePolicyUserAdmin(AuthorizationPolicyBuilder policy)
+        {
+            return policy.RequireAssertion(context => UserIsAdmin(context.User));
+        }
+
         public static AuthorizationPolicyBuilder ConfigurePolicyUserCentreAdmin(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => context.User.GetUserId() != null &&
-                           context.User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null &&
+                context => UserIsAdmin(context.User) &&
                            context.User.HasCentreAdminPermissions()
             );
         }
@@ -48,8 +54,7 @@
         )
         {
             return policy.RequireAssertion(
-                context => context.User.GetUserId() != null &&
-                           context.User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null &&
+                context => UserIsAdmin(context.User) &&
                            (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) == true) |
                            (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor) == true) |
                            (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) == true) |
@@ -62,8 +67,7 @@
         )
         {
             return policy.RequireAssertion(
-                context => context.User.GetUserId() != null &&
-                           context.User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null &&
+                context => UserIsAdmin(context.User) &&
                            context.User.HasCentreManagerPermissions()
             );
         }
@@ -73,8 +77,7 @@
         )
         {
             return policy.RequireAssertion(
-                context => context.User.GetUserId() != null &&
-                           context.User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null &&
+                context => UserIsAdmin(context.User) &&
                            (context.User.HasCentreAdminPermissions() || context.User.HasFrameworksAdminPermissions())
             );
         }
@@ -82,8 +85,7 @@
         public static AuthorizationPolicyBuilder ConfigurePolicyUserSupervisor(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => context.User.GetUserId() != null &&
-                           context.User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null &&
+                context => UserIsAdmin(context.User) &&
                            (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) == true ||
                             context.User.GetCustomClaimAsBool(CustomClaimTypes.IsNominatedSupervisor) == true)
             );
@@ -92,10 +94,14 @@
         public static AuthorizationPolicyBuilder ConfigurePolicyUserSuperAdmin(AuthorizationPolicyBuilder policy)
         {
             return policy.RequireAssertion(
-                context => context.User.GetUserId() != null &&
-                           context.User.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null &&
+                context => UserIsAdmin(context.User) &&
                            context.User.HasSuperAdminPermissions()
             );
+        }
+
+        private static bool UserIsAdmin(ClaimsPrincipal user)
+        {
+            return user.GetUserId() != null && user.GetCustomClaimAsInt(CustomClaimTypes.UserAdminId) != null;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CustomPolicies.cs
@@ -54,10 +54,10 @@
         {
             return policy.RequireAssertion(
                 context => context.User.IsAdminAccount() &&
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) == true) ||
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor) == true) ||
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) == true) ||
-                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceContributor) == true)
+                           (context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkDeveloper) == true ||
+                           context.User.GetCustomClaimAsBool(CustomClaimTypes.IsFrameworkContributor) == true ||
+                           context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceManager) == true ||
+                           context.User.GetCustomClaimAsBool(CustomClaimTypes.IsWorkforceContributor) == true)
             );
         }
 

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -82,6 +82,10 @@ namespace DigitalLearningSolutions.Web
                         policy => CustomPolicies.ConfigurePolicyUserDelegateOnly(policy)
                     );
                     options.AddPolicy(
+                        CustomPolicies.UserAdmin,
+                        policy => CustomPolicies.ConfigurePolicyUserAdmin(policy)
+                    );
+                    options.AddPolicy(
                         CustomPolicies.UserCentreAdmin,
                         policy => CustomPolicies.ConfigurePolicyUserCentreAdmin(policy)
                     );

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -120,7 +120,7 @@
                 </a>
               </li>
             }
-            @if (User.Identity.IsAuthenticated && User.GetAdminId() != null) {
+            @if (User.IsAdminAccount()) {
               <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
                 <a class="nhsuk-header__navigation-link" asp-controller="ApplicationSelector" asp-action="Index">
                   Switch application


### PR DESCRIPTION
### JIRA link
_[HEEDLS-996](https://softwiretech.atlassian.net/browse/HEEDLS-996)_

### Description
Added appropriate policies to ApplicationSelectorController and VerifyEmailController so that they are no longer. Also involves a new policy and a refactor of the CustomPolicies to de-duplicate code.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
