### PR TITLE
DLSV2-645 UI issues in View resource - Frameworks Manage resource sig…

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/frameworks/frameworksShared.scss
+++ b/DigitalLearningSolutions.Web/Styles/frameworks/frameworksShared.scss
@@ -239,3 +239,8 @@ h1.truncate-overflow::after {
 .searchable-element .nhsuk-expander {
   border: none
 }
+
+.text-wrap {
+  inline-size: 882px;
+  overflow-wrap: break-word;
+}

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_SignpostingResourceCard.cshtml
@@ -3,71 +3,71 @@
 @model CompetencyResourceSummaryViewModel
 
 @{
-  var parent = (CompetencyResourceSignpostingViewModel)ViewData["parent"];
+    var parent = (CompetencyResourceSignpostingViewModel)ViewData["parent"];
 }
 <details class="nhsuk-details nhsuk-expander  nhsuk-u-margin-bottom-3">
-  <summary class="nhsuk-details__summary">
-    <span class="nhsuk-details__summary-text">
-      @DisplayStringHelper.RemoveMarkup(Model.Resource.Title)
-    </span>
-  </summary>
-  <div class="nhsuk-card__content nhsuk-u-padding-bottom-3 nhsuk-u-padding-top-0 nhsuk-u-margin-1">
-    @if (!String.IsNullOrEmpty(Model.Resource.ResourceType))
-    {
-      <div class="nhsuk-grid-row nhsuk-u-margin-left-1 nhsuk-u-clear">
-        <strong class="nhsuk-tag nhsuk-tag--@(SignpostingHelper.DisplayTagColour(Model.Resource.ResourceType))">@DisplayStringHelper.AddSpacesToPascalCaseString(Model.Resource.ResourceType)</strong>
-      </div>
-    }
-    <div class="nhsuk-u-margin-left-1 nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3">
-      @Html.Raw(DisplayStringHelper.RemoveMarkup(Model.Description))
-    </div>
-    @if (Model.Catalogues.Count() > 0)
-    {
-      <form method="post" role="search" asp-controller="Frameworks">
-        <div class="nhsuk-card__content nhsuk-u-margin-1 nhsuk-u-padding-0">
-          <dl class="nhsuk-summary-list">
-            <div class="nhsuk-summary-list__row">
-              <dt class="nhsuk-summary-list__key">
-                Catalogues
-              </dt>
-              <dd class="nhsuk-summary-list__value"></dd>
+    <summary class="nhsuk-details__summary">
+        <span class="nhsuk-details__summary-text">
+            @DisplayStringHelper.RemoveMarkup(Model.Resource.Title)
+        </span>
+    </summary>
+    <div class="nhsuk-card__content nhsuk-u-padding-bottom-3 nhsuk-u-padding-top-0 nhsuk-u-margin-1">
+        @if (!String.IsNullOrEmpty(Model.Resource.ResourceType))
+        {
+            <div class="nhsuk-grid-row nhsuk-u-margin-left-1 nhsuk-u-clear">
+                <strong class="nhsuk-tag nhsuk-tag--@(SignpostingHelper.DisplayTagColour(Model.Resource.ResourceType))">@DisplayStringHelper.AddSpacesToPascalCaseString(Model.Resource.ResourceType)</strong>
             </div>
-            @foreach(var catalogue in Model.Catalogues)
-            {
-              <div class="nhsuk-summary-list__row">
-                <dt class="nhsuk-summary-list__key nhsuk-u-width-two-thirds">
-                  @catalogue
-                </dt>
-                <dd class="nhsuk-summary-list__value">
-                  <a class="nhsuk-button nhsuk-button--secondary small-edit-button nhsuk-u-margin-right-1"
-                      asp-controller="SignpostingSso"
-                      asp-action="ViewResource"
-                      asp-route-resourceReferenceId="@Model.ReferenceId">Preview</a>
-                  <button class="nhsuk-button small-edit-button"
-                      asp-action="AddCompetencyLearningResourceSummary"
-                      asp-route-SelectedCatalogue="@catalogue">
-                    Select
-                  </button>
-                </dd>
-              </div>
-            }
-          </dl>
+        }
+        <div class="nhsuk-u-margin-left-1 nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3 text-wrap">
+            @Html.Raw(DisplayStringHelper.RemoveMarkup(Model.Description))
         </div>
-        @Html.HiddenFor(m => m.FrameworkId)
-        @Html.HiddenFor(m => m.FrameworkCompetencyGroupId)
-        @Html.HiddenFor(m => m.FrameworkCompetencyId)
-        @Html.Hidden("ReferenceId", Model.ReferenceId)
-        @Html.Hidden("CatalogueId", parent.CatalogueId)
-        @Html.Hidden("Page", parent.Page)
-        @Html.Hidden("Resource.Title", Model.Resource?.Title)
-        @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
-        @Html.HiddenFor(m => m.Resource.Description)
-        @Html.Hidden("NameOfCompetency", parent.NameOfCompetency)
-        @Html.Hidden("SearchText", parent.SearchText)
-        @Html.HiddenFor(m => m.Link)
-        @Html.Hidden("Rating", Model.Resource?.Rating ?? 0)
-      </form>
-    }
-  </div>
+        @if (Model.Catalogues.Count() > 0)
+        {
+            <form method="post" role="search" asp-controller="Frameworks">
+                <div class="nhsuk-card__content nhsuk-u-margin-1 nhsuk-u-padding-0">
+                    <dl class="nhsuk-summary-list">
+                        <div class="nhsuk-summary-list__row">
+                        <dt class="nhsuk-summary-list__key">
+                            Catalogues
+                        </dt>
+                        <dd class="nhsuk-summary-list__value"></dd>
+                </div>
+                        @foreach (var catalogue in Model.Catalogues)
+                        {
+                    <div class="nhsuk-summary-list__row">
+                        <dt class="nhsuk-summary-list__key nhsuk-u-width-two-thirds">
+                                    @catalogue
+                        </dt>
+                        <dd class="nhsuk-summary-list__value">
+                            <a class="nhsuk-button nhsuk-button--secondary small-edit-button nhsuk-u-margin-right-1"
+                       asp-controller="SignpostingSso"
+                       asp-action="ViewResource"
+                       asp-route-resourceReferenceId="@Model.ReferenceId">Preview</a>
+                            <button class="nhsuk-button small-edit-button"
+                            asp-action="AddCompetencyLearningResourceSummary"
+                            asp-route-SelectedCatalogue="@catalogue">
+                                Select
+                            </button>
+                        </dd>
+                    </div>
+                        }
+                </dl>
+        </div>
+                @Html.HiddenFor(m => m.FrameworkId)
+                @Html.HiddenFor(m => m.FrameworkCompetencyGroupId)
+                @Html.HiddenFor(m => m.FrameworkCompetencyId)
+                @Html.Hidden("ReferenceId", Model.ReferenceId)
+                @Html.Hidden("CatalogueId", parent.CatalogueId)
+                @Html.Hidden("Page", parent.Page)
+                @Html.Hidden("Resource.Title", Model.Resource?.Title)
+                @Html.Hidden("Resource.ResourceType", Model.Resource?.ResourceType)
+                @Html.HiddenFor(m => m.Resource.Description)
+                @Html.Hidden("NameOfCompetency", parent.NameOfCompetency)
+                @Html.Hidden("SearchText", parent.SearchText)
+                @Html.HiddenFor(m => m.Link)
+                @Html.Hidden("Rating", Model.Resource?.Rating ?? 0)
+        </form>
+        }
+    </div>
 </details>
 


### PR DESCRIPTION
### JIRA link
[_DLSV2-645_](https://hee-dls.atlassian.net/browse/DLSV2-645)

### Description
The competency had its description going beyond the screen which is fixed now.

### Screenshots
![image](https://user-images.githubusercontent.com/111436026/190432555-797568ed-eb42-4479-b22c-c03576091a25.png)
![image](https://user-images.githubusercontent.com/111436026/190437013-d281abb4-afb4-47e3-aef2-d0952e9136e9.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
