### PR TITLE
TD-787-Password field missing in the External Register Summary Page.

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/Register/SummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Register/SummaryViewModel.cs
@@ -17,6 +17,7 @@
             CentreSpecificEmail = data.CentreSpecificEmail;
             ProfessionalRegistrationNumber = data.ProfessionalRegistrationNumber ?? "Not professionally registered";
             HasProfessionalRegistrationNumber = data.HasProfessionalRegistrationNumber;
+            IsPasswordSet = string.IsNullOrEmpty(data.PasswordHash) ? false:true;
         }
 
         public SummaryViewModel(DelegateRegistrationData data) : this((RegistrationData)data)
@@ -35,6 +36,7 @@
         public bool IsCentreSpecificRegistration { get; set; }
         public string? ProfessionalRegistrationNumber { get; set; }
         public bool? HasProfessionalRegistrationNumber { get; set; }
+        public bool IsPasswordSet { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {

--- a/DigitalLearningSolutions.Web/Views/Register/Summary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/Summary.cshtml
@@ -122,6 +122,19 @@
           </dd>
         </div>
       }
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Password set
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          @(Model.IsPasswordSet ? "Yes" : "No")
+        </dd>
+        <dd class="nhsuk-summary-list__actions">
+          <a asp-action="Password">
+            Change<span class="nhsuk-u-visually-hidden"> password settings</span>
+          </a>
+        </dd>
+      </div>
     </dl>
 
     <form method="post" asp-action="Summary">


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-787

**Description**
Password field added in the summary page.

**Screenshots**
Updated in Jira ticket
-----
**Developer checks**
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
