### PR TITLE
DLSV2-611 Competencies that do not have a description should not be bold in the self assessment overview

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -50,7 +50,7 @@
           }
           else
           {
-            <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-0">
+            <p class="@(competency.Description != null ? "nhsuk-u-font-weight-bold" : "") nhsuk-u-margin-bottom-0">
               <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>@competency.Name
             </p>
             @if (competency.Description != null)


### PR DESCRIPTION
Competencies that do not have a description should not be bold in the self assessment overview.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-611

### Description
In overview table, added `nhsuk-u-font-weight-bold` css class only for competencies with not null description.

### Screenshots
![Untitled](https://user-images.githubusercontent.com/94055251/184943900-59cafba3-93f4-48e6-b515-63a8fac32e26.png)

-----
### Developer checks

I have:
- Checked that competencies and description and those that use the expander, are not affected by this change.