### PR TITLE
Develop/fixes/dlsv2 656 text area height no js 2

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Helpers/ViewComponentValueToSetHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ViewComponentValueToSetHelperTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+
+namespace DigitalLearningSolutions.Web.Tests.Helpers
+{
+    using DigitalLearningSolutions.Web.ViewComponents;
+    using FluentAssertions;
+    using FluentAssertions.Execution;
+    using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    using NUnit.Framework;
+
+    public class ViewComponentValueToSetHelperTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void ValueToSetForSimpleType_returns_model_value()
+        {
+            // Given
+            var aspFor = "TestElement";
+            var populateWithCurrentValue = true;
+            var modelState = new ModelStateDictionary();
+            var modelMetadataProvider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
+            IEnumerable<string> errorMessages;
+
+            var model = new { TestElement = "SimpleValue" };
+
+            // When
+            var result =
+                ViewComponentValueToSetHelper.ValueToSetForSimpleType(
+                    model, aspFor, populateWithCurrentValue, viewData, out errorMessages
+                );
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo("SimpleValue");
+            }
+        }
+
+        //[Test]
+        //public void ValueToSetForComplexType_returns_model_value()
+        //{
+        //    // Given
+        //    var aspFor = "SubElement.SubValue";
+        //    var populateWithCurrentValue = true;
+        //    var modelState = new ModelStateDictionary();
+        //    var modelMetadataProvider = new EmptyModelMetadataProvider();
+        //    var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
+        //    IEnumerable<string> errorMessages;
+        //    var types = aspFor.Split('.');
+
+        //    var modelLeaf = new { Name = "NameValue" };
+        //    var simpleModel = new { TestElement = modelLeaf };
+        //    var complexModel = new { SubModel = simpleModel };
+
+        //    // When
+        //    var result =
+        //        ViewComponentValueToSetHelper.ValueToSetForComplexType(
+        //            complexModel, aspFor, populateWithCurrentValue, types, viewData, out errorMessages
+        //        );
+
+        //    // Then
+        //    using (new AssertionScope())
+        //    {
+        //        result.Should().BeEquivalentTo("SubValue");
+        //    }
+        //}
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Helpers/ViewComponentValueToSetHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ViewComponentValueToSetHelperTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace DigitalLearningSolutions.Web.Tests.Helpers
+﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
 {
     using DigitalLearningSolutions.Web.ViewComponents;
     using FluentAssertions;
@@ -11,64 +9,107 @@ namespace DigitalLearningSolutions.Web.Tests.Helpers
 
     public class ViewComponentValueToSetHelperTests
     {
+        private ModelStateDictionary? _modelState;
+        private EmptyModelMetadataProvider? _modelMetadataProvider;
+        private ViewDataDictionary? _viewData;
+        private bool _populateWithCurrentValue;
+
         [SetUp]
         public void Setup()
         {
+            _modelState = new ModelStateDictionary();
+            _modelMetadataProvider = new EmptyModelMetadataProvider();
+            _viewData = new ViewDataDictionary(_modelMetadataProvider, _modelState);
+            _populateWithCurrentValue = true;
         }
 
         [Test]
         public void ValueToSetForSimpleType_returns_model_value()
         {
             // Given
-            var aspFor = "TestElement";
-            var populateWithCurrentValue = true;
-            var modelState = new ModelStateDictionary();
-            var modelMetadataProvider = new EmptyModelMetadataProvider();
-            var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
-            IEnumerable<string> errorMessages;
-
-            var model = new { TestElement = "SimpleValue" };
+            const string aspFor = "Description";
+            const string modelItemValue = "Framework description text.";
+            var model = new { Description = modelItemValue };
 
             // When
             var result =
                 ViewComponentValueToSetHelper.ValueToSetForSimpleType(
-                    model, aspFor, populateWithCurrentValue, viewData, out errorMessages
+                    model, aspFor, _populateWithCurrentValue, _viewData!, out var errorMessages
                 );
 
             // Then
             using (new AssertionScope())
             {
-                result.Should().BeEquivalentTo("SimpleValue");
+                result.Should().BeEquivalentTo(modelItemValue);
+                errorMessages.Should().HaveCount(0);
             }
         }
 
-        //[Test]
-        //public void ValueToSetForComplexType_returns_model_value()
-        //{
-        //    // Given
-        //    var aspFor = "SubElement.SubValue";
-        //    var populateWithCurrentValue = true;
-        //    var modelState = new ModelStateDictionary();
-        //    var modelMetadataProvider = new EmptyModelMetadataProvider();
-        //    var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
-        //    IEnumerable<string> errorMessages;
-        //    var types = aspFor.Split('.');
+        [Test]
+        public void ValueToSetForComplexType_returns_model_value()
+        {
+            // Given
+            const string subModelItemValue = "Description of competency group base.";
+            var subModelItem = new { Description = subModelItemValue };
+            var complexModel = new { CompetencyGroupBase = subModelItem };
 
-        //    var modelLeaf = new { Name = "NameValue" };
-        //    var simpleModel = new { TestElement = modelLeaf };
-        //    var complexModel = new { SubModel = simpleModel };
+            const string aspFor = "CompetencyGroupBase.Description";
+            var types = aspFor.Split('.');
 
-        //    // When
-        //    var result =
-        //        ViewComponentValueToSetHelper.ValueToSetForComplexType(
-        //            complexModel, aspFor, populateWithCurrentValue, types, viewData, out errorMessages
-        //        );
+            // When
+            var result =
+                ViewComponentValueToSetHelper.ValueToSetForComplexType(
+                    complexModel, aspFor, _populateWithCurrentValue, types, _viewData!, out var errorMessages
+                );
 
-        //    // Then
-        //    using (new AssertionScope())
-        //    {
-        //        result.Should().BeEquivalentTo("SubValue");
-        //    }
-        //}
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(subModelItemValue);
+                errorMessages.Should().HaveCount(0);
+            }
+        }
+
+        [Test]
+        public void DeriveValueToSet_returns_derived_complex_model_value()
+        {
+            // Given
+            const string subModelItemValue = "Description of competency.";
+            var subModelItem = new { Description = subModelItemValue };
+            var complexModel = new { Competency = subModelItem };
+
+            var aspFor = "Competency.Description";
+
+            // When
+            var result = ViewComponentValueToSetHelper.DeriveValueToSet(ref aspFor, _populateWithCurrentValue, complexModel, _viewData!, out var errorMessages);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(subModelItemValue);
+                errorMessages.Should().HaveCount(0);
+            }
+        }
+
+        [Test]
+        public void DeriveValueToSet_returns_derived_simple_model_value()
+        {
+            // Given
+            const string modelItemValue = "Description of framework.";
+            var simpleModel = new { Description = modelItemValue };
+
+            var aspFor = "Description";
+
+            // When
+            var result = ViewComponentValueToSetHelper.DeriveValueToSet(ref aspFor, _populateWithCurrentValue, simpleModel, _viewData!, out var errorMessages);
+
+            // Then
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(modelItemValue);
+                errorMessages.Should().HaveCount(0);
+            }
+        }
+
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -143,7 +143,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 ModelState.AddModelError(nameof(FrameworkCompetency.Name), "Please enter a valid competency statement (between 3 and 500 characters)");
                 var detailFramework = frameworkService.GetDetailFrameworkByFrameworkId(frameworkId, GetAdminId());
                 var competencyFlags = frameworkService.GetCompetencyFlagsByFrameworkId(frameworkId, frameworkCompetency?.CompetencyID).ToList();
-                if(competencyFlags != null)
+                if (competencyFlags != null)
                     competencyFlags.ForEach(f => f.Selected = selectedFlagIds.Contains(f.FlagId));
                 if (detailFramework == null)
                     return StatusCode((int)HttpStatusCode.NotFound);
@@ -153,7 +153,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     FrameworkCompetencyGroupId = frameworkCompetencyId,
                     FrameworkCompetency = frameworkCompetency,
                     CompetencyFlags = competencyFlags
-            };
+                };
                 return View("Developer/Competency", model);
             }
             var adminId = GetAdminId();

--- a/DigitalLearningSolutions.Web/Helpers/ViewComponentValueToSetHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ViewComponentValueToSetHelper.cs
@@ -1,0 +1,65 @@
+﻿namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+    public static class ViewComponentValueToSetHelper
+    {
+        public static string? DeriveValueToSet(ref string aspFor, bool populateWithCurrentValue, object model, ViewDataDictionary viewData, out IEnumerable<string> errorMessages)
+        {
+            string valueToSet;
+            var types = aspFor.Split('.');
+
+            if (types.Length == 1)
+            {
+                valueToSet = ValueToSetForSimpleType(
+                    model,
+                    aspFor,
+                    populateWithCurrentValue,
+                    viewData,
+                    out errorMessages
+                );
+            }
+            else
+            {
+                valueToSet = ValueToSetForComplexType(
+                    model,
+                    aspFor,
+                    populateWithCurrentValue,
+                    types,
+                    viewData,
+                    out errorMessages
+                );
+                aspFor = types[1];
+            }
+
+            return valueToSet;
+        }
+
+        public static string? ValueToSetForSimpleType(object model, string aspFor, bool populateWithCurrentValue, ViewDataDictionary viewData, out IEnumerable<string> errorMessages)
+        {
+
+            var property = model.GetType().GetProperty(aspFor);
+            var valueToSet = populateWithCurrentValue ? property?.GetValue(model)?.ToString() : null;
+
+            errorMessages = viewData.ModelState[property?.Name]?.Errors.Select(e => e.ErrorMessage) ??
+                            new string[] { };
+
+            return valueToSet;
+        }
+        public static string? ValueToSetForComplexType(object model, string aspFor, bool populateWithCurrentValue, string[] types, ViewDataDictionary viewData, out IEnumerable<string> errorMessages)
+        {
+            var firstProperty = model.GetType().GetProperty(types[0]);
+            var nestedProperty = firstProperty.PropertyType.GetProperty(types[1]);
+
+            var valueToSetOfFirstProperty = populateWithCurrentValue ? firstProperty?.GetValue(model) : null;
+            var valueToSetOfNestedProperty = populateWithCurrentValue ? nestedProperty?.GetValue(valueToSetOfFirstProperty)?.ToString() : null;
+
+            errorMessages = viewData.ModelState[firstProperty?.Name]?.Errors.Select(e => e.ErrorMessage) ??
+                            new string[] { };
+
+            return valueToSetOfNestedProperty;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewComponents/TextAreaViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/TextAreaViewComponent.cs
@@ -1,7 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewComponents
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
     using Microsoft.AspNetCore.Mvc;
 
@@ -31,19 +29,7 @@
         {
             var model = ViewData.Model;
 
-            string valueToSet = string.Empty;
-            string[] types = aspFor.Split('.');
-            IEnumerable<string> errorMessages;
-
-            if (types.Length == 1)
-            {
-                valueToSet = ValueToSetForSimpleType(model, aspFor, populateWithCurrentValue, out errorMessages);
-            }
-            else
-            {
-                valueToSet = ValueToSetForComplexType(model, aspFor, populateWithCurrentValue, types, out errorMessages);
-                aspFor = types[1];
-            }
+            var valueToSet = ViewComponentValueToSetHelper.DeriveValueToSet(ref aspFor, populateWithCurrentValue, model, ViewData, out var errorMessages);
 
             var textBoxViewModel = new TextAreaViewModel(
                 aspFor,
@@ -57,34 +43,6 @@
                 string.IsNullOrEmpty(hintText) ? null : hintText,
                 characterCount);
             return View(textBoxViewModel);
-        }
-
-        private string ValueToSetForSimpleType(object model, string aspFor, bool populateWithCurrentValue, out IEnumerable<string> errorMessages)
-        {
-
-            var property = model.GetType().GetProperty(aspFor);
-            var valueToSet = populateWithCurrentValue ? property?.GetValue(model)?.ToString() : null;
-
-            errorMessages = ViewData.ModelState[property?.Name]?.Errors.Select(e => e.ErrorMessage) ??
-                                new string[] { };
-
-            return valueToSet;
-
-        }
-
-        private string ValueToSetForComplexType(object model, string aspFor, bool populateWithCurrentValue, string[] types, out IEnumerable<string> errorMessages)
-        {
-            var firstProperty = model.GetType().GetProperty(types[0]);
-            var nestedProperty = firstProperty.PropertyType.GetProperty(types[1]);
-
-            var valueToSetOfFirstProperty = populateWithCurrentValue ? firstProperty?.GetValue(model) : null;
-            var valueToSetOfNestedProperty = populateWithCurrentValue ? nestedProperty?.GetValue(valueToSetOfFirstProperty)?.ToString() : null;
-
-            errorMessages = ViewData.ModelState[firstProperty?.Name]?.Errors.Select(e => e.ErrorMessage) ??
-                                new string[] { };
-
-
-            return valueToSetOfNestedProperty;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewComponents/TextAreaViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/TextAreaViewComponent.cs
@@ -35,8 +35,15 @@
             string[] types = aspFor.Split('.');
             IEnumerable<string> errorMessages;
 
-            if (types.Length == 1) valueToSet = ValueToSetForSimpleType(model, aspFor, populateWithCurrentValue, out errorMessages);
-            else valueToSet = ValueToSetForComplexType(model, aspFor, populateWithCurrentValue, types, out errorMessages);
+            if (types.Length == 1)
+            {
+                valueToSet = ValueToSetForSimpleType(model, aspFor, populateWithCurrentValue, out errorMessages);
+            }
+            else
+            {
+                valueToSet = ValueToSetForComplexType(model, aspFor, populateWithCurrentValue, types, out errorMessages);
+                aspFor = types[1];
+            }
 
             var textBoxViewModel = new TextAreaViewModel(
                 aspFor,
@@ -75,6 +82,7 @@
 
             errorMessages = ViewData.ModelState[firstProperty?.Name]?.Errors.Select(e => e.ErrorMessage) ??
                                 new string[] { };
+
 
             return valueToSetOfNestedProperty;
         }

--- a/DigitalLearningSolutions.Web/ViewComponents/TextAreaViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/TextAreaViewComponent.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewComponents
 {
+    using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
     using Microsoft.AspNetCore.Mvc;
@@ -30,11 +31,12 @@
         {
             var model = ViewData.Model;
 
-            var property = model.GetType().GetProperty(aspFor);
-            var valueToSet = populateWithCurrentValue ? property?.GetValue(model)?.ToString() : null;
+            string valueToSet = string.Empty;
+            string[] types = aspFor.Split('.');
+            IEnumerable<string> errorMessages;
 
-            var errorMessages = ViewData.ModelState[property?.Name]?.Errors.Select(e => e.ErrorMessage) ??
-                                new string[] { };
+            if (types.Length == 1) valueToSet = ValueToSetForSimpleType(model, aspFor, populateWithCurrentValue, out errorMessages);
+            else valueToSet = ValueToSetForComplexType(model, aspFor, populateWithCurrentValue, types, out errorMessages);
 
             var textBoxViewModel = new TextAreaViewModel(
                 aspFor,
@@ -48,6 +50,33 @@
                 string.IsNullOrEmpty(hintText) ? null : hintText,
                 characterCount);
             return View(textBoxViewModel);
+        }
+
+        private string ValueToSetForSimpleType(object model, string aspFor, bool populateWithCurrentValue, out IEnumerable<string> errorMessages)
+        {
+
+            var property = model.GetType().GetProperty(aspFor);
+            var valueToSet = populateWithCurrentValue ? property?.GetValue(model)?.ToString() : null;
+
+            errorMessages = ViewData.ModelState[property?.Name]?.Errors.Select(e => e.ErrorMessage) ??
+                                new string[] { };
+
+            return valueToSet;
+
+        }
+
+        private string ValueToSetForComplexType(object model, string aspFor, bool populateWithCurrentValue, string[] types, out IEnumerable<string> errorMessages)
+        {
+            var firstProperty = model.GetType().GetProperty(types[0]);
+            var nestedProperty = firstProperty.PropertyType.GetProperty(types[1]);
+
+            var valueToSetOfFirstProperty = populateWithCurrentValue ? firstProperty?.GetValue(model) : null;
+            var valueToSetOfNestedProperty = populateWithCurrentValue ? nestedProperty?.GetValue(valueToSetOfFirstProperty)?.ToString() : null;
+
+            errorMessages = ViewData.ModelState[firstProperty?.Name]?.Errors.Select(e => e.ErrorMessage) ??
+                                new string[] { };
+
+            return valueToSetOfNestedProperty;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AssessmentQuestionOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AssessmentQuestionOptions.cshtml
@@ -1,160 +1,160 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks
 @model AssessmentQuestionViewModel;
 @{
-  ViewData["Title"] = "Assessment Question";
-  ViewData["Application"] = "Framework Service";
+    ViewData["Title"] = "Assessment Question";
+    ViewData["Application"] = "Framework Service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/jodit.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
-@section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
-        @if (Model.FrameworkCompetencyId == 0)
-        {
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Details">Framework Details</a></li>
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">Default Questions</a></li>
-          <li class="nhsuk-breadcrumb__item">@(Model.AssessmentQuestionDetail.ID == 0 ? "New" : "Edit") Assessment Question</li>
-        }
-        else
-        {
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-fragment="fc-@Model.FrameworkCompetencyId" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Framework Structure</a></li>
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">@Model.VocabSingular() Assessment Questions</a></li>
-          <li class="nhsuk-breadcrumb__item">@(Model.AssessmentQuestionDetail.ID == 0 ? "New" : "Edit") Assessment Question</li>
-        }
+    @section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
+                @if (Model.FrameworkCompetencyId == 0)
+                {
+                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Details">Framework Details</a></li>
+                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">Default Questions</a></li>
+                    <li class="nhsuk-breadcrumb__item">@(Model.AssessmentQuestionDetail.ID == 0 ? "New" : "Edit") Assessment Question</li>
+                }
+                else
+                {
+                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-fragment="fc-@Model.FrameworkCompetencyId" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Framework Structure</a></li>
+                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">@Model.VocabSingular() Assessment Questions</a></li>
+                    <li class="nhsuk-breadcrumb__item">@(Model.AssessmentQuestionDetail.ID == 0 ? "New" : "Edit") Assessment Question</li>
+                }
 
-      </ol>
-      @if (Model.FrameworkCompetencyId == 0)
-      {
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">Back to Default Questions</a></p>
-      }
-      else
-      {
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">Back to @Model.VocabSingular() Assessment Questions</a></p>
-      }
-    </div>
-  </nav>
+            </ol>
+            @if (Model.FrameworkCompetencyId == 0)
+            {
+                <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">Back to Default Questions</a></p>
+            }
+            else
+            {
+                <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">Back to @Model.VocabSingular() Assessment Questions</a></p>
+            }
+        </div>
+    </nav>
 }
-<h1>@Model.AssessmentQuestionDetail.Question</h1>
-<form method="post">
-  <fieldset class="nhsuk-fieldset">
-    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-      <span class="nhsuk-fieldset__heading">
-         Assessment Question Options
-      </span>
-    </legend>
-    <div class="nhsuk-form-group">
-      <label class="nhsuk-label" for="tb-scoringInstructions">
-        Scoring instructions
-      </label>
-      <div class="nhsuk-hint" id="tb-scoringInstructions-hint">
-        When this question is presented to the user, what instructions (if any) should be presented to assist them in answering?
-      </div>
-      <vc:text-area asp-for="AssessmentQuestionDetail.ScoringInstructions"
-                    label=""
-                    populate-with-current-value="true"
-                    rows="5"
-                    spell-check="false"
-                    hint-text=""
-                    css-class="html-editor"
-                    character-count="null" />
-    </div>
-    <div class="nhsuk-form-group">
-      <label class="nhsuk-label" asp-for="AssessmentQuestionDetail.IncludeComments">
-        Comments field
-      </label>
-      <div class="nhsuk-hint" id="includeComments-hint">
-        When this question is presented, should the user be prompted for supporting comments by default?
-      </div>
-      <div class="nhsuk-radios nhsuk-radios--conditional">
-        <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input" id="rb-includeComments-yes" asp-for="AssessmentQuestionDetail.IncludeComments" name="IncludeComments" type="radio" value="true" aria-controls="conditional-comments-options" aria-expanded="@(Model.AssessmentQuestionDetail.IncludeComments == true)">
-          <label class="nhsuk-label nhsuk-radios__label" for="rb-includeComments-yes">
-            Yes
-          </label>
-        </div>
-        <div class="@(Model.AssessmentQuestionDetail.IncludeComments == true ? "nhsuk-radios__conditional" : "nhsuk-radios__conditional nhsuk-radios__conditional--hidden")" id="conditional-comments-options">
-          <nhs-form-group nhs-validation-for="AssessmentQuestionDetail.CommentsPrompt">
-            <label class="nhsuk-label" for="comments-prompt">
-              Comments field prompt (optional)
-            </label>
-            <div class="nhsuk-hint" id="custom-prompt-text-hint">
-              By default the comments field will be labelled "Supporting comments". If required, enter a custom label for the comments box.
+    <h1>@Model.AssessmentQuestionDetail.Question</h1>
+    <form method="post">
+        <fieldset class="nhsuk-fieldset">
+            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                <span class="nhsuk-fieldset__heading">
+                    Assessment Question Options
+                </span>
+            </legend>
+            <div class="nhsuk-form-group">
+                <label class="nhsuk-label" for="tb-scoringInstructions">
+                    Scoring instructions
+                </label>
+                <div class="nhsuk-hint" id="tb-scoringInstructions-hint">
+                    When this question is presented to the user, what instructions (if any) should be presented to assist them in answering?
+                </div>
+                <vc:text-area asp-for="AssessmentQuestionDetail.ScoringInstructions"
+                          label=""
+                          populate-with-current-value="true"
+                          rows="5"
+                          spell-check="false"
+                          hint-text=""
+                          css-class="html-editor"
+                          character-count="null" />
             </div>
-            <input class="nhsuk-input nhsuk-u-width-two-thirds" id="comments-prompt" name="CommentsPrompt" asp-for="AssessmentQuestionDetail.CommentsPrompt" type="text">
-          </nhs-form-group>
-          <nhs-form-group nhs-validation-for="AssessmentQuestionDetail.CommentsHint">
-            <label class="nhsuk-label" for="comments-hint">
-              Comments field hint text (optional)
-            </label>
-            <div class="nhsuk-hint" id="custom-prompt-text-hint">
-              Briefly describe what the user should include in the commments field, if required.
+            <div class="nhsuk-form-group">
+                <label class="nhsuk-label" asp-for="AssessmentQuestionDetail.IncludeComments">
+                    Comments field
+                </label>
+                <div class="nhsuk-hint" id="includeComments-hint">
+                    When this question is presented, should the user be prompted for supporting comments by default?
+                </div>
+                <div class="nhsuk-radios nhsuk-radios--conditional">
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input" id="rb-includeComments-yes" asp-for="AssessmentQuestionDetail.IncludeComments" name="IncludeComments" type="radio" value="true" aria-controls="conditional-comments-options" aria-expanded="@(Model.AssessmentQuestionDetail.IncludeComments == true)">
+                        <label class="nhsuk-label nhsuk-radios__label" for="rb-includeComments-yes">
+                            Yes
+                        </label>
+                    </div>
+                    <div class="@(Model.AssessmentQuestionDetail.IncludeComments == true ? "nhsuk-radios__conditional" : "nhsuk-radios__conditional nhsuk-radios__conditional--hidden")" id="conditional-comments-options">
+                        <nhs-form-group nhs-validation-for="AssessmentQuestionDetail.CommentsPrompt">
+                            <label class="nhsuk-label" for="comments-prompt">
+                                Comments field prompt (optional)
+                            </label>
+                            <div class="nhsuk-hint" id="custom-prompt-text-hint">
+                                By default the comments field will be labelled "Supporting comments". If required, enter a custom label for the comments box.
+                            </div>
+                            <input class="nhsuk-input nhsuk-u-width-two-thirds" id="comments-prompt" name="CommentsPrompt" asp-for="AssessmentQuestionDetail.CommentsPrompt" type="text">
+                        </nhs-form-group>
+                        <nhs-form-group nhs-validation-for="AssessmentQuestionDetail.CommentsHint">
+                            <label class="nhsuk-label" for="comments-hint">
+                                Comments field hint text (optional)
+                            </label>
+                            <div class="nhsuk-hint" id="custom-prompt-text-hint">
+                                Briefly describe what the user should include in the commments field, if required.
+                            </div>
+                            <input class="nhsuk-input nhsuk-u-width-two-thirds" id="comments-hint" name="CommentsHint" asp-for="AssessmentQuestionDetail.CommentsHint" type="text">
+                        </nhs-form-group>
+                    </div>
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input" id="rb-includeComments-no" asp-for="AssessmentQuestionDetail.IncludeComments" name="IncludeComments" type="radio" value="false">
+                        <label class="nhsuk-label nhsuk-radios__label" for="rb-includeComments-no">
+                            No
+                        </label>
+                    </div>
+                </div>
             </div>
-            <input class="nhsuk-input nhsuk-u-width-two-thirds" id="comments-hint" name="CommentsHint" asp-for="AssessmentQuestionDetail.CommentsHint" type="text">
-          </nhs-form-group>
-        </div>
-        <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input" id="rb-includeComments-no" asp-for="AssessmentQuestionDetail.IncludeComments" name="IncludeComments" type="radio" value="false">
-          <label class="nhsuk-label nhsuk-radios__label" for="rb-includeComments-no">
-            No
-          </label>
-        </div>
-      </div>
-    </div>
-    <input name="ID" type="hidden" asp-for="AssessmentQuestionDetail.ID" />
-    <input name="MinValue" type="hidden" asp-for="AssessmentQuestionDetail.MinValue" />
-    <input name="MaxValue" type="hidden" asp-for="AssessmentQuestionDetail.MaxValue" />
-    <input name="MaxValueDescription" type="hidden" asp-for="AssessmentQuestionDetail.MaxValueDescription" />
-    <input name="MinValueDescription" type="hidden" asp-for="AssessmentQuestionDetail.MinValueDescription" />
-    <input name="Question" type="hidden" asp-for="AssessmentQuestionDetail.Question" />
-    <input name="AssessmentQuestionInputTypeID" type="hidden" asp-for="AssessmentQuestionDetail.AssessmentQuestionInputTypeID" />
-    <input name="InputTypeName" type="hidden" asp-for="AssessmentQuestionDetail.InputTypeName" />
-    <input name="AddedByAdminId" type="hidden" asp-for="AssessmentQuestionDetail.AddedByAdminId" />
-    <input name="UserIsOwner" type="hidden" asp-for="AssessmentQuestionDetail.UserIsOwner" />
-  </fieldset>
-  @if (Model.AssessmentQuestionDetail.AssessmentQuestionInputTypeID != 2)
-  {
-    <a class="nhsuk-button nhsuk-button--secondary" asp-action="AssessmentQuestionLevelDescriptor" asp-route-level="@Model.AssessmentQuestionDetail.MaxValue" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-assessmentQuestionId="@ViewContext.RouteData.Values["assessmentQuestionId"]" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">
-      Back
-    </a>
-  }
-  else
-  {
-    <a class="nhsuk-button nhsuk-button--secondary" asp-action="EditAssessmentQuestionScoring" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-assessmentQuestionId="@ViewContext.RouteData.Values["assessmentQuestionId"]" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">
-      Back
-    </a>
-  }
+            <input name="ID" type="hidden" asp-for="AssessmentQuestionDetail.ID" />
+            <input name="MinValue" type="hidden" asp-for="AssessmentQuestionDetail.MinValue" />
+            <input name="MaxValue" type="hidden" asp-for="AssessmentQuestionDetail.MaxValue" />
+            <input name="MaxValueDescription" type="hidden" asp-for="AssessmentQuestionDetail.MaxValueDescription" />
+            <input name="MinValueDescription" type="hidden" asp-for="AssessmentQuestionDetail.MinValueDescription" />
+            <input name="Question" type="hidden" asp-for="AssessmentQuestionDetail.Question" />
+            <input name="AssessmentQuestionInputTypeID" type="hidden" asp-for="AssessmentQuestionDetail.AssessmentQuestionInputTypeID" />
+            <input name="InputTypeName" type="hidden" asp-for="AssessmentQuestionDetail.InputTypeName" />
+            <input name="AddedByAdminId" type="hidden" asp-for="AssessmentQuestionDetail.AddedByAdminId" />
+            <input name="UserIsOwner" type="hidden" asp-for="AssessmentQuestionDetail.UserIsOwner" />
+        </fieldset>
+        @if (Model.AssessmentQuestionDetail.AssessmentQuestionInputTypeID != 2)
+    {
+        <a class="nhsuk-button nhsuk-button--secondary" asp-action="AssessmentQuestionLevelDescriptor" asp-route-level="@Model.AssessmentQuestionDetail.MaxValue" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-assessmentQuestionId="@ViewContext.RouteData.Values["assessmentQuestionId"]" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">
+            Back
+        </a>
+    }
+    else
+    {
+        <a class="nhsuk-button nhsuk-button--secondary" asp-action="EditAssessmentQuestionScoring" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-assessmentQuestionId="@ViewContext.RouteData.Values["assessmentQuestionId"]" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">
+            Back
+        </a>
+    }
 
-  <button class="nhsuk-button" type="submit">
-    Next
-  </button>
-  @if (Model.FrameworkCompetencyId == 0)
-  {
-    <div class="nhsuk-back-link">
-      <a class="nhsuk-back-link__link" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        Cancel
-      </a>
-    </div>
-  }
-  else
-  {
-    <div class="nhsuk-back-link">
-      <a class="nhsuk-back-link__link" asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        Cancel
-      </a>
-    </div>
-  }
+    <button class="nhsuk-button" type="submit">
+        Next
+    </button>
+    @if (Model.FrameworkCompetencyId == 0)
+    {
+        <div class="nhsuk-back-link">
+            <a class="nhsuk-back-link__link" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">
+                <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+                </svg>
+                Cancel
+            </a>
+        </div>
+    }
+    else
+    {
+        <div class="nhsuk-back-link">
+            <a class="nhsuk-back-link__link" asp-action="EditCompetencyAssessmentQuestions" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId">
+                <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+                </svg>
+                Cancel
+            </a>
+        </div>
+    }
 </form>
 @section scripts {
-  <script src="@Url.Content("~/js/frameworks/htmleditor.js")" asp-append-version="true"></script>
+    <script src="@Url.Content("~/js/frameworks/htmleditor.js")" asp-append-version="true"></script>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AssessmentQuestionOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AssessmentQuestionOptions.cshtml
@@ -54,7 +54,14 @@
       <div class="nhsuk-hint" id="tb-scoringInstructions-hint">
         When this question is presented to the user, what instructions (if any) should be presented to assist them in answering?
       </div>
-      <textarea class="nhsuk-input html-editor" placeholder="Optional" id="tb-scoringInstructions" asp-for="AssessmentQuestionDetail.ScoringInstructions" name="ScoringInstructions" type="text"></textarea>
+      <vc:text-area asp-for="AssessmentQuestionDetail.ScoringInstructions"
+                    label=""
+                    populate-with-current-value="true"
+                    rows="5"
+                    spell-check="false"
+                    hint-text=""
+                    css-class="html-editor"
+                    character-count="null" />
     </div>
     <div class="nhsuk-form-group">
       <label class="nhsuk-label" asp-for="AssessmentQuestionDetail.IncludeComments">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
@@ -9,7 +9,7 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
-@section NavBreadcrumbs {
+  @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
@@ -21,10 +21,10 @@
     </div>
   </nav>
 }
-<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-row">
 
-  <div class="nhsuk-grid-column-full">
-    @if (Model.FrameworkCompetency.Id > 0)
+    <div class="nhsuk-grid-column-full">
+      @if (Model.FrameworkCompetency.Id > 0)
     {
       <h1>
         Edit @Model.VocabSingular().ToLower()
@@ -61,25 +61,24 @@
                       hint-text=""
                       css-class="html-editor"
                       character-count="null"
-                      populate-with-current-value="true"
-                      />
+                      populate-with-current-value="true" />
       </div>
       @if (Model.CompetencyFlags?.Count() > 0)
       {
-      <div class="nhsuk-form-group">
-        <label class="nhsuk-label nhsuk-u-margin-bottom-2" id="competency-description-label" for="competency-description">
-          @Model.VocabSingular() tags
-        </label>
-        @foreach (var flag in Model.CompetencyFlags)
-        {
-          <div class="nhsuk-checkboxes__item">
-            <input class="nhsuk-checkboxes__input" name="selectedFlagIds" type="checkbox" value="@flag.FlagId" @(flag.Selected ? "checked" : string.Empty) />
-            <label class="nhsuk-label nhsuk-checkboxes__label">
-              @flag.FlagName
-            </label>
-          </div>
-        }
-      </div>
+        <div class="nhsuk-form-group">
+          <label class="nhsuk-label nhsuk-u-margin-bottom-2" id="competency-description-label" for="competency-description">
+            @Model.VocabSingular() tags
+          </label>
+          @foreach (var flag in Model.CompetencyFlags)
+          {
+            <div class="nhsuk-checkboxes__item">
+              <input class="nhsuk-checkboxes__input" name="selectedFlagIds" type="checkbox" value="@flag.FlagId" @(flag.Selected ? "checked" : string.Empty) />
+              <label class="nhsuk-label nhsuk-checkboxes__label">
+                @flag.FlagName
+              </label>
+            </div>
+          }
+        </div>
       }
 
       <input name="Id" type="hidden" asp-for="FrameworkCompetency.Id" />

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
@@ -53,10 +53,16 @@
         <input class="nhsuk-input" asp-for="FrameworkCompetency.Name" id="competency-name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-name-label">
       </nhs-form-group>
       <div class="nhsuk-form-group">
-        <label class="nhsuk-label" id="competency-description-label" for="competency-description">
-          @Model.VocabSingular() description
-        </label>
-        <textarea class="nhsuk-input html-editor" asp-for="FrameworkCompetency.Description" id="competency-description" name="Description" type="text" aria-describedby="competency-description-label"></textarea>
+        <vc:text-area asp-for="FrameworkCompetency.Description"
+                      label="@Model.VocabSingular() description"
+                      populate-with-current-value="true"
+                      rows="5"
+                      spell-check="false"
+                      hint-text=""
+                      css-class="html-editor"
+                      character-count="null"
+                      populate-with-current-value="true"
+                      />
       </div>
       @if (Model.CompetencyFlags?.Count() > 0)
       {

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
@@ -52,13 +52,16 @@
                 <span nhs-validation-for="CompetencyGroupBase.Name"></span>
                 <input class="nhsuk-input" asp-for="CompetencyGroupBase.Name" id="competency-group-name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-group-name-label">
             </nhs-form-group>
-            <nhs-form-group nhs-validation-for="CompetencyGroupBase.Description">
-                <label class="nhsuk-label" id="competency-group-description-label" for="competency-group-description">
-                    @Model.VocabSingular() group description
-                </label>
-                <span nhs-validation-for="CompetencyGroupBase.Description"></span>
-                <input class="nhsuk-input html-editor" asp-for="CompetencyGroupBase.Description" id="competency-group-description" name="Description" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-group-description-label" />
-            </nhs-form-group>
+@*            <nhs-form-group nhs-validation-for="CompetencyGroupBase.Description">
+                <vc:text-area asp-for="CompetencyGroupBase.Description"
+                              label="@Model.VocabSingular() group description"
+                              populate-with-current-value="true"
+                              rows="5"
+                              spell-check="false"
+                              hint-text=""
+                              css-class="html-editor"
+                              character-count="null" />
+            </nhs-form-group>*@
             <input name="ID" type="hidden" asp-for="CompetencyGroupBase.ID" />
             <input name="CompetencyGroupID" type="hidden" asp-for="CompetencyGroupBase.CompetencyGroupID" />
 

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
@@ -52,7 +52,8 @@
                 <span nhs-validation-for="CompetencyGroupBase.Name"></span>
                 <input class="nhsuk-input" asp-for="CompetencyGroupBase.Name" id="competency-group-name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-group-name-label">
             </nhs-form-group>
-@*            <nhs-form-group nhs-validation-for="CompetencyGroupBase.Description">
+            <nhs-form-group nhs-validation-for="CompetencyGroupBase.Description">
+                <span nhs-validation-for="CompetencyGroupBase.Description"></span>
                 <vc:text-area asp-for="CompetencyGroupBase.Description"
                               label="@Model.VocabSingular() group description"
                               populate-with-current-value="true"
@@ -61,7 +62,7 @@
                               hint-text=""
                               css-class="html-editor"
                               character-count="null" />
-            </nhs-form-group>*@
+            </nhs-form-group>
             <input name="ID" type="hidden" asp-for="CompetencyGroupBase.ID" />
             <input name="CompetencyGroupID" type="hidden" asp-for="CompetencyGroupBase.CompetencyGroupID" />
 

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Description.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Description.cshtml
@@ -61,7 +61,7 @@ else
                   character-count="null"
                   label="Description"
                   rows="5"
-                  css-class="nhsuk-input html-editor"
+                  css-class="html-editor"
                   hint-text=""
                   populate-with-current-value="true"
                   spell-check="false" />

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Description.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Description.cshtml
@@ -57,7 +57,14 @@ else
       Provide a description for your framework including any key information for people who wish to use it. Who was it created by? What is its purpose? What is the benefit of using it? This can be added or changed later.
     </div>
     <span nhs-validation-for="FrameworkName"></span>
-    <textarea class="nhsuk-input html-editor" placeholder="Optional" id="tb-description" asp-for="Description" name="Description" type="text"></textarea>
+    <vc:text-area asp-for="Description"
+                  character-count="null"
+                  label="Description"
+                  rows="5"
+                  css-class="nhsuk-input html-editor"
+                  hint-text=""
+                  populate-with-current-value="true"
+                  spell-check="false" />
   </nhs-form-group>
   <input name="ID" type="hidden" asp-for="ID" />
   <input name="FrameworkName" type="hidden" asp-for="FrameworkName" />


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?selectedIssue=DLSV2-656

### Description
Swapped the standard textarea controls to use textarea view component. This now correctly renders a 5 row textarea when javascript is disabled in the browser (with js enabled the control still renders as a textarea with the html-editor functionality).

The new control appears on the following four pages:
AssessmentQuestionsOptions.cshtml
Description.cshtml
Competency.cshtml
CompetencyGroup.cshtml

### Screenshots
See attached.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser


![final_assessement_outcome_js_desktop](https://user-images.githubusercontent.com/113513647/191230598-435d66a9-a74c-4717-aff4-73d5f14a6e24.png)
![final_assessement_outcome_nojs_desktop](https://user-images.githubusercontent.com/113513647/191230603-955988bc-0395-4fd4-93ab-e8fd343db76e.png)
![edit_competency_group_js_desktop](https://user-images.githubusercontent.com/113513647/191230608-83911647-81ed-4621-bbfb-bd97d20d2829.png)
![edit_competency_group_nojs_desktop](https://user-images.githubusercontent.com/113513647/191230612-9329d71d-fcdf-4310-becf-b5f5228f6bce.png)
![edit_competency_js_desktop](https://user-images.githubusercontent.com/113513647/191230619-33aaa169-5e13-4850-8613-119c23a0bd9c.png)
![edit_competency_nojs_desktop](https://user-images.githubusercontent.com/113513647/191230622-95a68a43-7dc3-4e48-9ac1-543b332e8e4e.png)
![edit_framework_description_js_desktop](https://user-images.githubusercontent.com/113513647/191230624-e85f8f20-ca19-4f16-9715-a87c2e0e1218.png)
![edit_framework_description_nojs_desktop](https://user-images.githubusercontent.com/113513647/191230628-957d8bfb-46f7-406b-95e5-0b091c025228.png)
