### PR TITLE
DLSV2-682 supervisor pending confirmation results should display the name of the assessor that confirmation has been requested from

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -61,7 +61,8 @@
                     sv.Requested,
                     sv.Verified,
                     sv.Comments,
-                    sv.SignedOff, 
+                    sv.SignedOff,
+                    adu.Forename + ' ' + adu.Surname AS SupervisorName,
                     CAST(CASE WHEN COALESCE(sd.SupervisorAdminID, 0) = @adminId THEN 1 ELSE 0 END AS Bit) AS UserIsVerifier,
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM CandidateAssessments ca
@@ -82,6 +83,8 @@
                     ON sv.CandidateAssessmentSupervisorID = cas.ID
                 LEFT OUTER JOIN SupervisorDelegates AS sd
                     ON cas.SupervisorDelegateId = sd.ID
+                LEFT OUTER JOIN AdminUsers AS adu
+						     ON sd.SupervisorAdminID = adu.AdminID
                 LEFT OUTER JOIN CompetencyAssessmentQuestionRoleRequirements rr
                     ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID
                         AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
@@ -129,6 +132,7 @@
             LAR.SelfAssessmentResultSupervisorVerificationId,
             LAR.Requested,
             LAR.Verified,
+            LAR.SupervisorName,
             LAR.Comments AS SupervisorComments,
             LAR.SignedOff,
             LAR.UserIsVerifier,

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
@@ -18,7 +18,8 @@
         public int MaxValue { get; set; }
         public int AssessmentQuestionInputTypeID { get; set; }
         public bool IncludeComments { get; set; }
-        public IEnumerable<LevelDescriptor> LevelDescriptors {get; set;}
+        public IEnumerable<LevelDescriptor> LevelDescriptors { get; set; }
+        public string? SupervisorName { get; set; }
         public string? SupportingComments { get; set; }
         public int? SelfAssessmentResultSupervisorVerificationId { get; set; }
         public DateTime? Requested { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/Services/SupervisorService.cs
@@ -270,7 +270,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
                 FROM CandidateAssessmentSupervisors AS cas INNER JOIN
                          CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID 
+                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID
                  LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
                 WHERE  (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = @supervisorDelegateId) AND (sa.ID = @selfAssessmentId)", new { selfAssessmentId, supervisorDelegateId }
                ).FirstOrDefault();
@@ -291,7 +291,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
                 FROM CandidateAssessmentSupervisors AS cas INNER JOIN
                          CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID 
+                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID
                 WHERE (ca.ID = @candidateAssessmentId)", new { candidateAssessmentId }
                ).FirstOrDefault();
         }
@@ -308,7 +308,7 @@ WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS Resu
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL)) AS ResultsVerificationRequests
                 FROM CandidateAssessmentSupervisors AS cas INNER JOIN
                          CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID 
+                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID
                  LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
                 WHERE  (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = @supervisorDelegateId) AND (ca.ID = @candidateAssessmentId)", new { candidateAssessmentId, supervisorDelegateId }
                ).FirstOrDefault();
@@ -590,7 +590,7 @@ WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
                     new { selfAssessmentId, supervisorDelegateId });
             }
 
-            if(deletedCandidateAssessmentSupervisors >= 1)
+            if (deletedCandidateAssessmentSupervisors >= 1)
             {
                 connection.Execute(
                     @"UPDATE SupervisorDelegates SET Removed = getUTCDate() 

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -59,83 +59,109 @@
   <dl class="nhsuk-summary-list">
 
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        @Model.Competency.Vocabulary
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.Competency.Name
-      </dd>
+    <dt class="nhsuk-summary-list__key">
+      @Model.Competency.Vocabulary
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.Competency.Name
+    </dd>
     </div>
-  @if (Model.Competency.CompetencyFlags.Any())
-  {
-    <div class="nhsuk-summary-list__row">
+    @if (Model.Competency.CompetencyFlags.Any())
+    {
+      <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
         Flags
       </dt>
       <dd class="nhsuk-summary-list__value">
         <partial name="_CompetencyFlags" model="Model.Competency.CompetencyFlags" />
       </dd>
-    </div>
-  }
-  @if (Model.Competency.Description != null)
-  {
-    <div class="nhsuk-summary-list__row">
+      </div>
+    }
+    @if (Model.Competency.Description != null)
+    {
+      <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
         Description
       </dt>
       <dd class="nhsuk-summary-list__value">
         @Html.Raw(Model.Competency.Description)
       </dd>
-    </div>
-  }
-  <div class="nhsuk-summary-list__row">
+      </div>
+    }
+    <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
       Question
     </dt>
     <dd class="nhsuk-summary-list__value">
       @Model.Competency.AssessmentQuestions.First().Question
     </dd>
-  </div>
+    </div>
 
-  <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
       Learner response
     </dt>
     <dd class="nhsuk-summary-list__value">
       <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
     </dd>
-  </div>
-  @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
-  {
-    <div class="nhsuk-summary-list__row">
+    </div>
+    @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
+    {
+      <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
         Role expectations
       </dt>
       <dd class="nhsuk-summary-list__value">
         @(Model.Competency.AssessmentQuestions.First().ResultRAG == 1 ? "Not meeting" : Model.Competency.AssessmentQuestions.First().ResultRAG == 2 ? "Partially meeting" : "Fully meeting")
       </dd>
-    </div>
-  }
-  @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
-  {
-    <div class="nhsuk-summary-list__row">
+      </div>
+    }
+    @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
+    {
+      <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
         Comments
       </dt>
       <dd class="nhsuk-summary-list__value">
         @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)
       </dd>
-    </div>
-  }
-  <div class="nhsuk-summary-list__row">
+      </div>
+    }
+    <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
       Status
     </dt>
     <dd class="nhsuk-summary-list__value">
       <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
     </dd>
-  </div>
-</dl>
+    </div>
+    @if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Verified == null && !(bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
+    {
+      <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Supervisor
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @Model.SupervisorName
+      </dd>
+      </div>
+      @if (Model.Competency.AssessmentQuestions.First().Requested != null)
+      {
+        <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Verification Requested
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          @{DateTime verificationRequested = (DateTime)Model.Competency.AssessmentQuestions.First().Requested; }
+          @verificationRequested.ToString("dd/MM/yyyy")
+        </dd>
+        </div>
+
+      }
+
+    }
+
+  </dl>
 @if (errorHasOccurred)
 {
   <vc:error-summary order-of-property-names="@new []{ nameof(ReviewCompetencySelfAsessmentViewModel) }" />

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -142,7 +142,7 @@
       Supervisor
     </dt>
     <dd class="nhsuk-summary-list__value">
-      @Model.SupervisorName
+      @Model.Competency.AssessmentQuestions.First().SupervisorName
     </dd>
     </div>
     @if (Model.Competency.AssessmentQuestions.First().Requested != null)

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -11,7 +11,7 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
-  @section NavBreadcrumbs {
+@section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
@@ -19,149 +19,149 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
         <li class="nhsuk-breadcrumb__item">
           <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-           asp-action="DelegateProfileAssessments"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+             asp-action="DelegateProfileAssessments"
+             asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName</a>
+          </li>
+          <li class="nhsuk-breadcrumb__item">
+            <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+               asp-action="ReviewDelegateSelfAssessment"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
+              @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
+            </a>
+          </li>
+          <li class="nhsuk-breadcrumb__item">
+            @(Model.Competency.Name.Length > 35 ? Model.Competency.Name.Substring(0, 32) + "..." : Model.Competency.Name)
+          </li>
+        </ol>
+      </div>
+      <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
            asp-action="ReviewDelegateSelfAssessment"
            asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
            asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
-            @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          @(Model.Competency.Name.Length > 35 ? Model.Competency.Name.Substring(0, 32) + "..." : Model.Competency.Name)
-        </li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="ReviewDelegateSelfAssessment"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-       asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
-        Back to  @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
-      </a>
-    </p>
-  </nav>
+          Back to  @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
+        </a>
+      </p>
+    </nav>
 }
-  <details class="nhsuk-details nhsuk-expander">
-    <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
-      </h1>
-    </summary>
-    <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegate" />
-    </div>
-  </details>
-  <h2>@Model.Competency.Vocabulary Self Assessment Result</h2>
-  <dl class="nhsuk-summary-list">
+<details class="nhsuk-details nhsuk-expander">
+  <summary class="nhsuk-details__summary">
+    <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+      @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
+    </h1>
+  </summary>
+  <div class="nhsuk-details__text">
+    <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegate" />
+  </div>
+</details>
+<h2>@Model.Competency.Vocabulary Self Assessment Result</h2>
+<dl class="nhsuk-summary-list">
 
+  <div class="nhsuk-summary-list__row">
+  <dt class="nhsuk-summary-list__key">
+    @Model.Competency.Vocabulary
+  </dt>
+  <dd class="nhsuk-summary-list__value">
+    @Model.Competency.Name
+  </dd>
+  </div>
+  @if (Model.Competency.CompetencyFlags.Any())
+  {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      @Model.Competency.Vocabulary
+      Flags
     </dt>
     <dd class="nhsuk-summary-list__value">
-      @Model.Competency.Name
+      <partial name="_CompetencyFlags" model="Model.Competency.CompetencyFlags" />
     </dd>
     </div>
-    @if (Model.Competency.CompetencyFlags.Any())
-    {
-      <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Flags
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        <partial name="_CompetencyFlags" model="Model.Competency.CompetencyFlags" />
-      </dd>
-      </div>
-    }
-    @if (Model.Competency.Description != null)
-    {
-      <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Description
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Html.Raw(Model.Competency.Description)
-      </dd>
-      </div>
-    }
+  }
+  @if (Model.Competency.Description != null)
+  {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Question
+      Description
     </dt>
     <dd class="nhsuk-summary-list__value">
-      @Model.Competency.AssessmentQuestions.First().Question
+      @Html.Raw(Model.Competency.Description)
     </dd>
     </div>
+  }
+  <div class="nhsuk-summary-list__row">
+  <dt class="nhsuk-summary-list__key">
+    Question
+  </dt>
+  <dd class="nhsuk-summary-list__value">
+    @Model.Competency.AssessmentQuestions.First().Question
+  </dd>
+  </div>
 
+  <div class="nhsuk-summary-list__row">
+  <dt class="nhsuk-summary-list__key">
+    Learner response
+  </dt>
+  <dd class="nhsuk-summary-list__value">
+    <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
+  </dd>
+  </div>
+  @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
+  {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Learner response
+      Role expectations
     </dt>
     <dd class="nhsuk-summary-list__value">
-      <partial name="Shared/_AssessmentQuestionResponse" model="Model.Competency.AssessmentQuestions.First()" />
+      @(Model.Competency.AssessmentQuestions.First().ResultRAG == 1 ? "Not meeting" : Model.Competency.AssessmentQuestions.First().ResultRAG == 2 ? "Partially meeting" : "Fully meeting")
     </dd>
     </div>
-    @if (Model.Competency.AssessmentQuestions.First().ResultRAG > 0)
-    {
-      <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Role expectations
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @(Model.Competency.AssessmentQuestions.First().ResultRAG == 1 ? "Not meeting" : Model.Competency.AssessmentQuestions.First().ResultRAG == 2 ? "Partially meeting" : "Fully meeting")
-      </dd>
-      </div>
-    }
-    @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
-    {
-      <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Comments
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)
-      </dd>
-      </div>
-    }
+  }
+  @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
+  {
     <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      Status
+      Comments
     </dt>
     <dd class="nhsuk-summary-list__value">
-      <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
+      @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)
     </dd>
     </div>
-    @if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Verified == null && !(bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
+  }
+  <div class="nhsuk-summary-list__row">
+  <dt class="nhsuk-summary-list__key">
+    Status
+  </dt>
+  <dd class="nhsuk-summary-list__value">
+    <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
+  </dd>
+  </div>
+  @if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Verified == null && !(bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
+  {
+    <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Supervisor
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.SupervisorName
+    </dd>
+    </div>
+    @if (Model.Competency.AssessmentQuestions.First().Requested != null)
     {
       <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
-        Supervisor
+        Verification Requested
       </dt>
       <dd class="nhsuk-summary-list__value">
-        @Model.SupervisorName
+        @{DateTime verificationRequested = (DateTime)Model.Competency.AssessmentQuestions.First().Requested; }
+        @verificationRequested.ToString("dd/MM/yyyy")
       </dd>
       </div>
-      @if (Model.Competency.AssessmentQuestions.First().Requested != null)
-      {
-        <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          Verification Requested
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          @{DateTime verificationRequested = (DateTime)Model.Competency.AssessmentQuestions.First().Requested; }
-          @verificationRequested.ToString("dd/MM/yyyy")
-        </dd>
-        </div>
-
-      }
 
     }
 
-  </dl>
+  }
+
+</dl>
 @if (errorHasOccurred)
 {
   <vc:error-summary order-of-property-names="@new []{ nameof(ReviewCompetencySelfAsessmentViewModel) }" />
@@ -228,44 +228,44 @@ else if (ViewContext.RouteData.Values["viewMode"].ToString() == "View" && Model.
     <dl class="nhsuk-summary-list">
 
       <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          Reviewed
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          @if (Model.Verified != null)
-          {
-            DateTime verified = (DateTime)Model.Verified;
-            verifiedString = verified.ToString("dd/MM/yyyy");
-          }
-          @Html.Raw(verifiedString)<text> </text>@Model.SupervisorName
-        </dd>
+      <dt class="nhsuk-summary-list__key">
+        Reviewed
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @if (Model.Verified != null)
+        {
+          DateTime verified = (DateTime)Model.Verified;
+          verifiedString = verified.ToString("dd/MM/yyyy");
+        }
+        @Html.Raw(verifiedString)<text> </text>@Model.SupervisorName
+      </dd>
       </div>
 
       <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-          Confirmed
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-          @if (Model.SignedOff)
-          {
-            <span class="nhsuk-tag nhsuk-tag--green">Yes</span>
-          }
-          else
-          {
-            <span class="nhsuk-tag nhsuk-tag--red">No</span>
-          }
-        </dd>
+      <dt class="nhsuk-summary-list__key">
+        Confirmed
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        @if (Model.SignedOff)
+        {
+          <span class="nhsuk-tag nhsuk-tag--green">Yes</span>
+        }
+        else
+        {
+          <span class="nhsuk-tag nhsuk-tag--red">No</span>
+        }
+      </dd>
       </div>
 
       @if (Model.SupervisorComments != null)
       {
         <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            @(Model.DelegateSelfAssessment.ReviewerCommentsLabel == null ? "Reviewer comments" : Model.DelegateSelfAssessment.ReviewerCommentsLabel.ToString())
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            @Html.Raw(Model.SupervisorComments)
-          </dd>
+        <dt class="nhsuk-summary-list__key">
+          @(Model.DelegateSelfAssessment.ReviewerCommentsLabel == null ? "Reviewer comments" : Model.DelegateSelfAssessment.ReviewerCommentsLabel.ToString())
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          @Html.Raw(Model.SupervisorComments)
+        </dd>
 
         </div>
       }


### PR DESCRIPTION
### JIRA link
[DLSV2-682](https://hee-dls.atlassian.net/browse/DLSV2-682)

### Description
Display the name of the supervisor the assessment result has been submitted to, and the date it was submitted, Particularly when the supervisor viewing is not the one assigned to the assessment.

### Screenshots
![mobileSupervisorName](https://user-images.githubusercontent.com/114475132/194012244-6317d3bb-c212-4e20-91c8-0e89b03a7352.PNG)
![SupervisorNameAndRequestDate](https://user-images.githubusercontent.com/114475132/194012247-ce5538ee-2c51-4bd5-b8fe-11607fe7b1c5.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
