### PR TITLE
DLSV2-538 Add clear button for competency questions

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202208301100_AllowNullSelfAssessmentResults.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202208301100_AllowNullSelfAssessmentResults.cs
@@ -1,0 +1,16 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202208301100)]
+    public class AllowNullSelfAssessmentResults : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessmentResults").AlterColumn("Result").AsInt32().Nullable();
+        }
+        public override void Down()
+        {
+            Alter.Table("SelfAssessmentResults").AlterColumn("Result").AsInt32().NotNullable().SetExistingRowsTo(0);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -338,16 +338,13 @@
 
             var minValue = assessmentQuestion.MinValue;
             var maxValue = assessmentQuestion.MaxValue;
-            if (result > 0)
+            if (result < minValue || result > maxValue)
             {
-                if (result < minValue || result > maxValue)
-                {
-                    logger.LogWarning(
-                        "Not saving self assessment result as result is invalid. " +
-                        $"{PrintResult(competencyId, selfAssessmentId, candidateId, assessmentQuestionId, result)}"
-                    );
-                    return;
-                }
+                logger.LogWarning(
+                    "Not saving self assessment result as result is invalid. " +
+                    $"{PrintResult(competencyId, selfAssessmentId, candidateId, assessmentQuestionId, result)}"
+                );
+                return;
             }
 
             var numberOfAffectedRows = connection.Execute(

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -338,7 +338,7 @@
 
             var minValue = assessmentQuestion.MinValue;
             var maxValue = assessmentQuestion.MaxValue;
-            if (result != null)
+            if (result > 0)
             {
                 if (result < minValue || result > maxValue)
                 {

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -166,7 +166,7 @@
                     assessment.Id,
                     candidateId,
                     assessmentQuestion.Id,
-                    assessmentQuestion.Result ?? 0,
+                    assessmentQuestion.Result,
                     assessmentQuestion.SupportingComments
                 );
             }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -161,17 +161,14 @@
 
             foreach (var assessmentQuestion in assessmentQuestions)
             {
-                if (assessmentQuestion.Result != null || assessmentQuestion.SupportingComments != null)
-                {
-                    selfAssessmentService.SetResultForCompetency(
-                        competencyId,
-                        assessment.Id,
-                        candidateId,
-                        assessmentQuestion.Id,
-                        assessmentQuestion.Result,
-                        assessmentQuestion.SupportingComments
-                    );
-                }
+                selfAssessmentService.SetResultForCompetency(
+                    competencyId,
+                    assessment.Id,
+                    candidateId,
+                    assessmentQuestion.Id,
+                    assessmentQuestion.Result ?? 0,
+                    assessmentQuestion.SupportingComments
+                );
             }
 
             selfAssessmentService.SetUpdatedFlag(selfAssessmentId, candidateId, true);


### PR DESCRIPTION
This pull request is intended to fix a bug reported in Jira ticket comment. There was a previous PR for developing this functionality and it's already merged.

### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-538

### Description
Made changes for inserting null result value on table `SelfAssessmentResults` when user clears previous assessment question result. 

#### More details
Since queries already handle null results to cover a scenario where no result was yet provided, this would have less impact than inserting zeroes (e.g. sql `AVG()` ignores null values). After performing a `left join`, result would be null in both cases (no result ever provided or null result was inserted). Main difference between no result and a null result, is that result `id` is still a number if we have inserted a null result. Tried to find a scenario where this could be an issue among all these queries. But they seem to look for max `ID` which returns null `Result` in both cases (either no matches in `SelfAssessmentResults` or a match with null `Result`).

### Screenshots

https://localhost:44363/LearningPortal/SelfAssessment/1/23

![image](https://user-images.githubusercontent.com/94055251/188154933-99c4e7ad-9b8d-4906-a99f-1a5a77a601a0.png)

-----
### Developer checks

- Checked null result is saved and retrieved correctly when user is completing selfassessments at the Learning Portal.
- Checked Export functionality handles null result and this overrides previous results.
