### PR TITLE
TD-570 - Framework - Preview option resulted in error

### DIFF
--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -1817,8 +1817,8 @@ WHERE (FrameworkID = @frameworkId)",
                                                   AQ.CommentsPrompt,
                                                   AQ.CommentsHint
                                                   FROM   Competencies AS C INNER JOIN
-             FrameworkCompetencies AS FC ON C.ID = FC.CompetencyID INNER JOIN
-             FrameworkCompetencyGroups AS FCG ON FC.FrameworkCompetencyGroupID = FCG.ID INNER JOIN
+             FrameworkCompetencies AS FC ON C.ID = FC.CompetencyID LEFT JOIN
+             FrameworkCompetencyGroups AS FCG ON FC.FrameworkCompetencyGroupID = FCG.ID LEFT JOIN
              CompetencyGroups AS CG ON FCG.CompetencyGroupID = CG.ID INNER JOIN
              CompetencyAssessmentQuestions AS CAQ ON C.ID = CAQ.CompetencyID INNER JOIN
              AssessmentQuestions AS AQ ON CAQ.AssessmentQuestionID = AQ.ID

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -194,7 +194,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             frameworkService.DeleteFrameworkCompetency(frameworkCompetencyId, GetAdminId());
             return frameworkCompetencyGroupId != null ? new RedirectResult(Url.Action("ViewFramework", new { tabname = "Structure", frameworkId, frameworkCompetencyGroupId }) + "#fcgroup-" + frameworkCompetencyGroupId.ToString()) : new RedirectResult(Url.Action("ViewFramework", new { tabname = "Structure", frameworkId }) + "#fc-ungrouped");
         }
-        [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyGroupId}/{frameworkCompetencyId}/Preview/")]
+        [Route("/Frameworks/{frameworkId}/Competency/{frameworkCompetencyGroupId:int=0}/{frameworkCompetencyId}/Preview/")]
         public IActionResult PreviewCompetency(int frameworkId, int frameworkCompetencyGroupId, int frameworkCompetencyId)
         {
             var adminId = GetAdminId();


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-570

**Description**
The attribute route is modified to work when frameworkgroupId is null. SQL query updated to retrieve ungrouped competencies.

**Screenshots**
N/A
-----
**Developer checks**
I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin] -- Issues not related to this code change.
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
