### PR TITLE
DLSV2-640 Fixed validation on null userEmail

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/FrameworkServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/FrameworkServiceTests.cs
@@ -481,6 +481,19 @@
             result.Should().Be(-3);
         }
         [Test]
+        public void AddCollaboratorToFramework_should_return_minus_3_if_collaborator_email_is_null()
+        {
+            // Given
+            string? userEmail = null;
+            const bool canModify = false;
+            
+            // When
+            var result = frameworkService.AddCollaboratorToFramework(ValidFrameworkId, userEmail, canModify);
+
+            // Then
+            result.Should().Be(-3);
+        }
+        [Test]
         public void GetFrameworkCompetencyGroups_returns_list_with_more_than_one_framework_competency_groups_for_valid_framework_id()
         {
             // When

--- a/DigitalLearningSolutions.Data.Tests/Services/FrameworkServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/FrameworkServiceTests.cs
@@ -486,7 +486,7 @@
             // Given
             string? userEmail = null;
             const bool canModify = false;
-            
+
             // When
             var result = frameworkService.AddCollaboratorToFramework(ValidFrameworkId, userEmail, canModify);
 

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -777,9 +777,9 @@
             );
         }
 
-        public int AddCollaboratorToFramework(int frameworkId, string userEmail, bool canModify)
+        public int AddCollaboratorToFramework(int frameworkId, string? userEmail, bool canModify)
         {
-            if (userEmail.Length == 0)
+            if (userEmail is null || userEmail.Length == 0)
             {
                 logger.LogWarning(
                     $"Not adding collaborator to framework as it failed server side valiidation. frameworkId: {frameworkId}, userEmail: {userEmail}, canModify:{canModify}"


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?selectedIssue=DLSV2-640

### Description
Where the user clicked the 'Add as Contributor' or 'Add as Reviewer' button on the 'Choose working group members' page, without entering an email address in the textbox, the system crashed with an unhandled null exception error and did not display a validation warning to the user.

The AddCollaboratorToFramework method in FrameworkService.cs was being passed in a null rather than empty string for userEmail, which is possible as it is directly called by the HttpPost AddCollaborator method in Frameworks.cs.

I updated the code to allow a null userEmail parameter and handle the error gracefully with a user validation error (see attached screenshots).

### Screenshots
Screenshots attached.

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser

![add_user_to_the_working_group_email_blank](https://user-images.githubusercontent.com/113513647/191270471-ad10e4db-4b16-4117-8894-b11edc79f539.png)
![add_user_to_the_working_group_email_blank_new_validation_error](https://user-images.githubusercontent.com/113513647/191270478-95492d10-db6c-45ca-9c21-2c5bc2966a98.png)

