### PR TITLE
Use TempData in the final step of the claim account journey

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/ClaimAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/ClaimAccountControllerTests.cs
@@ -6,6 +6,7 @@
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.Controllers.Register;
+    using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
     using DigitalLearningSolutions.Web.ViewModels.Common;
@@ -202,11 +203,18 @@
                 )
             ).MustHaveHappenedOnceExactly();
 
+            controller.TempData.Peek<ClaimAccountConfirmationViewModel>().Should().BeEquivalentTo(
+                new ClaimAccountConfirmationViewModel
+                {
+                    Email = model.Email,
+                    CentreName = model.CentreName,
+                    CandidateNumber = model.CandidateNumber,
+                    WasPasswordSetByAdmin = true,
+                }
+            );
+
             result.Should().BeRedirectToActionResult()
-                .WithActionName("Confirmation")
-                .WithRouteValue("email", model.Email)
-                .WithRouteValue("centreName", model.CentreName)
-                .WithRouteValue("candidateNumber", model.CandidateNumber);
+                .WithActionName("Confirmation");
         }
 
         [Test]
@@ -343,11 +351,18 @@
                 )
             ).MustHaveHappenedOnceExactly();
 
+            controller.TempData.Peek<ClaimAccountConfirmationViewModel>().Should().BeEquivalentTo(
+                new ClaimAccountConfirmationViewModel
+                {
+                    Email = model.Email,
+                    CentreName = model.CentreName,
+                    CandidateNumber = model.CandidateNumber,
+                    WasPasswordSetByAdmin = false,
+                }
+            );
+
             result.Should().BeRedirectToActionResult()
-                .WithActionName("Confirmation")
-                .WithRouteValue("email", model.Email)
-                .WithRouteValue("centreName", model.CentreName)
-                .WithRouteValue("candidateNumber", model.CandidateNumber);
+                .WithActionName("Confirmation");
         }
 
         [Test]
@@ -502,23 +517,28 @@
         }
 
         [Test]
-        public void Confirmation_returns_view_model()
+        public void Confirmation_clears_TempData_and_returns_view_model()
         {
             // Given
-            var model = new ClaimAccountViewModel
+            var model = new ClaimAccountConfirmationViewModel
             {
                 Email = DefaultEmail,
                 CentreName = DefaultCentreName,
                 CandidateNumber = DefaultCandidateNumber,
+                WasPasswordSetByAdmin = true,
             };
 
+            controller.TempData.Set(model);
+
             // When
-            var result = controller.Confirmation(model.Email, model.CentreName, model.CandidateNumber);
+            var result = controller.Confirmation();
 
             // Then
+            controller.TempData.Peek<ClaimAccountConfirmationViewModel>().Should().BeNull();
+
             result.Should().BeViewResult()
                 .WithDefaultViewName()
-                .ModelAs<ClaimAccountViewModel>().Should().BeEquivalentTo(model);
+                .ModelAs<ClaimAccountConfirmationViewModel>().Should().BeEquivalentTo(model);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/Register/ClaimAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/ClaimAccountController.cs
@@ -4,8 +4,10 @@
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Web.Attributes;
+    using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Models.Enums;
+    using DigitalLearningSolutions.Web.ServiceFilter;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.ViewModels.Common;
     using DigitalLearningSolutions.Web.ViewModels.Register.ClaimAccount;
@@ -141,26 +143,26 @@
                 password
             );
 
-            return RedirectToAction(
-                "Confirmation",
-                new
+            TempData.Set(
+                new ClaimAccountConfirmationViewModel
                 {
-                    email = model.Email,
-                    centreName = model.CentreName,
-                    candidateNumber = model.CandidateNumber,
+                    Email = model.Email,
+                    CentreName = model.CentreName,
+                    CandidateNumber = model.CandidateNumber,
+                    WasPasswordSetByAdmin = password == null,
                 }
             );
+
+            return RedirectToAction("Confirmation");
         }
 
         [HttpGet]
-        public IActionResult Confirmation(string email, string centreName, string candidateNumber)
+        [ServiceFilter(typeof(RedirectEmptySessionData<ClaimAccountConfirmationViewModel>))]
+        public IActionResult Confirmation()
         {
-            var model = new ClaimAccountViewModel
-            {
-                Email = email,
-                CentreName = centreName,
-                CandidateNumber = candidateNumber,
-            };
+            var model = TempData.Peek<ClaimAccountConfirmationViewModel>()!;
+
+            TempData.Clear();
 
             return View(model);
         }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -22,6 +22,7 @@ namespace DigitalLearningSolutions.Web
     using DigitalLearningSolutions.Web.Models;
     using DigitalLearningSolutions.Web.ServiceFilter;
     using DigitalLearningSolutions.Web.Services;
+    using DigitalLearningSolutions.Web.ViewModels.Register.ClaimAccount;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.ViewDelegate;
     using FluentMigrator.Runner;
     using Microsoft.AspNetCore.Authentication;
@@ -306,6 +307,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<RedirectEmptySessionData<BulkUploadResult>>();
             services.AddScoped<RedirectEmptySessionData<WelcomeEmailSentViewModel>>();
             services.AddScoped<RedirectEmptySessionData<EditLearningPathwayDefaultsData>>();
+            services.AddScoped<RedirectEmptySessionData<ClaimAccountConfirmationViewModel>>();
             services.AddScoped<VerifyAdminUserCanManageCourse>();
             services.AddScoped<VerifyAdminUserCanViewCourse>();
             services.AddScoped<VerifyAdminUserCanAccessGroup>();

--- a/DigitalLearningSolutions.Web/ViewModels/Register/ClaimAccount/ClaimAccountConfirmationViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/ClaimAccount/ClaimAccountConfirmationViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Register.ClaimAccount
+{
+    public class ClaimAccountConfirmationViewModel
+    {
+        public string CentreName { get; set; } = null!;
+        public string Email { get; set; } = null!;
+        public string CandidateNumber { get; set; } = null!;
+        public bool WasPasswordSetByAdmin { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/ClaimAccount/Confirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ClaimAccount/Confirmation.cshtml
@@ -1,5 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Register.ClaimAccount
-@model ClaimAccountViewModel
+@model ClaimAccountConfirmationViewModel
 
 @{
   ViewData["Title"] = "Delegate registration complete";


### PR DESCRIPTION
Fix the text on the page if the admin set a password

### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-974

### Description
* Fixed the message on /ClaimAccount/Confirmation when the account password was set by an admin during delegate registration
* Switched from URL params to TempData for the last step in the journey (Complete registration -> Confirmation) to avoid having to have 4 URL params in order to get the page to display properly

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
