### PR TITLE
DLSV2-614 Sign-off profile self-assessment text - HTML tags visible

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
@@ -176,7 +176,7 @@
                 Sign-off profile self-assessment
               </label>
               <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
-                @(Model.SelfAssessmentResultSummary.SignOffSupervisorStatement == null ?
+                @Html.Raw(Model.SelfAssessmentResultSummary.SignOffSupervisorStatement == null ?
                   "I confirm that this profile self-assessment accurately captures" +
                   $" {Model.SupervisorDelegate.FirstName} {Model.SupervisorDelegate.LastName}'s " +
                   "current capability in the areas assessed." :


### PR DESCRIPTION
### JIRA link
[_HEEDLS-XXXX_](https://hee-dls.atlassian.net/browse/DLSV2-614)

### Description
In Supervisor → My Staff → Review Self Assessment where a self assessment has a sign off request, reviewing the sign-off request loads some HTML from db, when it does, this text is displayed as plain text with HTML tags instead of as HTML

### Screenshots
![image](https://user-images.githubusercontent.com/111436026/185432784-4f5355c9-50ef-4334-af48-ded81e3c46bc.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [X ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
