### PR TITLE
DLSV2-636 Ungrouped competency with Manage resource signposting (No R…

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -891,7 +891,7 @@
         public IEnumerable<FrameworkCompetency> GetFrameworkCompetenciesUngrouped(int frameworkId)
         {
             return connection.Query<FrameworkCompetency>(
-                @"SELECT fc.ID, c.ID AS CompetencyID, c.Name, c.Description, fc.Ordering, COUNT(caq.AssessmentQuestionID) AS AssessmentQuestions
+                @"SELECT fc.ID, c.ID AS CompetencyID, c.Name, c.Description, fc.Ordering, COUNT(caq.AssessmentQuestionID) AS AssessmentQuestions,(select COUNT(CompetencyId) from CompetencyLearningResources where CompetencyID=c.ID) AS CompetencyLearningResourcesCount
                     FROM FrameworkCompetencies AS fc 
                         INNER JOIN Competencies AS c ON fc.CompetencyID = c.ID
                         LEFT OUTER JOIN

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Signposting.cs
@@ -19,7 +19,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         private static List<Catalogue> Catalogues { get; set; }
 
         [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/CompetencyGroup/{frameworkCompetencyGroupId}/Signposting")]
-        public IActionResult EditCompetencyLearningResources(int frameworkId, int frameworkCompetencyGroupId, int frameworkCompetencyId)
+        [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/Signposting")]
+        public IActionResult EditCompetencyLearningResources(int frameworkId, int frameworkCompetencyId, int? frameworkCompetencyGroupId)
         {
             var model = GetSignpostingResourceParameters(frameworkId, frameworkCompetencyId);
             multiPageFormService.SetMultiPageFormData(
@@ -32,8 +33,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
 
         [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyId}/CompetencyGroup/{frameworkCompetencyGroupId}/Signposting/AddResource/{page=1:int}")]
         public async Task<IActionResult> SearchLearningResourcesAsync(int frameworkId, int frameworkCompetencyId, int? frameworkCompetencyGroupId, int? catalogueId, string searchText, int page)
-            {
-            
+        {
+
             var model = new CompetencyResourceSignpostingViewModel(frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId);
             Catalogues = Catalogues ?? (await this.learningHubApiClient.GetCatalogues())?.Catalogues?.OrderBy(c => c.Name).ToList();
             if (catalogueId.HasValue)
@@ -96,7 +97,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 MultiPageFormDataFeature.AddCompetencyLearningResourceSummary,
                 TempData
             );
-            return RedirectToAction("AddCompetencyLearningResourceSummary", "Frameworks", new { model.FrameworkId , model.FrameworkCompetencyId, model.FrameworkCompetencyGroupId});
+                 return RedirectToAction("AddCompetencyLearningResourceSummary", "Frameworks", new { model.FrameworkId , model.FrameworkCompetencyId, model.FrameworkCompetencyGroupId});
         }
 
         [HttpPost]
@@ -189,7 +190,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     parameter.RelevanceAssessmentQuestion = session.Questions.FirstOrDefault(q => q.ID == compareToQuestionId);
                     parameter.RelevanceAssessmentQuestionId = parameter.RelevanceAssessmentQuestion?.ID;
                     parameter.CompareToRoleRequirements = false;
-                    break;                
+                    break;
             }
             multiPageFormService.SetMultiPageFormData(
                 session,
@@ -407,8 +408,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     MultiPageFormDataFeature.EditSignpostingParameter,
                     TempData
                 );
-                return RedirectToAction("SignpostingSetStatus", new { frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId }); 
-            }                
+                return RedirectToAction("SignpostingSetStatus", new { frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId });
+            }
             else
                 return RedirectToAction("CompareSelfAssessmentResult", new { frameworkId, frameworkCompetencyId, frameworkCompetencyGroupId });
         }
@@ -421,7 +422,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         }
 
         private CompetencyResourceSignpostingViewModel GetSignpostingResourceParameters(int frameworkId, int frameworkCompetencyId)
-        {            
+        {
             var frameworkCompetency = frameworkService.GetFrameworkCompetencyById(frameworkCompetencyId);
             var parameters = frameworkService.GetSignpostingResourceParametersByFrameworkAndCompetencyId(frameworkId, frameworkCompetency.CompetencyID);
             var model = new CompetencyResourceSignpostingViewModel(frameworkId, frameworkCompetencyId, frameworkCompetencyId)

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CompetencyCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CompetencyCard.cshtml
@@ -19,25 +19,34 @@
       @Model.FrameworkCompetency.Name
     </h4>
   }
-    <p class="nhsuk-u-secondary-text-color">
-      @if (Model.CanModify)
-      {
-        <a asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-frameworkCompetencyId="@Model.FrameworkCompetency.Id">
-          Manage assessment questions (@(Model.FrameworkCompetency.AssessmentQuestions == 0 ? "None" : Model.FrameworkCompetency.AssessmentQuestions.ToString()) assigned)
-        </a>
-        <br />
-        <a asp-controller="Frameworks" asp-action="EditCompetencyLearningResources"
-           asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]"
-           asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
-           asp-route-frameworkCompetencyId="@Model.FrameworkCompetency.Id">
-          Manage resource signposting (@(Model.FrameworkCompetency.CompetencyLearningResourcesCount == 0 ? "No" : Model.FrameworkCompetency.CompetencyLearningResourcesCount.ToString()) resources)
-        </a>
-      }
-      else
-      {
-        <span>@(Model.FrameworkCompetency.AssessmentQuestions == 0 ? "No " : Model.FrameworkCompetency.AssessmentQuestions.ToString()) assessment questions assigned</span>
-      }
-    </p>
+  <p class="nhsuk-u-secondary-text-color">
+    @if (Model.CanModify)
+    {
+      <a asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-frameworkCompetencyId="@Model.FrameworkCompetency.Id">
+        Manage assessment questions (@(Model.FrameworkCompetency.AssessmentQuestions == 0 ? "None" : Model.FrameworkCompetency.AssessmentQuestions.ToString()) assigned)
+      </a><br />
+          @if (Model.FrameworkCompetencyGroupId != null)
+          {
+          <a asp-controller="Frameworks" asp-action="EditCompetencyLearningResources"
+             asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]"
+             asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId"
+             asp-route-frameworkCompetencyId="@Model.FrameworkCompetency.Id">
+            Manage resource signposting (@(Model.FrameworkCompetency.CompetencyLearningResourcesCount == 0 ? "No" : Model.FrameworkCompetency.CompetencyLearningResourcesCount.ToString()) resources)
+          </a>
+          }
+          else
+          {
+            <a asp-controller="Frameworks" asp-action="EditCompetencyLearningResources"
+               asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]"
+               asp-route-frameworkCompetencyId="@Model.FrameworkCompetency.Id">
+              Manage resource signposting (@(Model.FrameworkCompetency.CompetencyLearningResourcesCount == 0 ? "No" : Model.FrameworkCompetency.CompetencyLearningResourcesCount.ToString()) resources)
+            </a>
+          }
+     }
+else
+{
+  <span>@(Model.FrameworkCompetency.AssessmentQuestions == 0 ? "No " : Model.FrameworkCompetency.AssessmentQuestions.ToString()) assessment questions assigned</span>      }
+  </p>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-three-quarters">
         @if (Model.CanModify)


### PR DESCRIPTION
…esources) results in page not found error

### JIRA link
[DLSV2-636](https://hee-dls.atlassian.net/browse/DLSV2-636)

### Description
A valid route for ungrouped competency was missing i.e. FrameworkCompetencyGroupId is returned as null and there was no route to handle this condition. Note that though FrameworkCompetencyGroupId is present in the route but never used by the action method. The route could be modified to remove FrameworkCompetencyGroupId but the existing code has been left as is.

### Screenshots
Screenshots provided in the jira; https://hee-dls.atlassian.net/browse/DLSV2-636

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
