### PR TITLE
TD-761-users-with-one-active-centre-UAR

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -291,7 +291,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
         public async Task Multiple_available_centres_should_redirect_to_ChooseACentre_page()
         {
             // Given
-            var userEntity = GetUserEntity(true, true);
+            var userEntity = GetUserEntityWithTwoDelegateAccounts(true, true);
 
             A.CallTo(() => loginService.AttemptLogin(A<string>._, A<string>._)).Returns(
                 new LoginResult(LoginAttemptResult.ChooseACentre, userEntity, 2)
@@ -734,6 +734,43 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
                 UserTestHelper.GetDefaultUserAccount(),
                 withAdminAccount ? new List<AdminAccount> { adminAccount } : new List<AdminAccount>(),
                 withDelegateAccount ? new List<DelegateAccount> { delegateAccount } : new List<DelegateAccount>()
+            );
+        }
+
+        private UserEntity GetUserEntityWithTwoDelegateAccounts(
+            bool withAdminAccount,
+            bool withDelegateAccount,
+            bool isAdminAccountActive = true,
+            bool isDelegateAccountActive = true,
+            bool isDelegateAccountApproved = true,
+            int centreId = 2,
+            bool isCentreActive = true
+        )
+        {
+            var adminAccount = UserTestHelper.GetDefaultAdminAccount(
+                centreId: centreId,
+                centreActive: isCentreActive,
+                active: isAdminAccountActive
+            );
+
+            var delegateAccount1 = UserTestHelper.GetDefaultDelegateAccount(
+                centreId: centreId,
+                centreActive: isCentreActive,
+                active: isDelegateAccountActive,
+                approved: isDelegateAccountApproved
+            );
+
+            var delegateAccount2 = UserTestHelper.GetDefaultDelegateAccount(
+                centreId: 3,
+                centreActive: isCentreActive,
+                active: isDelegateAccountActive,
+                approved: isDelegateAccountApproved
+            );
+
+            return new UserEntity(
+                UserTestHelper.GetDefaultUserAccount(),
+                withAdminAccount ? new List<AdminAccount> { adminAccount } : new List<AdminAccount>(),
+                withDelegateAccount ? new List<DelegateAccount> { delegateAccount1, delegateAccount2 } : new List<DelegateAccount>()
             );
         }
 


### PR DESCRIPTION
JIRA link
https://hee-tis.atlassian.net/browse/TD-761

**Description**
Code added to check active centre count.

Screenshots
N/A

-----
**Developer checks**
I have:
- [x] Run the formatter and made sure there are no IDE errors 
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
