### PR TITLE
Updated Add Competency Learning Resource search page layout.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/AddCompetencyLearningResources.cshtml
@@ -64,7 +64,7 @@
   <form method="get" role="search" asp-action="SearchLearningResourcesAsync">
     <h2>Search the Learning Hub</h2>
     <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-three-quarters">
+      <div class="nhsuk-grid-column-full">
         <div class="search-box-container" id="search">
           @Html.LabelFor(m => m.SearchText, "Search", new { @class = "nhsuk-u-visually-hidden", @for = "search-field" })
           @Html.TextBoxFor(m => m.SearchText, new { @class = "search-box nhsuk-input", id = "search-field", name = "searchString", type = "search", placeholder = "Search", autocomplete = "off" })
@@ -90,11 +90,6 @@
     </div>
   </form>
 
-  <form method="get">
-    <partial name="PaginatedPage/_TopPaginationNav" model="Model" />
-    @Html.Hidden("SearchText", Model.SearchText)
-  </form>
-
   @if (Model.LearningHubApiError)
 {
   <span class="nhsuk-u-margin-1 nhsuk-u-clear">This service is unavailable. Please try again later.</span>
@@ -102,6 +97,12 @@
 else if (Model.SearchResult?.Results != null)
 {
   <span class="nhsuk-u-margin-1 nhsuk-u-clear">@Model.TotalNumResources matches for "@Model.SearchText"</span>
+
+  <form method="get">
+    <partial name="PaginatedPage/_TopPaginationNav" model="Model" />
+    @Html.Hidden("SearchText", Model.SearchText)
+  </form>
+
   @foreach (var result in Model.SearchResult.Results)
   {
     <partial name="Developer/_SignpostingResourceCard" model="new CompetencyResourceSummaryViewModel(result)" view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?assignee=6321797ece3e476e42ac8a00&selectedIssue=DLSV2-646

### Description
Moved search results count text above new top pagination toolbar.
Expanded search textbox and dropdown to full width.

### Screenshots
Screenshot attached

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser

![646](https://user-images.githubusercontent.com/113513647/193863270-624ec8c6-5de7-4fd8-9eca-ca5e94bee589.png)
