### PR TITLE
Develop/fixes/dlsv2 687 page 500 error on choose working group members screen when given user email not associated with dls account and clicking the add as contributor or reviewer buttons

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/FrameworkServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/FrameworkServiceTests.cs
@@ -493,6 +493,22 @@
             // Then
             result.Should().Be(-3);
         }
+
+        [Test]
+        public void AddCollaboratorToFramework_should_return_minus_4_if_collaborator_email_is_not_admin()
+        {
+            // Given
+            string? userAdminEmail = "4dfbbaca-0055-44ea-b630-b08659aa82d0@xx";
+            const bool canModify = false;
+
+            // When
+            var result = frameworkService.AddCollaboratorToFramework(ValidFrameworkId, userAdminEmail, canModify);
+
+            // Then
+            result.Should().Be(-4);
+        }
+
+
         [Test]
         public void GetFrameworkCompetencyGroups_returns_list_with_more_than_one_framework_competency_groups_for_valid_framework_id()
         {

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -803,7 +803,7 @@
                 @"SELECT AdminID FROM AdminUsers WHERE Email = @userEmail AND Active = 1",
                 new { userEmail }
             );
-            if(adminId is null)
+            if (adminId is null)
             {
                 return -4;
             }

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -803,6 +803,10 @@
                 @"SELECT AdminID FROM AdminUsers WHERE Email = @userEmail AND Active = 1",
                 new { userEmail }
             );
+            if(adminId is null)
+            {
+                return -4;
+            }
 
             var numberOfAffectedRows = connection.Execute(
                 @"INSERT INTO FrameworkCollaborators (FrameworkID, AdminID, UserEmail, CanModify)


### PR DESCRIPTION


### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-687

### Description
When the user adds an email that doesn't belong to the admin group, the user email is stored regardless but without an AdminID. the system later experiences an error when trying to send an Invite Notification to the just invited contributor/reviewer because of the null AdminID that was initially saved to the database.

I updated the code and added a check to see if the user belongs to the admin user group.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
