### PR TITLE
TD-798 : Fixed Error message missing on 'Confirm Remove Staff Member

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -209,7 +209,6 @@
             }
             else
             {
-                //ModelState.ClearErrorsOnField("ActionConfirmed");
                 return View("RemoveConfirm", supervisorDelegate);
             }
         }

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -195,6 +195,13 @@
         [HttpPost]
         public IActionResult RemoveSupervisorDelegate(SupervisorDelegateViewModel supervisorDelegate)
         {
+          ModelState.ClearErrorsOnField("ActionConfirmed");
+          return View("RemoveConfirm", supervisorDelegate);
+        }
+
+        [HttpPost]
+        public IActionResult RemoveSupervisorDelegateConfirmed(SupervisorDelegateViewModel supervisorDelegate)
+        {
             if (ModelState.IsValid && supervisorDelegate.ActionConfirmed)
             {
                 supervisorService.RemoveSupervisorDelegateById(supervisorDelegate.Id, 0, GetAdminId());
@@ -202,7 +209,7 @@
             }
             else
             {
-                ModelState.ClearErrorsOnField("ActionConfirmed");
+                //ModelState.ClearErrorsOnField("ActionConfirmed");
                 return View("RemoveConfirm", supervisorDelegate);
             }
         }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
@@ -38,7 +38,7 @@
                             label="I am sure that I wish to remove @Model.FirstName @Model.LastName from my staff list"
                             hint-text="This action will remove the staff member from your staff list and you will no longer be able to review their self assessments." />
       </div>
-      <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveSupervisorDelegate">
+      <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveSupervisorDelegateConfirmed">
         Remove
       </button>
       @Html.HiddenFor(m => m.Id)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-798

### Description
Fixed Error message missing on 'Confirm Remove Staff Member' when clicked Remove' button before confirming it

### Screenshots
https://hee-tis.atlassian.net/browse/TD-798

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
