### PR TITLE
HEEDLS-1044 Make GetAllCentreEmailsForUser omit emails from inactive admin accounts

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
@@ -170,7 +170,7 @@
                     FROM AdminAccounts AS aa
                     INNER JOIN Centres AS c ON c.centreID = aa.CentreID
                     LEFT JOIN UserCentreDetails AS ucd ON ucd.UserID = aa.UserID AND ucd.CentreID = c.CentreID
-                    WHERE aa.UserID = @userId",
+                    WHERE aa.UserID = @userId AND aa.Active = 1",
                 new { userId }
             );
         }


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-1044

### Description
`GetAllCentreEmailsForUser` is only used by the `MyAccountController` to display/edit the list of centre emails when a user is not logged in to a centre. I have changed the query so that centre emails for centres where the user only has an inactive admin account are not returned.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
