### PR TITLE
HEEDLS-877 Fixed Back link on RegisterAtNewCentre/LearnerInformation

### DIFF
--- a/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/LearnerInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterAtNewCentre/LearnerInformation.cshtml
@@ -45,7 +45,7 @@
         }
       }
 
-      <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Register" asp-action="PersonalInformation" role="button">Back</a>
+      <a class="nhsuk-button nhsuk-button--secondary" asp-action="PersonalInformation" role="button">Back</a>
       <button class="nhsuk-button" type="submit">Next</button>
     </form>
 


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-877

### Description

Fixed back link on `/RegisterAtNewCentre/LearnerInformation` so that it uses the `RegisterAtNewCentre` controller instead of the `Register` controller.

-----

### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
