### PR TITLE
DLSV2-639 'HTML Editor' Console error on 'Framework Vocabulary' scree…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
@@ -110,6 +110,3 @@ else
   }
 
 </form>
-@section scripts {
-  <script src="@Url.Content("~/js/frameworks/htmleditor.js")" asp-append-version="true"></script>
-}


### PR DESCRIPTION
…n when creating a framework

### JIRA link
[DLSV2-639](https://hee-dls.atlassian.net/browse/DLSV2-639)

### Description
1) Frameworks
2) Manage Frameworks 
3) Create a new framework 
4) Click Next 
5) Framework Description 
6) Click Next 
7) Framework Vocabulary. 
On landing this page can see below ‘HTML Editor’ console error should not be there now.

### Screenshots
Screenshot can be found in the jira; https://hee-dls.atlassian.net/browse/DLSV2-639

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript. Full manual testing guidelines can be found here: https://softwiretech.atlassian.net/wiki/spaces/HEE/pages/6703648740/Testing
- [ ] Updated/added documentation in Swiki and/or Readme. Links (if any) are below:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken.
- [ ] Scanned over my own MR to ensure everything is as expected.
