### PR TITLE
Heedls 1035 bulk resource json endpoint

### DIFF
--- a/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
+++ b/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
@@ -11,6 +11,7 @@
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
+    using JsonSerializer = System.Text.Json.JsonSerializer;
 
     public interface ILearningHubApiClient
     {
@@ -75,18 +76,19 @@
             IEnumerable<int> resourceReferenceIds
         )
         {
-            var referenceIdQueryStrings =
-                resourceReferenceIds.Select(id => GetQueryString("resourceReferenceIds", id.ToString()));
-            var queryString = string.Join("&", referenceIdQueryStrings);
+            var referenceIds = resourceReferenceIds.ToList();
+            var objectWithReferenceIds = new { referenceIds = referenceIds.ToList() };
 
-            var response = await GetStringAsync($"/Resource/Bulk?{queryString}");
+            var jsonString = JsonSerializer.Serialize(objectWithReferenceIds);
+
+            var response = await GetStringAsync($"/Resource/Bulk?{jsonString}");
             var result = JsonConvert.DeserializeObject<BulkResourceReferences>(response);
             return result;
         }
 
         public async Task<CataloguesResult> GetCatalogues()
         {
-            var response = await GetStringAsync($"/Catalogues");
+            var response = await GetStringAsync("/Catalogues");
             var result = JsonConvert.DeserializeObject<CataloguesResult>(response);
             return result;
         }
@@ -104,7 +106,8 @@
             var offSetQueryString = GetQueryString("offset", offset?.ToString());
             var limitQueryString = GetQueryString("limit", limit?.ToString());
 
-            var queryStrings = new List<string> { textQueryString, catalogueIdString, offSetQueryString, limitQueryString };
+            var queryStrings = new List<string>
+                { textQueryString, catalogueIdString, offSetQueryString, limitQueryString };
 
             if (resourceTypes != null)
             {

--- a/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
+++ b/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
@@ -80,8 +80,8 @@
             var objectWithReferenceIds = new { referenceIds = referenceIds.ToList() };
 
             var jsonString = JsonSerializer.Serialize(objectWithReferenceIds);
+            var response = await GetStringAsync($"/Resource/BulkJson?{jsonString}");
 
-            var response = await GetStringAsync($"/Resource/Bulk?{jsonString}");
             var result = JsonConvert.DeserializeObject<BulkResourceReferences>(response);
             return result;
         }


### PR DESCRIPTION
### JIRA link
[_HEEDLS-1035_](https://softwiretech.atlassian.net/browse/HEEDLS-1035)

### Description
Adjusted the bulk endpoint in the LearningHubApiClient to call the new BulkJson endpoint with a Json of the reference Ids.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
