### PR TITLE
Develop/fixes/td 172 move app container max width to 1144px to match learning hub

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -335,3 +335,6 @@ nav, .nhsuk-header__navigation, #header-navigation {
     color: $color_nhsuk-dark-pink;
   }
 }
+.nhsuk-width-container {
+  max-width: 1144px !important;
+}

--- a/DigitalLearningSolutions.Web/Styles/nhsuk.scss
+++ b/DigitalLearningSolutions.Web/Styles/nhsuk.scss
@@ -7,7 +7,3 @@
 .nhsuk-hint {
   white-space: initial;
 }
-
-.nhsuk-width-container {
-  max-width:1144px !important;
-}

--- a/DigitalLearningSolutions.Web/Styles/nhsuk.scss
+++ b/DigitalLearningSolutions.Web/Styles/nhsuk.scss
@@ -7,3 +7,7 @@
 .nhsuk-hint {
   white-space: initial;
 }
+
+.nhsuk-width-container {
+  max-width:1144px !important;
+}


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-172

### Description
The css is overrideden in order to increase the width of the contgainer.

### Screenshots
Are provided in the jira

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
