### PR TITLE
empty framework comment validation

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Comments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Comments.cs
@@ -7,7 +7,7 @@
         [Route("/Framework/{frameworkId}/Comments/")]
         public IActionResult InsertComment(int frameworkId, string comment)
         {
-            if (comment == "") return RedirectToAction("ViewFramework", new { tabname = "Comments", frameworkId });
+            if (string.IsNullOrWhiteSpace(comment)) return RedirectToAction("ViewFramework", new { tabname = "Comments", frameworkId });
             var adminId = GetAdminId();
             var newCommentId = frameworkService.InsertComment(frameworkId, adminId, comment, null);
             frameworkNotificationService.SendCommentNotifications(adminId, frameworkId, newCommentId, comment, null, null);
@@ -30,7 +30,7 @@
         [Route("/Framework/{frameworkId}/Comments/{commentId}")]
         public IActionResult InsertReply(int frameworkId, int commentId, string comment, string parentComment)
         {
-            if (comment == "") return RedirectToAction("ViewThread", new { frameworkId, commentId });
+            if (string.IsNullOrWhiteSpace(comment)) return RedirectToAction("ViewThread", new { frameworkId, commentId });
             var adminId = GetAdminId();
             var newCommentId = frameworkService.InsertComment(frameworkId, adminId, comment, commentId);
             frameworkNotificationService.SendCommentNotifications(adminId, frameworkId, newCommentId, comment, commentId, parentComment);

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Review.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Review.cs
@@ -81,7 +81,7 @@
         {
             var adminId = GetAdminId();
             int? commentId = null;
-            if(comment != null) commentId = frameworkService.InsertComment(frameworkId, adminId, comment, null);
+            if(!string.IsNullOrWhiteSpace(comment)) commentId = frameworkService.InsertComment(frameworkId, adminId, comment, null);
             frameworkService.SubmitFrameworkReview(frameworkId, reviewId, signedOff, commentId);
             frameworkNotificationService.SendReviewOutcomeNotification(reviewId);
             return RedirectToAction("ViewFramework", "Frameworks", new { frameworkId , tabname = "Structure"});


### PR DESCRIPTION
### JIRA link
[TD-575](https://hee-dls.atlassian.net/browse/TD-575)

### Description
Error thrown when comment field is empty.

### Screenshots
Kindly check the jira link for a video

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
