### PR TITLE
TD-682 Courses displaying navigation to archived/incorrect content

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
@@ -112,6 +112,7 @@
                      AND Customisations.Active = 1
                      AND Sections.ArchivedDate IS NULL
                      AND Tutorials.ArchivedDate IS NULL
+                     AND Applications.ArchivedDate IS NULL
                      AND (CustomisationTutorials.Status = 1 OR CustomisationTutorials.DiagStatus = 1 OR Customisations.IsAssessed = 1)
                      AND Applications.DefaultContentTypeID <> 4
                    GROUP BY


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-682

### Description
All queries that return navigation data within the learning menu should exclude any Applications, Sections and Tutorial records that have an Archived date that is not null.

### Screenshots
No Screenshots

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
