### PR TITLE
develop/fixes/dlsv2 641 new framework summary page browser back404

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/RedirectToErrorEmptySessionData.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/RedirectToErrorEmptySessionData.cs
@@ -34,6 +34,11 @@
                 return;
             }
 
+            if (context.ActionArguments["actionname"].ToString() == "Edit")
+            {
+                return;
+            }
+
             if (_feature.TempDataKey != string.Empty && (controller.TempData == null || controller.TempData.Peek(_feature.TempDataKey) == null))
             {
                 context.Result = new StatusCodeResult((int)HttpStatusCode.Gone);

--- a/DigitalLearningSolutions.Web/ServiceFilter/RedirectToErrorEmptySessionData.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/RedirectToErrorEmptySessionData.cs
@@ -34,7 +34,7 @@
                 return;
             }
 
-            if (context.ActionArguments["actionname"].ToString() == "Edit")
+            if (context.ActionArguments.ContainsKey("actionname") && context.ActionArguments["actionname"].ToString() == "Edit")
             {
                 return;
             }


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?assignee=6321797ece3e476e42ac8a00&selectedIssue=DLSV2-641

### Description
Fixed issue where framework edit pages were failing due to new typefilter.

### Screenshots
Screenshot attached.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
