### PR TITLE
HEEDLS-916 Fix bug with showing unverified emails held by multiple ce…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/VerifyYourEmailController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/VerifyYourEmailController.cs
@@ -71,7 +71,7 @@
             emailVerificationService.CreateEmailVerificationHashesAndSendVerificationEmails(
                 userEntity!.UserAccount,
                 unverifiedEmails,
-                config.GetCurrentSystemBaseUrl()
+                config.GetAppRootPath()
             );
 
             return RedirectToAction(

--- a/DigitalLearningSolutions.Web/ViewComponents/UnverifiedEmailListViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/UnverifiedEmailListViewComponent.cs
@@ -19,9 +19,12 @@
                 groupedEmail => groupedEmail.Select(ge => ge.centreName).ToList()
             );
 
-            return View(
-                new UnverifiedEmailListViewModel(primaryEmailIfUnverified, dictionaryOfUnverifiedEmailsAndCentreNames)
+            var model = new UnverifiedEmailListViewModel(
+                primaryEmailIfUnverified,
+                dictionaryOfUnverifiedEmailsAndCentreNames
             );
+
+            return View(model);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/UnverifiedEmailListViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/UnverifiedEmailListViewModel.cs
@@ -8,7 +8,7 @@
         public readonly bool AtLeastOneCentreEmailIsUnverified;
         public readonly string? PrimaryEmailIfUnverified;
         public readonly bool PrimaryEmailIsVerified;
-        public readonly Dictionary<string, List<string>> UnverifiedCentreEmails;
+        public readonly Dictionary<string, List<string>> UnverifiedCentreEmailsDifferentFromPrimaryEmail;
 
         public UnverifiedEmailListViewModel(
             string? primaryEmailIfUnverified,
@@ -16,17 +16,33 @@
         )
         {
             PrimaryEmailIfUnverified = primaryEmailIfUnverified;
-            UnverifiedCentreEmails = unverifiedCentreEmails;
             PrimaryEmailIsVerified = string.IsNullOrWhiteSpace(primaryEmailIfUnverified);
             AtLeastOneCentreEmailIsUnverified = unverifiedCentreEmails.Any();
+
+            CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail =
+                !PrimaryEmailIsVerified && unverifiedCentreEmails.ContainsKey(PrimaryEmailIfUnverified!)
+                    ? unverifiedCentreEmails[PrimaryEmailIfUnverified]
+                    : null;
+            PrimaryEmailIsUnverifiedAndTheSameAsAnUnverifiedCentreEmail =
+                !PrimaryEmailIsVerified && CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail != null;
+            UnverifiedCentreEmailsDifferentFromPrimaryEmail =
+                GetUnverifiedCentreEmailsDifferentFromPrimaryEmail(unverifiedCentreEmails);
         }
 
-        public List<string>? CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail =>
-            PrimaryEmailIfUnverified != null && UnverifiedCentreEmails.ContainsKey(PrimaryEmailIfUnverified)
-                ? UnverifiedCentreEmails[PrimaryEmailIfUnverified]
-                : null;
+        public List<string>? CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail { get; set; }
+        public bool PrimaryEmailIsUnverifiedAndTheSameAsAnUnverifiedCentreEmail { get; set; }
 
-        public bool PrimaryEmailIsUnverifiedAndTheSameAsAnUnverifiedCentreEmail => !PrimaryEmailIsVerified &&
-            CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail != null;
+        private Dictionary<string, List<string>> GetUnverifiedCentreEmailsDifferentFromPrimaryEmail(
+            Dictionary<string, List<string>> unverifiedCentreEmails
+        )
+        {
+            if (PrimaryEmailIsUnverifiedAndTheSameAsAnUnverifiedCentreEmail)
+            {
+                unverifiedCentreEmails.Remove(PrimaryEmailIfUnverified!);
+                return unverifiedCentreEmails;
+            }
+
+            return unverifiedCentreEmails;
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/UnverifiedEmailList/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/UnverifiedEmailList/Default.cshtml
@@ -3,11 +3,6 @@
 @model UnverifiedEmailListViewModel
 
 @{
-  var primaryEmailIsSameAsAnUnverifiedCentreEmail =
-    Model.PrimaryEmailIfUnverified != null && Model.CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail != null;
-  if (primaryEmailIsSameAsAnUnverifiedCentreEmail) {
-    Model.UnverifiedCentreEmails.Remove(Model.PrimaryEmailIfUnverified);
-  }
   var numSpecificPhrases = new {
     account = Model.CentresWhereUnverifiedCentreEmailIsSameAsPrimaryEmail?.Count == 1 ? "account" : "accounts",
   };
@@ -39,7 +34,7 @@
 }
 
 @if (Model.AtLeastOneCentreEmailIsUnverified) {
-  foreach (var ((email, centreNames), index) in Model.UnverifiedCentreEmails
+  foreach (var ((email, centreNames), index) in Model.UnverifiedCentreEmailsDifferentFromPrimaryEmail
     .Select((emailAndCentreNames, index) => (emailAndCentreNames, index))) {
     var isTheFirstEmailListed = Model.PrimaryEmailIsVerified && index == 0;
 


### PR DESCRIPTION
### JIRA link
_HEEDLS-916_

### Description
Fixed a bug with the unverified emails list view component. Now when an email is unverified and used by as a user's centre email for more than once centre, or as their primary email and a centre email, this info is displayed properly.

Also fixed the link in the resent verification emails so it points to the right site.

### Screenshots
![localhost_44363_MyAccount (9)](https://user-images.githubusercontent.com/70278044/185668750-b7c80bf4-e633-48ab-b89b-7e3c1f5e10bf.png)
![localhost_44363_VerifyYourEmail_EmailNotVerified (2)](https://user-images.githubusercontent.com/70278044/185669033-fb99379e-4fc0-46a5-8416-7161d115fe8e.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
