### PR TITLE
DLSV2-597 TS Self assessment report view with DCSA report link

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -1,0 +1,120 @@
+﻿
+
+namespace DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService
+{
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models.SelfAssessments.Export;
+    using Microsoft.Extensions.Logging;
+    using System.Collections.Generic;
+    using System.Data;
+
+    public interface IDCSAReportDataService
+    {
+        IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId);
+        IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId);
+    }
+    public partial class DCSAReportDataService : IDCSAReportDataService
+    {
+        private readonly IDbConnection connection;
+        private readonly ILogger<SelfAssessmentDataService> logger;
+
+        public DCSAReportDataService(IDbConnection connection, ILogger<SelfAssessmentDataService> logger)
+        {
+            this.connection = connection;
+            this.logger = logger;
+        }
+        public IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId)
+        {
+            return connection.Query<DCSAOutcomeSummary>(
+                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
+                             THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
+                                 (SELECT COUNT(*) AS Expr1
+                                 FROM    FilteredLearningActivity AS fla
+                                 WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
+                                 (SELECT COUNT(*) AS Expr1
+                                 FROM    FilteredLearningActivity AS fla
+                                 WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1) AND (sar.CandidateID = ca.CandidateID)) AS DataInformationAndContentConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1) AND (sar.CandidateID = ca.CandidateID)) AS DataInformationAndContentRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2) AND (sar.CandidateID = ca.CandidateID)) AS TeachingLearningAndSelfDevelopmentConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2) AND (sar.CandidateID = ca.CandidateID)) AS TeachingLearningAndSelfDevelopmentRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3) AND (sar.CandidateID = ca.CandidateID)) AS CommunicationCollaborationParticipationConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3) AND (sar.CandidateID = ca.CandidateID)) AS CommunicationCollaborationParticipationRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4) AND (sar.CandidateID = ca.CandidateID)) AS TechnicalProficiencyConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4) AND (sar.CandidateID = ca.CandidateID)) AS TechnicalProficiencyRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5) AND (sar.CandidateID = ca.CandidateID)) AS CreationInnovationResearchConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5) AND (sar.CandidateID = ca.CandidateID)) AS CreationInnovationResearchRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6) AND (sar.CandidateID = ca.CandidateID)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                                (SELECT AVG(sar.Result) AS AvgConfidence
+                                FROM    SelfAssessmentResults AS sar INNER JOIN
+                                             Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                             SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6) AND (sar.CandidateID = ca.CandidateID)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
+                FROM   Candidates AS ca INNER JOIN
+                             CandidateAssessments AS caa ON ca.CandidateID = caa.CandidateID INNER JOIN
+                             JobGroups AS jg ON ca.JobGroupID = jg.JobGroupID
+                WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
+                ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
+                new { centreId }
+            );
+        }
+
+        public IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId)
+        {
+            return connection.Query<DCSADelegateCompletionStatus>(
+                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, ca.FirstName, ca.LastName, ca.EmailAddress AS Email, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
+                             THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status
+                FROM   Candidates AS ca INNER JOIN
+                             CandidateAssessments AS caa ON ca.CandidateID = caa.CandidateID INNER JOIN
+                             JobGroups AS jg ON ca.JobGroupID = jg.JobGroupID
+                WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
+                ORDER BY EnrolledYear DESC, EnrolledMonth DESC, ca.LastName, ca.FirstName",
+                new { centreId }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService
+﻿namespace DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService
 {
     using Dapper;
     using DigitalLearningSolutions.Data.Models.SelfAssessments.Export;

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/DCSADelegateCompletionStatus.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/DCSADelegateCompletionStatus.cs
@@ -1,7 +1,6 @@
-﻿using System;
-
-namespace DigitalLearningSolutions.Data.Models.SelfAssessments.Export
+﻿namespace DigitalLearningSolutions.Data.Models.SelfAssessments.Export
 {
+    using System;
     public class DCSADelegateCompletionStatus
     {
         public int? EnrolledMonth { get; set; }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/DCSADelegateCompletionStatus.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/DCSADelegateCompletionStatus.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace DigitalLearningSolutions.Data.Models.SelfAssessments.Export
+{
+    public class DCSADelegateCompletionStatus
+    {
+        public int? EnrolledMonth { get; set; }
+        public int? EnrolledYear { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? CentreField1 { get; set; }
+        public string? CentreField2 { get; set; }
+        public string? CentreField3 { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/DCSAOutcomeSummary.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/DCSAOutcomeSummary.cs
@@ -1,0 +1,28 @@
+﻿namespace DigitalLearningSolutions.Data.Models.SelfAssessments.Export
+{
+    using System;
+    public  class DCSAOutcomeSummary
+    {
+        public int? EnrolledMonth { get; set; }
+        public int? EnrolledYear { get; set; }
+        public string? JobGroup { get; set; }
+        public string? CentreField1 { get; set; }
+        public string? CentreField2 { get; set; }
+        public string? CentreField3 { get; set; }
+        public string? Status { get; set; }
+        public int? LearningLaunched { get; set; }
+        public int? LearningCompleted { get; set; }
+        public int? DataInformationAndContentConfidence { get; set; }
+        public int? DataInformationAndContentRelevance { get; set; }
+        public int? TeachinglearningAndSelfDevelopmentConfidence { get; set; }
+        public int? TeachinglearningAndSelfDevelopmentRelevance { get; set; }
+        public int? CommunicationCollaborationAndParticipationConfidence { get; set; }
+        public int? CommunicationCollaborationAndParticipationRelevance { get; set; }
+        public int? TechnicalProficiencyConfidence { get; set; }
+        public int? TechnicalProficiencyRelevance { get; set; }
+        public int? CreationInnovationAndResearchConfidence { get; set; }
+        public int? CreationInnovationAndResearchRelevance { get; set; }
+        public int? DigitalIdentityWellbeingSafetyAndSecurityConfidence { get; set; }
+        public int? DigitalIdentityWellbeingSafetyAndSecurityRelevance { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
@@ -1,0 +1,82 @@
+﻿namespace DigitalLearningSolutions.Data.Services
+{
+    using ClosedXML.Excel;
+    using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    public interface ISelfAssessmentReportService
+    {
+        byte[] GetDigitalCapabilityExcelExportForCentre(int centreId);
+    }
+    public class SelfAssessmentReportService : ISelfAssessmentReportService
+    {
+        private readonly IDCSAReportDataService dcsaReportDataService;
+
+        public SelfAssessmentReportService(
+            IDCSAReportDataService dcsaReportDataService
+        )
+        {
+            this.dcsaReportDataService = dcsaReportDataService;
+        }
+        public byte[] GetDigitalCapabilityExcelExportForCentre(int centreId)
+        {
+            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatusForCentre(centreId);
+            var outcomeSummary = dcsaReportDataService.GetOutcomeSummaryForCentre(centreId);
+            var summary = delegateCompletionStatus.Select(
+                x => new
+                {
+                    x.EnrolledMonth,
+                    x.EnrolledYear,
+                    x.FirstName,
+                    x.LastName,
+                    x.Email,
+                    x.CentreField1,
+                    x.CentreField2,
+                    x.CentreField3,
+                    x.Status
+                }
+                );
+            var details = outcomeSummary.Select(
+                x => new
+                {
+                    x.EnrolledMonth,
+                    x.EnrolledYear,
+                    x.JobGroup,
+                    x.CentreField1,
+                    x.CentreField2,
+                    x.CentreField3,
+                    x.Status,
+                    x.LearningLaunched,
+                    x.LearningCompleted,
+                    x.DataInformationAndContentConfidence,
+                    x.DataInformationAndContentRelevance,
+                    x.TeachinglearningAndSelfDevelopmentConfidence,
+                    x.TeachinglearningAndSelfDevelopmentRelevance,
+                    x.CommunicationCollaborationAndParticipationConfidence,
+                    x.CommunicationCollaborationAndParticipationRelevance,
+                    x.TechnicalProficiencyConfidence,
+                    x.TechnicalProficiencyRelevance,
+                    x.CreationInnovationAndResearchConfidence,
+                    x.CreationInnovationAndResearchRelevance,
+                    x.DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                    x.DigitalIdentityWellbeingSafetyAndSecurityRelevance
+                }
+                );
+            using var workbook = new XLWorkbook();
+            AddSheetToWorkbook(workbook, "Delegate Completion Status", delegateCompletionStatus);
+            AddSheetToWorkbook(workbook, "Assessment Outcome Summary", outcomeSummary);
+            using var stream = new MemoryStream();
+            workbook.SaveAs(stream);
+            return stream.ToArray();
+        }
+        private static void AddSheetToWorkbook(IXLWorkbook workbook, string sheetName, IEnumerable<object>? dataObjects)
+        {
+            var sheet = workbook.Worksheets.Add(sheetName);
+            var table = sheet.Cell(1, 1).InsertTable(dataObjects);
+            table.Theme = XLTableTheme.TableStyleLight9;
+            sheet.Columns().AdjustToContents();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -18,7 +18,7 @@
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
     [SetDlsSubApplication(nameof(DlsSubApplication.TrackingSystem))]
     [SetSelectedTab(nameof(NavMenuTab.Centre))]
-    [Route("/TrackingSystem/Centre/Reports")]
+    [Route("/TrackingSystem/Centre/Reports/Courses")]
     public class ReportsController : Controller
     {
         private readonly IActivityService activityService;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.SelfAssessmentReports
+{
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Mvc;
+    using System;
+
+    public class SelfAssessmentReportsController : Controller
+    {
+        private readonly ISelfAssessmentReportService selfAssessmentReportService;
+
+        public SelfAssessmentReportsController(
+            ISelfAssessmentReportService selfAssessmentReportService
+        )
+        {
+            this.selfAssessmentReportService = selfAssessmentReportService;
+        }
+        public IActionResult Index()
+        {
+            return View();
+        }
+        [HttpGet]
+        [Route("Download")]
+        public IActionResult DownloadDigitalCapabilityToExcel()
+        {
+            var centreId = User.GetCentreId();
+            var dataFile = selfAssessmentReportService.GetDigitalCapabilityExcelExportForCentre(centreId);
+            var fileName = $"DLS DCSA Report - Centre {centreId} - downloaded {DateTime.Today:yyyy-MM-dd}.xlsx";
+            return File(
+                dataFile,
+                FileHelper.GetContentTypeFromFileName(fileName),
+                fileName
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
@@ -2,9 +2,18 @@
 {
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.FeatureManagement.Mvc;
+    using DigitalLearningSolutions.Web.Attributes;
+    using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Data.Enums;
     using System;
-
+    [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
+    [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
+    [SetDlsSubApplication(nameof(DlsSubApplication.TrackingSystem))]
+    [SetSelectedTab(nameof(NavMenuTab.Centre))]
+    [Route("/TrackingSystem/Centre/Reports/SelfAssessments")]
     public class SelfAssessmentReportsController : Controller
     {
         private readonly ISelfAssessmentReportService selfAssessmentReportService;

--- a/DigitalLearningSolutions.Web/Models/Enums/CentrePage.cs
+++ b/DigitalLearningSolutions.Web/Models/Enums/CentrePage.cs
@@ -5,6 +5,7 @@
         Dashboard,
         Configuration,
         Administrators,
-        Reports
+        Reports,
+        SelfAssessmentReports
     }
 }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -229,6 +229,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IUserVerificationService, UserVerificationService>();
             services.AddScoped<IBrandsService, BrandsService>();
+            services.AddScoped<ISelfAssessmentReportService, SelfAssessmentReportService>();
         }
 
         private static void RegisterDataServices(IServiceCollection services)
@@ -269,6 +270,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IUserDataService, UserDataService>();
             services.AddScoped<ICandidateAssessmentDownloadFileService, CandidateAssessmentDownloadFileService>();
             services.AddScoped<IBrandsDataService, BrandsDataService>();
+            services.AddScoped<IDCSAReportDataService, DCSAReportDataService>();
         }
 
         private static void RegisterHelpers(IServiceCollection services)

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
@@ -1,0 +1,22 @@
+﻿@using DigitalLearningSolutions.Web.Models.Enums
+@{
+    ViewData["Title"] = "Self Assessment Reports";
+}
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-one-quarter">
+        <nav class="side-nav-menu" aria-label="Side navigation bar">
+            <partial name="~/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml" model="CentrePage.SelfAssessmentReports" />
+        </nav>
+    </div>
+
+    <div class="nhsuk-grid-column-three-quarters">
+        <h1 id="page-heading" class="nhsuk-heading-xl nhsuk-u-margin-bottom-7">
+          <span class="nhsuk-caption-l">
+                Beta
+              <span class="nhsuk-u-visually-hidden"> - </span>
+            </span>@ViewData["Title"]
+            </h1>
+            <p class="nhsuk-lede-text">This page will be used to provide acces to comprehensive competency framework self assessment reports for your centre. For now, it provides access to temporary reports for specific self assessments.</p>
+            <vc:action-link asp-controller="SelfAssessmentReports" asp-action="DownloadDigitalCapabilityToExcel" link-text="Download Digital Capability Self Assessment Report" />
+    </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml
@@ -5,26 +5,32 @@
 <h2 class="side-nav__heading">Centre</h2>
 <ul class="nhsuk-list side-nav__list">
 
-  <vc:side-menu-link asp-action="Index"
-                     asp-controller="Dashboard"
-                     link-text="Dashboard"
-                     is-current-page="Model == CentrePage.Dashboard" />
-
-  <vc:side-menu-link asp-action="Index"
-                     asp-controller="Configuration"
-                     link-text="Configuration"
-                     is-current-page="Model == CentrePage.Configuration" />
-
-  @if (User.HasCentreManagerPermissions()) {
     <vc:side-menu-link asp-action="Index"
+                       asp-controller="Dashboard"
+                       link-text="Dashboard"
+                       is-current-page="Model == CentrePage.Dashboard" />
+
+    <vc:side-menu-link asp-action="Index"
+                       asp-controller="Configuration"
+                       link-text="Configuration"
+                       is-current-page="Model == CentrePage.Configuration" />
+
+    @if (User.HasCentreManagerPermissions())
+    {
+        <vc:side-menu-link asp-action="Index"
                        asp-controller="Administrator"
                        link-text="Administrators"
-                       is-current-page="Model == CentrePage.Administrators" /> 
-  }
+                       is-current-page="Model == CentrePage.Administrators" />
+    }
 
-  <vc:side-menu-link asp-action="Index"
-                     asp-controller="Reports"
-                     link-text="Reports"
-                     is-current-page="Model == CentrePage.Reports" />
+    <vc:side-menu-link asp-action="Index"
+                       asp-controller="Reports"
+                       link-text="Course reports"
+                       is-current-page="Model == CentrePage.Reports" />
+
+    <vc:side-menu-link asp-action="Index"
+                       asp-controller="SelfAssessmentReports"
+                       link-text="Self assessment reports"
+                       is-current-page="Model == CentrePage.SelfAssessmentReports" />
 
 </ul>


### PR DESCRIPTION
### JIRA link
[DLSV2-597](https://hee-dls.atlassian.net/browse/DLSV2-597)

### Description
Implements a new "Self assessment reports" view with a link to the temporary digital capability self assessment report (rebuilt with additional enrolled month and enrolled year fields).

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/183372157-67bd312b-a822-43cc-8041-af248ed51832.png)
![image](https://user-images.githubusercontent.com/67740339/183372321-e852a859-5a37-47e9-b43f-2ac539342ded.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
