### PR TITLE
DLSV2-573 Add catalogue filtering to Signposting

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -5,7 +5,7 @@
     ViewData["Application"] = "Framework Service";
     var dropdownItems = Model.Catalogues
           .Select(c => new SelectListItem(
-            text: c.Name,
+            text: c.Name + (c.IsRestricted ? " (Restricted)" : ""),
             value: c.Id.ToString(),
             selected: c.Id == Model.CatalogueId)
           ).ToList();


### PR DESCRIPTION
This fixes reported bug by indicating when a catalogue is restricted in the Catalogues dropdown.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-573

### Description
Added the text _" (Restricted)"_ to the catalogue name when a catalogue is restricted in the Catalogues dropdown. The flag `IsRestricted `is populated with the information retrieved from LearningHub api.


### Screenshots
![image](https://user-images.githubusercontent.com/94055251/183418856-fba5f9c2-57c4-4481-ab7d-35c894b4e0b9.png)

-----
### Developer checks

Checked that "Restricted" text:
* Is added when LearningHub api returns isRestricted for a catalogue
* Is only added to the dropdown items and is not shown elsewhere in the application.
