### PR TITLE
Fix for Validation error when removing staff that has no assessment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -178,6 +178,10 @@
 
             return RedirectToAction("MyStaffList");
         }
+        public IActionResult RemoveSupervisorDelegate()
+        {
+            return RedirectToAction("MyStaffList");
+        }
 
         [Route("/Supervisor/Staff/{supervisorDelegateId}/Remove")]
         public IActionResult RemoveSupervisorDelegateConfirm(int supervisorDelegateId, ReturnPageQuery returnPageQuery)
@@ -202,7 +206,12 @@
             }
             else
             {
-                ModelState.ClearErrorsOnField("ActionConfirmed");
+                
+                if (supervisorDelegate.ConfirmedRemove)
+                {
+                    supervisorDelegate.ConfirmedRemove = false;
+                    ModelState.ClearErrorsOnField("ActionConfirmed");
+                }
                 return View("RemoveConfirm", supervisorDelegate);
             }
         }

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateViewModel.cs
@@ -3,6 +3,7 @@
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.Supervisor;
     using DigitalLearningSolutions.Web.Attributes;
+    using System.ComponentModel;
 
     public class SupervisorDelegateViewModel
     {
@@ -25,5 +26,7 @@
 
         [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm you wish to perform this action")]
         public bool ActionConfirmed { get; set; }
+        [DefaultValue(false)]
+        public bool ConfirmedRemove { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -91,8 +91,10 @@
                         Remove staff member
                     </button>
                     @Html.Hidden("Id", Model.SupervisorDelegateDetail.ID)
+                    @Html.Hidden("FirstName",@Model.SupervisorDelegateDetail.FirstName)
+                    @Html.Hidden("LastName",@Model.SupervisorDelegateDetail.LastName)
                     @Html.Hidden("DelegateEmail", Model.SupervisorDelegateDetail.DelegateEmail)
-                    @Html.Hidden("ConfirmedRemove", true)
+                    @Html.Hidden("ConfirmedRemove",true)
                     @Html.HiddenFor(m => m.ReturnPageQuery)
                 </form>
             }


### PR DESCRIPTION
### JIRA link
[TD-572](https://hee-tis.atlassian.net/browse/TD-572)

### Description
Error message not displayed when trying to remove staff with no assessment
The name of the staff being removed is not displayed on the confirmation page when the staff has no assessment.

### Screenshots
Kindly check the video on Jira

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
