### PR TITLE
DLSV2-569 Remove Supervisor fails and results in an error

### DIFF
--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -573,7 +573,7 @@ WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
                 @"DELETE FROM cas
 	                FROM CandidateAssessmentSupervisors AS cas
 				    LEFT JOIN CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
-				    LEFT JOIN SelfAssessmentResultSupervisorVerifications AS sarsr ON cas.ID = sarsr.ID
+				    LEFT JOIN SelfAssessmentResultSupervisorVerifications AS sarsr ON cas.ID = sarsr.CandidateAssessmentSupervisorID
                     WHERE (cas.SupervisorDelegateId = @supervisorDelegateId)
 					    AND (casv.ID IS NULL)
 					    AND (sarsr.ID IS NULL)",

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -323,7 +323,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
                     SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
                     CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID INNER JOIN
                     Candidates AS c ON ca.CandidateID = c.CandidateID
-                WHERE (sd.SupervisorAdminID = @adminId) AND (casv.Verified IS NULL)", new { adminId }
+                WHERE (sd.SupervisorAdminID = @adminId) AND (casv.Verified IS NULL) AND (sd.Removed IS NULL)", new { adminId }
                 );
         }
         public IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedReviews(int adminId)
@@ -343,7 +343,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
 						    FROM SelfAssessmentResults AS sar2
 						    WHERE sar2.SelfAssessmentID = sar.SelfAssessmentID AND sar2.CompetencyID = co.ID
 					)
-                WHERE (sd.SupervisorAdminID = @adminId) AND (sasv.Verified IS NULL)
+                WHERE (sd.SupervisorAdminID = @adminId) AND (sasv.Verified IS NULL) AND (sd.Removed IS NULL)
 				GROUP BY sa.ID, ca.ID, sd.ID, c.FirstName, c.LastName, sa.Name", new { adminId }
                 );
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -774,7 +774,7 @@
 
         public IActionResult RemoveSupervisor(int selfAssessmentId, int supervisorDelegateId)
         {
-            supervisorService.RemoveCandidateAssessmentSupervisor(selfAssessmentId, supervisorDelegateId);
+            supervisorService.RemoveCandidateAssessmentSupervisor(supervisorDelegateId);
             return RedirectToAction("ManageSupervisors", new { selfAssessmentId });
         }
 


### PR DESCRIPTION
Manage Supervisor/Remove Supervisor, fails to remove the supervisor and it results in error.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-569

### Description
**Introduction:** Since I cannot connect VS to UAT database I am guessing what the problem is based on database table relations and the code available.  There is a soft-delete on `SupervisorDelegates` and hard delete on `CandidateAssessmentSupervisor`. The later may be causing an error if the table is referenced from another table.

**Suggested solution:** Soft-delete `CandidateAssessmentSupervisors` if there are no records pointing to that table from `CandidateAssessmentSupervisorVerifications` nor `SelfAssessmentResultSupervisorVerifications`. Otherwise, a hard delete can be performed.

Any matching record in `SelfAssessmentResultSupervisorVerifications` can be hard deleted which has the same effect as pressing "Withdraw" for that request from the user interface.

No action was taken for matching `CandidateAssessmentSupervisorVerfications` at this point. There are queries like `GetSelfAssessmentResultSummary` at SupervisorService.cs line 755, that use these records to join other tables, e.g. `SelfAssessments AS sa INNER JOIN CandidateAssessmentSupervisorVerifications AS casv INNER JOIN CandidateAssessmentSupervisors`

### Implementation

Despite `CandidateAssessments` and `SelfAssessmentSupervisorRoles` (green tables) are referenced from records that are going to be deleted in `CandidateAssessmentSupervisors`, it must be noted that the relation goes in the oposite direction. What we want to delete (`CandidateAssessmentSupervisor`) is not pointed by these tables, hence it can be deleted. It seems blue tables are what we need to care about.

#### Relevant tables:
- In **Red**, tables containing records that need to be deleted.
- In **Blue**: tables pointing **to** red tables.
- In **Green**: tables pointed **by** red tables.

![image](https://user-images.githubusercontent.com/94055251/184838730-e5b00cce-401c-479a-9b3a-9dcbf0447760.png)

### Steps to reproduce the bug

**Add capability confirmation requests for a supervisor**

![Untitled1](https://user-images.githubusercontent.com/94055251/184914663-ee8659df-bc19-4047-bf13-294a6d1dfd96.png)

**Attempt to remove the supervisor**

![Untitled2](https://user-images.githubusercontent.com/94055251/184914863-9c243ca1-428c-4620-a3e4-a8ebff23d665.png)

**In Visual Studio this results in the following error:**

> Microsoft.Data.SqlClient.SqlException: 'The DELETE statement conflicted with the REFERENCE constraint "FK_SelfAssessmentResultSupervisorVerifications_CandidateAssessmentSupervisorID_CandidateAssessmentSupervisors_ID". The conflict occurred in database "mbdbx101", table "dbo.SelfAssessmentResultSupervisorVerifications", column 'CandidateAssessmentSupervisorID'.

Stacktrace points to RemoveCandidateAssessmentSupervisor method in SupervisorService.cs

**From user interface this can be seen:**

![image](https://user-images.githubusercontent.com/94055251/184916369-302b7f8c-4aea-4713-90cf-56b6c5815ce3.png)

-----
### Developer checks
Checked that:

- Neither hard or soft delete are resulting in an error in the cases I've tested.
- There are no more tables somewhere pointing to `CandidateAssessmentSupervisors`: run `sp_help 'CandidateAssessmentSupervisors'` as suggested [in this post](https://stackoverflow.com/a/23993240/2516718).
- Soft-deleted records are filtered out in queries: tried to find some queries that need to be updated but it seems they are already doing that filter or filtering the result by not removed supervisor delegate or they are export functions. There are tons of queries using these tables so it's quite possible I could be missing something.

