### PR TITLE
TD-745 Verify email Registration Link after delegate record activated…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/VerifyEmailControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/VerifyEmailControllerTests.cs
@@ -58,7 +58,7 @@
         }
 
         [Test]
-        public void Index_with_non_matching_email_and_code_returns_NotFound()
+        public void Index_with_non_matching_email_and_code_returns_ErrorView()
         {
             // Given
             A.CallTo(() => userService.GetEmailVerificationDataIfCodeMatchesAnyUnverifiedEmails(Email, Code)).Returns(
@@ -69,7 +69,7 @@
             var result = controller.Index(Email, Code);
 
             // Then
-            result.Should().BeNotFoundResult();
+            result.Should().BeViewResult().WithViewName("VerificationLinkError");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/VerifyEmailController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/VerifyEmailController.cs
@@ -35,7 +35,7 @@
 
             if (emailVerificationData == null)
             {
-                return NotFound();
+                return View("VerificationLinkError");
             }
 
             if (emailVerificationData.HashCreationDate + EmailVerificationHashLifetime < clockUtility.UtcNow)

--- a/DigitalLearningSolutions.Web/Views/VerifyEmail/VerificationLinkError.cshtml
+++ b/DigitalLearningSolutions.Web/Views/VerifyEmail/VerificationLinkError.cshtml
@@ -1,0 +1,15 @@
+﻿@{
+  ViewData["Title"] = "Verification error";
+}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
+    <p class="nhsuk-body-m">The possible causes are as below :</p>
+    <ul>
+      <li>The email you have requested to verify has already been verified.</li>
+      <li>The email or code you have used to verify is not valid.</li>
+    </ul>
+
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/VerifyEmail/VerificationLinkError.cshtml
+++ b/DigitalLearningSolutions.Web/Views/VerifyEmail/VerificationLinkError.cshtml
@@ -10,6 +10,6 @@
       <li>The email you have requested to verify has already been verified.</li>
       <li>The email or code you have used to verify is not valid.</li>
     </ul>
-
+    <p class="nhsuk-body-m">Please login and visit the My Account page to send a new verification link.</p>
   </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-745

### Description
The email is verified using both code and email address. So there are 2 cases broadly when we need to tell the user that the email verification link is invalid:
1.	When either the code or email or both(in the querystring) are invalid.
2.	When the user has already used the link to verify the email rendering the link as invalid. Then tries to use the link again.

An informative page will appear in both the scenarios. The steps to test the functionality are listed in the ticket

### Screenshots
These are provided in the ticket; https://hee-tis.atlassian.net/browse/TD-745

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
