### PR TITLE
TD-776: No Password Fields During Registration

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/_SetPasswordFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_SetPasswordFields.cshtml
@@ -9,7 +9,8 @@
   spell-check="false"
   hint-text="Your new password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
   autocomplete="new-password"
-  css-class="nhsuk-u-width-one-half" />
+  css-class="nhsuk-u-width-one-half"
+  required="true"/>
 
 <vc:text-input
   asp-for="@nameof(Model.ConfirmPassword)"
@@ -19,4 +20,5 @@
   spell-check="false"
   hint-text=""
   autocomplete="new-password"
-  css-class="nhsuk-u-width-one-half" />
+  css-class="nhsuk-u-width-one-half"
+  required="true"/>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-776

### Description
Added the required attribute in password and confirm password vc:textinput. As password and confirm password fields are not showing over there.

### Screenshots
https://hee-tis.atlassian.net/browse/TD-776

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
