### PR TITLE
TD-760 Deletes EmailVerificationHash records older than 4 days

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/RecurringSqlJobs/DeleteEmailVerificationHashOlderThan4Days.sql
+++ b/DigitalLearningSolutions.Data.Migrations/RecurringSqlJobs/DeleteEmailVerificationHashOlderThan4Days.sql
@@ -1,0 +1,6 @@
+﻿-- Deletes EmailVerificationHash records older than 4 days. Should be run every night at 2:02AM.
+
+DELETE
+FROM EmailVerificationHashes
+WHERE CreatedDate < DATEADD(day, -4, GETUTCDATE());
+


### PR DESCRIPTION
### JIRA link
[TD-760](https://hee-tis.atlassian.net/browse/TD-760)

### Description
SQL script to remove all entities in the EmailVerificationHashes table which are more than 4 days old in UTC time

### Screenshots
Nil

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
