### PR TITLE
Develop/fixes/dlsv2 616 adding learner filter enables request sign off

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentOverviewViewModel.cs
@@ -24,7 +24,7 @@
             AllQuestionsVerifiedOrNotRequired = true;
             foreach (var assessmentQuestion in unfilteredCompetencies.SelectMany(c => c.AssessmentQuestions))
             {
-                if ((assessmentQuestion.Result == null || assessmentQuestion.Verified == null) && assessmentQuestion.Required)
+                if ((assessmentQuestion.Result == null || assessmentQuestion.Verified == null || assessmentQuestion.SignedOff != true) && assessmentQuestion.Required)
                 {
                     AllQuestionsVerifiedOrNotRequired = false;
                     break;

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -17,7 +17,7 @@
   var competencySummaries = from g in Model.CompetencyGroups
       let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
       let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
-      let verifiedCount = questions.Count(q => q.Verified.HasValue)
+      let verifiedCount = questions.Count(q => q.Verified.HasValue && q.SignedOff is true)
       select new ViewDataDictionary(ViewData)
       {
         { "isSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed },


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?assignee=6321797ece3e476e42ac8a00&selectedIssue=DLSV2-616

### Description
I’ve updated the code so that Rejected items are excluded from the Confirmed count.
The ‘Request Educator/Manager Sign-off’ button is also now not available if one or more items are flagged as ‘Rejected’.

### Screenshots
See below.

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my own MR to ensure everything is as expected and it looks right in the browser

![localhost_44363_LearningPortal_SelfAssessment_4_Proficiencies (1)](https://user-images.githubusercontent.com/113513647/194321459-ba05c61c-72d6-41ed-9291-ca78a46cc77f.png)
