### PR TITLE
Fixed spacing issue between the 'View section' and 'Percentage learni…

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -338,3 +338,8 @@ nav, .nhsuk-header__navigation, #header-navigation {
 .nhsuk-width-container {
   max-width: 1144px !important;
 }
+@media only screen and (max-width: 767px) {
+  .nhsuk-grid-column-one-third {
+    margin-top: 10px;
+  }
+}

--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -339,7 +339,7 @@ nav, .nhsuk-header__navigation, #header-navigation {
   max-width: 1144px !important;
 }
 @media only screen and (max-width: 767px) {
-  .nhsuk-grid-column-one-third {
+  .section-card-result {
     margin-top: 10px;
   }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/_SectionCard.cshtml
@@ -16,7 +16,7 @@
           View section
         </a>
       </div>
-      <div class="nhsuk-grid-column-one-third">
+      <div class="nhsuk-grid-column-one-third section-card-result">
         <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color">
           @Model.PercentComplete
         </h3>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-780

### Description
Fixed Missing spacing issue between the 'View section' and 'Percentage learning completion'

### Screenshots
https://hee-tis.atlassian.net/browse/TD-780

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
