### PR TITLE
DLSV2-535 Use competency name instead of description in confirmation requests view

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
@@ -59,7 +59,7 @@
       <tr role="row" class="nhsuk-table__row">
         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
           <span class="nhsuk-table-responsive__heading">Comptenecy </span>
-          @DisplayStringHelper.RemoveMarkup(competency.Description)
+          @competency.Name
         </td>
         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
           <span class="nhsuk-table-responsive__heading">Question </span>


### PR DESCRIPTION
Use competency name instead of competency description in Confirmation Requests view. Description could be blank in the database.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-535

### Description
Edited `ReviewConfirmationRequests.cshtml` for using competency `Name` property instead of `Description`.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/186659819-75e0d742-df9a-45bf-b1ea-b747c90c3417.png)

-----
### Developer checks
Checked that there are no blank or null competency names in UAT database table Competencies: `select * from Competencies where [Name] is null or trim([Name]) = ''`
