### PR TITLE
Heedls 1024 verify multiple accounts together

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserCentreDetailsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserCentreDetailsDataServiceTests.cs
@@ -515,7 +515,7 @@
             var result = userDataService.GetCentreEmailVerificationDetails(code);
 
             // Then
-            result!.CentreIdIfEmailIsForUnapprovedDelegate.Should().Be(null);
+            result.Single().CentreIdIfEmailIsForUnapprovedDelegate.Should().Be(null);
         }
 
         [Test]
@@ -544,7 +544,7 @@
             var result = userDataService.GetCentreEmailVerificationDetails(code);
 
             // Then
-            result!.CentreIdIfEmailIsForUnapprovedDelegate.Should().Be(centreId);
+            result.Single().CentreIdIfEmailIsForUnapprovedDelegate.Should().Be(centreId);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserCentreDetailsDataService.cs
@@ -111,9 +111,9 @@
             );
         }
 
-        public EmailVerificationDetails? GetCentreEmailVerificationDetails(string code)
+        public IEnumerable<EmailVerificationDetails> GetCentreEmailVerificationDetails(string code)
         {
-            return connection.QuerySingleOrDefault<EmailVerificationDetails>(
+            return connection.Query<EmailVerificationDetails>(
                 @"SELECT
                         u.UserId,
                         u.Email,

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -196,7 +196,7 @@
 
         EmailVerificationDetails? GetPrimaryEmailVerificationDetails(string code);
 
-        EmailVerificationDetails? GetCentreEmailVerificationDetails(string code);
+        IEnumerable<EmailVerificationDetails> GetCentreEmailVerificationDetails(string code);
 
         void SetPrimaryEmailVerified(int userId, string email, DateTime verifiedDateTime);
 

--- a/DigitalLearningSolutions.Data/Models/EmailVerificationTransactionData.cs
+++ b/DigitalLearningSolutions.Data/Models/EmailVerificationTransactionData.cs
@@ -1,0 +1,30 @@
+﻿namespace DigitalLearningSolutions.Data.Models
+{
+    using System;
+
+    public class EmailVerificationTransactionData
+    {
+        public EmailVerificationTransactionData() { } // Constructor for Builder to use in tests
+
+        public EmailVerificationTransactionData(
+            string email,
+            DateTime hashCreationDate,
+            int? centreIdIfEmailIsForUnapprovedDelegate,
+            int userId
+        )
+        {
+            Email = email;
+            HashCreationDate = hashCreationDate;
+            CentreIdIfEmailIsForUnapprovedDelegate = centreIdIfEmailIsForUnapprovedDelegate;
+            UserId = userId;
+        }
+
+        public string Email { get; set; }
+
+        public int UserId { get; set; }
+
+        public DateTime? HashCreationDate { get; set; }
+
+        public int? CentreIdIfEmailIsForUnapprovedDelegate { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -94,7 +94,10 @@ namespace DigitalLearningSolutions.Web.Services
         (string? primaryEmail, List<(int centreId, string centreName, string centreEmail)> centreEmails)
             GetUnverifiedEmailsForUser(int userId);
 
-        EmailVerificationDetails? GetEmailVerificationDetails(string email, string code);
+        EmailVerificationTransactionData? GetEmailVerificationDataIfCodeMatchesAnyUnverifiedEmails(
+            string email,
+            string code
+        );
 
         void SetEmailVerified(int userId, string email, DateTime verifiedDateTime);
     }
@@ -326,9 +329,8 @@ namespace DigitalLearningSolutions.Web.Services
             return userDataService.GetCentreEmail(userId, centreId);
         }
 
-        public IEnumerable<(int centreId, string centreName, string? centreSpecificEmail)> GetAllActiveCentreEmailsForUser(
-            int userId
-        )
+        public IEnumerable<(int centreId, string centreName, string? centreSpecificEmail)>
+            GetAllActiveCentreEmailsForUser(int userId)
         {
             return userDataService.GetAllActiveCentreEmailsForUser(userId);
         }
@@ -470,27 +472,48 @@ namespace DigitalLearningSolutions.Web.Services
             }
         }
 
-        public EmailVerificationDetails? GetEmailVerificationDetails(string email, string code)
+        public EmailVerificationTransactionData? GetEmailVerificationDataIfCodeMatchesAnyUnverifiedEmails(
+            string email,
+            string code
+        )
         {
             var primaryEmailVerificationDetails = userDataService.GetPrimaryEmailVerificationDetails(code);
             var centreEmailVerificationDetails = userDataService.GetCentreEmailVerificationDetails(code);
 
-            if (primaryEmailVerificationDetails != null && centreEmailVerificationDetails != null)
+            var allVerificationDetails = centreEmailVerificationDetails
+                .Concat(new[] { primaryEmailVerificationDetails })
+                .Where(details => details != null)
+                .ToList();
+
+            var usersMatchedByCode = allVerificationDetails.Select(d => d.UserId).Distinct().ToList();
+
+            if (usersMatchedByCode.Count > 1)
             {
-                throw new Exception("Did not expect multiple records to match email verification code");
+                throw new InvalidOperationException(
+                    $"Email verification hash matches multiple users: {string.Join(", ", usersMatchedByCode)}"
+                );
             }
 
-            if (email == primaryEmailVerificationDetails?.Email)
+            var unverifiedEmailDataMatchingEmail = allVerificationDetails
+                .Where(details => details != null && details.Email == email && !details.IsEmailVerified)
+                .ToList();
+
+            if (!unverifiedEmailDataMatchingEmail.Any())
             {
-                return primaryEmailVerificationDetails;
+                return null;
             }
 
-            if (email == centreEmailVerificationDetails?.Email)
-            {
-                return centreEmailVerificationDetails;
-            }
+            // We can assume the hash entity is the same for all the records as we searched by hash
+            var hashCreationDate = unverifiedEmailDataMatchingEmail.First().EmailVerificationHashCreatedDate;
 
-            return null;
+            return new EmailVerificationTransactionData(
+                email,
+                hashCreationDate,
+                unverifiedEmailDataMatchingEmail
+                    .FirstOrDefault(details => details.CentreIdIfEmailIsForUnapprovedDelegate != null)
+                    ?.CentreIdIfEmailIsForUnapprovedDelegate,
+                usersMatchedByCode.SingleOrDefault()
+            );
         }
 
         public void SetEmailVerified(int userId, string email, DateTime verifiedDateTime)


### PR DESCRIPTION
### JIRA link
[_HEEDLS-1024_](https://softwiretech.atlassian.net/browse/HEEDLS-1024?focusedCommentId=268685)

### Description
Fixed bug found with ticket.
When a user had the same email used at multiple centres / as primary email and as a centre-specific email, the verification logic would fail because it expected to verify only one account at a time.
I've made changes so that it will verify all instances of the email as long as they're of the same user.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
    - I've moved tests around - it could be useful to think more carefully about tests, but this isn't a priority right now.
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
