### PR TITLE
DLSV2-564 Only shows top overall progress if self assessment supervis…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -49,11 +49,14 @@
   </p>
 }
 <h1>@Model.SelfAssessment.Name - @Model.VocabPlural()</h1>
-<div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-  <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-           model="@competencySummaries"
-           view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
-</div>
+    @if (Model.SelfAssessment.IsSupervised && Model.CompetencyGroups.Count() > 5)
+{
+    <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+        <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+             model="@competencySummaries"
+             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+    </div>
+}
 <partial name="SelfAssessments/_SearchSelfAssessmentOverview"
          model="@Model.SearchViewModel"
          view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />


### PR DESCRIPTION
…ed and more than 5 competency groups

### JIRA link
[DLSV2-564](https://hee-dls.atlassian.net/browse/DLSV2-564)

### Description
After adding the overall progress to the top of the self assessment page, it was noted that it is not, in fact, displayed at the bottom of the page for unsupervised assessments. This change hides the top overall progress for unsupervised self assessments. It also hides it if the self assessment contains less than 6 competency groups (since the lower progress is likely to be either visible or not too far away.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
