### PR TITLE
Missing hint text added.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/AddMultipleSupervisorDelegates.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/AddMultipleSupervisorDelegates.cshtml
@@ -36,7 +36,7 @@
                 populate-with-current-value="true"
                 rows="8"
                 spell-check="false"
-                hint-text="Provide the work email address of each member of staff to add to your supervision list on a separate line."
+                hint-text="Provide the work email address of each member of staff to add to your supervision list on a separate line. Email addresses will be skipped if already exists."
                 css-class=""
                 character-count="null" />
   <button class="nhsuk-button" type="submit">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
@@ -88,7 +88,7 @@
                              populate-with-current-value="false"
                              type="text"
                              spell-check="false"
-                             hint-text="Provide the work email address of a member of staff to add to your supervision list."
+                             hint-text="Provide the work email address of a member of staff to add to your supervision list. Email address will be skipped if already exists."
                              autocomplete="email"
                              css-class="nhsuk-input"
                              required="true" />


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-675

**Description**
Missing hint text added to text box controls.

**Screenshots**
![image](https://user-images.githubusercontent.com/115799039/198560494-5eb5984a-4f78-48ae-a3cc-8d481575de34.png)
![image](https://user-images.githubusercontent.com/115799039/198560626-ec9fa259-5e61-41bd-a9d3-fea811d33dfc.png)
-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors.
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
