### PR TITLE
DLSV2-569 Remove supervisor only for current selfassessment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -774,7 +774,7 @@
 
         public IActionResult RemoveSupervisor(int selfAssessmentId, int supervisorDelegateId)
         {
-            supervisorService.RemoveCandidateAssessmentSupervisor(supervisorDelegateId);
+            supervisorService.RemoveCandidateAssessmentSupervisor(selfAssessmentId, supervisorDelegateId);
             return RedirectToAction("ManageSupervisors", new { selfAssessmentId });
         }
 


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-569

### Description
Added filter for removing supervisor delegate only for current selfassessment in Manage Supervisor view.

### Screenshots
![image](https://user-images.githubusercontent.com/94055251/189114724-fe3db8f6-dcad-4792-b482-b3f3e177cc6b.png)

### Database diagram
![CandidateAssessmentSupervisors](https://user-images.githubusercontent.com/94055251/189114995-08bc21dc-b8a3-47e2-b55e-857e954ba7f2.png)

-----
### Developer checks
Checked that: 
- It works when deleting same supervisor from two different selfassessments, so deleting one doesn't have any effect on the other one.
- Deleted supervisor then appears on quick add list.
