### PR TITLE
DLSV2-523 competencies tags collapse issue

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -103,7 +103,7 @@
         @foreach (var competency in competencyGroup)
         {
           <tr role="row" class="nhsuk-table__row first-row">
-            <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
+            <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
               <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
               <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />
               @if (competency.Description != null && !competency.AlwaysShowDescription)


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-523

### Description
Self-assessment with multiple flags collapse without spacing

### Screenshots
![paddingfix](https://user-images.githubusercontent.com/114475132/193764616-e7681159-9948-430f-b6f3-eb7b477281dc.jpg)
![paddingMobil](https://user-images.githubusercontent.com/114475132/193765045-302832ee-cfb9-4b29-9902-f4fb20df8af9.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
