### PR TITLE
HEEDLS-991 When rejecting a delegate which has sessions, deactivate t…

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/SessionDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SessionDataServiceTests.cs
@@ -191,6 +191,29 @@
         }
 
         [Test]
+        public void HasDelegateGotSessions_returns_true_when_delegate_has_sessions()
+        {
+            // When
+            var result = sessionDataService.HasDelegateGotSessions(1);
+
+            // Then
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void HasDelegateGotSessions_returns_false_when_delegate_does_not_have_sessions()
+        {
+            // Given
+            const int fakeVeryLargeDelegateId = 123123123;
+
+            // When
+            var result = sessionDataService.HasDelegateGotSessions(fakeVeryLargeDelegateId);
+
+            // Then
+            result.Should().BeFalse();
+        }
+
+        [Test]
         public void GetSessionBySessionId_gets_session_correctly()
         {
             // Given

--- a/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
@@ -17,6 +17,8 @@
 
         bool HasAdminGotSessions(int adminId);
 
+        bool HasDelegateGotSessions(int delegateId);
+
         Session? GetSessionById(int sessionId);
 
         void AddTutorialTimeToSessionDuration(int sessionId, int tutorialTime);
@@ -77,6 +79,14 @@
             return connection.ExecuteScalar<bool>(
                 "SELECT 1 WHERE EXISTS (SELECT AdminSessionId FROM AdminSessions WHERE AdminID = @adminId)",
                 new { adminId }
+            );
+        }
+
+        public bool HasDelegateGotSessions(int delegateId)
+        {
+            return connection.ExecuteScalar<bool>(
+                "SELECT 1 WHERE EXISTS (SELECT CandidateID FROM Sessions WHERE CandidateID = @delegateId)",
+                new { delegateId }
             );
         }
 

--- a/DigitalLearningSolutions.Web/Services/DelegateApprovalsService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateApprovalsService.cs
@@ -32,12 +32,14 @@
         private readonly IEmailService emailService;
         private readonly ILogger<DelegateApprovalsService> logger;
         private readonly IUserDataService userDataService;
+        private readonly ISessionDataService sessionDataService;
 
         public DelegateApprovalsService(
             IUserDataService userDataService,
             ICentreRegistrationPromptsService centreRegistrationPromptsService,
             IEmailService emailService,
             ICentresDataService centresDataService,
+            ISessionDataService sessionDataService,
             ILogger<DelegateApprovalsService> logger,
             IConfiguration config
         )
@@ -46,6 +48,7 @@
             this.centreRegistrationPromptsService = centreRegistrationPromptsService;
             this.emailService = emailService;
             this.centresDataService = centresDataService;
+            this.sessionDataService = sessionDataService;
             this.logger = logger;
             this.config = config;
         }
@@ -117,7 +120,15 @@
                 );
             }
 
-            userDataService.RemoveDelegateAccount(delegateId);
+            if (sessionDataService.HasDelegateGotSessions(delegateId))
+            {
+                userDataService.DeactivateDelegateUser(delegateId);
+            }
+            else
+            {
+                userDataService.RemoveDelegateAccount(delegateId);
+            }
+
             SendRejectionEmail(delegateEntity);
         }
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-991

### Description
The only issue raised in https://softwiretech.atlassian.net/browse/HEEDLS-953 was occurring when trying to delete a delegate which had records in the `Sessions` table - `DelegateUserDataService.RemoveDelegateAccount` doesn't delete from `Sessions`, so referential integrity checks cause the SQL queries to result in an exception being thrown. (It has nothing to do with having multiple admin accounts.)

To solve this, `DelegateApprovalsService.RejectDelegate` now checks whether the delegate has any sessions, deactivates if is yes, or deletes it if no.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [z] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
