### PR TITLE
TD-721 Help link removal from list

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Support/Support.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/Support.cshtml
@@ -18,11 +18,8 @@
   <div class="nhsuk-grid-column-three-quarters">
     <h1 id="page-heading" class="nhsuk-heading-xl">Support</h1>
 
-    <p class="nhsuk-lede-text nhsuk-u-margin-top-4">Access Digital Learning Solutions support in 5 easy steps...</p>
+    <p class="nhsuk-lede-text nhsuk-u-margin-top-4">Access Digital Learning Solutions support in 4 easy steps...</p>
     <ol>
-      <li>
-        <a href="@SupportLinksHelper.GetHelpUrl(Model.CurrentSystemBaseUrl)" target="_blank">Check the online Help documentation</a>. It is searchable and comprehensive.
-      </li>
       <li>
         <a asp-action="Index" asp-controller="Faqs" asp-route-dlsSubApplication="@Model.DlsSubApplication">Search our Frequently Asked Questions (FAQs)</a>.
         If you've got a question about the platform, the chances are somebody has asked it before.


### PR DESCRIPTION
### JIRA link
[TD-721](https://hee-tis.atlassian.net/browse/TD-721)

### Description
Help link removed from support page

### Screenshots
![HelpLinkRemoval](https://user-images.githubusercontent.com/114475132/205921392-8ad06531-0568-4028-88a1-5ad6a275254a.PNG)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
