### PR TITLE
Develop/Fixes/TD-707_DelegateCoursesArchivedUIElements

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/CourseDataServiceTests.cs
@@ -346,6 +346,7 @@ namespace DigitalLearningSolutions.Data.Tests.DataServices
                 CategoryName = "Office 2007",
                 CourseTopic = "Microsoft Office",
                 LearningMinutes = "N/A",
+                Archived = false,
             };
 
             result.Should().HaveCount(259);

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -168,6 +168,12 @@ namespace DigitalLearningSolutions.Data.DataServices
                 WHERE ct.DiagStatus = 1 AND a.DiagAssess = 1 AND ct.CustomisationID = c.CustomisationID
                     AND a.ArchivedDate IS NULL AND a.DefaultContentTypeID <> 4";
 
+        private const string CourseStatus =
+            @"CASE WHEN ap.ArchivedDate IS NOT NULL THEN 'archived'
+		        WHEN cu.Active = 1 THEN 'active'
+		        WHEN cu.Active = 0 THEN 'inactive'
+	            END AS Status";
+
         private readonly IDbConnection connection;
         private readonly ILogger<CourseDataService> logger;
         private readonly ISelfAssessmentDataService selfAssessmentDataService;
@@ -188,7 +194,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                         cc.CategoryName,
                         ct.CourseTopic,
                         cu.LearningTimeMins AS LearningMinutes,
-                        cu.IsAssessed
+                        cu.IsAssessed,
+                        {CourseStatus}
                     FROM dbo.Customisations AS cu
                     INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = cu.ApplicationID
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = ca.ApplicationID

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -175,7 +175,7 @@ namespace DigitalLearningSolutions.Data.DataServices
         private readonly string CourseStatisticsQuery = @$"SELECT
                         cu.CustomisationID,
                         cu.CentreID,
-                        cu.Active,
+                        CASE WHEN ap.ArchivedDate IS NOT NULL THEN 0 ELSE cu.Active END AS Active,
                         cu.AllCentres,
                         ap.ApplicationId,
                         ap.ApplicationName,

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -168,12 +168,6 @@ namespace DigitalLearningSolutions.Data.DataServices
                 WHERE ct.DiagStatus = 1 AND a.DiagAssess = 1 AND ct.CustomisationID = c.CustomisationID
                     AND a.ArchivedDate IS NULL AND a.DefaultContentTypeID <> 4";
 
-        private const string CourseStatus =
-            @"CASE WHEN ap.ArchivedDate IS NOT NULL THEN 'archived'
-		        WHEN cu.Active = 1 THEN 'active'
-		        WHEN cu.Active = 0 THEN 'inactive'
-	            END AS Status";
-
         private readonly IDbConnection connection;
         private readonly ILogger<CourseDataService> logger;
         private readonly ISelfAssessmentDataService selfAssessmentDataService;
@@ -195,7 +189,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                         ct.CourseTopic,
                         cu.LearningTimeMins AS LearningMinutes,
                         cu.IsAssessed,
-                        {CourseStatus}
+                        CASE WHEN ap.ArchivedDate IS NOT NULL THEN 1 ELSE 0 END AS Archived
                     FROM dbo.Customisations AS cu
                     INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = cu.ApplicationID
                     INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = ca.ApplicationID

--- a/DigitalLearningSolutions.Data/Models/Courses/Course.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/Course.cs
@@ -6,7 +6,7 @@
         public int CentreId { get; set; }
         public int ApplicationId { get; set; }
         public bool Active { get; set; }
-
+        public string? Status { get; set; }
         public string CourseNameWithInactiveFlag => !Active ? "Inactive - " + CourseName : CourseName;
 
         public override bool Equals(object? obj)

--- a/DigitalLearningSolutions.Data/Models/Courses/Course.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/Course.cs
@@ -6,7 +6,7 @@
         public int CentreId { get; set; }
         public int ApplicationId { get; set; }
         public bool Active { get; set; }
-        public string? Status { get; set; }
+        public bool Archived { get; set; }
         public string CourseNameWithInactiveFlag => !Active ? "Inactive - " + CourseName : CourseName;
 
         public override bool Equals(object? obj)

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
@@ -30,6 +30,7 @@
             Active = courseStatistics.Active;
             CustomisationName = courseStatistics.CustomisationName;
             ApplicationName = courseStatistics.ApplicationName;
+            Status = courseStatistics.Status;
         }
 
         public IEnumerable<CourseAdminFieldWithResponseCounts> AdminFieldsWithResponses { get; set; }

--- a/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/CourseStatisticsWithAdminFieldResponseCounts.cs
@@ -30,7 +30,7 @@
             Active = courseStatistics.Active;
             CustomisationName = courseStatistics.CustomisationName;
             ApplicationName = courseStatistics.ApplicationName;
-            Status = courseStatistics.Status;
+            Archived = courseStatistics.Archived;
         }
 
         public IEnumerable<CourseAdminFieldWithResponseCounts> AdminFieldsWithResponses { get; set; }

--- a/DigitalLearningSolutions.Data/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Data/Services/CourseService.cs
@@ -351,7 +351,7 @@
         public CentreCourseDetails GetCentreCourseDetails(int centreId, int? categoryId)
         {
             var (courses, categories, topics) = (
-                GetNonArchivedCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(centreId, categoryId),
+                GetCentreSpecificCourseStatisticsWithAdminFieldResponseCounts(centreId, categoryId),
                 courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId)
                     .Select(c => c.CategoryName),
                 courseTopicsDataService.GetCourseTopicsAvailableAtCentre(centreId).Select(c => c.CourseTopic));

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/CourseSetupControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/CourseSetup/CourseSetupControllerTests.cs
@@ -81,6 +81,7 @@
                         HideInLearnerPortal = true,
                         DelegateCount = 1,
                         CompletedCount = 1,
+                        Archived = false,
                     },
                 }
             )

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
@@ -38,7 +38,7 @@
             new[]
             {
                 new FilterOptionModel(
-                    "Inactive",
+                    "Inactive/archived",
                     "Status" + FilteringHelper.Separator + "Active" + FilteringHelper.Separator +
                     "false",
                     FilterStatus.Warning

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesStatisticsViewModelFilterOptionsTests.cs
@@ -38,7 +38,7 @@
             new[]
             {
                 new FilterOptionModel(
-                    "Inactive",
+                    "Inactive/archived",
                     "Status" + FilteringHelper.Separator + "Active" + FilteringHelper.Separator +
                     "false",
                     FilterStatus.Warning

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -15,7 +15,7 @@
         //    FilterStatus.Warning
         //);
         public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
-            "Inactive/Archived",
+            "Inactive/archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
             FilterStatus.Warning
         );

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -10,75 +10,76 @@
         private const string Group = "Status";
 
         public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
-            "Inactive/archived",
+            "Inactive/Archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
             FilterStatus.Warning
         );
 
-        //public static readonly FilterOptionModel IsActive = new FilterOptionModel(
-        //    "Active",
-        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "true"),
-        //    FilterStatus.Success
-        //);
+        public static readonly FilterOptionModel IsActive = new FilterOptionModel(
+            "Active",
+            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "true"),
+            FilterStatus.Success
+        );
 
-        public const char FilterSeparator = '╡';
-        
-        public static FilterOptionModel IsActive
-        {
-            get
-            {
-                var activeFilterValue = FilteringHelper.BuildFilterValueString(
-                    "Active",
-                    nameof(CourseStatistics.Active),
-                    "true"
-                );
+        //public const char FilterSeparator = '╡';
 
-                var notArchivedFilterValue = FilteringHelper.BuildFilterValueString(
-                    "Archived",
-                    nameof(CourseStatistics.Archived),
-                    "false"
-                );
+        //public static FilterOptionModel IsActive
+        //{
+        //    get
+        //    {
+        //        var activeFilterValue = FilteringHelper.BuildFilterValueString(
+        //            "Active",
+        //            nameof(CourseStatistics.Active),
+        //            "true"
+        //        );
 
-                var filterValue = activeFilterValue + FilterSeparator + notArchivedFilterValue;
+        //        //var notArchivedFilterValue = FilteringHelper.BuildFilterValueString(
+        //        //    "Archived",
+        //        //    nameof(CourseStatistics.Archived),
+        //        //    "false"
+        //        //);
 
-                return new FilterOptionModel(
-                    "Active",
-                    filterValue,
-                    FilterStatus.Success
-                );
-            }
-        }
+        //        //var filterValue = activeFilterValue + FilterSeparator + notArchivedFilterValue;
+        //        var filterValue = activeFilterValue;
 
-        //public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
-        //    "Archived",
-        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
-        //    FilterStatus.Default
-        //);
+        //        return new FilterOptionModel(
+        //            "Active",
+        //            filterValue,
+        //            FilterStatus.Success
+        //        );
+        //    }
+        //}
 
-        public static FilterOptionModel IsArchived
-        {
-            get
-            {
-                var filterValue = FilteringHelper.BuildFilterValueString(
-                    "Archived",
-                    nameof(CourseStatistics.Archived),
-                    "true"
-                );
+        public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
+            "Inactive_Archived",
+            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
+            FilterStatus.Default
+        );
 
-                //TODO: Also need to OR with .Active=false
-                //var filterValue = FilteringHelper.BuildFilterValueString(
-                //    "Archived",
-                //    nameof(CourseStatistics.Archived),
-                //    "true"
-                //);
+        //public static FilterOptionModel IsArchived
+        //{
+        //    get
+        //    {
+        //        var filterValue = FilteringHelper.BuildFilterValueString(
+        //            "Archived",
+        //            nameof(CourseStatistics.Archived),
+        //            "true"
+        //        );
 
-                return new FilterOptionModel(
-                    Group,
-                    filterValue,
-                    FilterStatus.Success
-                );
-            }
-        }
+        //        //TODO: Also need to OR with .Active=false
+        //        //var filterValue = FilteringHelper.BuildFilterValueString(
+        //        //    "Archived",
+        //        //    nameof(CourseStatistics.Archived),
+        //        //    "true"
+        //        //);
+
+        //        return new FilterOptionModel(
+        //            Group,
+        //            filterValue,
+        //            FilterStatus.Success
+        //        );
+        //    }
+        //}
     }
 
     public static class CourseVisibilityFilterOptions

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -9,11 +9,6 @@
     {
         private const string Group = "Status";
 
-        //public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
-        //    "Inactive#Archived",
-        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
-        //    FilterStatus.Warning
-        //);
         public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
             "Inactive/archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
@@ -26,11 +21,6 @@
             FilterStatus.Success
         );
 
-        //public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
-        //    "Inactive_Archived",
-        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
-        //    FilterStatus.Default
-        //);
         public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
             "Archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -4,8 +4,6 @@
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
-    using DigitalLearningSolutions.Web.Models.Enums;
-    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public static class CourseStatusFilterOptions
     {
@@ -23,16 +21,11 @@
             FilterStatus.Success
         );
 
-
-
         public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
             "Archived",
-            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Status), "Archived"),
-            FilterStatus.Success
+            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
+            FilterStatus.Default
         );
-
-
-
     }
 
     public static class CourseVisibilityFilterOptions

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -10,22 +10,75 @@
         private const string Group = "Status";
 
         public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
-            "Inactive",
+            "Inactive/archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
             FilterStatus.Warning
         );
 
-        public static readonly FilterOptionModel IsActive = new FilterOptionModel(
-            "Active",
-            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "true"),
-            FilterStatus.Success
-        );
+        //public static readonly FilterOptionModel IsActive = new FilterOptionModel(
+        //    "Active",
+        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "true"),
+        //    FilterStatus.Success
+        //);
 
-        public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
-            "Archived",
-            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
-            FilterStatus.Default
-        );
+        public const char FilterSeparator = '╡';
+        
+        public static FilterOptionModel IsActive
+        {
+            get
+            {
+                var activeFilterValue = FilteringHelper.BuildFilterValueString(
+                    "Active",
+                    nameof(CourseStatistics.Active),
+                    "true"
+                );
+
+                var notArchivedFilterValue = FilteringHelper.BuildFilterValueString(
+                    "Archived",
+                    nameof(CourseStatistics.Archived),
+                    "false"
+                );
+
+                var filterValue = activeFilterValue + FilterSeparator + notArchivedFilterValue;
+
+                return new FilterOptionModel(
+                    "Active",
+                    filterValue,
+                    FilterStatus.Success
+                );
+            }
+        }
+
+        //public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
+        //    "Archived",
+        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
+        //    FilterStatus.Default
+        //);
+
+        public static FilterOptionModel IsArchived
+        {
+            get
+            {
+                var filterValue = FilteringHelper.BuildFilterValueString(
+                    "Archived",
+                    nameof(CourseStatistics.Archived),
+                    "true"
+                );
+
+                //TODO: Also need to OR with .Active=false
+                //var filterValue = FilteringHelper.BuildFilterValueString(
+                //    "Archived",
+                //    nameof(CourseStatistics.Archived),
+                //    "true"
+                //);
+
+                return new FilterOptionModel(
+                    Group,
+                    filterValue,
+                    FilterStatus.Success
+                );
+            }
+        }
     }
 
     public static class CourseVisibilityFilterOptions

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -22,6 +22,17 @@
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "true"),
             FilterStatus.Success
         );
+
+
+
+        public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
+            "Archived",
+            FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Status), "Archived"),
+            FilterStatus.Success
+        );
+
+
+
     }
 
     public static class CourseVisibilityFilterOptions

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/CourseFilterOptions.cs
@@ -9,6 +9,11 @@
     {
         private const string Group = "Status";
 
+        //public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
+        //    "Inactive#Archived",
+        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
+        //    FilterStatus.Warning
+        //);
         public static readonly FilterOptionModel IsInactive = new FilterOptionModel(
             "Inactive/Archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Active), "false"),
@@ -21,65 +26,16 @@
             FilterStatus.Success
         );
 
-        //public const char FilterSeparator = '╡';
-
-        //public static FilterOptionModel IsActive
-        //{
-        //    get
-        //    {
-        //        var activeFilterValue = FilteringHelper.BuildFilterValueString(
-        //            "Active",
-        //            nameof(CourseStatistics.Active),
-        //            "true"
-        //        );
-
-        //        //var notArchivedFilterValue = FilteringHelper.BuildFilterValueString(
-        //        //    "Archived",
-        //        //    nameof(CourseStatistics.Archived),
-        //        //    "false"
-        //        //);
-
-        //        //var filterValue = activeFilterValue + FilterSeparator + notArchivedFilterValue;
-        //        var filterValue = activeFilterValue;
-
-        //        return new FilterOptionModel(
-        //            "Active",
-        //            filterValue,
-        //            FilterStatus.Success
-        //        );
-        //    }
-        //}
-
+        //public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
+        //    "Inactive_Archived",
+        //    FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
+        //    FilterStatus.Default
+        //);
         public static readonly FilterOptionModel IsArchived = new FilterOptionModel(
-            "Inactive_Archived",
+            "Archived",
             FilteringHelper.BuildFilterValueString(Group, nameof(CourseStatistics.Archived), "true"),
             FilterStatus.Default
         );
-
-        //public static FilterOptionModel IsArchived
-        //{
-        //    get
-        //    {
-        //        var filterValue = FilteringHelper.BuildFilterValueString(
-        //            "Archived",
-        //            nameof(CourseStatistics.Archived),
-        //            "true"
-        //        );
-
-        //        //TODO: Also need to OR with .Active=false
-        //        //var filterValue = FilteringHelper.BuildFilterValueString(
-        //        //    "Archived",
-        //        //    nameof(CourseStatistics.Archived),
-        //        //    "true"
-        //        //);
-
-        //        return new FilterOptionModel(
-        //            Group,
-        //            filterValue,
-        //            FilterStatus.Success
-        //        );
-        //    }
-        //}
     }
 
     public static class CourseVisibilityFilterOptions

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -71,9 +71,7 @@
         {
             var tags = new List<SearchableTagViewModel>();
 
-
-
-            if (courseStatistics.Status == "archived")
+            if (courseStatistics.Archived)
             {
                 tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsArchived));
             }

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -71,11 +71,7 @@
         {
             var tags = new List<SearchableTagViewModel>();
 
-            if (courseStatistics.Archived)
-            {
-                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsArchived));
-            }
-            else if (courseStatistics.Active)
+            if (courseStatistics.Active)
             {
                 tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsActive));
             }
@@ -100,12 +96,22 @@
             CourseStatistics courseStatistics
         )
         {
-            return new List<SearchableTagViewModel>
+            var tags = new List<SearchableTagViewModel>();
+
+            if (courseStatistics.Archived)
             {
-                courseStatistics.Active
-                    ? new SearchableTagViewModel(CourseStatusFilterOptions.IsActive)
-                    : new SearchableTagViewModel(CourseStatusFilterOptions.IsInactive),
-            };
+                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsArchived));
+            }
+            else if (courseStatistics.Active)
+            {
+                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsActive));
+            }
+            else
+            {
+                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsInactive));
+            }
+
+            return tags;
         }
 
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForCourseDelegate(CourseDelegate courseDelegate)

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -71,7 +71,13 @@
         {
             var tags = new List<SearchableTagViewModel>();
 
-            if (courseStatistics.Active)
+
+
+            if (courseStatistics.Status == "archived")
+            {
+                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsArchived));
+            }
+            else if (courseStatistics.Active)
             {
                 tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsActive));
             }

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -114,6 +114,28 @@
             return tags;
         }
 
+        public static IEnumerable<SearchableTagViewModel> GetCurrentStatusTagsForDelegateCourses(
+            CourseStatistics courseStatistics
+        )
+        {
+            var tags = new List<SearchableTagViewModel>();
+
+            if (courseStatistics.Archived)
+            {
+                tags.Add(new SearchableTagViewModel("Archived", string.Empty, CourseStatusFilterOptions.IsArchived.TagStatus));
+            }
+            else if (courseStatistics.Active)
+            {
+                tags.Add(new SearchableTagViewModel("Active", string.Empty, CourseStatusFilterOptions.IsActive.TagStatus));
+            }
+            else
+            {
+                tags.Add(new SearchableTagViewModel("Inactive", string.Empty, CourseStatusFilterOptions.IsInactive.TagStatus));
+            }
+
+            return tags;
+        }
+
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForCourseDelegate(CourseDelegate courseDelegate)
         {
             var tags = new List<SearchableTagViewModel>();

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/courseSetup.scss
@@ -1,7 +1,16 @@
-﻿@use "../shared/cardWithButtons";
+﻿@use "nhsuk-frontend/packages/core/all" as *;
+@use "../shared/cardWithButtons";
 @use "../shared/searchableElements/searchableElements";
 @use "../shared/headingButtons.scss";
 
 .admin-field-count {
     width: 10%;
+}
+
+.status-inactive {
+  border-left: 6px solid tint($color_nhsuk-red, 80);
+}
+
+.status-archived {
+  border-left: 6px solid $color_nhsuk-grey-2;
 }

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
@@ -70,3 +70,8 @@
   border-left: 6px solid $color_nhsuk-grey-2;
 }
 
+
+.status-inactive_archived {
+  border-left: 6px solid $color_nhsuk-grey-2;
+}
+

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
@@ -69,9 +69,3 @@
 .status-archived {
   border-left: 6px solid $color_nhsuk-grey-2;
 }
-
-
-.status-inactive_archived {
-  border-left: 6px solid $color_nhsuk-grey-2;
-}
-

--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/viewDelegate.scss
@@ -61,3 +61,12 @@
     border-left: 6px solid $color_nhsuk-grey-2;
   }
 }
+
+.status-inactive {
+  border-left: 6px solid tint($color_nhsuk-red, 80);
+}
+
+.status-archived {
+  border-left: 6px solid $color_nhsuk-grey-2;
+}
+

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/SearchableTagViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/SearchableTagViewModel.cs
@@ -14,6 +14,16 @@
         {
             Hidden = hidden;
         }
+        
+        public SearchableTagViewModel(string displayText, string filterValue, FilterStatus tagStatus, bool hidden = false)
+            : base(
+                displayText,
+                filterValue,
+                tagStatus
+            )
+        {
+            Hidden = hidden;
+        }
 
         public bool Hidden { get; set; }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/SearchableTagViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/SearchableTagViewModel.cs
@@ -14,7 +14,7 @@
         {
             Hidden = hidden;
         }
-        
+
         public SearchableTagViewModel(string displayText, string filterValue, FilterStatus tagStatus, bool hidden = false)
             : base(
                 displayText,

--- a/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/SearchableTagViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/SearchablePage/SearchableTagViewModel.cs
@@ -2,7 +2,6 @@
 {
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
-    using DigitalLearningSolutions.Web.Models.Enums;
 
     public class SearchableTagViewModel : FilterOptionModel
     {

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -26,7 +26,6 @@
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             LaunchCourseLink = $"{config.GetAppRootPath()}/LearningMenu/{CustomisationId}";
-            //Status = DeriveCourseStatus(courseStatistics);
         }
 
         private string LaunchCourseLink { get; set; }
@@ -65,23 +64,5 @@
 
             return $"mailto:?subject={subject}&body={content}";
         }
-
-        //private static string DeriveCourseStatus(Course courseStatistics)
-        //{
-        //    string status;
-        //    if (courseStatistics.Archived)
-        //    {
-        //        status = "archived";
-        //    }
-        //    else if (courseStatistics.Active)
-        //    {
-        //        status = "active";
-        //    }
-        //    else
-        //    {
-        //        status = "inactive";
-        //    }
-        //    return status;
-        //}
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -22,11 +22,7 @@
             CategoryName = courseStatistics.CategoryName;
             CourseTopic = courseStatistics.CourseTopic;
             LearningMinutes = courseStatistics.LearningMinutes;
-
-
             Tags = FilterableTagHelper.GetCurrentTagsForCourseStatistics(courseStatistics);
-
-
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             LaunchCourseLink = $"{config.GetAppRootPath()}/LearningMenu/{CustomisationId}";

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -22,10 +22,15 @@
             CategoryName = courseStatistics.CategoryName;
             CourseTopic = courseStatistics.CourseTopic;
             LearningMinutes = courseStatistics.LearningMinutes;
+
+
             Tags = FilterableTagHelper.GetCurrentTagsForCourseStatistics(courseStatistics);
+
+
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             LaunchCourseLink = $"{config.GetAppRootPath()}/LearningMenu/{CustomisationId}";
+            Status = courseStatistics.Status;
         }
 
         private string LaunchCourseLink { get; set; }
@@ -38,6 +43,7 @@
         public string CourseTopic { get; set; }
         public string LearningMinutes { get; set; }
         public bool Assessed { get; set; }
+        public string? Status { get; set; }
         public IEnumerable<CourseAdminFieldWithResponseCounts> AdminFieldWithResponseCounts { get; set; }
         public bool HasAdminFields => AdminFieldWithResponseCounts.Any();
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -30,7 +30,7 @@
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             LaunchCourseLink = $"{config.GetAppRootPath()}/LearningMenu/{CustomisationId}";
-            Status = courseStatistics.Status;
+            Status = DeriveCourseStatus(courseStatistics);
         }
 
         private string LaunchCourseLink { get; set; }
@@ -68,6 +68,24 @@
             var content = Uri.EscapeDataString($"To start your {CourseName} course, go to {LaunchCourseLink}");
 
             return $"mailto:?subject={subject}&body={content}";
+        }
+
+        private static string DeriveCourseStatus(Course courseStatistics)
+        {
+            string status;
+            if (courseStatistics.Archived)
+            {
+                status = "archived";
+            }
+            else if (courseStatistics.Active)
+            {
+                status = "active";
+            }
+            else
+            {
+                status = "inactive";
+            }
+            return status;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/SearchableCourseStatisticsViewModel.cs
@@ -26,7 +26,7 @@
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             LaunchCourseLink = $"{config.GetAppRootPath()}/LearningMenu/{CustomisationId}";
-            Status = DeriveCourseStatus(courseStatistics);
+            //Status = DeriveCourseStatus(courseStatistics);
         }
 
         private string LaunchCourseLink { get; set; }
@@ -66,22 +66,22 @@
             return $"mailto:?subject={subject}&body={content}";
         }
 
-        private static string DeriveCourseStatus(Course courseStatistics)
-        {
-            string status;
-            if (courseStatistics.Archived)
-            {
-                status = "archived";
-            }
-            else if (courseStatistics.Active)
-            {
-                status = "active";
-            }
-            else
-            {
-                status = "inactive";
-            }
-            return status;
-        }
+        //private static string DeriveCourseStatus(Course courseStatistics)
+        //{
+        //    string status;
+        //    if (courseStatistics.Archived)
+        //    {
+        //        status = "archived";
+        //    }
+        //    else if (courseStatistics.Active)
+        //    {
+        //        status = "active";
+        //    }
+        //    else
+        //    {
+        //        status = "inactive";
+        //    }
+        //    return status;
+        //}
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesViewModel.cs
@@ -19,7 +19,34 @@
             "Search courses"
         )
         {
+            UpdateCourseActiveFlags(result);
+
             Courses = result.ItemsToDisplay.Select(c => new SearchableDelegateCourseStatisticsViewModel(c));
+        }
+
+        private static void UpdateCourseActiveFlags(SearchSortFilterPaginationResult<CourseStatisticsWithAdminFieldResponseCounts> result)
+        {
+            foreach (var course in result.ItemsToDisplay)
+            {
+                if (course.Active && !course.Archived)
+                {
+                    course.Active = true;
+                }
+                else
+                {
+                    course.Active = false;
+                }
+
+
+                if (course.Archived)
+                {
+                    course.Archived = true;
+                }
+                else
+                {
+                    course.Archived = false;
+                }
+            }
         }
 
         public IEnumerable<SearchableDelegateCourseStatisticsViewModel> Courses { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
@@ -19,7 +19,10 @@
             CategoryName = courseStatistics.CategoryName;
             CourseTopic = courseStatistics.CourseTopic;
             LearningMinutes = courseStatistics.LearningMinutes;
-            Tags = FilterableTagHelper.GetCurrentTagsForDelegateCourses(courseStatistics);
+
+            //Tags = FilterableTagHelper.GetCurrentTagsForDelegateCourses(courseStatistics);
+            Tags = FilterableTagHelper.GetCurrentStatusTagsForDelegateCourses(courseStatistics);
+
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             Status = DeriveCourseStatus(courseStatistics);
@@ -55,7 +58,7 @@
         {
             if (courseStatistics.Archived)
             {
-                return "inactive/archived";
+                return "archived";
             }
             else switch (courseStatistics.Active)
             {

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
@@ -22,6 +22,7 @@
             Tags = FilterableTagHelper.GetCurrentTagsForDelegateCourses(courseStatistics);
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
+            Status = DeriveCourseStatus(courseStatistics);
         }
 
         public int CustomisationId { get; set; }
@@ -32,6 +33,7 @@
         public string CourseTopic { get; set; }
         public string LearningMinutes { get; set; }
         public bool Assessed { get; set; }
+        public string? Status { get; set; }
 
         public IEnumerable<CourseAdminFieldWithResponseCounts> AdminFieldWithResponseCounts { get; set; }
 
@@ -49,5 +51,22 @@
                                               FilteringHelper.Separator +
                                               nameof(CourseStatisticsWithAdminFieldResponseCounts.HasAdminFields) +
                                               FilteringHelper.Separator + HasAdminFields.ToString().ToLowerInvariant();
+        private static string DeriveCourseStatus(Course courseStatistics)
+        {
+            string status;
+            if (courseStatistics.Archived)
+            {
+                status = "archived";
+            }
+            else if (courseStatistics.Active)
+            {
+                status = "active";
+            }
+            else
+            {
+                status = "inactive";
+            }
+            return status;
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
@@ -19,10 +19,7 @@
             CategoryName = courseStatistics.CategoryName;
             CourseTopic = courseStatistics.CourseTopic;
             LearningMinutes = courseStatistics.LearningMinutes;
-
-            //Tags = FilterableTagHelper.GetCurrentTagsForDelegateCourses(courseStatistics);
             Tags = FilterableTagHelper.GetCurrentStatusTagsForDelegateCourses(courseStatistics);
-
             Assessed = courseStatistics.IsAssessed;
             AdminFieldWithResponseCounts = courseStatistics.AdminFieldsWithResponses;
             Status = DeriveCourseStatus(courseStatistics);
@@ -66,7 +63,6 @@
                     return "active";
                 case false:
                     return "inactive";
-                default:
             }
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
@@ -53,20 +53,18 @@
                                               FilteringHelper.Separator + HasAdminFields.ToString().ToLowerInvariant();
         private static string DeriveCourseStatus(Course courseStatistics)
         {
-            string status;
             if (courseStatistics.Archived)
             {
-                status = "archived";
+                return "inactive/archived";
             }
-            else if (courseStatistics.Active)
+            else switch (courseStatistics.Active)
             {
-                status = "active";
+                case true:
+                    return "active";
+                case false:
+                    return "inactive";
+                default:
             }
-            else
-            {
-                status = "inactive";
-            }
-            return status;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_FilterableTags.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_FilterableTags.cshtml
@@ -2,7 +2,8 @@
 @model IEnumerable<SearchableTagViewModel>
 
 <div class="tags">
-  @foreach (var tag in Model) {
+  @foreach (var tag in Model)
+  {
     <div class="card-filter-tag" data-filter-value="@tag.FilterValue" @(tag.Hidden ? "hidden" : string.Empty)>
       <strong class="nhsuk-tag @tag.NhsTagStyle()">@tag.DisplayText</strong>
     </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_StatusTags.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_StatusTags.cshtml
@@ -1,0 +1,10 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage
+@model IEnumerable<SearchableTagViewModel>
+
+<div class="tags">
+  @foreach (var tag in Model) {
+    <div class="card-filter-tag" data-filter-value="@tag.FilterValue" @(tag.Hidden ? "hidden" : string.Empty)>
+      <strong class="nhsuk-tag @tag.NhsTagStyle()">@tag.DisplayText</strong>
+    </div>
+  }
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -1,22 +1,28 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @model SearchableCourseStatisticsViewModel
 
-<div class="searchable-element nhsuk-panel card-with-buttons word-break" id="@Model.CustomisationId-card">
+<div class="searchable-element nhsuk-panel card-with-buttons word-break status-@Model.Status" id="@Model.CustomisationId-card">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text searchable-element-title" id="@Model.CustomisationId-name" name="course-name">
         @Model.CourseName
-      </span>
+        </span>
     </summary>
 
     <div class="nhsuk-details__text">
+
+
+
+      
       <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
+
+
+
 
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
       <input type="hidden" data-filter-value="@Model.HasAdminFieldsFilter" />
-      @if (Model.HasAdminFields)
-      {
+      @if (Model.HasAdminFields) {
         <partial name="_CentreCourseCardAdminFields" model="@Model" />
       }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -10,15 +10,7 @@
     </summary>
 
     <div class="nhsuk-details__text">
-
-
-
-      
       <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
-
-
-
-
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
       <input type="hidden" data-filter-value="@Model.HasAdminFieldsFilter" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup
 @model SearchableCourseStatisticsViewModel
 
-<div class="searchable-element nhsuk-panel card-with-buttons word-break status-@Model.Status" id="@Model.CustomisationId-card">
+<div class="searchable-element nhsuk-panel card-with-buttons word-break" id="@Model.CustomisationId-card">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text searchable-element-title" id="@Model.CustomisationId-name" name="course-name">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -6,7 +6,7 @@
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text searchable-element-title" id="@Model.CustomisationId-name" name="course-name">
         @Model.CourseName
-        </span>
+      </span>
     </summary>
 
     <div class="nhsuk-details__text">
@@ -14,7 +14,8 @@
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
       <input type="hidden" data-filter-value="@Model.HasAdminFieldsFilter" />
-      @if (Model.HasAdminFields) {
+      @if (Model.HasAdminFields)
+      {
         <partial name="_CentreCourseCardAdminFields" model="@Model" />
       }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreCourseCard.cshtml
@@ -11,8 +11,9 @@
 
     <div class="nhsuk-details__text">
 
-      <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
-
+      @*<partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />*@
+      <partial name="SearchablePage/_StatusTags" model="@Model.Tags" />
+      
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
       <input type="hidden" data-filter-value="@Model.HasAdminFieldsFilter" />

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreCourseCard.cshtml
@@ -11,13 +11,13 @@
 
     <div class="nhsuk-details__text">
 
-      @*<partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />*@
       <partial name="SearchablePage/_StatusTags" model="@Model.Tags" />
-      
+
       <partial name="_CentreCourseCardDetails" model="@Model" />
 
       <input type="hidden" data-filter-value="@Model.HasAdminFieldsFilter" />
-      @if (Model.HasAdminFields) {
+      @if (Model.HasAdminFields)
+      {
         <partial name="_CentreCourseCardAdminFields" model="@Model" />
       }
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreCourseCard.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses
 @model SearchableDelegateCourseStatisticsViewModel
 
-<div class="searchable-element nhsuk-panel card-with-buttons word-break" id="@Model.CustomisationId-card">
+<div class="searchable-element nhsuk-panel card-with-buttons word-break status-@Model.Status" id="@Model.CustomisationId-card">
   <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
     <summary class="nhsuk-details__summary">
       <span class="nhsuk-details__summary-text searchable-element-title" id="@Model.CustomisationId-name" name="course-name">
@@ -10,6 +10,7 @@
     </summary>
 
     <div class="nhsuk-details__text">
+
       <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
 
       <partial name="_CentreCourseCardDetails" model="@Model" />


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-707

### Description
Updated Delegate Courses view to show left border colour for Archived and Inactive courses.
Also added Tag ui elements for Archived courses.
Please note that this page now returns archived courses in its results panel.

### Screenshots
Screenshots below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

Updated 'Active' status:
![td797_active](https://user-images.githubusercontent.com/113513647/207855460-73dbb3f1-5667-4c1c-af63-7b75a2dadb8a.jpg)

Updated 'Inactive/archived'
![td797_inactivearchvied](https://user-images.githubusercontent.com/113513647/207856338-8870a4ac-2288-459d-8b15-d2ad7122d6d8.png)

