### PR TITLE
TD-499 Fix problems with competency insert logic

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Frameworks/FrameworkCompetency.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/FrameworkCompetency.cs
@@ -1,7 +1,8 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.Frameworks
 {
+    using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using System.ComponentModel.DataAnnotations;
-    public class FrameworkCompetency
+    public class FrameworkCompetency : BaseSearchableItem
     {
         public int Id { get; set; }
         public int CompetencyID { get; set; }
@@ -12,5 +13,11 @@
         public int Ordering { get; set; }
         public int AssessmentQuestions { get; set; }
         public int CompetencyLearningResourcesCount { get; set; }
+
+        public override string SearchableName
+        {
+            get => SearchableNameOverrideForFuzzySharp ?? Name;
+            set => SearchableNameOverrideForFuzzySharp = value;
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -1,5 +1,5 @@
-﻿using DigitalLearningSolutions.Data.Models.Frameworks;
-using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+﻿using DigitalLearningSolutions.Data.Helpers;
+using DigitalLearningSolutions.Data.Models.Frameworks;
 using DigitalLearningSolutions.Data.Models.SelfAssessments;
 using DigitalLearningSolutions.Web.Helpers;
 using DigitalLearningSolutions.Web.ViewModels.Frameworks;
@@ -8,8 +8,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using System.Linq;
-using System.Web;
 using System.Net;
+using System.Web;
 
 namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
 {
@@ -170,6 +170,50 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 frameworkService.UpdateCompetencyFlags(frameworkId, frameworkCompetency.CompetencyID, selectedFlagIds);
                 return new RedirectResult(Url.Action("ViewFramework", new { tabname = "Structure", frameworkId, frameworkCompetencyGroupId, frameworkCompetencyId }) + "#fc-" + frameworkCompetencyId.ToString());
             }
+            var allCompetenciesWithSimilarName = frameworkService.GetAllCompetenciesForAdminId(frameworkCompetency.Name, adminId);
+
+            var sortedItems = GenericSortingHelper.SortAllItems(
+               allCompetenciesWithSimilarName.AsQueryable(),
+               GenericSortingHelper.DefaultSortOption,
+               GenericSortingHelper.Ascending
+           );
+
+            var similarItems = GenericSearchHelper.SearchItems(sortedItems, frameworkCompetency.Name, 55, true);
+            var matchingSearchResults = similarItems.ToList();
+            if (matchingSearchResults.Count > 0)
+            {
+                var model = new SimilarCompetencyViewModel()
+                {
+                    FrameworkId = frameworkId,
+                    FrameworkGroupId = frameworkCompetencyGroupId,
+                    FrameworkCompetencyId = frameworkCompetencyId,
+                    Competency = new FrameworkCompetency()
+                    {
+                        Name = frameworkCompetency.Name,
+                        Description = frameworkCompetency.Description
+                    },
+                    MatchingSearchResults = matchingSearchResults.Count,
+                    SameCompetency = similarItems
+                };
+                return View("Developer/SimilarCompetency", model);
+            }
+            return SaveCompetency(adminId, frameworkId, frameworkCompetency, frameworkCompetencyId, frameworkCompetencyGroupId, selectedFlagIds);
+        }
+
+        [HttpPost]
+        public IActionResult AddDuplicateCompetency(int frameworkId, string competencyName, string competencyDescription, int frameworkCompetencyId, int frameworkGroupId)
+        {
+            FrameworkCompetency competency = new FrameworkCompetency()
+            {
+                Name = competencyName,
+                Description = competencyDescription,
+            };
+            var adminId = GetAdminId();
+            return SaveCompetency(adminId, frameworkId, competency, frameworkCompetencyId, frameworkGroupId, null);
+        }
+
+        private IActionResult SaveCompetency(int adminId, int frameworkId, FrameworkCompetency frameworkCompetency, int frameworkCompetencyId, int? frameworkCompetencyGroupId, int[]? selectedFlagIds)
+        {
             var newCompetencyId = frameworkService.InsertCompetency(frameworkCompetency.Name, frameworkCompetency.Description, adminId);
             if (newCompetencyId > 0)
             {

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/SimilarCompetencyViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/SimilarCompetencyViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
+{
+    using DigitalLearningSolutions.Data.Models.Frameworks;
+    using System.Collections.Generic;
+    public class SimilarCompetencyViewModel
+    {
+        public int MatchingSearchResults { get; set; }
+        public FrameworkCompetency Competency { get; set; }
+        public int FrameworkId { get; set; }
+        public int? FrameworkGroupId { get; set; }
+        public int FrameworkCompetencyId { get; set; }  
+        public IEnumerable<FrameworkCompetency> SameCompetency { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -13,11 +13,11 @@
 <div class="nhsuk-form-group nhsuk-form-group--error">
     <h2>Duplicate framework competency name</h2>
     <p class="nhsuk-error-message">
-        Your framework competeny <span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span> has the same name as an existing framework:
+        Your framework competeny <span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span> has the same name as an existing competency.
     </p>
 </div>
 <p class="nhsuk-u-margin-top-6">
-    Your competency is name is not distinct, you can still create it but we recommand you to take a distinct name.
+    Your competency name is not distinct, you can still create it but we recommend that you give it a distinct name.
 </p>
 <h2>Duplications</h2>
 <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-bottom-6">
@@ -58,7 +58,7 @@
       asp-route-competencyName="@Model.Competency.Name" asp-route-competencyDescription="@Model.Competency.Description"
       asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkGroupId="@Model.FrameworkGroupId">
     <button class="nhsuk-button" type="submit">
-        Save competency
+        Confirm save
     </button>
 </form>
 <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="ViewFramework" asp-route-tabname="Structure" asp-route-frameworkId="@Model.FrameworkId">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -9,17 +9,17 @@
 @section NavMenuItems {
 <partial name="Shared/_NavMenuItems" />
 }
-<h1>Create a new Competency</h1>
+<h1>Duplicate competency name</h1>
 <div class="nhsuk-form-group nhsuk-form-group--error">
-    <h2>Duplicate competency name</h2>
     <p class="nhsuk-error-message">
-        Your framework competency "<span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span>" has the same name as an existing competency.
+        The item you are trying to add "<span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span>" has the same name as an existing competency.
+    </p>
+    <p class="nhsuk-u-margin-top-6">
+        You can still create this item but we recommend that you give it a distinct name.
     </p>
 </div>
-<p class="nhsuk-u-margin-top-6">
-    Your competency name is not distinct, you can still create it but we recommend that you give it a distinct name.
-</p>
-<h2>Duplications</h2>
+
+<h2>Duplicates</h2>
 <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-bottom-6">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">
         Competency

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -1,0 +1,66 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks
+@model SimilarCompetencyViewModel
+@{
+    ViewData["Title"] = "Similar Competency";
+    ViewData["Application"] = "Framework Service";
+    ViewData["HeaderPathName"] = "Framework Service";
+}
+
+@section NavMenuItems {
+<partial name="Shared/_NavMenuItems" />
+}
+<h1>Create a new Competency</h1>
+<div class="nhsuk-form-group nhsuk-form-group--error">
+    <h2>Duplicate framework competency name</h2>
+    <p class="nhsuk-error-message">
+        Your framework competeny <span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span> has the same name as an existing framework:
+    </p>
+</div>
+<p class="nhsuk-u-margin-top-6">
+    Your competency is name is not distinct, you can still create it but we recommand you to take a distinct name.
+</p>
+<h2>Duplications</h2>
+<table role="table" class="nhsuk-table-responsive nhsuk-u-margin-bottom-6">
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">
+        Competency
+    </caption>
+    <thead role="rowgroup" class="nhsuk-table__head">
+        <tr role="row">
+            <th role="columnheader" class="" scope="col">
+                Name
+            </th>
+            <th role="columnheader" class="" scope="col">
+                Description
+            </th>
+        </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+        @foreach (var competency in Model.SameCompetency)
+        {
+            <tr role="row" class="nhsuk-table__row framework-row">
+                <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                    <span class="nhsuk-table-responsive__heading">Framework </span>
+                    <span class="framework-brand">
+                        @competency.Name
+                    </span>
+                </td>
+                <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                    <span class="nhsuk-table-responsive__heading">Created </span>
+                    <span class="framework-created-date">
+                        @Html.Raw(competency.Description)
+                    </span>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>
+<form asp-action="AddDuplicateCompetency" asp-route-frameworkId="@Model.FrameworkId"
+      asp-route-competencyName="@Model.Competency.Name" asp-route-competencyDescription="@Model.Competency.Description"
+      asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkGroupId="@Model.FrameworkGroupId">
+    <button class="nhsuk-button" type="submit">
+        Save competency
+    </button>
+</form>
+<a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="ViewFramework" asp-route-tabname="Structure" asp-route-frameworkId="@Model.FrameworkId">
+    Cancel
+</a>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -11,9 +11,9 @@
 }
 <h1>Create a new Competency</h1>
 <div class="nhsuk-form-group nhsuk-form-group--error">
-    <h2>Duplicate framework competency name</h2>
+    <h2>Duplicate competency name</h2>
     <p class="nhsuk-error-message">
-        Your framework competeny <span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span> has the same name as an existing competency.
+        Your framework competency "<span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span>" has the same name as an existing competency.
     </p>
 </div>
 <p class="nhsuk-u-margin-top-6">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-499

### Description
When the user attempts to add a competency that matches an existing one, a warning message is displayed but the user is still allowed to create a duplicate competency if they wish to. Also, all the duplicate competencies are displayed to the user before they choose to create a duplicate.

### Screenshots
Video is attached to the jira; https://hee-tis.atlassian.net/browse/TD-499

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
