### PR TITLE
Develop/fixes/dlsv2 675 blank competency and competency group descriptions are being stored as empty strings instead of null values

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1063,6 +1063,7 @@ GROUP BY fc.ID, c.ID, c.Name, c.Description, fc.Ordering
                 );
                 return;
             }
+            description?.Trim();
             if (string.IsNullOrWhiteSpace(description))
             {
                 description = null;

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1063,7 +1063,10 @@ GROUP BY fc.ID, c.ID, c.Name, c.Description, fc.Ordering
                 );
                 return;
             }
-
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                description = null;
+            }
             //DO WE NEED SOMETHING IN HERE TO CHECK WHETHER IT IS USED ELSEWHERE AND WARN THE USER?
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE Competencies SET Name = @name, Description = @description, UpdatedByAdminID = @adminId


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-675

### Description
When Competency description is blank, then expanders are not appearing as expected but when Competency Description has spaces “ “  in it, expanders are appearing

### Screenshots
_Attach screenshots on mobile, tablet and desktop._
![Competency1](https://user-images.githubusercontent.com/114475132/193763739-9a21982f-be19-4528-b6f9-52cd5f9f64f4.PNG)
![Competency2](https://user-images.githubusercontent.com/114475132/193763744-7cc9d54b-8a95-480d-9606-779109333ba2.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
