### PR TITLE
DLSV2-606 Reviewed missing details

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Supervisor/SupervisorDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/SupervisorDelegate.cs
@@ -6,6 +6,7 @@ namespace DigitalLearningSolutions.Data.Models.Supervisor
     {
         public int ID { get; set; }
         public string SupervisorEmail { get; set; }
+        public string SupervisorName { get; set; }
         public int? SupervisorAdminID { get; set; }
         public int CentreId { get; set; }
         public string DelegateEmail { get; set; }

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -387,7 +387,9 @@
                 Competency = competency,
                 ResultSupervisorVerificationId = assessmentQuestion.SelfAssessmentResultSupervisorVerificationId,
                 SupervisorComments = assessmentQuestion.SupervisorComments,
-                SignedOff = assessmentQuestion.SignedOff != null ? (bool)assessmentQuestion.SignedOff : false
+                SignedOff = assessmentQuestion.SignedOff != null ? (bool)assessmentQuestion.SignedOff : false,
+                Verified = assessmentQuestion.Verified,
+                SupervisorName = supervisorDelegate.SupervisorName
             };
             ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
             return model;


### PR DESCRIPTION
'Reviewed' field is missed with the details of the reviewed when Supervisor reviewed the results of self assessment on the 'Competency Self Assessment Results' Page.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-606

### Description
Added supervisor name and verified date to the model before passing it to the view.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/188032137-bd0b945c-7366-4282-9c74-235f0dc6d666.png)

-----
### Developer checks
- Confirmed multiple results and as a supervisor, followed the confirmation link.
