### PR TITLE
Heedls 1042 tweaks to register by centre

### DIFF
--- a/DigitalLearningSolutions.Data/Enums/LoginAttemptResult.cs
+++ b/DigitalLearningSolutions.Data/Enums/LoginAttemptResult.cs
@@ -9,5 +9,6 @@
         AccountsHaveMismatchedPasswords,
         AccountLocked,
         UnverifiedEmail,
+        UnclaimedDelegateAccount,
     }
 }

--- a/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
@@ -25,5 +25,7 @@
         public DateTime? CentreSpecificDetailsLastChecked { get; set; }
         public string? RegistrationConfirmationHash { get; set; }
         public DateTime? RegistrationConfirmationHashCreationDateTime { get; set; }
+
+        public bool IsYetToBeClaimed => RegistrationConfirmationHash != null;
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
+namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
 {
     using System;
     using System.Collections.Generic;
@@ -243,6 +243,22 @@
             // Given
             A.CallTo(() => loginService.AttemptLogin(A<string>._, A<string>._)).Returns(
                 new LoginResult(LoginAttemptResult.InvalidCredentials)
+            );
+
+            // When
+            var result = await controller.Index(LoginTestHelper.GetDefaultLoginViewModel());
+
+            // Then
+            result.Should().BeViewResult().WithViewName("Index").ModelAs<LoginViewModel>();
+            Assert.IsFalse(controller.ModelState.IsValid);
+        }
+
+        [Test]
+        public async Task Login_to_unclaimed_delegate_account_should_render_basic_form_with_error()
+        {
+            // Given
+            A.CallTo(() => loginService.AttemptLogin(A<string>._, A<string>._)).Returns(
+                new LoginResult(LoginAttemptResult.UnclaimedDelegateAccount)
             );
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAdminControllerTests.cs
@@ -320,7 +320,7 @@
             controller.Summary(model);
 
             // Then
-            A.CallTo(() => userService.GetUserByEmailAddress(primaryEmail)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(primaryEmail)).MustHaveHappenedOnceExactly();
             A.CallTo(
                 () => emailVerificationService.CreateEmailVerificationHashesAndSendVerificationEmails(
                     A<UserAccount>._,
@@ -391,7 +391,7 @@
                 )
                 .Returns(userId);
             A.CallTo(
-                    () => userService.GetUserByEmailAddress(primaryEmail)
+                    () => userService.GetUserAccountByEmailAddress(primaryEmail)
                 )
                 .Returns(UserTestHelper.GetDefaultUserAccount(userId, primaryEmail));
             A.CallTo(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -34,6 +34,7 @@
         private PromptsService promptsService = null!;
         private IRegistrationService registrationService = null!;
         private IUserDataService userDataService = null!;
+        private IUserService userService = null!;
         private IClockUtility clockUtility = null!;
 
         [SetUp]
@@ -41,6 +42,7 @@
         {
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
             userDataService = A.Fake<IUserDataService>();
+            userService = A.Fake<IUserService>();
             promptsService = A.Fake<PromptsService>();
             cryptoService = A.Fake<ICryptoService>();
             registrationService = A.Fake<IRegistrationService>();
@@ -54,7 +56,8 @@
                     userDataService,
                     registrationService,
                     config,
-                    clockUtility
+                    clockUtility,
+                    userService
                 )
                 .WithDefaultContext()
                 .WithMockTempData();
@@ -73,7 +76,7 @@
                 CentreSpecificEmail = duplicateUser.EmailAddress,
             };
             A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentre(
+                    () => userService.EmailIsHeldAtCentre(
                         model.CentreSpecificEmail!,
                         model.Centre.Value
                     )
@@ -84,13 +87,6 @@
             var result = controller.PersonalInformation(model);
 
             // Then
-            A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentre(
-                        model.CentreSpecificEmail!,
-                        model.Centre.Value
-                    )
-                )
-                .MustHaveHappened();
             result.Should().BeViewResult().WithDefaultViewName();
         }
 
@@ -108,7 +104,7 @@
                 CentreSpecificEmail = duplicateUser.EmailAddress,
             };
             A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentre(
+                    () => userService.EmailIsHeldAtCentre(
                         model.CentreSpecificEmail!,
                         model.Centre.Value
                     )
@@ -119,13 +115,6 @@
             var result = controller.PersonalInformation(model);
 
             // Then
-            A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentre(
-                        model.CentreSpecificEmail!,
-                        model.Centre.Value
-                    )
-                )
-                .MustHaveHappened();
             result.Should().BeRedirectToActionResult().WithActionName("LearnerInformation");
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -339,7 +339,7 @@
                                     d.Answer5 == data.Answer5 &&
                                     d.Answer6 == data.Answer6 &&
                                     d.CentreAccountIsActive &&
-                                    !d.UserIsActive &&
+                                    d.UserIsActive &&
                                     d.Approved &&
                                     !d.IsSelfRegistered &&
                                     d.NotifyDate == data.WelcomeEmailDate &&

--- a/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
@@ -469,7 +469,7 @@
             A.CallTo(() => userService.EmailIsHeldAtCentre("email", 1)).Returns(true);
 
             // When
-            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetValidated(
                 "email",
                 1,
                 "EmailField",
@@ -489,7 +489,7 @@
             A.CallTo(() => userService.EmailIsHeldAtCentre("email", 1)).Returns(false);
 
             // When
-            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetValidated(
                 "email",
                 1,
                 "EmailField",
@@ -509,7 +509,7 @@
             modelState.AddModelError("EmailField", DefaultErrorMessage);
 
             // When
-            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetValidated(
                 "email",
                 1,
                 "EmailField",
@@ -528,7 +528,7 @@
             string? email = null;
 
             // When
-            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetValidated(
                 email,
                 1,
                 "EmailField",

--- a/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
@@ -1,12 +1,12 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
 {
-    using System.Collections.Generic;
     using System.Linq;
-    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Services;
     using FakeItEasy;
+    using FizzWare.NBuilder;
     using FluentAssertions;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
     using NUnit.Framework;
@@ -22,12 +22,14 @@
 
         private static ModelStateDictionary modelState = null!;
         private IUserDataService userDataService = null!;
+        private IUserService userService = null!;
         private ICentresService centresService = null!;
 
         [SetUp]
         public void Setup()
         {
             userDataService = A.Fake<IUserDataService>();
+            userService = A.Fake<IUserService>();
             centresService = A.Fake<ICentresService>();
             modelState = new ModelStateDictionary();
         }
@@ -459,6 +461,85 @@
 
             modelState.IsValid.Should().BeTrue();
         }
+
+        [Test]
+        public void ValidateEmailNotHeldAtCentre_raises_error_if_email_held_at_centre()
+        {
+            // Given
+            A.CallTo(() => userService.EmailIsHeldAtCentre("email", 1)).Returns(true);
+
+            // When
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+                "email",
+                1,
+                "EmailField",
+                modelState,
+                userService
+            );
+
+            // Then
+            modelState["EmailField"].Errors.Should()
+                .Contain(e => e.ErrorMessage == CommonValidationErrorMessages.EmailInUseAtCentre);
+        }
+
+        [Test]
+        public void ValidateEmailNotHeldAtCentre_does_not_raise_error_if_email_not_held_at_centre()
+        {
+            // Given
+            A.CallTo(() => userService.EmailIsHeldAtCentre("email", 1)).Returns(false);
+
+            // When
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+                "email",
+                1,
+                "EmailField",
+                modelState,
+                userService
+            );
+
+            // Then
+            modelState.IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void ValidateEmailNotHeldAtCentre_does_not_raise_error_if_email_already_validated()
+        {
+            // Given
+            A.CallTo(() => userService.EmailIsHeldAtCentre("email", 1)).Returns(true);
+            modelState.AddModelError("EmailField", DefaultErrorMessage);
+
+            // When
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+                "email",
+                1,
+                "EmailField",
+                modelState,
+                userService
+            );
+
+            // Then
+            modelState["EmailField"].Errors.Count.Should().Be(1);
+        }
+
+        [Test]
+        public void ValidateEmailNotHeldAtCentre_does_not_raise_error_if_email_is_null()
+        {
+            // Given
+            string? email = null;
+
+            // When
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+                email,
+                1,
+                "EmailField",
+                modelState,
+                userService
+            );
+
+            // Then
+            modelState.IsValid.Should().BeTrue();
+        }
+
 
         private static void AssertModelStateErrorIsExpected(string modelProperty, string expectedErrorMessage)
         {

--- a/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
@@ -540,7 +540,6 @@
             modelState.IsValid.Should().BeTrue();
         }
 
-
         private static void AssertModelStateErrorIsExpected(string modelProperty, string expectedErrorMessage)
         {
             var errorMessage = modelState[modelProperty].Errors.First().ErrorMessage;

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -820,7 +820,7 @@
                             Guid.TryParse(model.PrimaryEmail, out primaryEmailIsGuid) &&
                             model.NotifyDate == WelcomeEmailDate &&
                             model.IsSelfRegistered == false &&
-                            model.UserIsActive == false &&
+                            model.UserIsActive == true &&
                             model.CentreAccountIsActive == true &&
                             model.Approved == true &&
                             model.PasswordHash == null

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -44,6 +44,7 @@
         private IRegistrationService registrationService = null!;
         private ISupervisorDelegateService supervisorDelegateService = null!;
         private IUserDataService userDataService = null!;
+        private IUserService userService = null!;
 
         [SetUp]
         public void SetUp()
@@ -54,6 +55,7 @@
             );
 
             userDataService = A.Fake<IUserDataService>(x => x.Strict());
+            userService = A.Fake<IUserService>();
             registrationService = A.Fake<IRegistrationService>(x => x.Strict());
             supervisorDelegateService = A.Fake<ISupervisorDelegateService>();
             passwordResetService = A.Fake<IPasswordResetService>();
@@ -69,6 +71,7 @@
             delegateUploadFileService = new DelegateUploadFileService(
                 jobGroupsDataService,
                 userDataService,
+                userService,
                 registrationService,
                 supervisorDelegateService,
                 passwordResetService,
@@ -311,6 +314,30 @@
         }
 
         [Test]
+        public void ProcessDelegateTable_has_email_in_use_error_if_new_delegate_has_email_matching_existing_delegate()
+        {
+            var row = GetSampleDelegateDataRow(emailAddress: "email@centre.com", candidateNumber: "");
+            var table = CreateTableFromData(new[] { row });
+            A.CallTo(() => userService.EmailIsHeldAtCentre("email@centre.com", CentreId)).Returns(true);
+
+            // When
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate);
+
+            // Then
+            using (var _ = new AssertionScope())
+            {
+                AssertBulkUploadResultHasOnlyOneError(result);
+                result.Errors.First().RowNumber.Should().Be(2);
+                result.Errors.First().Reason.Should().Be(BulkUploadResult.ErrorReason.EmailAddressInUse);
+                A.CallTo(() => registrationService.CreateAccountAndReturnCandidateNumberAndDelegateId(
+                    A<DelegateRegistrationModel>._,
+                    A<bool>._,
+                    A<bool>._
+                )).MustNotHaveHappened();
+            }
+        }
+
+        [Test]
         public void
             ProcessDelegateTable_has_email_in_use_error_if_delegate_is_found_by_delegateId_but_email_exists_on_another_delegate()
         {
@@ -407,8 +434,7 @@
             var row = GetSampleDelegateDataRow(candidateNumber: string.Empty);
             var table = CreateTableFromData(new[] { row });
 
-            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre("email@test.com", CentreId))
-                .Returns(false);
+            A.CallTo(() => userService.EmailIsHeldAtCentre("email@test.com", CentreId)).Returns(false);
             A.CallTo(
                     () => registrationService.CreateAccountAndReturnCandidateNumberAndDelegateId(
                         A<DelegateRegistrationModel>._,

--- a/DigitalLearningSolutions.Web.Tests/Services/PasswordResetServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/PasswordResetServiceTests.cs
@@ -39,7 +39,7 @@
             registrationConfirmationDataService = A.Fake<IRegistrationConfirmationDataService>();
             passwordService = A.Fake<IPasswordService>();
 
-            A.CallTo(() => userService.GetUserByEmailAddress(A<string>._))
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(A<string>._))
                 .Returns(UserTestHelper.GetDefaultUserAccount());
 
             passwordResetService = new PasswordResetService(
@@ -56,7 +56,7 @@
         public void Trying_to_get_null_user_should_throw_an_exception()
         {
             // Given
-            A.CallTo(() => userService.GetUserByEmailAddress(A<string>._)).Returns(null);
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(A<string>._)).Returns(null);
 
             // Then
             Assert.ThrowsAsync<UserAccountNotFoundException>(
@@ -79,7 +79,7 @@
                 PrimaryEmail = emailAddress,
             };
 
-            A.CallTo(() => userService.GetUserByEmailAddress(emailAddress)).Returns(user);
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(emailAddress)).Returns(user);
 
             // When
             await passwordResetService.GenerateAndSendPasswordResetLink(emailAddress, "example.com");
@@ -112,7 +112,7 @@
                 ResetPasswordId = resetPasswordId,
             };
 
-            A.CallTo(() => userService.GetUserByEmailAddress(emailAddress)).Returns(user);
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(emailAddress)).Returns(user);
 
             // When
             await passwordResetService.GenerateAndSendPasswordResetLink(emailAddress, "example.com");
@@ -131,7 +131,7 @@
                 ResetPasswordId = null,
             };
 
-            A.CallTo(() => userService.GetUserByEmailAddress(emailAddress)).Returns(user);
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(emailAddress)).Returns(user);
 
             // When
             await passwordResetService.GenerateAndSendPasswordResetLink(emailAddress, "example.com");

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -404,7 +404,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             );
             var userAccount = UserTestHelper.GetDefaultUserAccount();
 
-            A.CallTo(() => userService.GetUserByEmailAddress(primaryEmail)).Returns(userAccount);
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(primaryEmail)).Returns(userAccount);
             A.CallTo(
                 () => emailVerificationService.CreateEmailVerificationHashesAndSendVerificationEmails(
                     A<UserAccount>._,
@@ -422,7 +422,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             );
 
             // Then
-            A.CallTo(() => userService.GetUserByEmailAddress(primaryEmail)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(primaryEmail)).MustHaveHappenedOnceExactly();
             A.CallTo(
                 () => emailVerificationService.CreateEmailVerificationHashesAndSendVerificationEmails(
                     userAccount,
@@ -451,7 +451,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             );
             var userAccount = UserTestHelper.GetDefaultUserAccount();
 
-            A.CallTo(() => userService.GetUserByEmailAddress(A<string>._)).Returns(userAccount);
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(A<string>._)).Returns(userAccount);
             A.CallTo(
                 () => emailVerificationService.CreateEmailVerificationHashesAndSendVerificationEmails(
                     A<UserAccount>._,
@@ -469,7 +469,7 @@ namespace DigitalLearningSolutions.Web.Tests.Services
             );
 
             // Then
-            A.CallTo(() => userService.GetUserByEmailAddress(primaryEmail)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => userService.GetUserAccountByEmailAddress(primaryEmail)).MustHaveHappenedOnceExactly();
             A.CallTo(
                 () => emailVerificationService.CreateEmailVerificationHashesAndSendVerificationEmails(
                     userAccount,

--- a/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RegistrationServiceTests.cs
@@ -1058,6 +1058,34 @@ namespace DigitalLearningSolutions.Web.Tests.Services
         }
 
         [Test]
+        public void RegisterDelegateByCentre_throws_if_email_already_held_by_a_user_at_the_centre()
+        {
+            // Given
+            var model = RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel(
+                centreSpecificEmail: "email",
+                centre: 1
+            );
+            A.CallTo(
+                    () => userService.EmailIsHeldAtCentre(
+                        "email",
+                        1
+                    )
+                )
+                .Returns(true);
+
+            // When
+            Action action = () => registrationService.RegisterDelegateByCentre(
+                model,
+                "",
+                false
+            );
+
+            // Then
+            action.Should().Throw<DelegateCreationFailedException>().Which.Error.Should()
+                .Be(DelegateCreationError.EmailAlreadyInUse);
+        }
+
+        [Test]
         public void
             PromoteDelegateToAdmin_throws_AdminCreationFailedException_if_active_admin_already_exists()
         {

--- a/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
-    using ClosedXML.Excel;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Exceptions;

--- a/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/UserServiceTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
+    using ClosedXML.Excel;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Exceptions;
@@ -1302,6 +1303,76 @@
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => userDataService.SetCentreEmailVerified(userId, email, verifiedDateTime))
                 .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void EmailIsHeldAtCentre_returns_true_if_email_used_as_centre_email()
+        {
+            // Given
+            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre("email", 1)).Returns(true);
+
+            // When
+            var result = userService.EmailIsHeldAtCentre("email", 1);
+
+            // Then
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void EmailIsHeldAtCentre_returns_true_if_used_as_primary_email_by_user_at_centre()
+        {
+            // Given
+            GivenPrimaryEmailHolderDelegateAccountIsAtCentre("email", 1);
+
+            // When
+            var result = userService.EmailIsHeldAtCentre("email", 1);
+
+            // Then
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void EmailIsHeldAtCentre_returns_false_if_email_not_used_at_all()
+        {
+            // Given
+            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre("email", 1)).Returns(false);
+            A.CallTo(() => userDataService.GetUserAccountByPrimaryEmail("email")).Returns(null);
+
+            // When
+            var result = userService.EmailIsHeldAtCentre("email", 1);
+
+            // Then
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void EmailIsHeldAtCentre_returns_false_if_email_used_only_at_other_centres()
+        {
+            // Given
+            GivenPrimaryEmailHolderDelegateAccountIsAtCentre("email", 2);
+            A.CallTo(() => userDataService.CentreSpecificEmailIsInUseAtCentre("email", 1)).Returns(false);
+
+            // When
+            var result = userService.EmailIsHeldAtCentre("email", 1);
+
+            // Then
+            result.Should().BeFalse();
+        }
+
+        private void GivenPrimaryEmailHolderDelegateAccountIsAtCentre(string emailAddress, int centreId)
+        {
+            var primaryEmailHolderUserAccount = Builder<UserAccount>.CreateNew()
+                .With(u => u.Id = 1)
+                .Build();
+
+            var primaryEmailHolderDelegateAccount = Builder<DelegateAccount>.CreateNew()
+                .With(da => da.CentreId = centreId)
+                .Build();
+
+            A.CallTo(() => userDataService.GetUserAccountByPrimaryEmail(emailAddress))
+                .Returns(primaryEmailHolderUserAccount);
+            A.CallTo(() => userDataService.GetDelegateAccountsByUserId(1))
+                .Returns(new[] { primaryEmailHolderDelegateAccount });
         }
 
         private void AssertAdminPermissionsCalledCorrectly(

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -72,6 +72,7 @@
             switch (loginResult.LoginAttemptResult)
             {
                 case LoginAttemptResult.InvalidCredentials:
+                case LoginAttemptResult.UnclaimedDelegateAccount:
                     ModelState.AddModelError("Password", "The credentials you have entered are incorrect");
                     return View("Index", model);
                 case LoginAttemptResult.AccountsHaveMismatchedPasswords:

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAdminController.cs
@@ -331,7 +331,7 @@
             string? centreSpecificEmail
         )
         {
-            var userAccount = userService.GetUserByEmailAddress(primaryEmail);
+            var userAccount = userService.GetUserAccountByEmailAddress(primaryEmail);
 
             var unverifiedEmails = new List<string> { primaryEmail };
             if (centreSpecificEmail != null)

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -282,7 +282,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void ValidateEmailAddress(RegisterDelegatePersonalInformationViewModel model)
         {
-            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetValidated(
                 model.CentreSpecificEmail,
                 model.Centre!.Value,
                 nameof(RegisterDelegatePersonalInformationViewModel.CentreSpecificEmail),

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -39,6 +39,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         private readonly IRegistrationService registrationService;
         private readonly IUserDataService userDataService;
         private readonly IClockUtility clockUtility;
+        private readonly IUserService userService;
 
         public RegisterDelegateByCentreController(
             IJobGroupsDataService jobGroupsDataService,
@@ -47,7 +48,8 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             IUserDataService userDataService,
             IRegistrationService registrationService,
             IConfiguration config,
-            IClockUtility clockUtility
+            IClockUtility clockUtility,
+            IUserService userService
         )
         {
             this.jobGroupsDataService = jobGroupsDataService;
@@ -57,6 +59,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             this.cryptoService = cryptoService;
             this.config = config;
             this.clockUtility = clockUtility;
+            this.userService = userService;
         }
 
         [Route("/TrackingSystem/Delegates/Register")]
@@ -279,12 +282,12 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void ValidateEmailAddress(RegisterDelegatePersonalInformationViewModel model)
         {
-            RegistrationEmailValidator.ValidateCentreEmailIfNecessary(
+            RegistrationEmailValidator.ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
                 model.CentreSpecificEmail,
-                model.Centre,
+                model.Centre!.Value,
                 nameof(RegisterDelegatePersonalInformationViewModel.CentreSpecificEmail),
                 ModelState,
-                userDataService
+                userService
             );
         }
 

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -42,6 +42,27 @@
             }
         }
 
+        public static void ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+            string? email,
+            int centreId,
+            string nameOfFieldToValidate,
+            ModelStateDictionary modelState,
+            IUserService userService
+        )
+        {
+            if (!IsValidationNecessary(email, nameOfFieldToValidate, modelState))
+            {
+                return;
+            }
+
+            var emailIsHeldAtCentre = userService.EmailIsHeldAtCentre(email, centreId);
+
+            if (emailIsHeldAtCentre)
+            {
+                modelState.AddModelError(nameOfFieldToValidate, CommonValidationErrorMessages.EmailInUseAtCentre);
+            }
+        }
+
         public static void ValidateCentreEmailWithUserIdIfNecessary(
             string? centreEmail,
             int? centreId,

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -42,7 +42,7 @@
             }
         }
 
-        public static void ValidateEmailNotHeldAtCentreIfEmailNotYetVerified(
+        public static void ValidateEmailNotHeldAtCentreIfEmailNotYetValidated(
             string? email,
             int centreId,
             string nameOfFieldToValidate,

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationMappingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationMappingHelper.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
     using System;
+    using DigitalLearningSolutions.Data.Models.DelegateUpload;
     using DigitalLearningSolutions.Data.Models.Register;
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Models;
@@ -101,6 +102,35 @@
                 data.ProfessionalRegistrationNumber,
                 true,
                 data.WelcomeEmailDate
+            );
+        }
+
+        public static DelegateRegistrationModel MapDelegateUploadTableRowToDelegateRegistrationModel(
+            DelegateTableRow delegateTableRow,
+            DateTime welcomeEmailDate,
+            int centreId
+        )
+        {
+            return new DelegateRegistrationModel(
+                delegateTableRow.FirstName!,
+                delegateTableRow.LastName!,
+                Guid.NewGuid().ToString(),
+                delegateTableRow.Email,
+                centreId,
+                delegateTableRow.JobGroupId!.Value,
+                null,
+                delegateTableRow.Answer1,
+                delegateTableRow.Answer2,
+                delegateTableRow.Answer3,
+                delegateTableRow.Answer4,
+                delegateTableRow.Answer5,
+                delegateTableRow.Answer6,
+                false,
+                delegateTableRow.Active!.Value,
+                false,
+                delegateTableRow.Prn,
+                true,
+                welcomeEmailDate
             );
         }
     }

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationMappingHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationMappingHelper.cs
@@ -98,7 +98,7 @@
                 data.Answer6,
                 false,
                 true,
-                false,
+                true,
                 data.ProfessionalRegistrationNumber,
                 true,
                 data.WelcomeEmailDate
@@ -127,7 +127,7 @@
                 delegateTableRow.Answer6,
                 false,
                 delegateTableRow.Active!.Value,
-                false,
+                true,
                 delegateTableRow.Prn,
                 true,
                 welcomeEmailDate

--- a/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
@@ -16,6 +16,7 @@ namespace DigitalLearningSolutions.Web.Services
     using DigitalLearningSolutions.Data.Models.Register;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Utilities;
+    using DigitalLearningSolutions.Web.Helpers;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
 
@@ -217,20 +218,20 @@ namespace DigitalLearningSolutions.Web.Services
             }
         }
 
-        private void RegisterDelegate(DelegateTableRow delegateRow, DateTime welcomeEmailDate, int centreId)
+        private void RegisterDelegate(DelegateTableRow delegateTableRow, DateTime welcomeEmailDate, int centreId)
         {
-            var model = new DelegateRegistrationModel(delegateRow, centreId, welcomeEmailDate);
+            var model = RegistrationMappingHelper.MapDelegateUploadTableRowToDelegateRegistrationModel(delegateTableRow, welcomeEmailDate, centreId);
 
             var (delegateId, _) =
                 registrationService.CreateAccountAndReturnCandidateNumberAndDelegateId(model, false, true);
 
             UpdateUserProfessionalRegistrationNumberIfNecessary(
-                delegateRow.HasPrn,
-                delegateRow.Prn,
+                delegateTableRow.HasPrn,
+                delegateTableRow.Prn,
                 delegateId
             );
 
-            SetUpSupervisorDelegateRelations(delegateRow.Email!, centreId, delegateId);
+            SetUpSupervisorDelegateRelations(delegateTableRow.Email!, centreId, delegateId);
 
             passwordResetService.GenerateAndScheduleDelegateWelcomeEmail(
                 delegateId,
@@ -239,7 +240,7 @@ namespace DigitalLearningSolutions.Web.Services
                 "DelegateBulkUpload_Refactor"
             );
 
-            delegateRow.RowStatus = RowStatus.Registered;
+            delegateTableRow.RowStatus = RowStatus.Registered;
         }
 
         private void UpdateUserProfessionalRegistrationNumberIfNecessary(

--- a/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
@@ -35,10 +35,12 @@ namespace DigitalLearningSolutions.Web.Services
         private readonly IRegistrationService registrationService;
         private readonly ISupervisorDelegateService supervisorDelegateService;
         private readonly IUserDataService userDataService;
+        private readonly IUserService userService;
 
         public DelegateUploadFileService(
             IJobGroupsDataService jobGroupsDataService,
             IUserDataService userDataService,
+            IUserService userService,
             IRegistrationService registrationService,
             ISupervisorDelegateService supervisorDelegateService,
             IPasswordResetService passwordResetService,
@@ -49,6 +51,7 @@ namespace DigitalLearningSolutions.Web.Services
         {
             this.jobGroupsDataService = jobGroupsDataService;
             this.userDataService = userDataService;
+            this.userService = userService;
             this.registrationService = registrationService;
             this.supervisorDelegateService = supervisorDelegateService;
             this.passwordResetService = passwordResetService;
@@ -104,7 +107,7 @@ namespace DigitalLearningSolutions.Web.Services
 
             if (string.IsNullOrEmpty(delegateRow.CandidateNumber))
             {
-                if (userDataService.CentreSpecificEmailIsInUseAtCentre(delegateRow.Email!, centreId))
+                if (userService.EmailIsHeldAtCentre(delegateRow.Email, centreId))
                 {
                     delegateRow.Error = BulkUploadResult.ErrorReason.EmailAddressInUse;
                     return;

--- a/DigitalLearningSolutions.Web/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Web/Services/LoginService.cs
@@ -40,6 +40,11 @@
                 return new LoginResult(LoginAttemptResult.InvalidCredentials);
             }
 
+            if (userEntity.DelegateAccounts.Any(da => da.IsYetToBeClaimed))
+            {
+                return new LoginResult(LoginAttemptResult.UnclaimedDelegateAccount);
+            }
+
             var verificationResult = userVerificationService.VerifyUserEntity(password, userEntity);
 
             if (verificationResult.PasswordMatchesAtLeastOneAccountPassword &&

--- a/DigitalLearningSolutions.Web/Services/PasswordResetService.cs
+++ b/DigitalLearningSolutions.Web/Services/PasswordResetService.cs
@@ -76,7 +76,7 @@
 
         public async Task GenerateAndSendPasswordResetLink(string emailAddress, string baseUrl)
         {
-            var user = userService.GetUserByEmailAddress(emailAddress);
+            var user = userService.GetUserAccountByEmailAddress(emailAddress);
 
             if (user == null)
             {

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -159,7 +159,7 @@ namespace DigitalLearningSolutions.Web.Services
                 SendApprovalEmailToAdmins(delegateRegistrationModel, refactoredTrackingSystemEnabled);
             }
 
-            var userAccount = userService.GetUserByEmailAddress(delegateRegistrationModel.PrimaryEmail);
+            var userAccount = userService.GetUserAccountByEmailAddress(delegateRegistrationModel.PrimaryEmail);
             var unverifiedEmails = new List<string>
                     { delegateRegistrationModel.PrimaryEmail, delegateRegistrationModel.CentreSpecificEmail }
                 .Where(email => email != null).ToList();

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -297,6 +297,14 @@ namespace DigitalLearningSolutions.Web.Services
         {
             using var transaction = new TransactionScope();
 
+            if (userService.EmailIsHeldAtCentre(
+                    delegateRegistrationModel.CentreSpecificEmail,
+                    delegateRegistrationModel.Centre
+                ))
+            {
+                throw new DelegateCreationFailedException(DelegateCreationError.EmailAlreadyInUse);
+            }
+
             var (delegateId, candidateNumber) = CreateAccountAndReturnCandidateNumberAndDelegateId(
                 delegateRegistrationModel,
                 registerJourneyContainsTermsAndConditions,

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -328,9 +328,8 @@ namespace DigitalLearningSolutions.Web.Services
             return userDataService.GetCentreEmail(userId, centreId);
         }
 
-        public IEnumerable<(int centreId, string centreName, string? centreSpecificEmail)> GetAllActiveCentreEmailsForUser(
-            int userId
-        )
+        public IEnumerable<(int centreId, string centreName, string? centreSpecificEmail)>
+            GetAllActiveCentreEmailsForUser(int userId)
         {
             return userDataService.GetAllActiveCentreEmailsForUser(userId);
         }

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -79,7 +79,7 @@ namespace DigitalLearningSolutions.Web.Services
 
         public UserAccount? GetUserAccountById(int userId);
 
-        UserAccount? GetUserByEmailAddress(string emailAddress);
+        UserAccount? GetUserAccountByEmailAddress(string emailAddress);
 
         string? GetCentreEmail(int userId, int centreId);
 
@@ -284,7 +284,7 @@ namespace DigitalLearningSolutions.Web.Services
             return userDataService.GetUserAccountById(userId);
         }
 
-        public UserAccount? GetUserByEmailAddress(string emailAddress)
+        public UserAccount? GetUserAccountByEmailAddress(string emailAddress)
         {
             return userDataService.GetUserAccountByPrimaryEmail(emailAddress);
         }

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -97,6 +97,8 @@ namespace DigitalLearningSolutions.Web.Services
         EmailVerificationDetails? GetEmailVerificationDetails(string email, string code);
 
         void SetEmailVerified(int userId, string email, DateTime verifiedDateTime);
+
+        bool EmailIsHeldAtCentre(string? email, int centreId);
     }
 
     public class UserService : IUserService
@@ -497,6 +499,23 @@ namespace DigitalLearningSolutions.Web.Services
         {
             userDataService.SetPrimaryEmailVerified(userId, email, verifiedDateTime);
             userDataService.SetCentreEmailVerified(userId, email, verifiedDateTime);
+        }
+
+        public bool EmailIsHeldAtCentre(string email, int centreId)
+        {
+            var inUseAsCentreEmailAtCentre = userDataService.CentreSpecificEmailIsInUseAtCentre(email!, centreId);
+
+            var primaryEmailOwnerIsAtCentre = EmailIsHeldAsPrimaryEmailByUserAtCentre(email, centreId);
+
+            return inUseAsCentreEmailAtCentre || primaryEmailOwnerIsAtCentre;
+        }
+
+        private bool EmailIsHeldAsPrimaryEmailByUserAtCentre(string email, int centreId)
+        {
+            var primaryEmailOwner = userDataService.GetUserAccountByPrimaryEmail(email);
+            var primaryEmailOwnerIsAtCentre = primaryEmailOwner != null && userDataService
+                .GetDelegateAccountsByUserId(primaryEmailOwner.Id).Any(da => da.CentreId == centreId);
+            return primaryEmailOwnerIsAtCentre;
         }
 
         private bool NewUserRolesExceedAvailableSpots(


### PR DESCRIPTION
### JIRA link
[_HEEDLS-1042_](https://softwiretech.atlassian.net/browse/HEEDLS-1042)

### Description
Tweaks to Register By Centre:
* Make user entity tied to unclaimed delegate active
* Prevent login to unclaimed delegate
* Prevent registration-by-centre of an email address which is being used as primary email by someone who already has a delegate account at the centre.

### Screenshots

Upload where email matches primary email of existing delegate at centre
![image](https://user-images.githubusercontent.com/34240660/186405293-acfac4a0-6e47-4576-bb58-7ce41afc39dc.png)

Register where email matches primary email of existing delegate at centre
![image](https://user-images.githubusercontent.com/34240660/186405933-03764858-35f9-4a72-88ed-37a6aba48f54.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
