### PR TITLE
 TD-825 fix data for constraints

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202206281724_AddUniquenessConstraintsToCandidateAssessmentsAndSupervisorDelegates.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202206281724_AddUniquenessConstraintsToCandidateAssessmentsAndSupervisorDelegates.cs
@@ -8,9 +8,82 @@
     {
         private const string CandidateAssessmentsIndexName = "IX_CandidateAssessments_DelegateUserId_SelfAssessmentId";
         private const string SupervisorDelegatesIndexName = "IX_SupervisorDelegates_DelegateUserId_SupervisorAdminId";
+        private const string DeleteIllegalDuplicatesSql =
+            @"DELETE FROM CandidateAssessmentOptionalCompetencies
+FROM   CandidateAssessments AS CA INNER JOIN
+             CandidateAssessmentOptionalCompetencies ON CA.ID = CandidateAssessmentOptionalCompetencies.CandidateAssessmentID
+WHERE (CA.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    CandidateAssessments AS CA1
+                 WHERE (CA.SelfAssessmentID = SelfAssessmentID) AND (CA.DelegateUserID = DelegateUserID)))
+
+DELETE FROM CandidateAssessmentSupervisorVerifications 
+FROM   CandidateAssessments INNER JOIN
+             CandidateAssessmentSupervisors ON CandidateAssessments.ID = CandidateAssessmentSupervisors.CandidateAssessmentID INNER JOIN
+             CandidateAssessmentSupervisorVerifications ON CandidateAssessmentSupervisors.ID = CandidateAssessmentSupervisorVerifications.CandidateAssessmentSupervisorID
+WHERE (CandidateAssessments.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    CandidateAssessments AS CA1
+                 WHERE (CandidateAssessments.SelfAssessmentID = SelfAssessmentID) AND (CandidateAssessments.DelegateUserID = DelegateUserID)))
+
+DELETE FROM SelfAssessmentResultSupervisorVerifications
+FROM   CandidateAssessments INNER JOIN
+             CandidateAssessmentSupervisors ON CandidateAssessments.ID = CandidateAssessmentSupervisors.CandidateAssessmentID INNER JOIN
+             SelfAssessmentResultSupervisorVerifications ON CandidateAssessmentSupervisors.ID = SelfAssessmentResultSupervisorVerifications.CandidateAssessmentSupervisorID
+WHERE (CandidateAssessments.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    CandidateAssessments AS CA1
+                 WHERE (CandidateAssessments.SelfAssessmentID = SelfAssessmentID) AND (CandidateAssessments.DelegateUserID = DelegateUserID)))
+
+DELETE FROM CandidateAssessmentSupervisors
+FROM   CandidateAssessments INNER JOIN
+             CandidateAssessmentSupervisors ON CandidateAssessments.ID = CandidateAssessmentSupervisors.CandidateAssessmentID
+WHERE (CandidateAssessments.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    CandidateAssessments AS CA1
+                 WHERE (CandidateAssessments.SelfAssessmentID = SelfAssessmentID) AND (CandidateAssessments.DelegateUserID = DelegateUserID)))
+
+DELETE FROM CandidateAssessments
+WHERE (ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    CandidateAssessments AS CA1
+                 WHERE (CandidateAssessments.SelfAssessmentID = SelfAssessmentID) AND (CandidateAssessments.DelegateUserID = DelegateUserID)))
+
+DELETE FROM SelfAssessmentResultSupervisorVerifications
+FROM   SupervisorDelegates INNER JOIN
+             CandidateAssessmentSupervisors ON SupervisorDelegates.ID = CandidateAssessmentSupervisors.SupervisorDelegateId INNER JOIN
+             SelfAssessmentResultSupervisorVerifications ON CandidateAssessmentSupervisors.ID = SelfAssessmentResultSupervisorVerifications.CandidateAssessmentSupervisorID
+WHERE (SupervisorDelegates.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    SupervisorDelegates AS SupervisorDelegates_1
+                 WHERE (SupervisorDelegates.DelegateUserID = DelegateUserID) AND (SupervisorDelegates.SupervisorAdminID = SupervisorAdminID)))
+
+DELETE FROM CandidateAssessmentSupervisorVerifications
+FROM   SupervisorDelegates INNER JOIN
+             CandidateAssessmentSupervisors ON SupervisorDelegates.ID = CandidateAssessmentSupervisors.SupervisorDelegateId INNER JOIN
+             CandidateAssessmentSupervisorVerifications ON CandidateAssessmentSupervisors.ID = CandidateAssessmentSupervisorVerifications.CandidateAssessmentSupervisorID
+WHERE (SupervisorDelegates.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    SupervisorDelegates AS SupervisorDelegates_1
+                 WHERE (SupervisorDelegates.DelegateUserID = DelegateUserID) AND (SupervisorDelegates.SupervisorAdminID = SupervisorAdminID)))
+
+DELETE FROM CandidateAssessmentSupervisors
+FROM   SupervisorDelegates INNER JOIN
+             CandidateAssessmentSupervisors ON SupervisorDelegates.ID = CandidateAssessmentSupervisors.SupervisorDelegateId
+WHERE (SupervisorDelegates.ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    SupervisorDelegates AS SupervisorDelegates_1
+                 WHERE (SupervisorDelegates.DelegateUserID = DelegateUserID) AND (SupervisorDelegates.SupervisorAdminID = SupervisorAdminID)))
+
+DELETE FROM SupervisorDelegates
+WHERE (ID <
+                 (SELECT MAX(ID) AS Expr1
+                 FROM    SupervisorDelegates AS SupervisorDelegates_1
+                 WHERE (SupervisorDelegates.DelegateUserID = DelegateUserID) AND (SupervisorDelegates.SupervisorAdminID = SupervisorAdminID)))";
 
         public override void Up()
         {
+            Execute.Sql(DeleteIllegalDuplicatesSql);
             Create.Index(CandidateAssessmentsIndexName)
                 .OnTable("CandidateAssessments").WithOptions().UniqueNullsNotDistinct()
                 .OnColumn("SelfAssessmentID").Ascending()


### PR DESCRIPTION
### JIRA link
_[TD-825](https://hee-tis.atlassian.net/browse/TD-825)_

### Description
Adds script to remove duplicate data that breaks the constraints introduced by the migration.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
