### PR TITLE
DLSV2-625 Fixes broken self assessment overview links

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -188,13 +188,13 @@
                         SELECT
                             DENSE_RANK() OVER (ORDER BY SAS.Ordering) as RowNo,
                             sas.CompetencyID
-                        FROM SelfAssessmentStructure as sas
-                        INNER JOIN CandidateAssessments AS CA
-                            ON CA.SelfAssessmentID = @selfAssessmentId AND CA.CandidateID = @candidateId
-                        LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
-                            ON CA.ID = CAOC.CandidateAssessmentID AND sas.CompetencyID = CAOC.CompetencyID
-                                AND sas.CompetencyGroupID = CAOC.CompetencyGroupID
-                        WHERE (sas.SelfAssessmentID = @selfAssessmentId) AND ((sas.Optional = 0) OR (CAOC.IncludedInSelfAssessment = 1))
+                        FROM            SelfAssessmentStructure AS sas INNER JOIN
+                                         CandidateAssessments AS CA ON CA.SelfAssessmentID = @selfAssessmentId AND CA.CandidateID = @candidateId INNER JOIN
+                                         CompetencyAssessmentQuestions AS caq ON sas.CompetencyID = caq.CompetencyID LEFT OUTER JOIN
+                                         CandidateAssessmentOptionalCompetencies AS CAOC ON CA.ID = CAOC.CandidateAssessmentID AND sas.CompetencyID = CAOC.CompetencyID AND 
+                                         sas.CompetencyGroupID = CAOC.CompetencyGroupID
+                        WHERE        (sas.SelfAssessmentID = @selfAssessmentId) AND (sas.Optional = 0) OR
+                         (sas.SelfAssessmentID = @selfAssessmentId) AND (CAOC.IncludedInSelfAssessment = 1)
                     ),
                     {LatestAssessmentResults}
                     SELECT {CompetencyFields}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -195,6 +195,7 @@
                                          sas.CompetencyGroupID = CAOC.CompetencyGroupID
                         WHERE        (sas.SelfAssessmentID = @selfAssessmentId) AND (sas.Optional = 0) OR
                          (sas.SelfAssessmentID = @selfAssessmentId) AND (CAOC.IncludedInSelfAssessment = 1)
+						 GROUP BY sas.CompetencyID, SAS.Ordering
                     ),
                     {LatestAssessmentResults}
                     SELECT {CompetencyFields}


### PR DESCRIPTION
### JIRA link
[DLSV2-625](https://hee-dls.atlassian.net/browse/DLSV2-625)

### Description
Adds an INNER JOIN to CompetencyAssessmentQuestions to the Row Number part of the GetNthCompetency query to ensure a 1-1 match with the competencies in the result set. this ensures that the links on the self assessment overview are valid and matched.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.