### PR TITLE
DLSV2-564 Repeat overall progress for self assessment at top of overview page

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -5,63 +5,70 @@
 @model SelfAssessmentOverviewViewModel
 
 @{
-    var selfAssessedTotal = 0;
-    var verifiedTotal = 0;
-    var questionsTotal = 0;
-    var latestSignoff = Model.SupervisorSignOffs
-        .Select(s => s.Verified)
-        .DefaultIfEmpty(DateTime.MinValue)
-        .Max();
-    var latestResult = Model.CompetencyGroups
-      .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
-      .Select(q => q.ResultDateTime)
+  var latestSignoff = Model.SupervisorSignOffs
+      .Select(s => s.Verified)
       .DefaultIfEmpty(DateTime.MinValue)
       .Max();
-    Layout = "SelfAssessments/_Layout";
-    ViewData["Title"] = "Self Assessment";
-    ViewData["SelfAssessmentTitle"] = Model.SelfAssessment.Name;
+  var latestResult = Model.CompetencyGroups
+    .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
+    .Select(q => q.ResultDateTime)
+    .DefaultIfEmpty(DateTime.MinValue)
+    .Max();
+  var competencySummaries = from g in Model.CompetencyGroups
+      let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
+      let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
+      let verifiedCount = questions.Count(q => q.Verified.HasValue)
+      select new ViewDataDictionary(ViewData)
+      {
+        { "isSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed },
+        { "questionsCount", questions.Count() },
+        { "selfAssessedCount", selfAssessedCount },
+        { "verifiedCount", verifiedCount }
+      };
+
+  Layout = "SelfAssessments/_Layout";
+  ViewData["Title"] = "Self Assessment";
+  ViewData["SelfAssessmentTitle"] = Model.SelfAssessment.Name;
 }
 @section breadcrumbs {
-<li class="nhsuk-breadcrumb__item">
+  <li class="nhsuk-breadcrumb__item">
     <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
-</li>
-<li class="nhsuk-breadcrumb__item">@(Model.VocabPlural()) home</li>
+  </li>
+  <li class="nhsuk-breadcrumb__item">@(Model.VocabPlural()) home</li>
 }
 
 @section mobilebacklink
 {
-<p class="nhsuk-breadcrumb__back">
+  <p class="nhsuk-breadcrumb__back">
     <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
        asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-        Back to @Model.SelfAssessment.Name
+      Back to @Model.SelfAssessment.Name
     </a>
-</p>
+  </p>
 }
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
 <h1>@Model.SelfAssessment.Name - @Model.VocabPlural()</h1>
-<partial name="SelfAssessments/_SearchSelfAssessmentOverview" model="@Model.SearchViewModel" view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
+<div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+  <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+           model="@competencySummaries"
+           view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+</div>
+<partial name="SelfAssessments/_SearchSelfAssessmentOverview"
+         model="@Model.SearchViewModel"
+         view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
 <partial name="_OverviewActionButtons.cshtml" model=Model />
 <p><span role="alert">@Model.CompetencyGroups.Sum(g => g.Count()) matching @Model.VocabPlural().ToLower()</span></p>
 @if (Model.CompetencyGroups.Any())
 {
-
+  var competencySummariesEnumerator = competencySummaries.GetEnumerator();
   foreach (var competencyGroup in Model.CompetencyGroups)
   {
     var groupDetails = competencyGroup.First();
     var questions = competencyGroup.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
     var selfAssessedCount = questions.Count(q => q.ResultId.HasValue);
     var verifiedCount = questions.Count(q => q.Verified.HasValue);
-    var competencySummaryViewData = new ViewDataDictionary(ViewData)
-{
-      { "isSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed },
-      { "questionsCount", questions.Count() },
-      { "selfAssessedCount", selfAssessedCount },
-      { "verifiedCount", verifiedCount }
-    };
-    selfAssessedTotal += selfAssessedCount;
-    verifiedTotal += verifiedCount;
-    questionsTotal += questions.Count();
+    competencySummariesEnumerator.MoveNext();
     <div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
       @{
         var expanderOpen = Model.CompetencyGroups.Count() == 1
@@ -77,7 +84,7 @@
           </span>
         </summary>
         <div class="nhsuk-details__text">
-          <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummaryViewData" />
+          <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
           @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
           {
             <p class="nhsuk-body-l nhsuk-u-margin-left-7">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
@@ -120,96 +127,91 @@
                    model="competencyGroup" />
 
 
-                </div>
-            </details>
-            <div class="outer-score-container">
-                <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummaryViewData" />
-            </div>
-            @if (Model.SelfAssessment.LinearNavigation)
-            {
-                <div class="outer-score-container nhsuk-u-padding-bottom-4">
-                    <partial name="SelfAssessments/_MeanScores"
-                             view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
-                </div>
-            }
         </div>
-    }
-    <partial name="_OverviewActionButtons.cshtml" model=Model />
+      </details>
+      <div class="outer-score-container">
+        <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
+      </div>
+      @if (Model.SelfAssessment.LinearNavigation)
+      {
+        <div class="outer-score-container nhsuk-u-padding-bottom-4">
+          <partial name="SelfAssessments/_MeanScores"
+                   view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+        </div>
+      }
+    </div>
+  }
+  <partial name="_OverviewActionButtons.cshtml" model=Model />
 }
 
 @if (Model.SelfAssessment.IncludesSignposting)
 {
-    <p class="nhsuk-u-reading-width">Once you are happy with your responses, submit your self-assessment to retrieve a list of recommended learning resources.</p>
+  <p class="nhsuk-u-reading-width">Once you are happy with your responses, submit your self-assessment to retrieve a list of recommended learning resources.</p>
 
-    @if (Configuration.IsSignpostingUsed())
-    {
-        <a class="nhsuk-button finish-review-button trigger-loader"
-           asp-controller="RecommendedLearning"
-           asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-           asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-           role="button">
-            Submit results
-        </a>
-    }
-    else
-    {
-        <a class="nhsuk-button finish-review-button trigger-loader"
-           asp-controller="RecommendedLearning"
-           asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-           asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-           role="button">
-            Submit self assessment
-        </a>
-    }
+  @if (Configuration.IsSignpostingUsed())
+  {
+    <a class="nhsuk-button finish-review-button trigger-loader"
+       asp-controller="RecommendedLearning"
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+       asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+       role="button">
+      Submit results
+    </a>
+  }
+  else
+  {
+    <a class="nhsuk-button finish-review-button trigger-loader"
+       asp-controller="RecommendedLearning"
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+       asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+       role="button">
+      Submit self assessment
+    </a>
+  }
 }
 @if (Model.SelfAssessment.IsSupervised)
 {
-    <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-        <h2>Overall Progress</h2>
-        <p class="nhsuk-body-l">
-            <span class="score">Self assessed: @selfAssessedTotal / @questionsTotal</span>
-            @if (Model.SelfAssessment.IsSupervisorResultsReviewed)
-            {
-                <span class="score">Confirmed: @verifiedTotal / @questionsTotal</span>
-            }
-        </p>
-        <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
-        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
-        @if (Model.AllQuestionsVerifiedOrNotRequired())
-        {
-            @if (!Model.SupervisorSignOffs.Any())
-            {
-                <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
-            }
-            else if (latestResult > latestSignoff)
-            {
-                <div class="nhsuk-warning-callout">
-                    <h3 class="nhsuk-warning-callout__label">
-                        <span role="text">
-                            <span class="nhsuk-u-visually-hidden">New self assessment results</span>
-                            New self assessment results
-                        </span>
-                    </h3>
-                    <p>
-                        You have submitted new self assessment results since this self assessment was signed off.
-                        Please resubmit your self assessment for sign off once these results are confirmed.
-                    </p>
-                </div>
-            }
-            <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-               asp-action="RequestSignOff"
-               asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
-               asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-               role="button">
-                Request @Model.SelfAssessment.SignOffRoleName sign-off
-            </a>
-        }
-        else
-        {
-            <p class="nhsuk-body-l">
-                All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
-                before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
-            </p>
-        }
-    </div>
+  <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+    <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+             model="@competencySummaries"
+             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+    <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
+    <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
+    @if (Model.AllQuestionsVerifiedOrNotRequired())
+    {
+      @if (!Model.SupervisorSignOffs.Any())
+      {
+        <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
+      }
+      else if (latestResult > latestSignoff)
+      {
+        <div class="nhsuk-warning-callout">
+          <h3 class="nhsuk-warning-callout__label">
+            <span role="text">
+              <span class="nhsuk-u-visually-hidden">New self assessment results</span>
+              New self assessment results
+            </span>
+          </h3>
+          <p>
+            You have submitted new self assessment results since this self assessment was signed off.
+            Please resubmit your self assessment for sign off once these results are confirmed.
+          </p>
+        </div>
+      }
+      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
+         asp-action="RequestSignOff"
+         asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
+         asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+         role="button">
+        Request @Model.SelfAssessment.SignOffRoleName sign-off
+      </a>
+    }
+    else
+    {
+      <p class="nhsuk-body-l">
+        All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
+        before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
+      </p>
+    }
+  </div>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentOverallProgress.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentOverallProgress.cshtml
@@ -1,0 +1,14 @@
+﻿@model IEnumerable<ViewDataDictionary>
+@{
+  var questionsTotal = Model.Sum(c => (int)c["questionsCount"]);
+  var selfAssessedTotal = Model.Sum(c => (int)c["selfAssessedCount"]);
+  var verifiedTotal = Model.Sum(c => (int)c["verifiedCount"]);
+}
+<h2>Overall Progress</h2>
+<p class="nhsuk-body-l">
+  <span class="score">Self assessed: @selfAssessedTotal / @questionsTotal</span>
+  @if ((bool)ViewData["IsSupervisorResultsReviewed"])
+  {
+    <span class="score">Confirmed: @verifiedTotal / @questionsTotal</span>
+  }
+</p>


### PR DESCRIPTION
Repeat overall progress for self assessment at top of overview page.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-564

### Description
So far, totals were being calculated as the page is rendered and each competency group is displayed. For that reason, we cannot simply copy/paste "Overall Progress" section to the beginning of the page, since totals are zero at that point. So I have generated counts I need beforehand and passed them to a new partial view for displaying that "Overall Progress" section on top and bottom of the page.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/184123532-cbaba33e-8858-4784-b521-dbce43365e8c.png)

-----
### Developer checks

- Checked that counts displayed on the page for each competency group were the same before and after my changes. 
  Because the new implementation uses an enumerator and I am assuming competency groups order wouldn't change, I did a screen capture and checked counts displayed on the page for each competency group were the same before and after my changes.
