### PR TITLE
HEEDLS-1036: Fix - use candidateAssessmentId instead of selfAssessmentId

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CandidateAssessmentsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CandidateAssessmentsDataServiceTests.cs
@@ -288,6 +288,7 @@
             const int delegateId = 254480;
             var expectedCandidateAssessment = new CandidateAssessment
             {
+                Id = 1,
                 DelegateId = delegateId,
                 SelfAssessmentId = SelfAssessmentId,
                 CompletedDate = null,

--- a/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/ActionPlanServiceTests.cs
@@ -8,6 +8,7 @@
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
     using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using DigitalLearningSolutions.Data.Models.LearningResources;
+    using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Data.Services;
     using FakeItEasy;
     using FizzWare.NBuilder;
@@ -64,6 +65,7 @@
             const int learningResourceReferenceId = 1;
             const int delegateId = 2;
             const int selfAssessmentId = 3;
+            const int candidateAssessmentId = 4;
             const string resourceName = "Activity";
             const string resourceLink = "www.test.com";
             const int learningLogId = 4;
@@ -93,6 +95,11 @@
             A.CallTo(() => selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(selfAssessmentId))
                 .Returns(assessmentCompetencies);
 
+            A.CallTo(() => selfAssessmentDataService.GetCandidateAssessments(delegateId, selfAssessmentId))
+                .Returns(
+                    new[] { Builder<CandidateAssessment>.CreateNew().With(ca => ca.Id = candidateAssessmentId).Build() }
+                );
+
             A.CallTo(
                 () => learningLogItemsDataService.InsertLearningLogItem(
                     A<int>._,
@@ -120,7 +127,7 @@
             ).MustHaveHappenedOnceExactly();
             A.CallTo(
                 () => learningLogItemsDataService.InsertCandidateAssessmentLearningLogItem(
-                    selfAssessmentId,
+                    candidateAssessmentId,
                     learningLogId
                 )
             ).MustHaveHappenedOnceExactly();

--- a/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
@@ -21,7 +21,7 @@
             int learningResourceReferenceId
         );
 
-        void InsertCandidateAssessmentLearningLogItem(int assessmentId, int learningLogId);
+        void InsertCandidateAssessmentLearningLogItem(int candidateAssessmentId, int learningLogId);
 
         void InsertLearningLogItemCompetencies(int learningLogId, int competencyId, DateTime associatedDate);
 
@@ -156,13 +156,13 @@
             return learningLogItemId;
         }
 
-        public void InsertCandidateAssessmentLearningLogItem(int assessmentId, int learningLogId)
+        public void InsertCandidateAssessmentLearningLogItem(int candidateAssessmentId, int learningLogId)
         {
             connection.Execute(
                 @"INSERT INTO CandidateAssessmentLearningLogItems
                     (CandidateAssessmentID, LearningLogItemID)
-                    VALUES (@assessmentId, @learningLogId)",
-                new { assessmentId, learningLogId }
+                    VALUES (@candidateAssessmentId, @learningLogId)",
+                new { candidateAssessmentId, learningLogId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -235,6 +235,7 @@
         {
             return connection.Query<CandidateAssessment>(
                 @"SELECT
+                        ID,
                         CandidateId AS DelegateId,
                         SelfAssessmentID,
                         CompletedDate,

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CandidateAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CandidateAssessment.cs
@@ -4,6 +4,8 @@
 
     public class CandidateAssessment
     {
+        public int Id { get; set; }
+
         public int DelegateId { get; set; }
 
         public int SelfAssessmentId { get; set; }

--- a/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Data/Services/ActionPlanService.cs
@@ -111,7 +111,23 @@
                 learningResourceReferenceId
             );
 
-            learningLogItemsDataService.InsertCandidateAssessmentLearningLogItem(selfAssessmentId, learningLogItemId);
+            // We can assume a single Candidate Assessment because we'll be adding a uniqueness constraint
+            // on CandidateAssessments (candidateId, selfAssessmentId) before releasing (see HEEDLS-932)
+            var candidateAssessmentIdIfAny = selfAssessmentDataService
+                .GetCandidateAssessments(delegateId, selfAssessmentId)
+                .SingleOrDefault()?.Id;
+
+            if (candidateAssessmentIdIfAny == null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot add resource to action plan as user {delegateId} is not enrolled on self assessment {selfAssessmentId}"
+                );
+            }
+
+            learningLogItemsDataService.InsertCandidateAssessmentLearningLogItem(
+                candidateAssessmentIdIfAny!.Value,
+                learningLogItemId
+            );
 
             foreach (var competencyId in learningLogCompetenciesToAdd)
             {


### PR DESCRIPTION
### JIRA link
[_HEEDLS-1036_](https://softwiretech.atlassian.net/browse/HEEDLS-1036?focusedCommentId=269006)


### Description
Bug fix: When resources were being added to an action plan, an entity was being added to CandidateAssessmentLearningLogItems with the _self assessment id_ as the FK to _CandidateAssessments_. This was wrong: it should have been the _candidate assessment id_.


### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
