### PR TITLE
Develop/fixes/td 710 display the name of the framework and framework specific vocabulary

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Frameworks/FrameworkCompetency.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/FrameworkCompetency.cs
@@ -13,6 +13,7 @@
         public int Ordering { get; set; }
         public int AssessmentQuestions { get; set; }
         public int CompetencyLearningResourcesCount { get; set; }
+        public string? FrameworkName { get; set; }
 
         public override string SearchableName
         {

--- a/DigitalLearningSolutions.Data/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/Services/FrameworkService.cs
@@ -446,10 +446,14 @@
 
         public IEnumerable<FrameworkCompetency> GetAllCompetenciesForAdminId(string name, int adminId)
         {
-            return connection.Query<FrameworkCompetency>(
-                $@"SELECT * FROM Competencies WHERE [Name] = @name AND [UpdatedByAdminID] = @adminId",
-                new { name, adminId }
-            );
+          return connection.Query<FrameworkCompetency>(
+               $@"SELECT f.FrameworkName,c.Description,c.UpdatedByAdminID,c.Name from Competencies as c
+                    INNER JOIN FrameworkCompetencies AS fc ON c.ID = fc.CompetencyID
+                    INNER JOIN Frameworks AS f ON fc.FrameworkID = f.ID
+                    WHERE fc.FrameworkID = f.ID AND c.Name = @name AND c.UpdatedByAdminID = @adminId",
+               new { name, adminId }
+           );
+
         }
 
         public BrandedFramework CreateFramework(DetailFramework detailFramework, int adminId)

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -139,12 +139,12 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             frameworkCompetency.Description = SanitizerHelper.SanitizeHtmlData(frameworkCompetency.Description);
             frameworkCompetency.Description?.Trim();
             var description = HttpUtility.HtmlDecode(HttpUtility.HtmlDecode(frameworkCompetency.Description));
+            var detailFramework = frameworkService.GetDetailFrameworkByFrameworkId(frameworkId, GetAdminId());
             if (string.IsNullOrWhiteSpace(description)) { frameworkCompetency.Description = null; }
             if (!ModelState.IsValid)
             {
                 ModelState.Remove(nameof(FrameworkCompetency.Name));
                 ModelState.AddModelError(nameof(FrameworkCompetency.Name), "Please enter a valid competency statement (between 3 and 500 characters)");
-                var detailFramework = frameworkService.GetDetailFrameworkByFrameworkId(frameworkId, GetAdminId());
                 var competencyFlags = frameworkService.GetCompetencyFlagsByFrameworkId(frameworkId, frameworkCompetency?.CompetencyID).ToList();
                 if (competencyFlags != null)
                     competencyFlags.ForEach(f => f.Selected = selectedFlagIds.Contains(f.FlagId));
@@ -187,6 +187,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     FrameworkId = frameworkId,
                     FrameworkGroupId = frameworkCompetencyGroupId,
                     FrameworkCompetencyId = frameworkCompetencyId,
+                    FrameworkConfig = detailFramework?.FrameworkConfig,
                     Competency = new FrameworkCompetency()
                     {
                         Name = frameworkCompetency.Name,

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/SimilarCompetencyViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/SimilarCompetencyViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.Frameworks
 {
     using DigitalLearningSolutions.Data.Models.Frameworks;
+    using DigitalLearningSolutions.Web.Helpers;
     using System.Collections.Generic;
     public class SimilarCompetencyViewModel
     {
@@ -8,7 +9,13 @@
         public FrameworkCompetency Competency { get; set; }
         public int FrameworkId { get; set; }
         public int? FrameworkGroupId { get; set; }
-        public int FrameworkCompetencyId { get; set; }  
+        public int FrameworkCompetencyId { get; set; }
+        public string FrameworkConfig { get; set; }
         public IEnumerable<FrameworkCompetency> SameCompetency { get; set; }
+
+        public string VocabSingular()
+        {
+            return FrameworkVocabularyHelper.VocabularySingular(FrameworkConfig);
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
@@ -1,8 +1,8 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks;
 @model FrameworkCompetencyViewModel;
 @{
-  ViewData["Title"] = "Competency";
-  ViewData["Application"] = "Framework Service";
+    ViewData["Title"] = !string.IsNullOrWhiteSpace(Model.VocabSingular()) ? Model.VocabSingular(): "Competency";
+    ViewData["Application"] = "Framework Service";
   ViewData["HeaderPathName"] = "Framework Service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
@@ -16,7 +16,7 @@
       <ol class="nhsuk-breadcrumb__list">
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId" asp-fragment="fc-@Model.FrameworkCompetency.Id" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Framework Structure</a></li>
-        <li class="nhsuk-breadcrumb__item">Competency</li>
+        <li class="nhsuk-breadcrumb__item">@Model.VocabSingular()</li>
       </ol>
       <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId" asp-fragment="fc-@Model.FrameworkCompetency.Id" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Back to framework structure</a></p>
     </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -27,6 +27,9 @@
     <thead role="rowgroup" class="nhsuk-table__head">
         <tr role="row">
             <th role="columnheader" class="" scope="col">
+                Framework
+            </th>
+            <th role="columnheader" class="" scope="col">
                 Name
             </th>
             <th role="columnheader" class="" scope="col">
@@ -38,6 +41,12 @@
         @foreach (var competency in Model.SameCompetency)
         {
             <tr role="row" class="nhsuk-table__row framework-row">
+               <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-19">
+                    <span class="nhsuk-table-responsive__heading">Framework </span>
+                    <span class="framework-brand">
+                       @competency.FrameworkName
+                    </span>
+                </td>
                 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-19">
                     <span class="nhsuk-table-responsive__heading">Name </span>
                     <span class="framework-brand">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks
 @model SimilarCompetencyViewModel
 @{
-    ViewData["Title"] = "Similar Competency";
+    ViewData["Title"] = $"Similar {Model.VocabSingular()}";
     ViewData["Application"] = "Framework Service";
     ViewData["HeaderPathName"] = "Framework Service";
 }
@@ -9,10 +9,10 @@
 @section NavMenuItems {
 <partial name="Shared/_NavMenuItems" />
 }
-<h1>Duplicate competency name</h1>
+<h1>Duplicate @Model.VocabSingular() name</h1>
 <div class="nhsuk-form-group nhsuk-form-group--error">
     <p class="nhsuk-error-message">
-        The item you are trying to add "<span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span>" has the same name as an existing competency.
+        The item you are trying to add "<span class="nhsuk-u-font-weight-bold">@Model.Competency.Name</span>" has the same name as an existing @Model.VocabSingular().
     </p>
     <p class="nhsuk-u-margin-top-6">
         You can still create this item but we recommend that you give it a distinct name.
@@ -22,7 +22,7 @@
 <h2>Duplicates</h2>
 <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-bottom-6">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">
-        Competency
+        @Model.VocabSingular()
     </caption>
     <thead role="rowgroup" class="nhsuk-table__head">
         <tr role="row">


### PR DESCRIPTION
### JIRA link
[TD-710](https://hee-tis.atlassian.net/browse/TD-710)

### Description
Addition of Framework name to list of similar competencies.
The use of framework vocabulary in place of the default competency keyword.

### Screenshots
![DuplicateCompetency](https://user-images.githubusercontent.com/114475132/205915429-56064abb-4460-4b8a-859b-ed76e6994368.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
