### PR TITLE
DLSV2-560 Prevent error when navigating back after deleting a delegate

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -166,8 +166,12 @@
         [Route("/Supervisor/Staff/{supervisorDelegateId}/Remove")]
         public IActionResult RemoveSupervisorDelegateConfirm(int supervisorDelegateId, ReturnPageQuery returnPageQuery)
         {
-            var superviseDelegate =
-                supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminID(), 0);
+            var superviseDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminID(), 0);
+            if(superviseDelegate == null)
+            {
+                return RedirectToAction("MyStaffList");
+            }
+
             var model = new SupervisorDelegateViewModel(superviseDelegate, returnPageQuery);
             return View("RemoveConfirm", model);
         }


### PR DESCRIPTION
After deleting a delegate in Supervisor application (with confirmation prompt), prevent error as user navigates back by clicking browser's Back button.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-560

### Description
Check that delegate is not null before returning delete confirmation page. If delegate is null, return to My Staff list, as the delegate is already deleted or it doesn't exists. 

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/186632344-dd7d4d15-74e5-4592-b858-b90b017461fe.png)

-----
### Developer checks

After confirming deletion, back button redirects to My Staff list.

