### PR TITLE
DLSV2-564 Makes display of overall progress consistent

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -169,12 +169,12 @@
     </a>
   }
 }
-<div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-  <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-           model="@competencySummaries"
-           view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
-  @if (Model.SelfAssessment.IsSupervised)
-  {
+@if (Model.SelfAssessment.IsSupervised)
+{
+  <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+    <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+             model="@competencySummaries"
+             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
     <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
     <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
     @if (Model.AllQuestionsVerifiedOrNotRequired())
@@ -213,5 +213,5 @@
         before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
       </p>
     }
-  }
-</div>
+  </div>
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -169,12 +169,12 @@
     </a>
   }
 }
-@if (Model.SelfAssessment.IsSupervised)
-{
-  <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-    <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-             model="@competencySummaries"
-             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+<div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+  <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+           model="@competencySummaries"
+           view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+  @if (Model.SelfAssessment.IsSupervised)
+  {
     <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
     <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
     @if (Model.AllQuestionsVerifiedOrNotRequired())
@@ -213,5 +213,5 @@
         before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
       </p>
     }
-  </div>
-}
+  }
+</div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -5,20 +5,20 @@
 @model SelfAssessmentOverviewViewModel
 
 @{
-  var latestSignoff = Model.SupervisorSignOffs
-      .Select(s => s.Verified)
+    var latestSignoff = Model.SupervisorSignOffs
+        .Select(s => s.Verified)
+        .DefaultIfEmpty(DateTime.MinValue)
+        .Max();
+    var latestResult = Model.CompetencyGroups
+      .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
+      .Select(q => q.ResultDateTime)
       .DefaultIfEmpty(DateTime.MinValue)
       .Max();
-  var latestResult = Model.CompetencyGroups
-    .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
-    .Select(q => q.ResultDateTime)
-    .DefaultIfEmpty(DateTime.MinValue)
-    .Max();
-  var competencySummaries = from g in Model.CompetencyGroups
-      let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
-      let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
-      let verifiedCount = questions.Count(q => q.Verified.HasValue)
-      select new ViewDataDictionary(ViewData)
+    var competencySummaries = from g in Model.CompetencyGroups
+                              let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
+                              let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
+                              let verifiedCount = questions.Count(q => q.Verified.HasValue)
+                              select new ViewDataDictionary(ViewData)
       {
         { "isSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed },
         { "questionsCount", questions.Count() },
@@ -26,34 +26,37 @@
         { "verifiedCount", verifiedCount }
       };
 
-  Layout = "SelfAssessments/_Layout";
-  ViewData["Title"] = "Self Assessment";
-  ViewData["SelfAssessmentTitle"] = Model.SelfAssessment.Name;
+    Layout = "SelfAssessments/_Layout";
+    ViewData["Title"] = "Self Assessment";
+    ViewData["SelfAssessmentTitle"] = Model.SelfAssessment.Name;
 }
 @section breadcrumbs {
-  <li class="nhsuk-breadcrumb__item">
-    <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
-  </li>
-  <li class="nhsuk-breadcrumb__item">@(Model.VocabPlural()) home</li>
+    <li class="nhsuk-breadcrumb__item">
+        <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
+    </li>
+    <li class="nhsuk-breadcrumb__item">@(Model.VocabPlural()) home</li>
 }
 
-@section mobilebacklink
-{
-  <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
+    @section mobilebacklink
+    {
+    <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
        asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-      Back to @Model.SelfAssessment.Name
-    </a>
-  </p>
+            Back to @Model.SelfAssessment.Name
+        </a>
+    </p>
 }
 
-<link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
-<h1>@Model.SelfAssessment.Name - @Model.VocabPlural()</h1>
-<div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-  <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-           model="@competencySummaries"
-           view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
-</div>
+    <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
+    <h1>@Model.SelfAssessment.Name - @Model.VocabPlural()</h1>
+    @if (Model.SelfAssessment.IsSupervised && Model.CompetencyGroups.Count() > 5)
+{
+    <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+        <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+             model="@competencySummaries"
+             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+    </div>
+}
 <partial name="SelfAssessments/_SearchSelfAssessmentOverview"
          model="@Model.SearchViewModel"
          view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
@@ -61,157 +64,158 @@
 <p><span role="alert">@Model.CompetencyGroups.Sum(g => g.Count()) matching @Model.VocabPlural().ToLower()</span></p>
 @if (Model.CompetencyGroups.Any())
 {
-  var competencySummariesEnumerator = competencySummaries.GetEnumerator();
-  foreach (var competencyGroup in Model.CompetencyGroups)
-  {
-    var groupDetails = competencyGroup.First();
-    var questions = competencyGroup.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
-    var selfAssessedCount = questions.Count(q => q.ResultId.HasValue);
-    var verifiedCount = questions.Count(q => q.Verified.HasValue);
-    competencySummariesEnumerator.MoveNext();
-    <div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
-      @{
-        var expanderOpen = Model.CompetencyGroups.Count() == 1
-        ? "open"
-        : ViewContext.RouteData.Values.ContainsKey("competencyGroupId")
-          ? ViewContext.RouteData.Values["competencyGroupId"].Equals(competencyGroup.First().CompetencyGroupID.ToString()) ? "open" : ""
-          : "";
-      }
-      <details class="nhsuk-details nhsuk-expander" @(expanderOpen)>
-        <summary class="nhsuk-details__summary">
-          <span class="competency-group-title nhsuk-details__summary-text">
-            @competencyGroup.Key
-          </span>
-        </summary>
-        <div class="nhsuk-details__text">
-          <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
-          @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
-          {
-            <p class="nhsuk-body-l nhsuk-u-margin-left-7">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
-          }
-          @if (Model.SelfAssessment.LinearNavigation)
-          {
-            <partial name="SelfAssessments/_MeanScores"
+    var competencySummariesEnumerator = competencySummaries.GetEnumerator();
+    foreach (var competencyGroup in Model.CompetencyGroups)
+    {
+        var groupDetails = competencyGroup.First();
+        var questions = competencyGroup.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
+        var selfAssessedCount = questions.Count(q => q.ResultId.HasValue);
+        var verifiedCount = questions.Count(q => q.Verified.HasValue);
+        competencySummariesEnumerator.MoveNext();
+        <div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
+            @{
+                var expanderOpen = Model.CompetencyGroups.Count() == 1
+                ? "open"
+                : ViewContext.RouteData.Values.ContainsKey("competencyGroupId")
+                ? ViewContext.RouteData.Values["competencyGroupId"].Equals(competencyGroup.First().CompetencyGroupID.ToString()) ? "open" : ""
+                : "";
+            }
+            <details class="nhsuk-details nhsuk-expander" @(expanderOpen)>
+                <summary class="nhsuk-details__summary">
+                    <span class="competency-group-title nhsuk-details__summary-text">
+                        @competencyGroup.Key
+                    </span>
+                </summary>
+                <div class="nhsuk-details__text">
+                    <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
+                    @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
+                    {
+                        <p class="nhsuk-body-l nhsuk-u-margin-left-7">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
+                    }
+                    @if (Model.SelfAssessment.LinearNavigation)
+                    {
+                        <partial name="SelfAssessments/_MeanScores"
                      view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
-          }
-          <style>
-            .nhsuk-expander[open] details.nhsuk-details[open] .nhsuk-details__summary-text::before {
-              display: block;
-              width: 0;
-              height: 0;
-              border-style: solid;
-              border-color: transparent;
-              clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
-              border-width: 12.124px 7px 0 7px;
-              border-top-color: inherit;
-            }
-            .nhsuk-details[open] .nhsuk-details .nhsuk-details__summary-text::before {
-              bottom: 0;
-              content: "";
-              left: 0;
-              margin: auto;
-              position: absolute;
-              top: 0;
-              display: block;
-              width: 0;
-              height: 0;
-              border-style: solid;
-              border-color: transparent;
-              clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
-              border-width: 7px 0 7px 12.124px;
-              border-left-color: inherit;
-            }
-          </style>
-          <partial name="SelfAssessments/_OverviewTable"
-                   view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation }, { "selfAssessment", Model.SelfAssessment }, { "ReviewerCommentsLabel", Model.SelfAssessment.ReviewerCommentsLabel } })"
-                   model="competencyGroup" />
+                    }
+                    <style>
+                        .nhsuk-expander[open] details.nhsuk-details[open] .nhsuk-details__summary-text::before {
+                            display: block;
+                            width: 0;
+                            height: 0;
+                            border-style: solid;
+                            border-color: transparent;
+                            clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+                            border-width: 12.124px 7px 0 7px;
+                            border-top-color: inherit;
+                        }
+
+                        .nhsuk-details[open] .nhsuk-details .nhsuk-details__summary-text::before {
+                            bottom: 0;
+                            content: "";
+                            left: 0;
+                            margin: auto;
+                            position: absolute;
+                            top: 0;
+                            display: block;
+                            width: 0;
+                            height: 0;
+                            border-style: solid;
+                            border-color: transparent;
+                            clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+                            border-width: 7px 0 7px 12.124px;
+                            border-left-color: inherit;
+                        }
+                    </style>
+                    <partial name="SelfAssessments/_OverviewTable"
+                     view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation }, { "selfAssessment", Model.SelfAssessment }, { "ReviewerCommentsLabel", Model.SelfAssessment.ReviewerCommentsLabel } })"
+                     model="competencyGroup" />
 
 
+                </div>
+            </details>
+            <div class="outer-score-container">
+                <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
+            </div>
+            @if (Model.SelfAssessment.LinearNavigation)
+            {
+                <div class="outer-score-container nhsuk-u-padding-bottom-4">
+                    <partial name="SelfAssessments/_MeanScores"
+                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                </div>
+            }
         </div>
-      </details>
-      <div class="outer-score-container">
-        <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
-      </div>
-      @if (Model.SelfAssessment.LinearNavigation)
-      {
-        <div class="outer-score-container nhsuk-u-padding-bottom-4">
-          <partial name="SelfAssessments/_MeanScores"
-                   view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
-        </div>
-      }
-    </div>
-  }
-  <partial name="_OverviewActionButtons.cshtml" model=Model />
+    }
+    <partial name="_OverviewActionButtons.cshtml" model=Model />
 }
 
 @if (Model.SelfAssessment.IncludesSignposting)
 {
-  <p class="nhsuk-u-reading-width">Once you are happy with your responses, submit your self-assessment to retrieve a list of recommended learning resources.</p>
+    <p class="nhsuk-u-reading-width">Once you are happy with your responses, submit your self-assessment to retrieve a list of recommended learning resources.</p>
 
-  @if (Configuration.IsSignpostingUsed())
-  {
-    <a class="nhsuk-button finish-review-button trigger-loader"
-       asp-controller="RecommendedLearning"
-       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-       asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-       role="button">
-      Submit results
-    </a>
-  }
-  else
-  {
-    <a class="nhsuk-button finish-review-button trigger-loader"
-       asp-controller="RecommendedLearning"
-       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-       asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-       role="button">
-      Submit self assessment
-    </a>
-  }
-}
-@if (Model.SelfAssessment.IsSupervised)
-{
-  <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-    <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-             model="@competencySummaries"
-             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
-    <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
-    <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
-    @if (Model.AllQuestionsVerifiedOrNotRequired())
+    @if (Configuration.IsSignpostingUsed())
     {
-      @if (!Model.SupervisorSignOffs.Any())
-      {
-        <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
-      }
-      else if (latestResult > latestSignoff)
-      {
-        <div class="nhsuk-warning-callout">
-          <h3 class="nhsuk-warning-callout__label">
-            <span role="text">
-              <span class="nhsuk-u-visually-hidden">New self assessment results</span>
-              New self assessment results
-            </span>
-          </h3>
-          <p>
-            You have submitted new self assessment results since this self assessment was signed off.
-            Please resubmit your self assessment for sign off once these results are confirmed.
-          </p>
-        </div>
-      }
-      <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-         asp-action="RequestSignOff"
-         asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
-         asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-         role="button">
-        Request @Model.SelfAssessment.SignOffRoleName sign-off
-      </a>
+        <a class="nhsuk-button finish-review-button trigger-loader"
+   asp-controller="RecommendedLearning"
+   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+   role="button">
+            Submit results
+        </a>
     }
     else
     {
-      <p class="nhsuk-body-l">
-        All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
-        before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
-      </p>
+        <a class="nhsuk-button finish-review-button trigger-loader"
+   asp-controller="RecommendedLearning"
+   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+   role="button">
+            Submit self assessment
+        </a>
     }
-  </div>
+}
+@if (Model.SelfAssessment.IsSupervised)
+{
+    <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+        <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+             model="@competencySummaries"
+             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+        <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
+        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
+        @if (Model.AllQuestionsVerifiedOrNotRequired())
+        {
+            @if (!Model.SupervisorSignOffs.Any())
+            {
+                <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
+            }
+            else if (latestResult > latestSignoff)
+            {
+                <div class="nhsuk-warning-callout">
+                    <h3 class="nhsuk-warning-callout__label">
+                        <span role="text">
+                            <span class="nhsuk-u-visually-hidden">New self assessment results</span>
+                            New self assessment results
+                        </span>
+                    </h3>
+                    <p>
+                        You have submitted new self assessment results since this self assessment was signed off.
+                        Please resubmit your self assessment for sign off once these results are confirmed.
+                    </p>
+                </div>
+            }
+            <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
+       asp-action="RequestSignOff"
+       asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+       role="button">
+                Request @Model.SelfAssessment.SignOffRoleName sign-off
+            </a>
+        }
+        else
+        {
+            <p class="nhsuk-body-l">
+                All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
+                before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
+            </p>
+        }
+    </div>
 }


### PR DESCRIPTION
### JIRA link
[DLSV2-564](https://hee-dls.atlassian.net/browse/DLSV2-564)

### Description
After adding the overall progress to the top of the self assessment page, it was noted that it is not, in fact, displayed at the bottom of the page for unsupervised assessments. This change hides the top overall progress for unsupervised self assessments. It also hides it if the self assessment contains less than 6 competency groups (since the lower progress is likely to be either visible or not too far away.

### Screenshots


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
