### PR TITLE
DLSV2-616 Learner - Adding a filter has enabled request sign off

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -300,7 +300,8 @@
                 CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup),
                 PreviousCompetencyNumber = 2,
                 SupervisorSignOffs = supervisorSignOffs,
-                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null)
+                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
+                AllQuestionsVerifiedOrNotRequired = true
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
                 .Returns(selfAssessment);
@@ -362,7 +363,8 @@
                 CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup),
                 PreviousCompetencyNumber = 1,
                 SupervisorSignOffs = supervisorSignOffs,
-                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null)
+                SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
+                AllQuestionsVerifiedOrNotRequired = true
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
                 .Returns(selfAssessment);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -357,6 +357,8 @@
                 SupervisorSignOffs = supervisorSignOffs,
                 SearchViewModel = searchViewModel
             };
+            model.Initialise(recentResults);
+
             if (searchModel != null)
             {
                 searchModel.IsSupervisorResultsReviewed = assessment.IsSupervisorResultsReviewed;

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
@@ -10,40 +10,33 @@
     {
         public CurrentSelfAssessment SelfAssessment { get; set; }
         public IEnumerable<IGrouping<string, Competency>> CompetencyGroups { get; set; }
-
         public IEnumerable<SupervisorSignOff>? SupervisorSignOffs { get; set; }
         public int PreviousCompetencyNumber { get; set; }
         public int NumberOfOptionalCompetencies { get; set; }
+        public bool AllQuestionsVerifiedOrNotRequired { get; set; }
         public SearchSelfAssessmentOvervieviewViewModel SearchViewModel { get; set; }
         public string VocabPlural()
         {
             return FrameworkVocabularyHelper.VocabularyPlural(SelfAssessment.Vocabulary);
         }
-        public bool AllQuestionsVerifiedOrNotRequired()
+        public void Initialise(List<Competency> unfilteredCompetencies)
         {
-            bool allVerifiedOrNotRequired = true;
-            foreach (var competencyGroup in CompetencyGroups)
+            AllQuestionsVerifiedOrNotRequired = true;
+            foreach (var assessmentQuestion in unfilteredCompetencies.SelectMany(c => c.AssessmentQuestions))
             {
-                foreach (var competency in competencyGroup)
+                if ((assessmentQuestion.Result == null || assessmentQuestion.Verified == null) && assessmentQuestion.Required)
                 {
-                    foreach (var assessmentQuestion in competency.AssessmentQuestions)
-                    {
-                        if ((assessmentQuestion.Result == null || assessmentQuestion.Verified == null) && assessmentQuestion.Required)
-                        {
-                            allVerifiedOrNotRequired = false;
-                            break;
-                        }
+                    AllQuestionsVerifiedOrNotRequired = false;
+                    break;
+                }
 
-                        if (SelfAssessment.EnforceRoleRequirementsForSignOff &&
-                            assessmentQuestion.ResultRAG == 1 | assessmentQuestion.ResultRAG == 2)
-                        {
-                            allVerifiedOrNotRequired = false;
-                            break;
-                        }
-                    }
+                if (SelfAssessment.EnforceRoleRequirementsForSignOff &&
+                    (assessmentQuestion.ResultRAG == 1 || assessmentQuestion.ResultRAG == 2))
+                {
+                    AllQuestionsVerifiedOrNotRequired = false;
+                    break;
                 }
             }
-            return allVerifiedOrNotRequired;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -177,7 +177,7 @@
              view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
     <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
     <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
-    @if (Model.AllQuestionsVerifiedOrNotRequired())
+    @if (Model.AllQuestionsVerifiedOrNotRequired)
     {
       @if (!Model.SupervisorSignOffs.Any())
       {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -43,6 +43,7 @@
   @Html.HiddenFor(m => m.IsSupervisorResultsReviewed)
   @Html.HiddenFor(m => m.IncludeRequirementsFilters)
   @Html.HiddenFor(m => m.Vocabulary)
+  @Html.HiddenFor(m => m.AnyQuestionPartiallyMeetingRequirements)
   @Html.Hidden(nameof(Model.SearchText), Model.SearchText)
   @for (int i = 0; i < Model.AppliedFilters.Count; i++)
   {


### PR DESCRIPTION
Learner - Adding a filter has enabled request sign off.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-616

### Description
Button sign-off should be visible or not regardless of the filter applied by user. So I am running validation `AllQuestionsVerifiedOrNotRequired` on unfiltered competencies. 

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/186129033-89059203-9d5e-4a6d-9ce0-83caa72c6438.png)

-----
### Developer checks
Checked that given a selfassessment that doesn't display sign-off button, user cannot make the button to appear by searching for confirmed competencies
