### PR TITLE
TD-706 Replaces TRIM() function with LTRIM RTRIM

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202204071530_PopulateUsersTableFromAccountsTables.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202204071530_PopulateUsersTableFromAccountsTables.cs
@@ -33,7 +33,7 @@ namespace DigitalLearningSolutions.Data.Migrations
             connection.Execute(
                 @"UPDATE AdminAccounts
                     SET       Email = Forename_deprecated + '.' + Surname_deprecated + '@not.given'
-                    WHERE (Email IS NULL) OR TRIM(Email) = ''"
+                    WHERE (Email IS NULL) OR RTRIM(LTRIM(Email)) = ''"
                 );
             // Set unique email for delegate accounts where email + centreId combination is duplicated
             connection.Execute(
@@ -85,7 +85,7 @@ namespace DigitalLearningSolutions.Data.Migrations
                     NULL,
                     0,
                     GETUTCDATE(),
-                    CASE WHEN Email IS NOT NULL AND TRIM(Email) <> '' THEN GETUTCDATE() ELSE NULL END
+                    CASE WHEN Email IS NOT NULL AND RTRIM(LTRIM(Email)) <> '' THEN GETUTCDATE() ELSE NULL END
                     FROM AdminAccounts"
             );
 
@@ -128,7 +128,7 @@ namespace DigitalLearningSolutions.Data.Migrations
                     FROM DelegateAccounts
                     WHERE Email IN (
                         SELECT Email FROM DelegateAccounts
-                        WHERE Email IS NOT NULL AND TRIM(Email) IS NOT NULL AND TRIM(Email) <> ''
+                        WHERE Email IS NOT NULL AND RTRIM(LTRIM(Email)) <> ''
                         GROUP BY Email
                         HAVING COUNT(*) = 1
                         EXCEPT
@@ -144,7 +144,7 @@ namespace DigitalLearningSolutions.Data.Migrations
                         CentreSpecificDetailsLastChecked = GETUTCDATE()
                     WHERE Email IN (
                         SELECT Email FROM DelegateAccounts
-                        WHERE Email IS NOT NULL AND TRIM(Email) IS NOT NULL AND TRIM(Email) <> ''
+                        WHERE Email IS NOT NULL AND RTRIM(LTRIM(Email)) <> ''
                         GROUP BY Email
                         HAVING COUNT(*) = 1
                         EXCEPT


### PR DESCRIPTION
### JIRA link
[TD-706](https://hee-tis.atlassian.net/browse/TD-706)

### Description
Replaces references to the SQL TRIM function with compatible equivalents (LTRIM/RTRIM) for production SQL server version.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my own MR to ensure everything is as expected and it looks right in the browser
