### PR TITLE
DLSV2-654 Fixes error after importing competencies

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/ImportCompleted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/ImportCompleted.cshtml
@@ -8,7 +8,6 @@
     ViewData["Application"] = "Framework Service";
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     var cancelLinkData = Html.GetRouteValues();
-    cancelLinkData.Add("tabname", "Structure");
 }
 <link rel="stylesheet" href="@Url.Content(" ~ /css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {


### PR DESCRIPTION
### JIRA link
[DLSV2-654](https://hee-dls.atlassian.net/browse/DLSV2-654)

### Description
Removes add tabname item to cancelLinkData dictionary because it already exists and threw an error when trying to load the import summary page.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [x] Scanned over my own MR to ensure everything is as expected.
