### PR TITLE
Heedls 902 bug fixes

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
@@ -61,7 +61,7 @@
 
             // When
             var returnedAdmins =
-                userDataService.GetAdminsByCentreId(expectedAdminEntity.AdminAccount.CentreId).ToList();
+                userDataService.GetActiveAdminsByCentreId(expectedAdminEntity.AdminAccount.CentreId).ToList();
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -155,7 +155,7 @@
             ).SingleOrDefault();
         }
 
-        public IEnumerable<AdminEntity> GetAdminsByCentreId(int centreId)
+        public IEnumerable<AdminEntity> GetActiveAdminsByCentreId(int centreId)
         {
             var sql = $@"{BaseAdminEntitySelectQuery} WHERE aa.centreID = @centreId AND aa.Active = 1 AND u.Active = 1";
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -12,7 +12,7 @@
     {
         AdminEntity? GetAdminById(int id);
 
-        IEnumerable<AdminEntity> GetAdminsByCentreId(int centreId);
+        IEnumerable<AdminEntity> GetActiveAdminsByCentreId(int centreId);
 
         AdminUser? GetAdminUserById(int id);
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -347,7 +347,7 @@
 
             var errorMessage = result.As<ViewResult>().ViewData.ModelState.Select(x => x.Value.Errors)
                 .Where(y => y.Count > 0).ToList().First().First().ErrorMessage;
-            errorMessage.Should().BeEquivalentTo("This email is in already use by another user at the centre");
+            errorMessage.Should().BeEquivalentTo("This email is already in use by another user at the centre");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
@@ -113,6 +113,32 @@
         }
 
         [Test]
+        public void IndexGet_with_logged_in_user_redirects_to_RegisterInternalAdmin()
+        {
+            // Given
+            var controllerWithLoggedInUser = new RegisterAdminController(
+                    centresDataService,
+                    centresService,
+                    cryptoService,
+                    jobGroupsDataService,
+                    registrationService,
+                    userDataService,
+                    registerAdminService
+                )
+                .WithDefaultContext()
+                .WithMockUser(true);
+
+            // When
+            var result = controllerWithLoggedInUser.Index(DefaultCentreId);
+
+            // Then
+            result.Should().BeRedirectToActionResult()
+                .WithControllerName("RegisterInternalAdmin")
+                .WithActionName("Index")
+                .WithRouteValue("centreId", DefaultCentreId);
+        }
+
+        [Test]
         public void PersonalInformationPost_does_not_continue_to_next_page_with_invalid_model()
         {
             // Given

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
@@ -6,7 +6,6 @@
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Web.Controllers.Register;
     using DigitalLearningSolutions.Web.Extensions;
-    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -82,14 +81,15 @@
         {
             // Given
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).Returns("Some centre");
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).Returns(false);
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, null)).Returns(false);
 
             // When
             var result = controller.Index(DefaultCentreId);
 
             // Then
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, null))
+                .MustHaveHappenedOnceExactly();
             result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions")
                 .WithActionName("AccessDenied");
         }
@@ -99,14 +99,15 @@
         {
             // Given
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).Returns("Some centre");
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).Returns(true);
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, null)).Returns(true);
 
             // When
             var result = controller.Index(DefaultCentreId);
 
             // Then
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, null))
+                .MustHaveHappenedOnceExactly();
             var data = controller.TempData.Peek<RegistrationData>()!;
             data.Centre.Should().Be(DefaultCentreId);
             result.Should().BeRedirectToActionResult().WithActionName("PersonalInformation");
@@ -213,7 +214,6 @@
         {
             // Given
             const int jobGroupId = 1;
-            var centreEmailOrPrimaryIfNull = centreSpecificEmail ?? primaryEmail;
             const string professionalRegistrationNumber = "PRN1234";
             var model = new SummaryViewModel
             {
@@ -232,7 +232,7 @@
                 HasProfessionalRegistrationNumber = true,
             };
             controller.TempData.Set(data);
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).Returns(true);
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, null)).Returns(true);
             if (centreSpecificEmail != null)
             {
                 A.CallTo(() => userDataService.GetAdminUserByEmailAddress(centreSpecificEmail)).Returns(null);

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterInternalAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterInternalAdminControllerTests.cs
@@ -86,6 +86,7 @@
 
             // Then
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).MustHaveHappenedOnceExactly();
+
             result.Should().BeNotFoundResult();
         }
 
@@ -94,14 +95,15 @@
         {
             // Given
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).Returns("Some centre");
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).Returns(false);
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId)).Returns(false);
 
             // When
             var result = controller.Index(DefaultCentreId);
 
             // Then
-            A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId))
+                .MustHaveHappenedOnceExactly();
+
             result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions")
                 .WithActionName("AccessDenied");
         }
@@ -111,13 +113,12 @@
         {
             // Given
             A.CallTo(() => centresDataService.GetCentreName(DefaultCentreId)).Returns("Some centre");
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).Returns(true);
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId)).Returns(true);
 
             // When
             var result = controller.Index(DefaultCentreId);
 
             // Then
-            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId)).MustHaveHappenedOnceExactly();
             result.Should().BeViewResult().ModelAs<InternalAdminInformationViewModel>();
         }
 
@@ -126,10 +127,13 @@
         {
             // Given
             var model = GetDefaultInternalAdminInformationViewModel();
+
             controller.ModelState.AddModelError(
                 nameof(InternalAdminInformationViewModel.CentreSpecificEmail),
                 "error message"
             );
+
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId)).Returns(true);
 
             // When
             var result = await controller.Index(model);
@@ -137,6 +141,25 @@
             // Then
             result.Should().BeViewResult().ModelAs<InternalAdminInformationViewModel>();
             controller.ModelState.IsValid.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task IndexPost_with_not_allowed_admin_registration_returns_access_denied()
+        {
+            // Given
+            var model = GetDefaultInternalAdminInformationViewModel();
+
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId)).Returns(false);
+
+            // When
+            var result = await controller.Index(model);
+
+            // Then
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId))
+                .MustHaveHappenedOnceExactly();
+
+            result.Should().BeRedirectToActionResult().WithControllerName("LearningSolutions")
+                .WithActionName("AccessDenied");
         }
 
         [Test]
@@ -152,6 +175,7 @@
         {
             // Given
             var model = GetDefaultInternalAdminInformationViewModel(centreSpecificEmail);
+
             if (centreSpecificEmail != null)
             {
                 A.CallTo(
@@ -159,6 +183,8 @@
                 ).Returns(false);
                 A.CallTo(() => userDataService.GetCentreEmail(DefaultUserId, DefaultCentreId)).Returns(null);
             }
+
+            A.CallTo(() => registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, DefaultUserId)).Returns(true);
 
             A.CallTo(
                     () => centresService.IsAnEmailValidForCentreManager(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
@@ -65,10 +65,10 @@
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => userDataService.GetAdminsByCentreId(A<int>._)).MustHaveHappened();
+                A.CallTo(() => userDataService.GetActiveAdminsByCentreId(A<int>._)).MustHaveHappened();
                 A.CallTo(() => courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(A<int>._))
                     .MustHaveHappened();
-                A.CallTo(() => userDataService.GetAdminsByCentreId(A<int>._)).MustHaveHappened();
+                A.CallTo(() => userDataService.GetActiveAdminsByCentreId(A<int>._)).MustHaveHappened();
                 A.CallTo(
                     () => searchSortFilterPaginateService.SearchFilterSortAndPaginate(
                         A<IEnumerable<AdminEntity>>._,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -145,7 +145,7 @@
                 result.As<ViewResult>().Model.Should().BeOfType<EditDelegateViewModel>();
                 AssertModelStateErrorIsExpected(
                     result,
-                    "This email is in already use by another user at the centre"
+                    "This email is already in use by another user at the centre"
                 );
             }
         }

--- a/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
@@ -483,7 +483,7 @@
 
             AssertModelStateErrorIsExpected(
                 nameof(PersonalInformationViewModel.CentreSpecificEmail),
-                DuplicateEmailErrorMessage
+                CommonValidationErrorMessages.CentreEmailAlreadyInUse
             );
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
@@ -347,7 +347,7 @@
 
         [Test]
         public void
-            ValidateEmailForCentreManagerIfNecessary_adds_error_message_when_neither_primary_nor_centre_email_is_valid_for_centre_manager()
+            ValidateEmailsForCentreManagerIfNecessary_adds_error_message_when_neither_primary_nor_centre_email_is_valid_for_centre_manager()
         {
             // Given
             A.CallTo(
@@ -359,7 +359,7 @@
             ).Returns(false);
 
             // When
-            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+            RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(
                 DefaultPrimaryEmail,
                 DefaultCentreSpecificEmail,
                 DefaultCentreId,
@@ -377,7 +377,7 @@
 
         [Test]
         public void
-            ValidateEmailForCentreManagerIfNecessary_does_not_add_error_message_when_either_primary_or_centre_email_is_valid_for_centre_manager()
+            ValidateEmailsForCentreManagerIfNecessary_does_not_add_error_message_when_either_primary_or_centre_email_is_valid_for_centre_manager()
         {
             // Given
             A.CallTo(
@@ -389,7 +389,7 @@
             ).Returns(true);
 
             // When
-            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+            RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(
                 DefaultPrimaryEmail,
                 DefaultCentreSpecificEmail,
                 DefaultCentreId,
@@ -404,7 +404,7 @@
 
         [Test]
         public void
-            ValidateEmailForCentreManagerIfNecessary_does_not_add_another_error_message_when_the_model_is_already_invalid()
+            ValidateEmailsForCentreManagerIfNecessary_does_not_add_another_error_message_when_the_model_is_already_invalid()
         {
             // Given
             modelState.AddModelError(DefaultFieldName, DefaultErrorMessage);
@@ -418,7 +418,7 @@
             ).Returns(false);
 
             // When
-            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+            RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(
                 DefaultPrimaryEmail,
                 DefaultCentreSpecificEmail,
                 DefaultCentreId,
@@ -436,10 +436,10 @@
 
         [Test]
         public void
-            ValidateEmailForCentreManagerIfNecessary_does_nothing_if_centreId_is_null()
+            ValidateEmailsForCentreManagerIfNecessary_does_nothing_if_centreId_is_null()
         {
             // When
-            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+            RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(
                 DefaultPrimaryEmail,
                 DefaultCentreSpecificEmail,
                 null,

--- a/DigitalLearningSolutions.Web.Tests/Services/CentresServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/CentresServiceTests.cs
@@ -118,9 +118,10 @@
         [Test]
         [TestCase("primary@email")]
         [TestCase("PRIMARY@EMAIL")]
-        public void DoEmailsMatchCentre_calls_dataService_and_returns_true_if_primary_email_matches_case_insensitively(
-            string primaryEmail
-        )
+        public void
+            IsAnEmailValidForCentreManager_calls_dataService_and_returns_true_if_primary_email_matches_case_insensitively(
+                string primaryEmail
+            )
         {
             // Given
             const int centreId = 1;
@@ -136,9 +137,10 @@
         [Test]
         [TestCase("centre@email")]
         [TestCase("CENTRE@EMAIL")]
-        public void DoEmailsMatchCentre_calls_dataService_and_returns_true_if_centre_email_matches_case_insensitively(
-            string centreEmail
-        )
+        public void
+            IsAnEmailValidForCentreManager_calls_dataService_and_returns_true_if_centre_email_matches_case_insensitively(
+                string centreEmail
+            )
         {
             // Given
             const int centreId = 1;
@@ -152,7 +154,7 @@
         }
 
         [Test]
-        public void DoEmailsMatchCentre_calls_dataService_and_returns_false_if_email_does_not_match()
+        public void IsAnEmailValidForCentreManager_calls_dataService_and_returns_false_if_email_does_not_match()
         {
             // Given
             const int centreId = 1;

--- a/DigitalLearningSolutions.Web.Tests/Services/RegisterAdminServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegisterAdminServiceTests.cs
@@ -38,9 +38,6 @@
             var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId);
 
             // Then
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
-                .MustHaveHappenedOnceExactly();
             result.Should().BeFalse();
         }
 
@@ -56,9 +53,6 @@
             var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId);
 
             // Then
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
-                .MustHaveHappenedOnceExactly();
             result.Should().BeFalse();
         }
 
@@ -74,9 +68,6 @@
             var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId);
 
             // Then
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
-                .MustHaveHappenedOnceExactly();
             result.Should().BeFalse();
         }
 
@@ -98,9 +89,6 @@
             var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId);
 
             // Then
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
-                .MustHaveHappenedOnceExactly();
             result.Should().BeFalse();
         }
 
@@ -119,10 +107,32 @@
             var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId);
 
             // Then
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).MustHaveHappenedOnceExactly();
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void IsRegisterAdminAllowed_with_logged_in_user_already_an_admin_of_the_centre_returns_false()
+        {
+            // Given
+            const int loggedInUserId = 2;
+            var adminAccount = UserTestHelper.GetDefaultAdminAccount(
+                userId: loggedInUserId,
+                centreId: DefaultCentreId
+            );
+
+            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId))
+                .Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
-                .MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreDetailsById(DefaultCentreId)).MustHaveHappenedOnceExactly();
+                .Returns((false, DefaultCentreEmail));
+            A.CallTo(() => centresDataService.GetCentreDetailsById(DefaultCentreId))
+                .Returns(CentreTestHelper.GetDefaultCentre(active: true));
+            A.CallTo(() => userDataService.GetAdminAccountsByUserId(loggedInUserId))
+                .Returns(new List<AdminAccount> { adminAccount });
+
+            // When
+            var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId, loggedInUserId);
+
+            // Then
             result.Should().BeFalse();
         }
 
@@ -141,10 +151,6 @@
             var result = registerAdminService.IsRegisterAdminAllowed(DefaultCentreId);
 
             // Then
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
-                .MustHaveHappenedOnceExactly();
-            A.CallTo(() => centresDataService.GetCentreDetailsById(DefaultCentreId)).MustHaveHappenedOnceExactly();
             result.Should().BeTrue();
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/Services/RegisterAdminServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegisterAdminServiceTests.cs
@@ -30,7 +30,7 @@
         public void IsRegisterAdminAllowed_with_centre_autoregistered_true_returns_false()
         {
             // Given
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).Returns(new List<AdminEntity>());
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId)).Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((true, DefaultCentreEmail));
 
@@ -45,7 +45,7 @@
         public void IsRegisterAdminAllowed_with_centre_autoregisteremail_null_returns_false()
         {
             // Given
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).Returns(new List<AdminEntity>());
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId)).Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((false, null));
 
@@ -60,7 +60,7 @@
         public void IsRegisterAdminAllowed_with_centre_autoregisteremail_whitespace_returns_false()
         {
             // Given
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId)).Returns(new List<AdminEntity>());
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId)).Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((false, "   "));
 
@@ -80,7 +80,7 @@
                 isCentreManager: true,
                 active: true
             );
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId))
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId))
                 .Returns(new List<AdminEntity> { adminEntity });
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((false, DefaultCentreEmail));
@@ -96,7 +96,7 @@
         public void IsRegisterAdminAllowed_with_inactive_centre_returns_false()
         {
             // Given
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId))
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId))
                 .Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((false, DefaultCentreEmail));
@@ -120,7 +120,7 @@
                 centreId: DefaultCentreId
             );
 
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId))
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId))
                 .Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((false, DefaultCentreEmail));
@@ -140,7 +140,7 @@
         public void IsRegisterAdminAllowed_with_correct_data_returns_true()
         {
             // Given
-            A.CallTo(() => userDataService.GetAdminsByCentreId(DefaultCentreId))
+            A.CallTo(() => userDataService.GetActiveAdminsByCentreId(DefaultCentreId))
                 .Returns(new List<AdminEntity>());
             A.CallTo(() => centresDataService.GetCentreAutoRegisterValues(DefaultCentreId))
                 .Returns((false, DefaultCentreEmail));

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -212,7 +212,7 @@
             {
                 ModelState.AddModelError(
                     nameof(MyAccountEditDetailsFormData.Email),
-                    CommonValidationErrorMessages.EmailAlreadyInUse
+                    CommonValidationErrorMessages.EmailInUse
                 );
             }
 
@@ -264,7 +264,7 @@
             {
                 ModelState.AddModelError(
                     nameof(MyAccountEditDetailsFormData.CentreSpecificEmail),
-                    CommonValidationErrorMessages.CentreEmailAlreadyInUse
+                    CommonValidationErrorMessages.EmailInUseAtCentre
                 );
             }
         }
@@ -277,7 +277,7 @@
                 {
                     ModelState.AddModelError(
                         $"{nameof(MyAccountEditDetailsFormData.AllCentreSpecificEmailsDictionary)}_{centreId}",
-                        CommonValidationErrorMessages.CentreEmailAlreadyInUse
+                        CommonValidationErrorMessages.EmailInUseAtCentre
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -76,12 +76,7 @@
             var model = new PersonalInformationViewModel(data);
             SetCentreName(model);
 
-            RegistrationEmailValidator.ValidateEmailAddressesForAdminRegistration(
-                model,
-                ModelState,
-                userDataService,
-                centresDataService
-            );
+            ValidateEmailAddresses(model);
 
             return View(model);
         }
@@ -92,12 +87,7 @@
         {
             var data = TempData.Peek<RegistrationData>()!;
 
-            RegistrationEmailValidator.ValidateEmailAddressesForAdminRegistration(
-                model,
-                ModelState,
-                userDataService,
-                centresDataService
-            );
+            ValidateEmailAddresses(model);
 
             if (!ModelState.IsValid)
             {
@@ -273,6 +263,36 @@
         {
             model.Centre = centresDataService.GetCentreName((int)data.Centre!);
             model.JobGroup = jobGroupsDataService.GetJobGroupName((int)data.JobGroup!);
+        }
+
+        private void ValidateEmailAddresses(PersonalInformationViewModel model)
+        {
+            RegistrationEmailValidator.ValidatePrimaryEmailIfNecessary(
+                model.PrimaryEmail,
+                nameof(RegistrationData.PrimaryEmail),
+                ModelState,
+                userDataService,
+                CommonValidationErrorMessages.EmailInUseDuringAdminRegistration
+            );
+
+            RegistrationEmailValidator.ValidateCentreEmailIfNecessary(
+                model.CentreSpecificEmail,
+                model.Centre,
+                nameof(RegistrationData.CentreSpecificEmail),
+                ModelState,
+                userDataService
+            );
+
+            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+                model.PrimaryEmail,
+                model.CentreSpecificEmail,
+                model.Centre,
+                model.CentreSpecificEmail == null
+                    ? nameof(PersonalInformationViewModel.PrimaryEmail)
+                    : nameof(PersonalInformationViewModel.CentreSpecificEmail),
+                ModelState,
+                centresService
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -283,7 +283,7 @@
                 userDataService
             );
 
-            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+            RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(
                 model.PrimaryEmail,
                 model.CentreSpecificEmail,
                 model.Centre,

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -49,7 +49,7 @@
         {
             if (User.Identity.IsAuthenticated)
             {
-                return RedirectToAction("Index", "Home");
+                return RedirectToAction("Index", "RegisterInternalAdmin", new { centreId });
             }
 
             if (!centreId.HasValue || centresDataService.GetCentreName(centreId.Value) == null)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAtNewCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAtNewCentreController.cs
@@ -299,20 +299,15 @@
 
         private void ValidateEmailAddress(InternalPersonalInformationViewModel model)
         {
-            var userId = User.GetUserIdKnownNotNull();
-
-            if (
-                model.Centre != null && model.CentreSpecificEmail != null &&
-                userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
-                    model.CentreSpecificEmail,
-                    model.Centre.Value,
-                    userId
-                )
-            )
+            if (model.Centre != null)
             {
-                ModelState.AddModelError(
+                RegistrationEmailValidator.ValidateCentreEmailWithUserIdIfNecessary(
+                    model.CentreSpecificEmail,
+                    model.Centre,
+                    User.GetUserIdKnownNotNull(),
                     nameof(PersonalInformationViewModel.CentreSpecificEmail),
-                    "This email is already in use by another user"
+                    ModelState,
+                    userDataService
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -119,11 +119,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
             // Check this email and centre combination doesn't already exist in case we were redirected
             // back here by the user trying to submit the final page of the form
-            RegistrationEmailValidator.ValidateEmailAddressesForDelegateRegistration(
-                model,
-                ModelState,
-                userDataService
-            );
+            ValidateEmailAddresses(model);
 
             return View(model);
         }
@@ -132,11 +128,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         [HttpPost]
         public IActionResult PersonalInformation(PersonalInformationViewModel model)
         {
-            RegistrationEmailValidator.ValidateEmailAddressesForDelegateRegistration(
-                model,
-                ModelState,
-                userDataService
-            );
+            ValidateEmailAddresses(model);
 
             var data = TempData.Peek<DelegateRegistrationData>()!;
 
@@ -395,6 +387,25 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             model.Centre = centresDataService.GetCentreName((int)data.Centre!);
             model.JobGroup = jobGroupsDataService.GetJobGroupName((int)data.JobGroup!);
             model.DelegateRegistrationPrompts = GetDelegateRegistrationPromptsFromData(data);
+        }
+
+        private void ValidateEmailAddresses(PersonalInformationViewModel model)
+        {
+            RegistrationEmailValidator.ValidatePrimaryEmailIfNecessary(
+                model.PrimaryEmail,
+                nameof(PersonalInformationViewModel.PrimaryEmail),
+                ModelState,
+                userDataService,
+                CommonValidationErrorMessages.EmailInUseDuringDelegateRegistration
+            );
+
+            RegistrationEmailValidator.ValidateCentreEmailIfNecessary(
+                model.CentreSpecificEmail,
+                model.Centre,
+                nameof(PersonalInformationViewModel.CentreSpecificEmail),
+                ModelState,
+                userDataService
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -1,6 +1,5 @@
 namespace DigitalLearningSolutions.Web.Controllers.Register
 {
-    using System;
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
@@ -78,7 +77,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
             var model = new RegisterDelegatePersonalInformationViewModel(data);
 
-            ValidatePersonalInformation(model);
+            ValidateEmailAddress(model);
 
             return View(model);
         }
@@ -89,7 +88,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         {
             var data = TempData.Peek<DelegateRegistrationByCentreData>()!;
 
-            ValidatePersonalInformation(model);
+            ValidateEmailAddress(model);
 
             if (!ModelState.IsValid)
             {
@@ -278,20 +277,15 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             TempData.Set(centreDelegateRegistrationData);
         }
 
-        private void ValidatePersonalInformation(RegisterDelegatePersonalInformationViewModel model)
+        private void ValidateEmailAddress(RegisterDelegatePersonalInformationViewModel model)
         {
-            if (model.CentreSpecificEmail == null)
-            {
-                return;
-            }
-
-            if (userDataService.CentreSpecificEmailIsInUseAtCentre(model.CentreSpecificEmail, model.Centre!.Value))
-            {
-                ModelState.AddModelError(
-                    nameof(RegisterDelegatePersonalInformationViewModel.CentreSpecificEmail),
-                    "A user with this email is already registered at this centre"
-                );
-            }
+            RegistrationEmailValidator.ValidateCentreEmailIfNecessary(
+                model.CentreSpecificEmail,
+                model.Centre,
+                nameof(RegisterDelegatePersonalInformationViewModel.CentreSpecificEmail),
+                ModelState,
+                userDataService
+            );
         }
 
         private IEnumerable<EditDelegateRegistrationPromptViewModel> GetEditCustomFieldsFromModel(

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
@@ -92,7 +92,7 @@
                 userDataService
             );
 
-            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+            RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(
                 model.PrimaryEmail,
                 model.CentreSpecificEmail,
                 model.Centre,

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
@@ -75,11 +75,21 @@
         {
             var userId = User.GetUserIdKnownNotNull();
 
-            RegistrationEmailValidator.ValidateEmailsForInternalAdminRegistration(
+            RegistrationEmailValidator.ValidateCentreEmailWithUserIdIfNecessary(
+                model.CentreSpecificEmail,
+                model.Centre,
                 userId,
-                model,
+                nameof(InternalAdminInformationViewModel.CentreSpecificEmail),
                 ModelState,
-                userDataService,
+                userDataService
+            );
+
+            RegistrationEmailValidator.ValidateEmailForCentreManagerIfNecessary(
+                model.PrimaryEmail,
+                model.CentreSpecificEmail,
+                model.Centre,
+                nameof(InternalAdminInformationViewModel.CentreSpecificEmail),
+                ModelState,
                 centresService
             );
 

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
@@ -49,12 +49,15 @@
         public IActionResult Index(int? centreId = null)
         {
             var centreName = centreId == null ? null : centresDataService.GetCentreName(centreId.Value);
+
             if (centreName == null)
             {
                 return NotFound();
             }
 
-            if (!registerAdminService.IsRegisterAdminAllowed(centreId.Value))
+            var userId = User.GetUserIdKnownNotNull();
+
+            if (!registerAdminService.IsRegisterAdminAllowed(centreId.Value, userId))
             {
                 return RedirectToAction("AccessDenied", "LearningSolutions");
             }
@@ -74,6 +77,11 @@
         public async Task<IActionResult> Index(InternalAdminInformationViewModel model)
         {
             var userId = User.GetUserIdKnownNotNull();
+
+            if (!registerAdminService.IsRegisterAdminAllowed(model.Centre!.Value, userId))
+            {
+                return RedirectToAction("AccessDenied", "LearningSolutions");
+            }
 
             RegistrationEmailValidator.ValidateCentreEmailWithUserIdIfNecessary(
                 model.CentreSpecificEmail,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -67,7 +67,7 @@
             );
 
             var centreId = User.GetCentreIdKnownNotNull();
-            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId);
+            var adminsAtCentre = userDataService.GetActiveAdminsByCentreId(centreId);
             var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
             var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
 
@@ -104,7 +104,7 @@
             var centreId = User.GetCentreIdKnownNotNull();
             var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
 
-            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId);
+            var adminsAtCentre = userDataService.GetActiveAdminsByCentreId(centreId);
             var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
             var model = new AllAdminsViewModel(
                 adminsAtCentre,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EditDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EditDelegateController.cs
@@ -102,7 +102,7 @@
             {
                 ModelState.AddModelError(
                     nameof(EditDetailsFormData.CentreSpecificEmail),
-                    CommonValidationErrorMessages.CentreEmailAlreadyInUse
+                    CommonValidationErrorMessages.EmailInUseAtCentre
                 );
 
                 return ReturnToEditDetailsViewWithErrors(formData, delegateId, centreId);

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -8,11 +8,23 @@
         public const string TooLongEmail = "Email must be 255 characters or fewer";
         public const string InvalidEmail = "Enter an email in the correct format, like name@example.com";
         public const string WhitespaceInEmail = "Email must not contain any whitespace characters";
-        public const string EmailAlreadyInUse = "This email is already in use";
-        public const string CentreEmailAlreadyInUse = "This email is in already use by another user at the centre";
+        public const string EmailInUse = "This email is already in use";
+        public const string EmailInUseAtCentre = "This email is in already use by another user at the centre";
+
+        public const string EmailInUseDuringDelegateRegistration =
+            "A user with this email address is already registered; if this is you, please log in and register at this centre via the My Account page";
+
+        public const string EmailInUseDuringAdminRegistration =
+            "A user with this email address is already registered; if this is you, please log in using the button below";
+
+        public const string WrongEmailForCentreDuringAdminRegistration =
+            "This email address does not match the one held by the centre; either your primary email or centre email must match the one held by the centre";
 
         public const string PasswordRegex = @"(?=.*?[^\w\s])(?=.*?[0-9])(?=.*?[A-Za-z]).*";
-        public const string PasswordInvalidCharacters = "Password must contain at least 1 letter, 1 number and 1 symbol";
+
+        public const string PasswordInvalidCharacters =
+            "Password must contain at least 1 letter, 1 number and 1 symbol";
+
         public const string PasswordRequired = "Enter a password";
         public const string PasswordMinLength = "Password must be 8 characters or more";
         public const string PasswordMaxLength = "Password must be 100 characters or fewer";

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -9,7 +9,7 @@
         public const string InvalidEmail = "Enter an email in the correct format, like name@example.com";
         public const string WhitespaceInEmail = "Email must not contain any whitespace characters";
         public const string EmailInUse = "This email is already in use";
-        public const string EmailInUseAtCentre = "This email is in already use by another user at the centre";
+        public const string EmailInUseAtCentre = "This email is already in use by another user at the centre";
 
         public const string EmailInUseDuringDelegateRegistration =
             "A user with this email address is already registered; if this is you, please log in and register at this centre via the My Account page";

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -59,7 +59,7 @@
                 {
                     modelState.AddModelError(
                         nameof(InternalAdminInformationViewModel.CentreSpecificEmail),
-                        DuplicateEmailErrorMessage
+                        CommonValidationErrorMessages.CentreEmailAlreadyInUse
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -61,7 +61,7 @@
             }
         }
 
-        public static void ValidateEmailForCentreManagerIfNecessary(
+        public static void ValidateEmailsForCentreManagerIfNecessary(
             string? primaryEmail,
             string? centreEmail,
             int? centreId,

--- a/DigitalLearningSolutions.Web/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Web/Services/CentresService.cs
@@ -20,7 +20,7 @@
 
         IEnumerable<CentreSummaryForMap> GetAllCentreSummariesForMap();
 
-        bool IsAnEmailValidForCentreManager(string primaryEmail, string? centreSpecificEmail, int centreId);
+        bool IsAnEmailValidForCentreManager(string? primaryEmail, string? centreSpecificEmail, int centreId);
     }
 
     public class CentresService : ICentresService
@@ -66,7 +66,7 @@
             return centresDataService.GetAllCentreSummariesForMap();
         }
 
-        public bool IsAnEmailValidForCentreManager(string primaryEmail, string? centreSpecificEmail, int centreId)
+        public bool IsAnEmailValidForCentreManager(string? primaryEmail, string? centreSpecificEmail, int centreId)
         {
             var autoRegisterManagerEmail =
                 centresDataService.GetCentreAutoRegisterValues(centreId).autoRegisterManagerEmail;

--- a/DigitalLearningSolutions.Web/Services/RegisterAdminService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegisterAdminService.cs
@@ -6,8 +6,9 @@
 
     public interface IRegisterAdminService
     {
-        bool IsRegisterAdminAllowed(int centreId);
+        bool IsRegisterAdminAllowed(int centreId, int? loggedInUserId = null);
     }
+
     public class RegisterAdminService : IRegisterAdminService
     {
         private readonly IUserDataService userDataService;
@@ -22,13 +23,23 @@
             this.centresDataService = centresDataService;
         }
 
-        public bool IsRegisterAdminAllowed(int centreId)
+        public bool IsRegisterAdminAllowed(int centreId, int? loggedInUserId = null)
         {
-            var admins = userDataService.GetAdminsByCentreId(centreId);
+            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId).ToList();
+            var currentUserIsAlreadyAdminOfCentre =
+                loggedInUserId.HasValue &&
+                userDataService.GetAdminAccountsByUserId(loggedInUserId.Value).Any(
+                    adminAccount => adminAccount.CentreId == centreId
+                );
+
             var centre = centresDataService.GetCentreDetailsById(centreId);
-            var hasCentreManagerAdmin = admins.Any(admin => admin.AdminAccount.IsCentreManager);
+            var hasCentreManagerAdmin = adminsAtCentre.Any(admin => admin.AdminAccount.IsCentreManager);
             var (autoRegistered, autoRegisterManagerEmail) = centresDataService.GetCentreAutoRegisterValues(centreId);
-            return centre?.Active == true && !hasCentreManagerAdmin && !autoRegistered &&
+
+            return centre?.Active == true &&
+                   !currentUserIsAlreadyAdminOfCentre &&
+                   !hasCentreManagerAdmin &&
+                   !autoRegistered &&
                    !string.IsNullOrWhiteSpace(autoRegisterManagerEmail);
         }
     }

--- a/DigitalLearningSolutions.Web/Services/RegisterAdminService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegisterAdminService.cs
@@ -25,7 +25,7 @@
 
         public bool IsRegisterAdminAllowed(int centreId, int? loggedInUserId = null)
         {
-            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId).ToList();
+            var adminsAtCentre = userDataService.GetActiveAdminsByCentreId(centreId).ToList();
             var currentUserIsAlreadyAdminOfCentre =
                 loggedInUserId.HasValue &&
                 userDataService.GetAdminAccountsByUserId(loggedInUserId.Value).Any(

--- a/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Index.cshtml
@@ -10,7 +10,7 @@
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
+  <div class="nhsuk-grid-column-full word-break">
     <h1 class="nhsuk-heading-xl">Register</h1>
 
     @if (Model.CentreName != null) {

--- a/DigitalLearningSolutions.Web/Views/RegisterInternalAdmin/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterInternalAdmin/Index.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
+  <div class="nhsuk-grid-column-full word-break">
     <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="Index">
 
       @if (errorHasOccurred) {


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-902

### Description
* Redirect from `/RegisterAdmin?centreId=1` to `/RegisterInternalAdmin?centreId=1` when the user is logged in
* Added word-wrap to a couple of views which display CentreName
* Redirect to access denied when trying to access the internal admin registration journey as a user who is already an admin at the centre
* Changes to registration journey error messages:
  - Internal admin registration journey (/RegisterInternalAdmin):
    - If you enter a centre email which is already in use at the centre, the error message has changed:
      - from "A user with this email address is already registered; if this is you, please log in and register at this centre via the My Account page"
      - to "This email is in already use by another user at the centre"
  - External admin registration journey (/RegisterAdmin):
    - Error messages about the given email(s) having to match the one "held by the centre" now only appear if there are no other errors present (i.e. first/last name are present, email addresses are in a valid format, email addresses aren't already in use)
    - If you enter a primary email which is already in use, the error message has changed:
      - from "A user with this email address is already registered; if this is you, please log in and register at this centre via the My Account page"
      - to "A user with this email address is already registered; if this is you, please log in using the button below"
    - If you enter a centre email which is already in use at the centre, the error message has changed:
      - from "A user with this email address is already registered; if this is you, please log in and register at this centre via the My Account page"
      - to "This email is in already use by another user at the centre"
  - Internal delegate registration journey (/RegisterAtNewCentre):
    - If you enter a centre email which is already in use at the centre, the error message has changed:
      - from "This email is already in use by another user"
      - to "This email is already use by another user at the centre"
  - External delegate registration journey (/Register):
    - If you enter a centre email which is already in use at the centre, the error message has changed:
      - from "A user with this email address is already registered; if this is you, please log in and register at this centre via the My Account page"
      - to "This email is in already use by another user at the centre"
  - Admin registers a delegate journey (/TrackingSystem/Delegates/Register):
    - If you enter a centre email which is already in use at the centre, the error message has changed:
      - from "A user with this email is already registered at this centre"
      - to "This email is in already use by another user at the centre"

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
