### PR TITLE
Heedls 1038 reinstate archived courses

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -290,13 +290,13 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
         }
 
         [Test]
-        public void GetNumberOfActiveCoursesAtCentreFilteredByCategory_excludes_courses_from_archived_applications()
+        public void GetNumberOfActiveCoursesAtCentreFilteredByCategory_includes_courses_from_archived_applications()
         {
             // When
             var count = courseDataService.GetNumberOfActiveCoursesAtCentreFilteredByCategory(101, null);
 
             // Then
-            count.Should().Be(141);
+            count.Should().Be(144);
         }
 
         [Test]
@@ -324,6 +324,40 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
 
             // When
             var result = courseDataService.GetCourseStatisticsAtCentreFilteredByCategory(centreId, categoryId).ToList();
+
+            // Then
+            var expectedFirstCourse = new CourseStatistics
+            {
+                CustomisationId = 100,
+                CentreId = 101,
+                Active = false,
+                AllCentres = false,
+                ApplicationId = 1,
+                ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD",
+                CustomisationName = "Standard",
+                DelegateCount = 25,
+                AllAttempts = 49,
+                AttemptsPassed = 34,
+                CompletedCount = 5,
+                HideInLearnerPortal = false,
+                CategoryName = "Office 2007",
+                CourseTopic = "Microsoft Office",
+                LearningMinutes = "N/A",
+            };
+
+            result.Should().HaveCount(259);
+            result.First().Should().BeEquivalentTo(expectedFirstCourse);
+        }
+
+        [Test]
+        public void GetNonArchivedCourseStatisticsAtCentreFilteredByCategory_should_return_course_statistics_correctly()
+        {
+            // Given
+            const int centreId = 101;
+            int? categoryId = null;
+
+            // When
+            var result = courseDataService.GetNonArchivedCourseStatisticsAtCentreFilteredByCategory(centreId, categoryId).ToList();
 
             // Then
             var expectedFirstCourse = new CourseStatistics
@@ -446,6 +480,37 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
 
             // When
             var result = courseDataService.GetCoursesAvailableToCentreByCategory(centreId, categoryId).ToList();
+
+            // Then
+            var expectedFirstCourse = new CourseAssessmentDetails
+            {
+                CustomisationId = 100,
+                CentreId = 101,
+                ApplicationId = 1,
+                ApplicationName = "Entry Level - Win XP, Office 2003/07 OLD",
+                CustomisationName = "Standard",
+                Active = false,
+                CategoryName = "Undefined",
+                CourseTopic = "Undefined",
+                HasDiagnostic = false,
+                HasLearning = true,
+                IsAssessed = false,
+            };
+
+            result.Should().HaveCount(259);
+            result.First().Should().BeEquivalentTo(expectedFirstCourse);
+        }
+
+        [Test]
+        public void GetNonArchivedCoursesAvailableToCentreByCategory_returns_expected_values()
+        {
+            // Given
+            const int centreId = 101;
+            int? categoryId = null;
+
+            // When
+            var result = courseDataService.GetNonArchivedCoursesAvailableToCentreByCategory(centreId, categoryId)
+                .ToList();
 
             // Then
             var expectedFirstCourse = new CourseAssessmentDetails

--- a/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/CourseServiceTests.cs
@@ -550,14 +550,14 @@
             const int categoryId = 1;
             const int centreId = 1;
             var courseOptions = new List<CourseAssessmentDetails>();
-            A.CallTo(() => courseDataService.GetCoursesAvailableToCentreByCategory(centreId, categoryId))
+            A.CallTo(() => courseDataService.GetNonArchivedCoursesAvailableToCentreByCategory(centreId, categoryId))
                 .Returns(courseOptions);
 
             // When
             var result = courseService.GetCourseOptionsAlphabeticalListForCentre(centreId, categoryId);
 
             // Then
-            A.CallTo(() => courseDataService.GetCoursesAvailableToCentreByCategory(centreId, categoryId))
+            A.CallTo(() => courseDataService.GetNonArchivedCoursesAvailableToCentreByCategory(centreId, categoryId))
                 .MustHaveHappened();
             result.Should().BeEquivalentTo(courseOptions);
         }

--- a/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseAdminFieldsDataService.cs
@@ -68,8 +68,7 @@
                     LEFT JOIN CoursePrompts AS cp3
                         ON cu.CourseField3PromptID = cp3.CoursePromptID
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = cu.ApplicationID
-                    WHERE ap.ArchivedDate IS NULL
-                        AND ap.DefaultContentTypeID <> 4
+                    WHERE ap.DefaultContentTypeID <> 4
                         AND cu.CustomisationID = @customisationId",
                 new { customisationId }
             ).Single();
@@ -183,7 +182,6 @@
                     FROM Customisations AS cu
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = cu.ApplicationID
                     WHERE CustomisationID = @customisationId
-                        AND ap.ArchivedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { customisationId }
             ).Single();

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -309,7 +309,6 @@ namespace DigitalLearningSolutions.Data.DataServices
                             AND cu.Active = 1
                             AND cu.CentreID = @centreId
                             AND ca.CentreID = @centreId
-                            AND ap.ArchivedDate IS NULL
                             AND ap.DefaultContentTypeID <> 4",
                 new { centreId, adminCategoryId }
             );
@@ -346,7 +345,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                     WHERE (ap.CourseCategoryID = @categoryId OR @categoryId IS NULL)
                         AND (cu.CentreID = @centreId OR (cu.AllCentres = 1 AND ca.Active = 1))
                         AND ca.CentreID = @centreId
-                        AND ap.ArchivedDate IS NULL
+                        --AND ap.ArchivedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { centreId, categoryId }
             );
@@ -357,7 +356,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             return connection.Query<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
                     WHERE pr.CandidateID = @delegateId
-                        AND ap.ArchivedDate IS NULL
+                        --AND ap.ArchivedDate IS NULL
                         AND pr.RemovedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { delegateId }
@@ -369,7 +368,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             return connection.QuerySingleOrDefault<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
                     WHERE pr.ProgressID = @progressId
-                        AND ap.ArchivedDate IS NULL
+                        --AND ap.ArchivedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { progressId }
             );
@@ -496,7 +495,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                     INNER JOIN Applications AS ap ON ap.ApplicationID = c.ApplicationID
                     INNER JOIN CourseCategories AS cc ON ap.CourseCategoryId = cc.CourseCategoryId
                     INNER JOIN CourseTopics AS ct ON ap.CourseTopicId = ct.CourseTopicId
-                    WHERE ap.ArchivedDate IS NULL
+                    --WHERE ap.ArchivedDate IS NULL
                         AND (c.CentreID = @centreId OR c.AllCentres = 1)
                         AND (ap.CourseCategoryID = @categoryId OR @categoryId IS NULL)
                         AND EXISTS (SELECT CentreApplicationID FROM CentreApplications WHERE (ApplicationID = c.ApplicationID) AND (CentreID = @centreID) AND (Active = 1))
@@ -567,7 +566,6 @@ namespace DigitalLearningSolutions.Data.DataServices
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = c.ApplicationID
                     WHERE cn.CentreID = @centreID
                         AND (ap.CourseCategoryID = @categoryId OR @categoryId IS NULL)
-                        AND ap.ArchivedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { centreId, categoryId }
             );

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -408,7 +408,6 @@ namespace DigitalLearningSolutions.Data.DataServices
             return connection.Query<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
                     WHERE pr.CandidateID = @delegateId
-                        --AND ap.ArchivedDate IS NULL
                         AND pr.RemovedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { delegateId }
@@ -420,7 +419,6 @@ namespace DigitalLearningSolutions.Data.DataServices
             return connection.QuerySingleOrDefault<DelegateCourseInfo>(
                 $@"{selectDelegateCourseInfoQuery}
                     WHERE pr.ProgressID = @progressId
-                        --AND ap.ArchivedDate IS NULL
                         AND ap.DefaultContentTypeID <> 4",
                 new { progressId }
             );

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -156,7 +156,7 @@
             );
         }
 
-        public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>
+        private IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>
             GetNonArchivedCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(
                 int centreId,
                 int? categoryId,

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -156,6 +156,22 @@
             );
         }
 
+        public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>
+            GetNonArchivedCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(
+                int centreId,
+                int? categoryId,
+                bool includeAllCentreCourses = false
+            )
+        {
+            var allCourses = courseDataService.GetNonArchivedCourseStatisticsAtCentreFilteredByCategory(centreId, categoryId);
+            return allCourses.Where(c => c.CentreId == centreId || c.AllCentres && includeAllCentreCourses).Select(
+                c => new CourseStatisticsWithAdminFieldResponseCounts(
+                    c,
+                    courseAdminFieldsService.GetCourseAdminFieldsWithAnswerCountsForCourse(c.CustomisationId, centreId)
+                )
+            );
+        }
+
         public IEnumerable<DelegateCourseInfo> GetAllCoursesInCategoryForDelegate(
             int delegateId,
             int centreId,
@@ -335,7 +351,7 @@
         public CentreCourseDetails GetCentreCourseDetails(int centreId, int? categoryId)
         {
             var (courses, categories, topics) = (
-                GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(centreId, categoryId),
+                GetNonArchivedCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(centreId, categoryId),
                 courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId)
                     .Select(c => c.CategoryName),
                 courseTopicsDataService.GetCourseTopicsAvailableAtCentre(centreId).Select(c => c.CourseTopic));

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -257,7 +257,7 @@
             int? categoryId
         )
         {
-            var activeCourses = courseDataService.GetCoursesAvailableToCentreByCategory(centreId, categoryId)
+            var activeCourses = courseDataService.GetNonArchivedCoursesAvailableToCentreByCategory(centreId, categoryId)
                 .Where(c => c.Active = true);
             var orderedCourses = activeCourses.OrderBy(c => c.ApplicationName);
             return orderedCourses.Select(c => (c.CustomisationId, c.CourseName));


### PR DESCRIPTION
### JIRA link
_[HEEDLS-1038](https://softwiretech.atlassian.net/browse/HEEDLS-1038)_

### Description
A number of methods have been changed to no longer exclude Archived courses. Some methods have been split into exclusionary and non-exclusionary versions. Only endpoints associated with the CourseSetup section of the Tracking System should exclude archived courses. Methods addressing a specific customisation or progress entry by ID should not exclude archived courses regardless of section. This ticket only pertains to the Tracking System.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors.
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [X] Scanned over my own MR to ensure everything is as expected.
