### PR TITLE
Develop/fixes/dlsv2 609 issue with the mismatch of the field names in mobile view compared to desktop view when viewing proficiency on the self assessment page

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -132,7 +132,6 @@
             LAR.SelfAssessmentResultSupervisorVerificationId,
             LAR.Requested,
             LAR.Verified,
-            LAR.SupervisorName,
             LAR.Comments AS SupervisorComments,
             LAR.SignedOff,
             LAR.UserIsVerifier,
@@ -241,7 +240,8 @@
             var resultIdFilter = selfAssessmentResultId.HasValue ? $"ResultID = {selfAssessmentResultId.Value}" : "1=1";
             var result = connection.Query<Competency, AssessmentQuestion, Competency>(
                 $@"WITH {SpecificAssessmentResults}
-                    SELECT {CompetencyFields}
+                    SELECT {CompetencyFields},
+                    LAR.SupervisorName
                     FROM {SpecificCompetencyTables}
                     WHERE (CAOC.IncludedInSelfAssessment = 1 OR SAS.Optional = 0) AND {resultIdFilter}
                     ORDER BY SAS.Ordering, CAQ.Ordering",

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -9,7 +9,7 @@
       </th>
       <th class="" scope="col">
         @(string.IsNullOrWhiteSpace(Model.FirstOrDefault().QuestionLabel) ?
-            "Question" : Model.FirstOrDefault().QuestionLabel)
+            "Assessment" : Model.FirstOrDefault().QuestionLabel)
       </th>
       <th class="" scope="col">
         Self-assessment<br />status


### PR DESCRIPTION
### JIRA link
[_DLSV2-609_](https://hee-dls.atlassian.net/browse/DLSV2-609)

### Description
Some column headers are still displayed as Questions instead of assessments. The error was a result of a label being defaulted to question when null or empty. This has been updated to a default value of assessment. 



### Screenshots
![DesktopHeaderCapabilities](https://user-images.githubusercontent.com/114475132/194986543-44fe96c4-e6e5-4d2f-bf7a-d2c4538970dd.PNG)
![MobileColumnView](https://user-images.githubusercontent.com/114475132/194986548-88ddc9a2-7da4-4fc8-8e4f-a9557eea1f7f.PNG)
![DesktopHeader](https://user-images.githubusercontent.com/114475132/194986550-b9b8a3fe-9e39-4376-98f9-4131c28612b8.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
