### PR TITLE
TD-721 : Removal of the Help menu item

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Models/Enums/DlsSubApplicationTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Models/Enums/DlsSubApplicationTests.cs
@@ -117,7 +117,6 @@
                 dlsSubApplication.HeaderExtension.Should().Be(headerExtension);
                 dlsSubApplication.UrlSegment.Should().Be(urlSegment);
                 dlsSubApplication.FaqTargetGroupId.Should().Be(faqTargetGroupId);
-                dlsSubApplication.DisplayHelpMenuItem.Should().Be(displayHelpMenuItem);
 
                 if (hasNullHeaderData)
                 {

--- a/DigitalLearningSolutions.Web/Models/Enums/DlsSubApplication.cs
+++ b/DigitalLearningSolutions.Web/Models/Enums/DlsSubApplication.cs
@@ -16,8 +16,7 @@ namespace DigitalLearningSolutions.Web.Models.Enums
             "/TrackingSystem/Centre/Dashboard",
             "Tracking System",
             "TrackingSystem",
-            0,
-            false
+            0
         );
 
         public static readonly DlsSubApplication Frameworks = new DlsSubApplication(
@@ -56,11 +55,10 @@ namespace DigitalLearningSolutions.Web.Models.Enums
             "Super Admin",
             "/SuperAdmin/Admins",
             "Super Admin - System Configuration",
-            "SuperAdmin",
-            displayHelpMenuItem: false
+            "SuperAdmin"
         );
 
-        public readonly bool DisplayHelpMenuItem;
+
         public readonly int? FaqTargetGroupId;
 
         public readonly string HeaderExtension;
@@ -75,8 +73,7 @@ namespace DigitalLearningSolutions.Web.Models.Enums
             string? headerPath,
             string? headerPathName,
             string? urlSegment,
-            int? faqTargetGroupId = null,
-            bool displayHelpMenuItem = true
+            int? faqTargetGroupId = null
         ) : base(id, name)
         {
             HeaderExtension = headerExtension;
@@ -90,8 +87,6 @@ namespace DigitalLearningSolutions.Web.Models.Enums
             HeaderPathName = headerPathName;
 
             UrlSegment = urlSegment;
-
-            DisplayHelpMenuItem = displayHelpMenuItem;
         }
 
         public static DlsSubApplication Default => Main;

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -13,7 +13,6 @@
     ViewData[LayoutViewDataKeys.HeaderPathName] ??= dlsSubApplication.HeaderPathName;
   }
   var headerExtension = (string)ViewData[LayoutViewDataKeys.Application];
-  var shouldDisplayHelpMenuItem = dlsSubApplication?.DisplayHelpMenuItem ?? headerExtension != DlsSubApplication.TrackingSystem.HeaderExtension;
 }
 
 <!DOCTYPE html>
@@ -103,23 +102,6 @@
               @RenderSection("NavMenuItems", true)
             } else if (dlsSubApplication != null) {
               <partial name="_AutoNavMenuItems.cshtml" model="@dlsSubApplication" />
-            }
-
-            @if (shouldDisplayHelpMenuItem) {
-              string helpPage;
-              if (User.HasClaim(c => c.Type == CustomClaimTypes.UserAdminId)) {
-                helpPage = "/help/Introduction.html";
-              } else if (User.Identity.IsAuthenticated) {
-                helpPage = "/learningportal/help/LearningPortal.html";
-              } else {
-                helpPage = "/help/Introduction.html";
-              }
-              <li class="nhsuk-header__navigation-item">
-                <a class="nhsuk-header__navigation-link" href="@(Configuration["CurrentSystemBaseUrl"] + helpPage)" target="_blank">
-                  Help
-                  <partial name="_NhsChevronRight" />
-                </a>
-              </li>
             }
             @if (User.Identity.IsAuthenticated && User.GetAdminId() != null) {
               <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">

--- a/DigitalLearningSolutions.Web/Views/Support/Shared/_SupportSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Shared/_SupportSideNavMenu.cshtml
@@ -15,18 +15,6 @@
                      link-text="Support"
                      is-current-page="@(Model.CurrentPage == SupportPage.Support)" />
 
-  @if (Model.CurrentPage == SupportPage.HelpDocumentation) {
-    <li class="side-nav__item side-nav__item--selected" aria-current="page">
-      <span class="nhsuk-contents-list__current">Help documentation</span>
-    </li>
-  } else {
-    <li class="side-nav__item">
-      <a class="side-nav__link" href="@SupportLinksHelper.GetHelpUrl(Model.CurrentSystemBaseUrl)" target="_blank">
-        Help documentation
-      </a>
-    </li>
-  }
-
   <vc:side-menu-link asp-action="Index"
                      asp-controller="Faqs"
                      asp-all-route-data="@routeData"


### PR DESCRIPTION
### JIRA link
[TD-721](https://hee-tis.atlassian.net/browse/TD-721)

### Description
Removal of the help link on the top menu bar and side navigation

### Screenshots
![menu1](https://user-images.githubusercontent.com/114475132/203830181-63d6af07-6f04-4ae5-8292-95a00a1ad07b.PNG)
![SideMenu2](https://user-images.githubusercontent.com/114475132/203830186-55b0bbb3-53b2-41c4-995d-2d478ede9196.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
