### PR TITLE
Develop/fixes/td 623 learner request sign off issue

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -44,7 +44,8 @@ namespace DigitalLearningSolutions.Web.Helpers
                                        let searchTextMatchesCompetencyName = wordsInSearchText.Any(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
                                        let responseStatusFilterMatchesAnyQuestion =
                                           (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.Verified == null && q.ResultId != null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.ResultRAG > 1 &&
+                                              !(q.Verified == null && q.Requested != null) && !(q.Verified.HasValue && q.SignedOff != null)))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -19,6 +19,7 @@
       </button>
     </div>
   </div>
+
   <div class="filter-value-container">
     @Html.DropDownListFor(m => m.SelectedFilter,
       Model.Filters.First().FilterOptions

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SearchSelfAssessmentOverview.cshtml
@@ -19,7 +19,6 @@
       </button>
     </div>
   </div>
-
   <div class="filter-value-container">
     @Html.DropDownListFor(m => m.SelectedFilter,
       Model.Filters.First().FilterOptions


### PR DESCRIPTION
### JIRA link
https://hee-dls.atlassian.net/jira/software/c/projects/TD/boards/3?modal=detail&selectedIssue=TD-623&assignee=6321797ece3e476e42ac8a00

### Description
Fixed the filter for ‘Self Assessed but Confirmation Not Requested’. It also excludes proficicencies set to ‘Not Started’. You shouldn’t see any ‘Awaiting Confirmation’ rows now.

### Screenshots
Screenshot below.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
- [ ] 
![localhost_44363_LearningPortal_SelfAssessment_4_Proficiency_Filtered (1)](https://user-images.githubusercontent.com/113513647/196983243-322cf545-a1be-453d-bb86-ceafffc48b28.png)
