### PR TITLE
Skipped adding framework competency to the competency group when it is null.

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -876,7 +876,8 @@
                     ORDER BY fcg.Ordering, fc.Ordering",
                 (frameworkCompetencyGroup, frameworkCompetency) =>
                 {
-                    frameworkCompetencyGroup.FrameworkCompetencies.Add(frameworkCompetency);
+                    if (frameworkCompetency != null)
+                        frameworkCompetencyGroup.FrameworkCompetencies.Add(frameworkCompetency);
                     return frameworkCompetencyGroup;
                 },
                 new { frameworkId }
@@ -885,7 +886,8 @@
                 group =>
                 {
                     var groupedFrameworkCompetencyGroup = group.First();
-                    groupedFrameworkCompetencyGroup.FrameworkCompetencies = group.Select(
+                    groupedFrameworkCompetencyGroup.FrameworkCompetencies = group.Where(frameworkCompetencyGroup => frameworkCompetencyGroup.FrameworkCompetencies.Count > 0)
+                    .Select(
                         frameworkCompetencyGroup => frameworkCompetencyGroup.FrameworkCompetencies.Single()
                     ).ToList();
                     return groupedFrameworkCompetencyGroup;


### PR DESCRIPTION
JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-659

Description
Skipped adding framework competency to the competency group when it is null.

Screenshots
A screenshot is attached to the Jira ticket.

Developer checks

I have:
- [x ] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x ] Manually tested my work with and without JavaScript
- [x ] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation.
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
