### PR TITLE
Develop/fixes/td 549 incorrect password showing on change your password page

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -42,6 +42,12 @@
             var adminId = User.GetAdminId();
             var delegateId = User.GetCandidateId();
 
+            if (!ModelState.IsValid)
+            {
+                var model = new ChangePasswordViewModel(formData, dlsSubApplication);
+                return View(model);
+            }
+
             var verifiedLinkedUsersAccounts = string.IsNullOrEmpty(formData.CurrentPassword)
                 ? new UserAccountSet()
                 : userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, formData.CurrentPassword!);
@@ -54,11 +60,11 @@
                 );
             }
 
-            if (!ModelState.IsValid)
-            {
-                var model = new ChangePasswordViewModel(formData, dlsSubApplication);
-                return View(model);
-            }
+            //if (!ModelState.IsValid)
+            //{
+            //    var model = new ChangePasswordViewModel(formData, dlsSubApplication);
+            //    return View(model);
+            //}
 
             var newPassword = formData.Password!;
 

--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -42,15 +42,17 @@
             var adminId = User.GetAdminId();
             var delegateId = User.GetCandidateId();
 
+          
+
+            var verifiedLinkedUsersAccounts = string.IsNullOrEmpty(formData.CurrentPassword)
+                ? new UserAccountSet()
+                : userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, formData.CurrentPassword!);
+
             if (!ModelState.IsValid)
             {
                 var model = new ChangePasswordViewModel(formData, dlsSubApplication);
                 return View(model);
             }
-
-            var verifiedLinkedUsersAccounts = string.IsNullOrEmpty(formData.CurrentPassword)
-                ? new UserAccountSet()
-                : userService.GetVerifiedLinkedUsersAccounts(adminId, delegateId, formData.CurrentPassword!);
 
             if (!verifiedLinkedUsersAccounts.Any())
             {
@@ -58,14 +60,10 @@
                     nameof(ChangePasswordFormData.CurrentPassword),
                     CommonValidationErrorMessages.IncorrectPassword
                 );
+                return View(new ChangePasswordViewModel(formData, dlsSubApplication));
             }
 
-            //if (!ModelState.IsValid)
-            //{
-            //    var model = new ChangePasswordViewModel(formData, dlsSubApplication);
-            //    return View(model);
-            //}
-
+           
             var newPassword = formData.Password!;
 
             await passwordService.ChangePasswordAsync(verifiedLinkedUsersAccounts.GetUserRefs(), newPassword);

--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -42,7 +42,7 @@
             var adminId = User.GetAdminId();
             var delegateId = User.GetCandidateId();
 
-          
+
 
             var verifiedLinkedUsersAccounts = string.IsNullOrEmpty(formData.CurrentPassword)
                 ? new UserAccountSet()
@@ -63,7 +63,7 @@
                 return View(new ChangePasswordViewModel(formData, dlsSubApplication));
             }
 
-           
+
             var newPassword = formData.Password!;
 
             await passwordService.ChangePasswordAsync(verifiedLinkedUsersAccounts.GetUserRefs(), newPassword);


### PR DESCRIPTION
### JIRA link
[TD-549](https://hee-tis.atlassian.net/browse/TD-549)

### Description
The Password field blanks out whenever there is a validation error.
Incorrect error message displayed for the current password field.

### Screenshots
![ChangePassword](https://user-images.githubusercontent.com/114475132/198670445-70224453-3953-497e-a1e3-6f1c3bec88b2.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
