### PR TITLE
DLSV2-649 Fixes LH OpenAPI client BulkJson requests

### DIFF
--- a/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
+++ b/DigitalLearningSolutions.Data/ApiClients/LearningHubApiClient.cs
@@ -80,7 +80,7 @@
             var objectWithReferenceIds = new { referenceIds = referenceIds.ToList() };
 
             var jsonString = JsonSerializer.Serialize(objectWithReferenceIds);
-            var response = await GetStringAsync($"/Resource/BulkJson?{jsonString}");
+            var response = await GetStringAsync($"/Resource/BulkJson?resourceReferences={jsonString}");
 
             var result = JsonConvert.DeserializeObject<BulkResourceReferences>(response);
             return result;


### PR DESCRIPTION
### JIRA link
[DLSV2-649](https://hee-dls.atlassian.net/browse/DLSV2-649)

### Description
Adds missing parameter name to Resources/bulkJson API endpoint requests.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
