### PR TITLE
DLSV2-681 Add Centre Manager role tag and filtering to Centre Admins page

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Helpers/FilterableTagHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/FilterableTagHelperTests.cs
@@ -22,6 +22,7 @@
             {
                 new SearchableTagViewModel(AdminAccountStatusFilterOptions.IsLocked),
                 new SearchableTagViewModel(AdminRoleFilterOptions.CentreAdministrator),
+                new SearchableTagViewModel(AdminRoleFilterOptions.CentreManager),
                 new SearchableTagViewModel(AdminRoleFilterOptions.Supervisor),
                 new SearchableTagViewModel(AdminRoleFilterOptions.Trainer),
                 new SearchableTagViewModel(AdminRoleFilterOptions.CmsAdministrator),

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/AdminFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/AdminFilterOptions.cs
@@ -11,6 +11,12 @@
     {
         private const string Group = "Role";
 
+        public static readonly FilterOptionModel CentreManager = new FilterOptionModel(
+            "Centre manager",
+            FilteringHelper.BuildFilterValueString(Group, nameof(AdminUser.IsCentreManager), "true"),
+            FilterStatus.Default
+        );
+
         public static readonly FilterOptionModel CentreAdministrator = new FilterOptionModel(
             "Centre administrator",
             FilteringHelper.BuildFilterValueString(Group, nameof(AdminUser.IsCentreAdmin), "true"),

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -22,6 +22,11 @@
                 tags.Add(new SearchableTagViewModel(AdminAccountStatusFilterOptions.IsNotLocked, true));
             }
 
+            if (adminUser.IsCentreManager)
+            {
+                tags.Add(new SearchableTagViewModel(AdminRoleFilterOptions.CentreManager));
+            }
+
             if (adminUser.IsCentreAdmin)
             {
                 tags.Add(new SearchableTagViewModel(AdminRoleFilterOptions.CentreAdministrator));
@@ -32,7 +37,7 @@
                 tags.Add(new SearchableTagViewModel(AdminRoleFilterOptions.Supervisor));
             }
 
-            if(adminUser.IsNominatedSupervisor)
+            if (adminUser.IsNominatedSupervisor)
             {
                 tags.Add(new SearchableTagViewModel(AdminRoleFilterOptions.NominatedSupervisor));
             }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/AdministratorsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/AdministratorsViewModelFilterOptions.cs
@@ -15,6 +15,7 @@
     {
         public static readonly IEnumerable<FilterOptionModel> RoleOptions = new[]
         {
+            AdminRoleFilterOptions.CentreManager,
             AdminRoleFilterOptions.CentreAdministrator,
             AdminRoleFilterOptions.Supervisor,
             AdminRoleFilterOptions.NominatedSupervisor,


### PR DESCRIPTION
### JIRA link
[DLSV2-681](https://hee-dls.atlassian.net/browse/DLSV2-681)

### Description
Switch application → Tracking system → Administrators
Displays all admins at a centre with tags showing their admin roles.
The list can be filtered by role.

### Screenshots
The screenshots can be found at https://hee-dls.atlassian.net/browse/DLSV2-681

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
