### PR TITLE
HEEDLS-874 Use new job group id when updating delegate groups in bulk upload

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -603,7 +603,7 @@
                     A<RegistrationFieldAnswers>.That.Matches(
                         answers =>
                             answers.CentreId == candidateNumberDelegate.DelegateAccount.CentreId &&
-                            answers.JobGroupId == candidateNumberDelegate.UserAccount.JobGroupId &&
+                            answers.JobGroupId == Int32.Parse(row.JobGroupID) &&
                             answers.Answer1 == row.Answer1 &&
                             answers.Answer2 == row.Answer2 &&
                             answers.Answer3 == row.Answer3 &&

--- a/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
@@ -183,7 +183,7 @@ namespace DigitalLearningSolutions.Web.Services
                     ),
                     new RegistrationFieldAnswers(
                         delegateEntity.DelegateAccount.CentreId,
-                        delegateEntity.UserAccount.JobGroupId,
+                        delegateRow.JobGroupId.Value,
                         delegateRow.Answer1,
                         delegateRow.Answer2,
                         delegateRow.Answer3,


### PR DESCRIPTION
### JIRA link
https://softwiretech.atlassian.net/browse/HEEDLS-874

### Description
The previous code was using the wrong job group id when calling `UpdateSynchronisedDelegateGroupsBasedOnUserChanges` - it was using the id from before the update, rather than after. As a result, job group id changes in bulk upload did not trigger group changes in the database, although Answer[n] column changes did.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
