### PR TITLE
HEEDLS-975 Throw an exception when trying to claim a user with unexpe…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
@@ -200,7 +200,7 @@
                 string registrationConfirmationHash
             )
         {
-            var matchingUserAndCentreIds = connection.Query<(int, int, string)>(
+            return connection.QuerySingleOrDefault<(int?, int?, string?)>(
                 @"SELECT ucd.UserID, c.CentreID, c.CentreName
                     FROM UserCentreDetails AS ucd
                     INNER JOIN DelegateAccounts AS da ON da.UserID = ucd.UserID AND da.CentreID = ucd.CentreID
@@ -208,11 +208,7 @@
                     WHERE ucd.Email = @centreSpecificEmail
                         AND da.RegistrationConfirmationHash = @registrationConfirmationHash",
                 new { centreSpecificEmail, registrationConfirmationHash }
-            ).ToList();
-
-            return matchingUserAndCentreIds.Any()
-                ? matchingUserAndCentreIds.Single()
-                : ((int?)null, (int?)null, (string?)null);
+            );
         }
 
         public void LinkUserCentreDetailsToNewUser(

--- a/DigitalLearningSolutions.Web/Services/ClaimAccountService.cs
+++ b/DigitalLearningSolutions.Web/Services/ClaimAccountService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Services
 {
+    using System;
     using System.Linq;
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.DataServices;
@@ -49,8 +50,22 @@
         {
             var userMatchingEmail = userDataService.GetUserAccountByPrimaryEmail(email);
             var userAccountToBeClaimed = userDataService.GetUserAccountById(userIdForRegistration);
-            var delegateAccountToBeClaimed = userDataService.GetDelegateAccountsByUserId(userIdForRegistration)
-                .SingleOrDefault(da => da.CentreId == centreId);
+            var delegateAccounts = userDataService.GetDelegateAccountsByUserId(userIdForRegistration).ToList();
+            var adminAccounts = userDataService.GetAdminAccountsByUserId(userIdForRegistration).ToList();
+
+            if (
+                delegateAccounts.Count != 1 ||
+                adminAccounts.Count != 0 ||
+                delegateAccounts.Any(da => da.CentreId != centreId)
+            )
+            {
+                throw new Exception(
+                    "Expected user account being claimed to only have one delegate account at the correct centre"
+                );
+            }
+
+            var delegateAccountToBeClaimed = delegateAccounts.First();
+
             var supportEmail = configDataService.GetConfigValue(ConfigDataService.SupportEmail);
 
             return new ClaimAccountViewModel


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-975

### Description
Throw an exception according to the spec:
> The user entity associated with the new delegate record must not have any other centre account records. If it does, return a server error (you can just use e.g. IEnumerable.Single()). This shouldn’t happen anyway, since the user entity is a (possibly) temporary entity created by the register-by-centre or bulk upload journey and can’t be logged into until claimed.

(Note: you can't just use IEnumerable.Single())

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
