### PR TITLE
HEEDLS-1031: Warn that users can't register at new centres with an unverified primary email

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/VerifyYourEmailTextHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/VerifyYourEmailTextHelper.cs
@@ -2,11 +2,11 @@
 {
     public static class VerifyYourEmailTextHelper
     {
-        public static string UnverifiedCentreEmailConsequences =
+        public const string UnverifiedCentreEmailConsequences =
             "You will not be able to access that account until you verify the address.";
 
-        public static string UnverifiedPrimaryEmailConsequences =>
-            "You can edit your account details, but you cannot access any centre accounts until it is verified.";
+        public const string UnverifiedPrimaryEmailConsequences =
+            "You can edit your account details, but you will not be able to access any centre accounts or register at new centres until it is verified.";
 
         public static string VerifyEmailLinkCommonInfo(bool multipleEmailsAreUnverified)
         {


### PR DESCRIPTION

### JIRA link
[_HEEDLS-1031_](https://softwiretech.atlassian.net/browse/HEEDLS-1031)

### Description
This was basically all done. Just needed to warn users that they couldn't register at new centres with an unverified primary email - this warning was already shown on the ChooseACentre page, but not on the MyAccount callout or the Verify Your Email page.

### Screenshots
MyAccount
![image](https://user-images.githubusercontent.com/34240660/186685514-b3381bd3-1ae3-466e-8be6-7d3f7da0d8f7.png)

Verify your email
![image](https://user-images.githubusercontent.com/34240660/186685713-14bccb51-76a0-4f43-8d00-2d0d1f51942f.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
