### PR TITLE
DLSV2-581 removed enrol delegate button while the delegate is inactive and query

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -392,7 +392,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
             int supervisorDelegateId = (int)connection.ExecuteScalar(
                     @"SELECT COALESCE
-                 ((SELECT ID FROM SupervisorDelegates WHERE [SupervisorAdminId] = @supervisorId), 0) AS ID",
+                 ((SELECT TOP 1 ID FROM SupervisorDelegates WHERE [SupervisorAdminId] = @supervisorId), 0) AS ID",
                     new { supervisorId }
                 );
 

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -392,8 +392,8 @@ namespace DigitalLearningSolutions.Data.DataServices
 
             int supervisorDelegateId = (int)connection.ExecuteScalar(
                     @"SELECT COALESCE
-                 ((SELECT TOP 1 ID FROM SupervisorDelegates WHERE [SupervisorAdminId] = @supervisorId), 0) AS ID",
-                    new { supervisorId }
+                 ((SELECT TOP 1 ID FROM SupervisorDelegates WHERE SupervisorAdminID = @supervisorId AND CandidateID = @candidateId), 0) AS ID",
+                    new { supervisorId, candidateId }
                 );
 
             if (candidateAssessmentId > 0 && supervisorDelegateId > 0 && selfAssessmentSupervisorRoleId > 0)

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -95,7 +95,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         IEnumerable<CourseDelegateForExport> GetDelegatesOnCourseForExport(int customisationId, int centreId);
 
-        int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId,
+        int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail,
             int selfAssessmentSupervisorRoleId, DateTime completeByDate);
     }
 
@@ -352,7 +352,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             }
         }
 
-        public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId,
+        public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail,
             int selfAssessmentSupervisorRoleId, DateTime completeByDate)
         {
             DateTime startedDate = DateTime.Now;
@@ -395,6 +395,14 @@ namespace DigitalLearningSolutions.Data.DataServices
                  ((SELECT TOP 1 ID FROM SupervisorDelegates WHERE SupervisorAdminID = @supervisorId AND CandidateID = @candidateId), 0) AS ID",
                     new { supervisorId, candidateId }
                 );
+            if (supervisorDelegateId == 0)
+            {
+                supervisorDelegateId = connection.QuerySingle<int>(@"INSERT INTO SupervisorDelegates (SupervisorAdminID, DelegateEmail, CandidateID, SupervisorEmail, AddedByDelegate)
+                    SELECT @supervisorId, EmailAddress, @candidateId, @adminEmail, 0
+                        FROM Candidates
+                        WHERE CandidateID = @candidateId;
+                        SELECT CAST(SCOPE_IDENTITY() as int)", new { supervisorId, candidateId, adminEmail });
+            }
 
             if (candidateAssessmentId > 0 && supervisorDelegateId > 0 && selfAssessmentSupervisorRoleId > 0)
             {

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -252,10 +252,12 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             }
             else
             {
+                var adminEmail = User.GetUserEmail();
                 var selfAssessmentId = courseDataService.EnrolOnActivitySelfAssessment(
                     sessionEnrol.AssessmentID.GetValueOrDefault(),
                     delegateId,
                     sessionEnrol.SupervisorID.GetValueOrDefault(),
+                    adminEmail,
                     sessionEnrol.SelfAssessmentSupervisorRoleId.GetValueOrDefault(),
                     sessionEnrol.CompleteByDate.GetValueOrDefault()
                     );

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -143,14 +143,17 @@
         <partial name="_DelegateCourseInfoCard" model="delegateCourseInfoViewModel" />
       }
     }
-    <a class="nhsuk-button nhsuk-button--secondary"
-         role="button"
-         asp-controller="Enrol"
-         asp-action="StartEnrolProcess"
-         asp-route-delegateId="@Model.DelegateInfo.Id"
-         asp-route-delegateName="@Model.DelegateInfo.Name"
-       >
-        Enrol on activity
-      </a>
+     @if (Model.DelegateInfo.IsActive)
+        {
+          <a class="nhsuk-button nhsuk-button--secondary"
+             role="button"
+             asp-controller="Enrol"
+             asp-action="StartEnrolProcess"
+             asp-route-delegateId="@Model.DelegateInfo.Id"
+             asp-route-delegateName="@Model.DelegateInfo.Name"
+           >
+            Enrol on activity
+          </a>
+        }
   </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/browse/DLSV2-581

### Description
after UAT changes given for while delegate is inactive hide the button for the enrol and resolved the query issue for the submit.

### Screenshots
The screenshots can be found at https://hee-dls.atlassian.net/browse/DLSV2-581

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
