### PR TITLE
Develop/fixes/dlsv2 616 learner request sign off issue

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -15,9 +15,9 @@
     .DefaultIfEmpty(DateTime.MinValue)
     .Max();
   var competencySummaries = from g in Model.CompetencyGroups
-      let questions = g.SelectMany(c => c.AssessmentQuestions)
+      let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
       let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
-      let verifiedCount = questions.Count(q => q.Verified.HasValue && q.SignedOff is true)
+      let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
       select new ViewDataDictionary(ViewData)
       {
         { "isSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed },

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -15,7 +15,7 @@
     .DefaultIfEmpty(DateTime.MinValue)
     .Max();
   var competencySummaries = from g in Model.CompetencyGroups
-      let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
+      let questions = g.SelectMany(c => c.AssessmentQuestions)
       let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
       let verifiedCount = questions.Count(q => q.Verified.HasValue && q.SignedOff is true)
       select new ViewDataDictionary(ViewData)


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/projects/DLSV2/boards/1?assignee=6321797ece3e476e42ac8a00&selectedIssue=DLSV2-616

### Description
Additional fix for display logic to not include 'Awaiting Confirmation' proficiencies in total counts.

### Screenshots
Screenshot attached.

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser

![localhost_44363_LearningPortal_SelfAssessment_4_Proficiency_1080 (1)](https://user-images.githubusercontent.com/113513647/196137014-31571d4f-fe5a-40f0-8e38-abf17832f99a.png)
