### PR TITLE
DLSV2-621 Make self assessment exported Excel report read only

### DIFF
--- a/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
@@ -27,6 +27,8 @@
         private const string JavascriptSearchSortFilterPaginateItemLimitKey =
             "JavascriptSearchSortFilterPaginateItemLimit";
 
+        private const string ExcelPassword = "ExcelPassword";
+
         public static string GetAppRootPath(this IConfiguration config)
         {
             return config[AppRootPathName];
@@ -105,6 +107,11 @@
         public static int GetJavascriptSearchSortFilterPaginateItemLimit(this IConfiguration config)
         {
             return int.Parse(config[JavascriptSearchSortFilterPaginateItemLimitKey]);
+        }
+
+        public static string GetExcelPassword(this IConfiguration config)
+        {
+            return config[ExcelPassword];
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Services/CandidateAssessmentDownloadFileService.cs
+++ b/DigitalLearningSolutions.Data/Services/CandidateAssessmentDownloadFileService.cs
@@ -2,7 +2,9 @@
 {
     using ClosedXML.Excel;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Models.SelfAssessments.Export;
+    using Microsoft.Extensions.Configuration;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -10,22 +12,24 @@
 
     public interface ICandidateAssessmentDownloadFileService
     {
-        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId);
+        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId, bool isProtected);
     }
 
     public class CandidateAssessmentDownloadFileService : ICandidateAssessmentDownloadFileService
     {
         private readonly ISelfAssessmentDataService selfAssessmentDataService;
+        private readonly IConfiguration config;
 
         public CandidateAssessmentDownloadFileService(
-            ISelfAssessmentDataService selfAssessmentDataService
+            ISelfAssessmentDataService selfAssessmentDataService,
+            IConfiguration config
         )
         {
             this.selfAssessmentDataService = selfAssessmentDataService;
+            this.config = config;
         }
-        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId)
+        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId, bool isProtected)
         {
-
             var summaryData = selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, candidateId);
             var detailData = selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, candidateId);
             var details = detailData.Select(
@@ -47,20 +51,26 @@
                 }
             );
             using var workbook = new XLWorkbook();
-            AddSummarySheet(workbook, summaryData);
-            AddSheetToWorkbook(workbook, "Details", details);
+            var excelPassword = config.GetExcelPassword();
+            AddSummarySheet(workbook, summaryData, excelPassword, isProtected);
+            AddSheetToWorkbook(workbook, "Details", details, excelPassword, isProtected);
             using var stream = new MemoryStream();
             workbook.SaveAs(stream);
             return stream.ToArray();
         }
-        private static void AddSheetToWorkbook(IXLWorkbook workbook, string sheetName, IEnumerable<object>? dataObjects)
+        private static void AddSheetToWorkbook(IXLWorkbook workbook, string sheetName, IEnumerable<object>? dataObjects,string excelPassword, bool? isProtected = false)
         {
             var sheet = workbook.Worksheets.Add(sheetName);
             var table = sheet.Cell(1, 1).InsertTable(dataObjects);
             table.Theme = XLTableTheme.TableStyleLight9;
             sheet.Columns().AdjustToContents();
+            if (isProtected.Value)
+            {
+                sheet.Protect(excelPassword);
+                sheet.Columns().Style.Protection.SetLocked(true);
+            }
         }
-        private static void AddSummarySheet(IXLWorkbook workbook, CandidateAssessmentExportSummary candidateAssessmentExportSummary)
+        private static void AddSummarySheet(IXLWorkbook workbook, CandidateAssessmentExportSummary candidateAssessmentExportSummary,string excelPassword, bool? isProtected = false)
         {
             var sheet = workbook.Worksheets.Add("Summary");
             var rowNum = 1;
@@ -99,7 +109,7 @@
                     sheet.Cell(rowNum, 1).Value = "Questions with no role requirements set";
                     sheet.Cell(rowNum, 1).Style.Fill.BackgroundColor = XLColor.LightBlue;
                     sheet.Cell(rowNum, 2).Value = candidateAssessmentExportSummary.NoRequirementsSetCount;
-                rowNum++;
+                    rowNum++;
 
                 }
                 if (candidateAssessmentExportSummary.MeetingCount > 0)
@@ -153,7 +163,12 @@
             sheet.Cells(true).Style.Font.FontSize = 16;
             sheet.Rows().AdjustToContents();
             sheet.Columns().AdjustToContents();
-            sheet.Columns("2").Style.Alignment.SetHorizontal(XLAlignmentHorizontalValues.Right).Font.SetBold(); 
+            sheet.Columns("2").Style.Alignment.SetHorizontal(XLAlignmentHorizontalValues.Right).Font.SetBold();
+            if (isProtected.Value)
+            {
+                sheet.Protect(excelPassword);
+                sheet.Columns().Style.Protection.SetLocked(true);
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1230,7 +1230,7 @@
         }
         public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string vocabulary)
         {
-            var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, GetCandidateId());
+            var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, GetCandidateId(), true);
             var fileName = $"DLS {vocabulary} Assessment Export {DateTime.Today:yyyy-MM-dd}.xlsx";
             return File(
                 content,

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -27,5 +27,6 @@
     "LoginEndpoint": "/login",
     "LinkingEndpoint": "/create-user",
     "ClientCode": "DigitalLearningSolutions"
-  }
+  },
+  "ExcelPassword": "0f8cc6f0-9f21-4f0f-9cb9-365675490458"
 }


### PR DESCRIPTION
### JIRA link
_HEEDLS-XXXX_

### Description
The competency excel is made read only and password protected. If the user tries to unprotect the workbook, a password need to be entered which the user would not have.

### Screenshots
Provided in the jira; https://hee-dls.atlassian.net/browse/DLSV2-621

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X ] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
