### PR TITLE
HEEDLS-1036 Only request 150 resources from Learning Hub API

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202208101435_AddMaxSignpostedResourcesConfigValue.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202208101435_AddMaxSignpostedResourcesConfigValue.cs
@@ -1,0 +1,22 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202208101435)]
+    public class AddMaxSignpostedResourcesConfigValue : Migration
+    {
+        private const string MaxSignpostedResourcesValue = "150";
+
+        public override void Up()
+        {
+            Execute.Sql(
+                @$"IF NOT EXISTS (SELECT ConfigID FROM Config WHERE ConfigName = 'MaxSignpostedResources')
+                    BEGIN
+                      INSERT INTO Config VALUES ('MaxSignpostedResources', '{MaxSignpostedResourcesValue}', 0)
+                    END"
+            );
+        }
+
+        public override void Down() { }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/Services/LearningHubResourceServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/LearningHubResourceServiceTests.cs
@@ -462,5 +462,22 @@
                     .MustHaveHappenedOnceExactly();
             }
         }
+
+        [Test]
+        public void GetResourceReferenceDetailsByReferenceIds_calls_data_service()
+        {
+            // Given
+            var resourceReferenceIds = new List<int> { 1, 2, 3 };
+
+            // When
+            learningHubResourceService.GetResourceReferenceDetailsByReferenceIds(resourceReferenceIds);
+
+            // Then
+            A.CallTo(
+                () => learningResourceReferenceDataService.GetResourceReferenceDetailsByReferenceIds(
+                    resourceReferenceIds
+                )
+            ).MustHaveHappenedOnceExactly();
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/ConfigDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ConfigDataService.cs
@@ -8,7 +8,9 @@
     public interface IConfigDataService
     {
         string? GetConfigValue(string key);
+
         bool GetCentreBetaTesting(int centreId);
+
         string GetConfigValueMissingExceptionMessage(string missingConfigValue);
     }
 
@@ -24,6 +26,7 @@
         public const string TermsText = "TermsAndConditions";
         public const string ContactText = "ContactUsHtml";
         public const string AppBaseUrl = "V2AppBaseUrl";
+        public const string MaxSignpostedResources = "MaxSignpostedResources";
 
         private readonly IDbConnection connection;
 

--- a/DigitalLearningSolutions.Data/Services/LearningHubResourceService.cs
+++ b/DigitalLearningSolutions.Data/Services/LearningHubResourceService.cs
@@ -28,6 +28,10 @@
 
         Task<(BulkResourceReferences bulkResourceReferences, bool apiIsAccessible)>
             GetBulkResourcesByReferenceIdsAndPopulateDeletedDetailsFromDatabase(IList<int> resourceReferenceIds);
+
+        IEnumerable<ResourceReferenceWithResourceDetails> GetResourceReferenceDetailsByReferenceIds(
+            IEnumerable<int> resourceReferenceIds
+        );
     }
 
     public class LearningHubResourceService : ILearningHubResourceService
@@ -63,7 +67,7 @@
                 }
 
                 var fallBackResourceDetails =
-                    GetFallbackDataForResourceReferenceIds(new List<int> { resourceReferenceId }).SingleOrDefault();
+                    GetResourceReferenceDetailsByReferenceIds(new List<int> { resourceReferenceId }).SingleOrDefault();
 
                 return (fallBackResourceDetails, false);
             }
@@ -80,7 +84,7 @@
             }
 
             var fallBackResourceDetails =
-                GetFallbackDataForResourceReferenceIds(new List<int> { resourceReferenceId }).SingleOrDefault();
+                GetResourceReferenceDetailsByReferenceIds(new List<int> { resourceReferenceId }).SingleOrDefault();
 
             if (fallBackResourceDetails != null)
             {
@@ -103,7 +107,7 @@
             }
             catch (LearningHubResponseException)
             {
-                var fallbackResources = GetFallbackDataForResourceReferenceIds(resourceReferenceIds).ToList();
+                var fallbackResources = GetResourceReferenceDetailsByReferenceIds(resourceReferenceIds).ToList();
 
                 var bulkResourceReferences = new BulkResourceReferences
                 {
@@ -128,7 +132,7 @@
             }
 
             var deletedFallbackResources =
-                GetFallbackDataForResourceReferenceIds(bulkResourceResponse.UnmatchedResourceReferenceIds).ToList();
+                GetResourceReferenceDetailsByReferenceIds(bulkResourceResponse.UnmatchedResourceReferenceIds).ToList();
 
             foreach (var resource in deletedFallbackResources)
             {
@@ -143,16 +147,10 @@
             return (bulkResourceResponse, true);
         }
 
-        private IEnumerable<ResourceReferenceWithResourceDetails> GetFallbackDataForResourceReferenceIds(
-            IList<int> resourceReferenceIds
+        public IEnumerable<ResourceReferenceWithResourceDetails> GetResourceReferenceDetailsByReferenceIds(
+            IEnumerable<int> resourceReferenceIds
         )
         {
-            var commaSeparatedListOfIds =
-                new StringBuilder().AppendJoin(", ", resourceReferenceIds.OrderBy(i => i)).ToString();
-            logger.LogWarning(
-                $"Attempting to use fallback data for resource references Ids: {commaSeparatedListOfIds}"
-            );
-
             return learningResourceReferenceDataService.GetResourceReferenceDetailsByReferenceIds(resourceReferenceIds);
         }
     }

--- a/DigitalLearningSolutions.Data/Services/RecommendedLearningService.cs
+++ b/DigitalLearningSolutions.Data/Services/RecommendedLearningService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Services
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -25,18 +26,21 @@
         private readonly ILearningHubResourceService learningHubResourceService;
         private readonly ILearningLogItemsDataService learningLogItemsDataService;
         private readonly ISelfAssessmentDataService selfAssessmentDataService;
+        private readonly IConfigDataService configDataService;
 
         public RecommendedLearningService(
             ISelfAssessmentDataService selfAssessmentDataService,
             ICompetencyLearningResourcesDataService competencyLearningResourcesDataService,
             ILearningHubResourceService learningHubResourceService,
-            ILearningLogItemsDataService learningLogItemsDataService
+            ILearningLogItemsDataService learningLogItemsDataService,
+            IConfigDataService configDataService
         )
         {
             this.selfAssessmentDataService = selfAssessmentDataService;
             this.competencyLearningResourcesDataService = competencyLearningResourcesDataService;
             this.learningHubResourceService = learningHubResourceService;
             this.learningLogItemsDataService = learningLogItemsDataService;
+            this.configDataService = configDataService;
         }
 
         public async Task<(IEnumerable<RecommendedResource> recommendedResources, bool apiIsAccessible)>
@@ -45,27 +49,41 @@
                 int delegateId
             )
         {
-            var competencyIds = selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(selfAssessmentId);
+            var hasMaxSignpostedResources = Int32.TryParse(
+                configDataService.GetConfigValue(ConfigDataService.MaxSignpostedResources),
+                out var maxSignpostedResources
+            );
 
+            var competencyIds = selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(selfAssessmentId);
             var competencyLearningResources = new List<CompetencyLearningResource>();
+
             foreach (var competencyId in competencyIds)
             {
                 var learningHubResourceReferencesForCompetency =
                     competencyLearningResourcesDataService.GetActiveCompetencyLearningResourcesByCompetencyId(
                         competencyId
                     );
+
                 competencyLearningResources.AddRange(learningHubResourceReferencesForCompetency);
             }
 
             var resourceReferences = competencyLearningResources.Select(
                 clr => (clr.LearningHubResourceReferenceId, clr.LearningResourceReferenceId)
-            ).Distinct().ToDictionary(x => x.LearningHubResourceReferenceId, x => x.LearningResourceReferenceId);
+            ).Distinct().ToDictionary(
+                x => x.LearningHubResourceReferenceId,
+                x => x.LearningResourceReferenceId
+            );
 
-            var uniqueLearningHubReferenceIds = competencyLearningResources
-                .Select(clr => clr.LearningHubResourceReferenceId).Distinct().ToList();
+            var uniqueLearningHubReferenceIds = competencyLearningResources.Select(
+                clr => clr.LearningHubResourceReferenceId
+            ).Distinct();
 
             var resources =
-                await learningHubResourceService.GetBulkResourcesByReferenceIds(uniqueLearningHubReferenceIds);
+                await learningHubResourceService.GetBulkResourcesByReferenceIds(
+                    hasMaxSignpostedResources
+                        ? uniqueLearningHubReferenceIds.Take(maxSignpostedResources).ToList()
+                        : uniqueLearningHubReferenceIds.ToList()
+                );
 
             var delegateLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId);
 
@@ -80,7 +98,10 @@
                 )
             );
 
-            return (recommendedResources.WhereNotNull(), resources.apiIsAccessible);
+            return (
+                recommendedResources.WhereNotNull().OrderByDescending(resource => resource.RecommendationScore),
+                resources.apiIsAccessible
+            );
         }
 
         private RecommendedResource? GetPopulatedRecommendedResource(

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/BasicAuthenticatedAccessibilityTests.cs
@@ -8,8 +8,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
     {
         public BasicAuthenticatedAccessibilityTests(AuthenticatedAccessibilityTestsFixture<Startup> fixture) : base(
             fixture
-        )
-        { }
+        ) { }
 
         [Theory]
         [InlineData("/MyAccount", "My account")]
@@ -40,7 +39,7 @@ namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
             "/TrackingSystem/Centre/Configuration/RegistrationPrompts/1/Remove",
             "Remove delegate registration prompt"
         )]
-        [InlineData("/TrackingSystem/Centre/Reports", "Centre reports")]
+        [InlineData("/TrackingSystem/Centre/Reports/Courses", "Centre reports")]
         [InlineData("/TrackingSystem/Centre/SystemNotifications", "New system notifications")]
         [InlineData("/TrackingSystem/Centre/TopCourses", "Top courses")]
         [InlineData("/TrackingSystem/CourseSetup", "Centre course setup")]

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/ReportsControllerAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/ReportsControllerAccessibilityTests.cs
@@ -16,7 +16,7 @@
         {
             // given
             Driver.LogUserInAsAdminAndDelegate(BaseUrl);
-            const string reportsEditFiltersUrl = "/TrackingSystem/Centre/Reports/EditFilters";
+            const string reportsEditFiltersUrl = "/TrackingSystem/Centre/Reports/Courses/EditFilters";
 
             // when
             Driver.Navigate().GoToUrl(BaseUrl + reportsEditFiltersUrl);


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-1036

### Description
* Migration to add `MaxSignpostedResources` = 150 to the Config database table.
* Limit the number of resource ids given to `learningHubResourceService.GetBulkResourcesByReferenceIds` to `Config.MaxSignpostedResources`
* Order resources returned from the API by descending `RecommendationScore`

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
