### PR TITLE
Heedls 874b fix synchronisation

### DIFF
--- a/DigitalLearningSolutions.Data/Models/User/RegistrationFieldAnswers.cs
+++ b/DigitalLearningSolutions.Data/Models/User/RegistrationFieldAnswers.cs
@@ -26,7 +26,7 @@
             Answer6 = answer6;
         }
 
-        public RegistrationFieldAnswers(DelegateDetailsData delegateDetailsData, int jobGroupId)
+        public RegistrationFieldAnswers(DelegateDetailsData delegateDetailsData, int jobGroupId, int centreId)
         {
             Answer1 = delegateDetailsData.Answer1;
             Answer2 = delegateDetailsData.Answer2;
@@ -35,6 +35,7 @@
             Answer5 = delegateDetailsData.Answer5;
             Answer6 = delegateDetailsData.Answer6;
             JobGroupId = jobGroupId;
+            CentreId = centreId;
         }
 
         public int CentreId { get; set; }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
@@ -32,7 +32,7 @@
                 centreAnswersData,
                 delegateDetails.GetRegistrationFieldAnswers(),
                 null,
-                TODO
+                new List<Group>()
             );
 
             // Then
@@ -57,9 +57,6 @@
                 linkedToField: 2,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -68,7 +65,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup }
             );
 
             // Then
@@ -94,9 +91,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -105,7 +99,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup }
             );
 
             // Then
@@ -131,9 +125,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -142,7 +133,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup }
             );
 
             // Then
@@ -168,9 +159,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -179,7 +167,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup }
             );
 
             // Then
@@ -211,9 +199,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup1, synchronisedGroup2 }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -222,7 +207,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup1, synchronisedGroup2 }
             );
 
             // Then
@@ -243,9 +228,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -254,7 +236,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup }
             );
 
             // Then
@@ -281,9 +263,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -292,7 +271,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup }
             );
 
             // Then
@@ -324,9 +303,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup1, synchronisedGroup2 }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -335,7 +311,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup1, synchronisedGroup2 }
             );
 
             // Then
@@ -368,9 +344,6 @@
                 linkedToField: 1,
                 changesToRegistrationDetailsShouldChangeGroupMembership: true
             );
-            A.CallTo(() => groupsDataService.GetGroupsForCentre(A<int>._)).Returns(
-                new List<Group> { synchronisedGroup1, synchronisedGroup2 }
-            );
 
             // When
             groupsService.SynchroniseUserChangesWithGroups(
@@ -379,7 +352,7 @@
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
                 null,
-                TODO
+                new List<Group> { synchronisedGroup1, synchronisedGroup2 }
             );
 
             // Then

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
@@ -406,12 +406,12 @@
             DelegateMustHaveBeenAddedToGroups(new List<int> { synchronisedGroup.GroupId });
             A.CallTo(
                 () => groupsDataService.AddDelegateToGroup(
-                    A<int>._,
-                    A<int>._,
+                    reusableDelegateDetails.Id,
+                    unsynchronisedGroup.GroupId,
                     A<DateTime>._,
                     A<int>._
                 )
-            ).MustHaveHappenedOnceExactly();
+            ).MustNotHaveHappened();
         }
 
         [Test]
@@ -453,12 +453,12 @@
             DelegateMustHaveBeenAddedToGroups(new List<int> { synchronisedGroup.GroupId });
             A.CallTo(
                 () => groupsDataService.AddDelegateToGroup(
-                    A<int>._,
-                    A<int>._,
+                    reusableDelegateDetails.Id,
+                    unsynchronisedGroup.GroupId,
                     A<DateTime>._,
                     A<int>._
                 )
-            ).MustHaveHappenedOnceExactly();
+            ).MustNotHaveHappened();
         }
 
         private void DelegateMustHaveBeenRemovedFromGroups(IEnumerable<int> groupIds)

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
@@ -26,7 +26,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 delegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
@@ -47,7 +47,8 @@
         }
 
         [Test]
-        public void SynchroniseUserChangesWithGroups_does_nothing_if_synchronised_groups_are_not_for_changed_fields()
+        public void
+            UpdateDelegateGroupsBasedOnUserChanges_does_nothing_if_synchronised_groups_are_not_for_changed_fields()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -59,7 +60,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
@@ -81,7 +82,7 @@
 
         [Test]
         public void
-            SynchroniseUserChangesWithGroups_does_nothing_if_synchronised_groups_for_changed_fields_have_different_values()
+            UpdateDelegateGroupsBasedOnUserChanges_does_nothing_if_synchronised_groups_for_changed_fields_have_different_values()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -93,7 +94,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
@@ -114,7 +115,7 @@
         }
 
         [Test]
-        public void SynchroniseUserChangesWithGroups_removes_delegate_from_synchronised_old_answer_group()
+        public void UpdateDelegateGroupsBasedOnUserChanges_removes_delegate_from_synchronised_old_answer_group()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -127,11 +128,14 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
-                UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
+                UserTestHelper.GetDefaultRegistrationFieldAnswers(
+                    reusableDelegateDetails.CentreId,
+                    answer1: "old answer"
+                ),
                 null,
                 new List<Group> { synchronisedGroup }
             );
@@ -142,7 +146,7 @@
 
         [Test]
         public void
-            SynchroniseUserChangesWithGroups_removes_delegate_from_synchronised_old_answer_group_when_group_label_includes_prompt_name()
+            UpdateDelegateGroupsBasedOnUserChanges_removes_delegate_from_synchronised_old_answer_group_when_group_label_includes_prompt_name()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -161,11 +165,14 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
-                UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
+                UserTestHelper.GetDefaultRegistrationFieldAnswers(
+                    reusableDelegateDetails.CentreId,
+                    answer1: "old answer"
+                ),
                 null,
                 new List<Group> { synchronisedGroup }
             );
@@ -176,7 +183,7 @@
 
         [Test]
         public void
-            SynchroniseUserChangesWithGroups_removes_delegate_from_all_synchronised_old_answer_groups_if_multiple_exist()
+            UpdateDelegateGroupsBasedOnUserChanges_removes_delegate_from_all_synchronised_old_answer_groups_if_multiple_exist()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -201,11 +208,14 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
-                UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
+                UserTestHelper.GetDefaultRegistrationFieldAnswers(
+                    reusableDelegateDetails.CentreId,
+                    answer1: "old answer"
+                ),
                 null,
                 new List<Group> { synchronisedGroup1, synchronisedGroup2 }
             );
@@ -217,7 +227,7 @@
         }
 
         [Test]
-        public void SynchroniseUserChangesWithGroups_adds_delegate_to_synchronised_new_answer_group()
+        public void UpdateDelegateGroupsBasedOnUserChanges_adds_delegate_to_synchronised_new_answer_group()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -230,7 +240,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
@@ -245,7 +255,7 @@
 
         [Test]
         public void
-            SynchroniseUserChangesWithGroups_adds_delegate_to_synchronised_new_answer_group_when_group_label_includes_prompt_name()
+            UpdateDelegateGroupsBasedOnUserChanges_adds_delegate_to_synchronised_new_answer_group_when_group_label_includes_prompt_name()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -265,7 +275,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
@@ -280,7 +290,7 @@
 
         [Test]
         public void
-            SynchroniseUserChangesWithGroups_adds_delegate_to_all_synchronised_new_answer_groups_if_multiple_exist()
+            UpdateDelegateGroupsBasedOnUserChanges_adds_delegate_to_all_synchronised_new_answer_groups_if_multiple_exist()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -305,7 +315,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,
@@ -320,7 +330,7 @@
 
         [Test]
         public void
-            SynchroniseUserChangesWithGroups_adds_delegate_to_synchronised_new_answer_groups_when_group_labels_differ_in_casing()
+            UpdateDelegateGroupsBasedOnUserChanges_adds_delegate_to_synchronised_new_answer_groups_when_group_labels_differ_in_casing()
         {
             // Given
             var centreAnswersData = UserTestHelper.GetDefaultRegistrationFieldAnswers(answer1: "new answer");
@@ -346,7 +356,7 @@
             );
 
             // When
-            groupsService.SynchroniseUserChangesWithGroups(
+            groupsService.UpdateDelegateGroupsBasedOnUserChanges(
                 reusableDelegateDetails.Id,
                 reusableEditAccountDetailsData,
                 centreAnswersData,

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceSynchroniseGroupsTests.cs
@@ -31,7 +31,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 delegateDetails.GetRegistrationFieldAnswers(),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -66,7 +67,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -102,7 +104,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -138,7 +141,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -174,7 +178,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -216,7 +221,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId, answer1: "old answer"),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -247,7 +253,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -284,7 +291,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -326,7 +334,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
-                null
+                null,
+                TODO
             );
 
             // Then
@@ -369,7 +378,8 @@
                 reusableEditAccountDetailsData,
                 centreAnswersData,
                 UserTestHelper.GetDefaultRegistrationFieldAnswers(reusableDelegateDetails.CentreId),
-                null
+                null,
+                TODO
             );
 
             // Then

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -10,6 +10,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Models.Notifications;
     using DigitalLearningSolutions.Data.Models.Register;
@@ -397,37 +398,9 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => groupsService.SynchroniseUserChangesWithGroups(
+                () => groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
-                    A<AccountDetailsData>.That.Matches(add =>
-                        add.FirstName == model.FirstName &&
-                        add.Surname == model.LastName &&
-                        add.Email == model.PrimaryEmail),
-                    A<RegistrationFieldAnswers>.That.Matches(
-                        answers =>
-                            answers.Answer1 == model.Answer1 &&
-                            answers.Answer2 == model.Answer2 &&
-                            answers.Answer3 == model.Answer3 &&
-                            answers.Answer4 == model.Answer4 &&
-                            answers.Answer5 == model.Answer5 &&
-                            answers.Answer6 == model.Answer6 &&
-                            answers.JobGroupId == model.JobGroup &&
-                            answers.CentreId == model.Centre
-                    ),
-                    A<RegistrationFieldAnswers>.That.Matches(
-                        answers =>
-                            answers.Answer1 == null &&
-                            answers.Answer2 == null &&
-                            answers.Answer3 == null &&
-                            answers.Answer4 == null &&
-                            answers.Answer5 == null &&
-                            answers.Answer6 == null &&
-                            answers.JobGroupId == 0 &&
-                            answers.CentreId == model.Centre
-                    ),
-                    model.CentreSpecificEmail,
-                    TODO
-                )
+                    model)
             ).MustHaveHappenedOnceExactly();
         }
 
@@ -446,37 +419,9 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => groupsService.SynchroniseUserChangesWithGroups(
+                () => groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
-                    A<AccountDetailsData>.That.Matches(add =>
-                        add.FirstName == model.FirstName &&
-                        add.Surname == model.LastName &&
-                        add.Email == model.PrimaryEmail),
-                    A<RegistrationFieldAnswers>.That.Matches(
-                        answers =>
-                            answers.Answer1 == model.Answer1 &&
-                            answers.Answer2 == model.Answer2 &&
-                            answers.Answer3 == model.Answer3 &&
-                            answers.Answer4 == model.Answer4 &&
-                            answers.Answer5 == model.Answer5 &&
-                            answers.Answer6 == model.Answer6 &&
-                            answers.JobGroupId == model.JobGroup &&
-                            answers.CentreId == model.Centre
-                    ),
-                    A<RegistrationFieldAnswers>.That.Matches(
-                        answers =>
-                            answers.Answer1 == null &&
-                            answers.Answer2 == null &&
-                            answers.Answer3 == null &&
-                            answers.Answer4 == null &&
-                            answers.Answer5 == null &&
-                            answers.Answer6 == null &&
-                            answers.JobGroupId == 0 &&
-                            answers.CentreId == model.Centre
-                    ),
-                    model.CentreSpecificEmail,
-                    TODO
-                )
+                    model)
             ).MustHaveHappenedOnceExactly();
         }
 
@@ -1295,6 +1240,22 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
+                () => groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(
+                    NewDelegateIdAndCandidateNumber.Item1,
+                    A<DelegateRegistrationModel>.That.Matches(
+                        m =>
+                            m.Answer1 == model.Answer1 &&
+                            m.Answer2 == model.Answer2 &&
+                            m.Answer3 == model.Answer3 &&
+                            m.Answer4 == model.Answer4 &&
+                            m.Answer5 == model.Answer5 &&
+                            m.Answer6 == model.Answer6 &&
+                            m.JobGroup == userEntity.UserAccount.JobGroupId &&
+                            m.Centre == model.Centre
+                            ))
+            ).MustHaveHappenedOnceExactly();
+            /*
+            A.CallTo(
                 () => groupsService.SynchroniseUserChangesWithGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
                     A<AccountDetailsData>.That.Matches(add =>
@@ -1324,9 +1285,9 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             answers.CentreId == model.Centre
                     ),
                     model.CentreSpecificEmail,
-                    TODO
+                    A<List<Group>>._
                 )
-            ).MustHaveHappenedOnceExactly();
+            ).MustHaveHappenedOnceExactly();*/
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -425,7 +425,8 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             answers.JobGroupId == 0 &&
                             answers.CentreId == model.Centre
                     ),
-                    model.CentreSpecificEmail
+                    model.CentreSpecificEmail,
+                    TODO
                 )
             ).MustHaveHappenedOnceExactly();
         }
@@ -473,7 +474,8 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             answers.JobGroupId == 0 &&
                             answers.CentreId == model.Centre
                     ),
-                    model.CentreSpecificEmail
+                    model.CentreSpecificEmail,
+                    TODO
                 )
             ).MustHaveHappenedOnceExactly();
         }
@@ -1321,7 +1323,8 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             answers.JobGroupId == 0 &&
                             answers.CentreId == model.Centre
                     ),
-                    model.CentreSpecificEmail
+                    model.CentreSpecificEmail,
+                    TODO
                 )
             ).MustHaveHappenedOnceExactly();
         }

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -1254,40 +1254,6 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             m.Centre == model.Centre
                             ))
             ).MustHaveHappenedOnceExactly();
-            /*
-            A.CallTo(
-                () => groupsService.SynchroniseUserChangesWithGroups(
-                    NewDelegateIdAndCandidateNumber.Item1,
-                    A<AccountDetailsData>.That.Matches(add =>
-                        add.FirstName == userEntity.UserAccount.FirstName &&
-                        add.Surname == userEntity.UserAccount.LastName &&
-                        add.Email == userEntity.UserAccount.PrimaryEmail),
-                    A<RegistrationFieldAnswers>.That.Matches(
-                        answers =>
-                            answers.Answer1 == model.Answer1 &&
-                            answers.Answer2 == model.Answer2 &&
-                            answers.Answer3 == model.Answer3 &&
-                            answers.Answer4 == model.Answer4 &&
-                            answers.Answer5 == model.Answer5 &&
-                            answers.Answer6 == model.Answer6 &&
-                            answers.JobGroupId == userEntity.UserAccount.JobGroupId &&
-                            answers.CentreId == model.Centre
-                    ),
-                    A<RegistrationFieldAnswers>.That.Matches(
-                        answers =>
-                            answers.Answer1 == null &&
-                            answers.Answer2 == null &&
-                            answers.Answer3 == null &&
-                            answers.Answer4 == null &&
-                            answers.Answer5 == null &&
-                            answers.Answer6 == null &&
-                            answers.JobGroupId == 0 &&
-                            answers.CentreId == model.Centre
-                    ),
-                    model.CentreSpecificEmail,
-                    A<List<Group>>._
-                )
-            ).MustHaveHappenedOnceExactly();*/
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -398,7 +398,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(
+                () => groupsService.AddNewDelegateToAppropriateGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
                     model)
             ).MustHaveHappenedOnceExactly();
@@ -419,7 +419,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(
+                () => groupsService.AddNewDelegateToAppropriateGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
                     model)
             ).MustHaveHappenedOnceExactly();
@@ -1240,7 +1240,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () => groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(
+                () => groupsService.AddNewDelegateToAppropriateGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
                     A<DelegateRegistrationModel>.That.Matches(
                         m =>

--- a/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
@@ -296,7 +296,8 @@
                             rfa.Answer5 == delegateUser.Answer5 &&
                             rfa.Answer6 == delegateUser.Answer6
                     ),
-                    null
+                    null,
+                    TODO
                 )
             ).MustHaveHappened();
         }

--- a/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
@@ -8,6 +8,7 @@
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Data.Utilities;
@@ -272,7 +273,7 @@
                 )
                 .MustHaveHappened();
             A.CallTo(
-                () => groupsService.SynchroniseUserChangesWithGroups(
+                () => groupsService.SynchroniseUserChangesWithSynchronisedGroups(
                     delegateDetailsData.DelegateId,
                     accountDetailsData,
                     A<RegistrationFieldAnswers>.That.Matches(
@@ -296,8 +297,7 @@
                             rfa.Answer5 == delegateUser.Answer5 &&
                             rfa.Answer6 == delegateUser.Answer6
                     ),
-                    null,
-                    TODO
+                    null
                 )
             ).MustHaveHappened();
         }

--- a/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
@@ -273,7 +273,7 @@
                 )
                 .MustHaveHappened();
             A.CallTo(
-                () => groupsService.SynchroniseUserChangesWithSynchronisedGroups(
+                () => groupsService.UpdateSynchronisedDelegateGroupsBasedOnUserChanges(
                     delegateDetailsData.DelegateId,
                     accountDetailsData,
                     A<RegistrationFieldAnswers>.That.Matches(

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -39,7 +39,7 @@
             int? addedByAdminId = null
         );
 
-        void SynchroniseUserChangesWithSynchronisedGroups(
+        void UpdateSynchronisedDelegateGroupsBasedOnUserChanges(
             int delegateId,
             AccountDetailsData accountDetailsData,
             RegistrationFieldAnswers registrationFieldAnswers,
@@ -47,18 +47,18 @@
             string? centreEmail
         );
 
-        void AddNewlyRegisteredUserToAddNewRegistrantGroups(
+        void AddNewDelegateToAppropriateGroups(
             int delegateId,
             DelegateRegistrationModel delegateRegistrationModel
         );
 
-        void SynchroniseUserChangesWithGroups(
+        void UpdateDelegateGroupsBasedOnUserChanges(
             int delegateId,
             AccountDetailsData accountDetailsData,
             RegistrationFieldAnswers newDelegateDetails,
             RegistrationFieldAnswers oldRegistrationFieldAnswers,
             string? centreEmail,
-            List<Group> groupsToSynchronise
+            List<Group> groupsForSynchronisation
         );
 
         void EnrolDelegateOnGroupCourses(
@@ -183,7 +183,7 @@
             return groupsDataService.AddDelegateGroup(groupDetails);
         }
 
-        public void SynchroniseUserChangesWithSynchronisedGroups(
+        public void UpdateSynchronisedDelegateGroupsBasedOnUserChanges(
             int delegateId,
             AccountDetailsData accountDetailsData,
             RegistrationFieldAnswers registrationFieldAnswers,
@@ -191,28 +191,28 @@
             string? centreEmail
         )
         {
-            var synchronisedGroupsForCentre =
+            var groupsForSynchronisation =
                 GetSynchronisedGroupsForCentre(registrationFieldAnswers.CentreId).ToList();
 
-            SynchroniseUserChangesWithGroups(
+            UpdateDelegateGroupsBasedOnUserChanges(
                 delegateId,
                 accountDetailsData,
                 registrationFieldAnswers,
                 oldRegistrationFieldAnswers,
                 centreEmail,
-                synchronisedGroupsForCentre
+                groupsForSynchronisation
             );
         }
 
-        public void AddNewlyRegisteredUserToAddNewRegistrantGroups(
+        public void AddNewDelegateToAppropriateGroups(
             int delegateId,
             DelegateRegistrationModel delegateRegistrationModel
         )
         {
-            var addNewRegistrantGroups =
+            var groupsForSynchronisation =
                 GetAddNewRegistrantGroupsForCentre(delegateRegistrationModel.Centre).ToList();
 
-            SynchroniseUserChangesWithGroups(
+            UpdateDelegateGroupsBasedOnUserChanges(
                 delegateId,
                 new AccountDetailsData(
                     delegateRegistrationModel.FirstName,
@@ -231,17 +231,17 @@
                     null
                 ),
                 delegateRegistrationModel.CentreSpecificEmail,
-                addNewRegistrantGroups
+                groupsForSynchronisation
             );
         }
 
-        public void SynchroniseUserChangesWithGroups(
+        public void UpdateDelegateGroupsBasedOnUserChanges(
             int delegateId,
             AccountDetailsData accountDetailsData,
             RegistrationFieldAnswers registrationFieldAnswers,
             RegistrationFieldAnswers oldRegistrationFieldAnswers,
             string? centreEmail,
-            List<Group> groupsToSynchronise
+            List<Group> groupsForSynchronisation
         )
         {
             using var transaction = new TransactionScope();
@@ -254,12 +254,12 @@
 
             foreach (var changedAnswer in changedLinkedFields)
             {
-                var groupsToRemoveDelegateFrom = groupsToSynchronise.Where(
+                var groupsToRemoveDelegateFrom = groupsForSynchronisation.Where(
                     g => g.LinkedToField == changedAnswer.LinkedFieldNumber &&
                          GroupLabelMatchesAnswer(g.GroupLabel, changedAnswer.OldValue, changedAnswer.LinkedFieldName)
                 );
 
-                var groupsToAddDelegateTo = groupsToSynchronise.Where(
+                var groupsToAddDelegateTo = groupsForSynchronisation.Where(
                     g => g.LinkedToField == changedAnswer.LinkedFieldNumber &&
                          GroupLabelMatchesAnswer(g.GroupLabel, changedAnswer.NewValue, changedAnswer.LinkedFieldName)
                 );

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -192,7 +192,7 @@
         )
         {
             var groupsForSynchronisation =
-                GetSynchronisedGroupsForCentre(registrationFieldAnswers.CentreId).ToList();
+                GetGroupsWhichShouldUpdateWhenUserDetailsChangeForCentre(registrationFieldAnswers.CentreId).ToList();
 
             UpdateDelegateGroupsBasedOnUserChanges(
                 delegateId,
@@ -210,7 +210,7 @@
         )
         {
             var groupsForSynchronisation =
-                GetAddNewRegistrantGroupsForCentre(delegateRegistrationModel.Centre).ToList();
+                GetGroupsWhichShouldAddNewRegistrantsForCentre(delegateRegistrationModel.Centre).ToList();
 
             UpdateDelegateGroupsBasedOnUserChanges(
                 delegateId,
@@ -639,13 +639,13 @@
             emailService.ScheduleEmail(email, addedByProcess);
         }
 
-        private IEnumerable<Group> GetSynchronisedGroupsForCentre(int centreId)
+        private IEnumerable<Group> GetGroupsWhichShouldUpdateWhenUserDetailsChangeForCentre(int centreId)
         {
             return groupsDataService.GetGroupsForCentre(centreId)
                 .Where(g => g.ChangesToRegistrationDetailsShouldChangeGroupMembership);
         }
 
-        private IEnumerable<Group> GetAddNewRegistrantGroupsForCentre(int centreId)
+        private IEnumerable<Group> GetGroupsWhichShouldAddNewRegistrantsForCentre(int centreId)
         {
             return groupsDataService.GetGroupsForCentre(centreId)
                 .Where(g => g.ShouldAddNewRegistrantsToGroup);

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -11,6 +11,7 @@
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Models.Progress;
+    using DigitalLearningSolutions.Data.Models.Register;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Helpers;
@@ -38,12 +39,26 @@
             int? addedByAdminId = null
         );
 
+        void SynchroniseUserChangesWithSynchronisedGroups(
+            int delegateId,
+            AccountDetailsData accountDetailsData,
+            RegistrationFieldAnswers registrationFieldAnswers,
+            RegistrationFieldAnswers oldRegistrationFieldAnswers,
+            string? centreEmail
+        );
+
+        void AddNewlyRegisteredUserToAddNewRegistrantGroups(
+            int delegateId,
+            DelegateRegistrationModel delegateRegistrationModel
+        );
+
         void SynchroniseUserChangesWithGroups(
             int delegateId,
             AccountDetailsData accountDetailsData,
             RegistrationFieldAnswers newDelegateDetails,
             RegistrationFieldAnswers oldRegistrationFieldAnswers,
-            string? centreEmail
+            string? centreEmail,
+            List<Group> groupsToSynchronise
         );
 
         void EnrolDelegateOnGroupCourses(
@@ -168,12 +183,65 @@
             return groupsDataService.AddDelegateGroup(groupDetails);
         }
 
-        public void SynchroniseUserChangesWithGroups(
+        public void SynchroniseUserChangesWithSynchronisedGroups(
             int delegateId,
             AccountDetailsData accountDetailsData,
             RegistrationFieldAnswers registrationFieldAnswers,
             RegistrationFieldAnswers oldRegistrationFieldAnswers,
             string? centreEmail
+        )
+        {
+            var synchronisedGroupsForCentre =
+                GetSynchronisedGroupsForCentre(registrationFieldAnswers.CentreId).ToList();
+
+            SynchroniseUserChangesWithGroups(
+                delegateId,
+                accountDetailsData,
+                registrationFieldAnswers,
+                oldRegistrationFieldAnswers,
+                centreEmail,
+                synchronisedGroupsForCentre
+            );
+        }
+
+        public void AddNewlyRegisteredUserToAddNewRegistrantGroups(
+            int delegateId,
+            DelegateRegistrationModel delegateRegistrationModel
+        )
+        {
+            var addNewRegistrantGroups =
+                GetAddNewRegistrantGroupsForCentre(delegateRegistrationModel.Centre).ToList();
+
+            SynchroniseUserChangesWithGroups(
+                delegateId,
+                new AccountDetailsData(
+                    delegateRegistrationModel.FirstName,
+                    delegateRegistrationModel.LastName,
+                    delegateRegistrationModel.PrimaryEmail
+                ),
+                delegateRegistrationModel.GetRegistrationFieldAnswers(),
+                new RegistrationFieldAnswers(
+                    delegateRegistrationModel.Centre,
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ),
+                delegateRegistrationModel.CentreSpecificEmail,
+                addNewRegistrantGroups
+            );
+        }
+
+        public void SynchroniseUserChangesWithGroups(
+            int delegateId,
+            AccountDetailsData accountDetailsData,
+            RegistrationFieldAnswers registrationFieldAnswers,
+            RegistrationFieldAnswers oldRegistrationFieldAnswers,
+            string? centreEmail,
+            List<Group> groupsToSynchronise
         )
         {
             using var transaction = new TransactionScope();
@@ -184,17 +252,14 @@
                 centreRegistrationPromptsService
             );
 
-            var allSynchronisedGroupsAtCentre =
-                GetSynchronisedGroupsForCentre(registrationFieldAnswers.CentreId).ToList();
-
             foreach (var changedAnswer in changedLinkedFields)
             {
-                var groupsToRemoveDelegateFrom = allSynchronisedGroupsAtCentre.Where(
+                var groupsToRemoveDelegateFrom = groupsToSynchronise.Where(
                     g => g.LinkedToField == changedAnswer.LinkedFieldNumber &&
                          GroupLabelMatchesAnswer(g.GroupLabel, changedAnswer.OldValue, changedAnswer.LinkedFieldName)
                 );
 
-                var groupsToAddDelegateTo = allSynchronisedGroupsAtCentre.Where(
+                var groupsToAddDelegateTo = groupsToSynchronise.Where(
                     g => g.LinkedToField == changedAnswer.LinkedFieldNumber &&
                          GroupLabelMatchesAnswer(g.GroupLabel, changedAnswer.NewValue, changedAnswer.LinkedFieldName)
                 );
@@ -504,27 +569,6 @@
             transaction.Complete();
         }
 
-        private void EnrolNewDelegateOnGroupCourse(
-            DelegateEntity newDelegateEntity,
-            int groupId,
-            int? addedByAdminId = null
-        )
-        {
-            var groupCourses = GetUsableGroupCoursesForCentre(groupId, newDelegateEntity.DelegateAccount.CentreId);
-
-            foreach (var groupCourse in groupCourses)
-            {
-                EnrolDelegateOnGroupCourse(
-                    newDelegateEntity.DelegateAccount.Id,
-                    newDelegateEntity.EmailForCentreNotifications,
-                    newDelegateEntity.UserAccount.FullName,
-                    addedByAdminId,
-                    groupCourse,
-                    false
-                );
-            }
-        }
-
         private void EnrolDelegateOnGroupCourse(
             int delegateUserId,
             string delegateUserEmailAddress,
@@ -601,9 +645,19 @@
                 .Where(g => g.ChangesToRegistrationDetailsShouldChangeGroupMembership);
         }
 
+        private IEnumerable<Group> GetAddNewRegistrantGroupsForCentre(int centreId)
+        {
+            return groupsDataService.GetGroupsForCentre(centreId)
+                .Where(g => g.ShouldAddNewRegistrantsToGroup);
+        }
+
         private static bool GroupLabelMatchesAnswer(string groupLabel, string? answer, string linkedFieldName)
         {
-            return !string.IsNullOrEmpty(answer) && string.Equals(groupLabel, answer, StringComparison.CurrentCultureIgnoreCase) || string.Equals(
+            return !string.IsNullOrEmpty(answer) && string.Equals(
+                groupLabel,
+                answer,
+                StringComparison.CurrentCultureIgnoreCase
+            ) || string.Equals(
                 groupLabel,
                 GetGroupNameWithPrefix(linkedFieldName, answer!),
                 StringComparison.CurrentCultureIgnoreCase

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -653,15 +653,17 @@
 
         private static bool GroupLabelMatchesAnswer(string groupLabel, string? answer, string linkedFieldName)
         {
-            return !string.IsNullOrEmpty(answer) && string.Equals(
-                groupLabel,
-                answer,
-                StringComparison.CurrentCultureIgnoreCase
-            ) || string.Equals(
-                groupLabel,
-                GetGroupNameWithPrefix(linkedFieldName, answer!),
-                StringComparison.CurrentCultureIgnoreCase
-            );
+            return !string.IsNullOrEmpty(answer) &&
+                   (string.Equals(
+                           groupLabel,
+                           answer,
+                           StringComparison.CurrentCultureIgnoreCase
+                       ) || string.Equals(
+                           groupLabel,
+                           GetGroupNameWithPrefix(linkedFieldName, answer!),
+                           StringComparison.CurrentCultureIgnoreCase
+                       )
+                   );
         }
 
         private static bool ProgressShouldBeUpdatedOnEnrolment(

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -232,7 +232,7 @@ namespace DigitalLearningSolutions.Web.Services
                     ReregisterDelegateAccountForExistingUser(userId, delegateId, delegateRegistrationModel);
                 }
 
-                groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(delegateId, delegateRegistrationModel);
+                groupsService.AddNewDelegateToAppropriateGroups(delegateId, delegateRegistrationModel);
             }
             catch (DelegateCreationFailedException exception)
             {
@@ -443,8 +443,8 @@ namespace DigitalLearningSolutions.Web.Services
                     delegateRegistrationModel,
                     registerJourneyContainsTermsAndConditions
                 );
-                
-                groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(delegateId, delegateRegistrationModel);
+
+                groupsService.AddNewDelegateToAppropriateGroups(delegateId, delegateRegistrationModel);
 
                 return (delegateId, candidateNumber);
             }

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -232,26 +232,7 @@ namespace DigitalLearningSolutions.Web.Services
                     ReregisterDelegateAccountForExistingUser(userId, delegateId, delegateRegistrationModel);
                 }
 
-                groupsService.SynchroniseUserChangesWithGroups(
-                    delegateId,
-                    new AccountDetailsData(
-                        delegateRegistrationModel.FirstName,
-                        delegateRegistrationModel.LastName,
-                        delegateRegistrationModel.PrimaryEmail
-                    ),
-                    delegateRegistrationModel.GetRegistrationFieldAnswers(),
-                    new RegistrationFieldAnswers(
-                        delegateRegistrationModel.Centre,
-                        0,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null
-                    ),
-                    delegateRegistrationModel.CentreSpecificEmail
-                );
+                groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(delegateId, delegateRegistrationModel);
             }
             catch (DelegateCreationFailedException exception)
             {
@@ -462,27 +443,8 @@ namespace DigitalLearningSolutions.Web.Services
                     delegateRegistrationModel,
                     registerJourneyContainsTermsAndConditions
                 );
-
-                groupsService.SynchroniseUserChangesWithGroups(
-                    delegateId,
-                    new AccountDetailsData(
-                        delegateRegistrationModel.FirstName,
-                        delegateRegistrationModel.LastName,
-                        delegateRegistrationModel.PrimaryEmail
-                    ),
-                    delegateRegistrationModel.GetRegistrationFieldAnswers(),
-                    new RegistrationFieldAnswers(
-                        delegateRegistrationModel.Centre,
-                        0,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null
-                    ),
-                    delegateRegistrationModel.CentreSpecificEmail
-                );
+                
+                groupsService.AddNewlyRegisteredUserToAddNewRegistrantGroups(delegateId, delegateRegistrationModel);
 
                 return (delegateId, candidateNumber);
             }

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -373,7 +373,7 @@ namespace DigitalLearningSolutions.Web.Services
             if (delegateDetailsData != null)
             {
                 var delegateAccountWithDetails = userDataService.GetDelegateUserById(delegateDetailsData.DelegateId)!;
-                groupsService.SynchroniseUserChangesWithSynchronisedGroups(
+                groupsService.UpdateSynchronisedDelegateGroupsBasedOnUserChanges(
                     delegateDetailsData.DelegateId,
                     editAccountDetailsData,
                     new RegistrationFieldAnswers(delegateDetailsData, editAccountDetailsData.JobGroupId, centreId),

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -376,7 +376,7 @@ namespace DigitalLearningSolutions.Web.Services
                 groupsService.SynchroniseUserChangesWithGroups(
                     delegateDetailsData.DelegateId,
                     editAccountDetailsData,
-                    new RegistrationFieldAnswers(delegateDetailsData, editAccountDetailsData.JobGroupId),
+                    new RegistrationFieldAnswers(delegateDetailsData, editAccountDetailsData.JobGroupId, centreId),
                     delegateAccountWithDetails.GetRegistrationFieldAnswers(),
                     centreEmail
                 );

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -373,7 +373,7 @@ namespace DigitalLearningSolutions.Web.Services
             if (delegateDetailsData != null)
             {
                 var delegateAccountWithDetails = userDataService.GetDelegateUserById(delegateDetailsData.DelegateId)!;
-                groupsService.SynchroniseUserChangesWithGroups(
+                groupsService.SynchroniseUserChangesWithSynchronisedGroups(
                     delegateDetailsData.DelegateId,
                     editAccountDetailsData,
                     new RegistrationFieldAnswers(delegateDetailsData, editAccountDetailsData.JobGroupId, centreId),


### PR DESCRIPTION
### JIRA link
_[HEEDLS-874](https://softwiretech.atlassian.net/browse/HEEDLS-874)_

### Description
The groups to synchronise with are now properly selected for new registrations or edits to established users, and a bug in the composition of the `RegistrationFieldAnswers` object in the `UserService` has been fixed.

Some simple new methods have not had tests added. 

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
