### PR TITLE
Develop/fixes/dlsv2 652 spurious validation error on remove unsupervised user

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -189,6 +189,7 @@
             }
             else
             {
+                ModelState.ClearErrorsOnField("ActionConfirmed");
                 return View("RemoveConfirm", supervisorDelegate);
             }
         }


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?assignee=6321797ece3e476e42ac8a00&selectedIssue=DLSV2-652

### Description
On page Supervisor>My Staff if you click the 'Remove staff member' for a person that does not have any self assessments, the following page displayed a spurious error on load (see attached screenshot).

This was caused by an error occuring in the viewmodel validation because in SupervisorDelegateViewModel.cs the property ActionConfirmed is validated as must be true (via the [BooleanMustBeTrue] decorator).

However in this edge case this ActionConfirmed = false is a valid model state, because the user has not ticked the confirmation checkbox on the 'confirm remove' page.

The solution was to clear the spurious error on this field (see attached screenshot for correct loading of the 'Confirm Remove Staff Member' page.

### Screenshots
See attached before and after screenshots.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser


![bug652issue](https://user-images.githubusercontent.com/113513647/191712611-1562c90c-7051-4c69-8f17-ff9197a606df.png)
![bug652fixed](https://user-images.githubusercontent.com/113513647/191712637-bc0bda44-7c9b-4510-9490-8def8f66a08d.png)

