### PR TITLE
Check notification preferences before sending emails on unapproved in…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceAddCourseTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceAddCourseTests.cs
@@ -563,6 +563,44 @@
         }
 
         [Test]
+        public void AddCourseToGroup_does_not_send_email_to_delegates_without_required_notification_preference()
+        {
+            // Given
+            var groupCourse = GroupTestHelper.GetDefaultGroupCourse(
+                customisationId: 13,
+                applicationName: "application",
+                customisationName: "customisation",
+                completeWithinMonths: 0
+            );
+            SetupEnrolProcessFakes(
+                GenericNewProgressId,
+                GenericRelatedTutorialId,
+                notifyDelegates: false
+            );
+            SetUpAddCourseEnrolProcessFakes(groupCourse);
+
+            // When
+            groupsService.AddCourseToGroup(
+                groupCourse.GroupId,
+                groupCourse.CustomisationId,
+                0,
+                1,
+                true,
+                1,
+                CentreId
+            );
+
+            // Then
+            A.CallTo(
+                () => emailService.ScheduleEmail(
+                    A<Email>._,
+                    A<string>._,
+                    A<DateTime>._
+                )
+            ).MustNotHaveHappened();
+        }
+
+        [Test]
         public void AddCourseToGroup_sends_correct_email_with_additional_CompleteByDate()
         {
             // Given

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -693,5 +693,52 @@
             ).MustHaveHappened();
         }
 
+        [Test]
+        public void
+            EnrolDelegateOnGroupCourses_does_not_send_email_to_delegates_without_required_notification_preference()
+        {
+            // Given
+            const string centreEmail = "test@email.com";
+            var groupCourse = GroupTestHelper.GetDefaultGroupCourse(
+                customisationId: 13,
+                applicationName: "application",
+                customisationName: "customisation",
+                completeWithinMonths: 0
+            );
+            var oldDelegateDetails = UserTestHelper.GetDefaultDelegateUser(
+                firstName: "oldFirst",
+                lastName: "oldLast",
+                emailAddress: "oldEmail"
+            );
+            var newAccountDetails = UserTestHelper.GetDefaultAccountDetailsData(
+                firstName: "newFirst",
+                surname: "newLast",
+                email: "newEmail"
+            );
+            SetupEnrolProcessFakes(
+                GenericNewProgressId,
+                GenericRelatedTutorialId,
+                notifyDelegates: false
+            );
+            SetUpAddDelegateEnrolProcessFakes(groupCourse);
+
+            // When
+            groupsService.EnrolDelegateOnGroupCourses(
+                oldDelegateDetails.Id,
+                oldDelegateDetails.CentreId,
+                newAccountDetails,
+                centreEmail,
+                8
+            );
+
+            // Then
+            A.CallTo(
+                () => emailService.ScheduleEmail(
+                    A<Email>._,
+                    A<string>._,
+                    A<DateTime>._
+                )
+            ).MustNotHaveHappened();
+        }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.Email;
@@ -52,6 +53,7 @@
         private IProgressDataService progressDataService = null!;
         private ITutorialContentDataService tutorialContentDataService = null!;
         private IUserDataService userDataService = null!;
+        private INotificationPreferencesDataService notificationPreferencesDataService = null!;
 
         [SetUp]
         public void Setup()
@@ -66,6 +68,7 @@
             logger = A.Fake<ILogger<IGroupsService>>();
             jobGroupsDataService = A.Fake<IJobGroupsDataService>(x => x.Strict());
             userDataService = A.Fake<IUserDataService>();
+            notificationPreferencesDataService = A.Fake<INotificationPreferencesDataService>();
 
             A.CallTo(() => jobGroupsDataService.GetJobGroupsAlphabetical()).Returns(
                 JobGroupsTestHelper.GetDefaultJobGroupsAlphabetical()
@@ -86,7 +89,8 @@
                 configuration,
                 centreRegistrationPromptsService,
                 logger,
-                userDataService
+                userDataService,
+                notificationPreferencesDataService
             );
         }
 
@@ -757,7 +761,8 @@
         private void SetupEnrolProcessFakes(
             int newProgressId,
             int relatedTutorialId,
-            Progress? progress = null
+            Progress? progress = null,
+            bool notifyDelegates = true
         )
         {
             A.CallTo(() => clockUtility.UtcNow).Returns(testDate);
@@ -779,6 +784,15 @@
             ).Returns(newProgressId);
             A.CallTo(() => tutorialContentDataService.GetTutorialIdsForCourse(A<int>._))
                 .Returns(new List<int> { relatedTutorialId });
+
+            if (notifyDelegates)
+            {
+                A.CallTo(() => notificationPreferencesDataService.GetNotificationPreferencesForDelegate(A<int>._))
+                    .Returns(
+                        new List<NotificationPreference>
+                            { new NotificationPreference { NotificationId = 10, Accepted = true } }
+                    );
+            }
         }
 
         private void SetUpAddDelegateEnrolProcessFakes(GroupCourse groupCourse)

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -10,7 +10,6 @@ namespace DigitalLearningSolutions.Web.Tests.Services
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models;
-    using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Models.Notifications;
     using DigitalLearningSolutions.Data.Models.Register;
@@ -181,6 +180,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
         {
             // Given
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
+            GivenAdminsToNotifyHaveEmails(new[] { ApproverEmail });
 
             // When
             registrationService.CreateDelegateAccountForNewUser(
@@ -192,12 +192,17 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () =>
-                    notificationDataService.GetAdminRecipientsForCentreNotification(
-                        model.Centre,
-                        4
+                    () => emailService.SendEmail(
+                        A<Email>.That.Matches(
+                            e =>
+                                e.To[0] == ApproverEmail &&
+                                e.Cc.IsNullOrEmpty() &&
+                                e.Bcc.IsNullOrEmpty() &&
+                                e.Subject == "Digital Learning Solutions Registration Requires Approval"
+                        )
                     )
-            ).MustHaveHappened();
+                )
+                .MustHaveHappenedOnceExactly();
         }
 
         [Test]
@@ -205,6 +210,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
         {
             // Given
             var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel();
+            GivenAdminsToNotifyHaveEmails(new[] { ApproverEmail });
 
             // When
             registrationService.CreateDelegateAccountForNewUser(
@@ -216,12 +222,17 @@ namespace DigitalLearningSolutions.Web.Tests.Services
 
             // Then
             A.CallTo(
-                () =>
-                    notificationDataService.GetAdminRecipientsForCentreNotification(
-                        model.Centre,
-                        4
+                    () => emailService.SendEmail(
+                        A<Email>.That.Matches(
+                            e =>
+                                e.To[0] == ApproverEmail &&
+                                e.Cc.IsNullOrEmpty() &&
+                                e.Bcc.IsNullOrEmpty() &&
+                                e.Subject == "Digital Learning Solutions Registration Requires Approval"
+                        )
                     )
-            ).MustHaveHappened();
+                )
+                .MustHaveHappenedOnceExactly();
         }
 
         [Test]
@@ -239,10 +250,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             );
 
             // Then
-            A.CallTo(
-                () =>
-                    emailService.SendEmail(A<Email>._)
-            ).MustNotHaveHappened();
+            A.CallTo(() => emailService.SendEmail(A<Email>._)).MustNotHaveHappened();
         }
 
         [Test]
@@ -400,7 +408,8 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             A.CallTo(
                 () => groupsService.AddNewDelegateToAppropriateGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
-                    model)
+                    model
+                )
             ).MustHaveHappenedOnceExactly();
         }
 
@@ -421,7 +430,8 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             A.CallTo(
                 () => groupsService.AddNewDelegateToAppropriateGroups(
                     NewDelegateIdAndCandidateNumber.Item1,
-                    model)
+                    model
+                )
             ).MustHaveHappenedOnceExactly();
         }
 
@@ -1222,7 +1232,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             m.Answer4 == model.Answer4 &&
                             m.Answer5 == model.Answer5 &&
                             m.Answer6 == model.Answer6
-                        ),
+                    ),
                     userId,
                     A<DateTime>._,
                     A<IDbTransaction?>._
@@ -1252,7 +1262,8 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                             m.Answer6 == model.Answer6 &&
                             m.JobGroup == userEntity.UserAccount.JobGroupId &&
                             m.Centre == model.Centre
-                            ))
+                    )
+                )
             ).MustHaveHappenedOnceExactly();
         }
 
@@ -1373,6 +1384,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             const bool refactoredTrackingSystemEnabled = false;
             const int userId = 2;
             var model = RegistrationModelTestHelper.GetDefaultInternalDelegateRegistrationModel();
+            GivenAdminsToNotifyHaveEmails(new[] { ApproverEmail });
 
             // When
             registrationService.CreateDelegateAccountForExistingUser(
@@ -1404,6 +1416,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             const bool refactoredTrackingSystemEnabled = false;
             const int userId = 2;
             var model = RegistrationModelTestHelper.GetDefaultInternalDelegateRegistrationModel();
+            GivenAdminsToNotifyHaveEmails(new[] { ApproverEmail });
 
             // When
             registrationService.CreateDelegateAccountForExistingUser(
@@ -1431,6 +1444,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             const bool refactoredTrackingSystemEnabled = true;
             const int userId = 2;
             var model = RegistrationModelTestHelper.GetDefaultInternalDelegateRegistrationModel();
+            GivenAdminsToNotifyHaveEmails(new[] { ApproverEmail });
 
             // When
             registrationService.CreateDelegateAccountForExistingUser(
@@ -1541,6 +1555,21 @@ namespace DigitalLearningSolutions.Web.Tests.Services
                         email => Builder<NotificationRecipient>.CreateNew().With(r => r.Email = email).Build()
                     )
                 );
+        }
+
+        private void RegistrationRequiresApprovalEmailMustHaveBeenSentTo(NotificationRecipient notificationRecipient)
+        {
+            A.CallTo(
+                () => emailService.SendEmail(
+                    A<Email>.That.Matches(
+                        email =>
+                            email.To[0] == notificationRecipient.Email && email.To.Length == 1 &&
+                            email.Cc.IsNullOrEmpty() &&
+                            email.Bcc.IsNullOrEmpty() &&
+                            email.Subject == "Digital Learning Solutions Registration Requires Approval"
+                    )
+                )
+            ).MustHaveHappened();
         }
     }
 }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-1010

### Description
* When a new, unapproved delegate is created via the internal registration journey (`RegistrationService.CreateDelegateAccountForExistingUser`), notifications are now sent in the same way as for the external registration journey (`CreateDelegateAccountForNewUser`), i.e. using `notificationDataService.GetAdminRecipientsForCentreNotification` instead of `centresDataService.GetCentreManagerDetails`
* When a delegate is enrolled on a course, the enrolment email is only sent if the delegate has an accepted preference for notifications of id `10` ("New course enrollment") according to `GetNotificationPreferencesForDelegate`

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
