### PR TITLE
DLSV2-601 Indicate completed and removed courses on delegate progress…

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
@@ -30,7 +30,20 @@
   .nhsuk-summary-list__value {
     width: 40%;
   }
+
   .nhsuk-summary-list__actions {
     width: 30%;
+  }
+}
+
+.nhsuk-expander-group {
+  &.completed {
+    background-color: #fff;
+    border-left: 6px solid $color_nhsuk-green;
+  }
+
+  &.removed {
+    background-color: #fff;
+    border-left: 6px solid $color_nhsuk-red;
   }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
@@ -125,5 +125,17 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
 
         public string? PassRateDisplayString =>
             TotalAttempts != 0 ? PassRate + "%" : null;
+        public string Status()
+        {
+            if (Completed != null)
+            {
+                return "completed";
+            }
+            if (RemovedDate != null)
+            {
+                return "removed";
+            }
+            return "";
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/_DelegateCourseInfoCard.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Shared
 @model DelegateCourseInfoViewModel
 
-<div class="nhsuk-expander-group word-break" id="@Model.CustomisationId-card">
+<div class="nhsuk-expander-group word-break @Model.Status()" id="@Model.CustomisationId-card">
   <details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text" id="@Model.CustomisationId-name" name="name">


### PR DESCRIPTION
… page without having to expand the course cards

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-601

### Description
Add a green left border to the box (with screen reader only text) to indicate a completed course.
Add a red left border to the box (with screen reader only text) to indicate a removed course.

The red border for removed courses could not be added because once removed, the courses do not appear in the list.

### Screenshots
![image](https://user-images.githubusercontent.com/111436026/187904679-df5d600d-2526-49fb-8b3b-ab11c0af2914.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ X] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
