### PR TITLE
TD-584 'Required/Optional proficiencies' on the self assessments shou…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CommentsInput.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CommentsInput.cshtml
@@ -3,7 +3,7 @@
 <div class="nhsuk-form-group">
   <label class="nhsuk-label" for="tb-supportingComments-@Model.Id">
     <span class="nhsuk-u-visually-hidden">@Model.Question @if (!Model.Required)
-    {<span>(Optional)</span>}</span>
+    {<span>(optional)</span>}</span>
     @(Model.CommentsPrompt == null ? "Supporting comments" : Model.CommentsPrompt)
   </label>
   @if (Model.CommentsHint != null)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CommentsInput.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_CommentsInput.cshtml
@@ -1,7 +1,9 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments
 @model AssessmentQuestion
 <div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="tb-supportingComments-@Model.Id"><span class="nhsuk-u-visually-hidden">@Model.Question</span>
+  <label class="nhsuk-label" for="tb-supportingComments-@Model.Id">
+    <span class="nhsuk-u-visually-hidden">@Model.Question @if (!Model.Required)
+    {<span>(Optional)</span>}</span>
     @(Model.CommentsPrompt == null ? "Supporting comments" : Model.CommentsPrompt)
   </label>
   @if (Model.CommentsHint != null)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
@@ -6,7 +6,7 @@
     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
       <h3 class="nhsuk-fieldset__heading">
         @Model.Question @if (!Model.Required)
-        {<span>(Optional)</span>}
+        {<span>(optional)</span>}
       </h3>
       <div class="nhsuk-hint">
         @if (Model.ScoringInstructions != null)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_RadioQuestion.cshtml
@@ -5,7 +5,8 @@
   <fieldset class="nhsuk-fieldset">
     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
       <h3 class="nhsuk-fieldset__heading">
-        @Model.Question
+        @Model.Question @if (!Model.Required)
+        {<span>(Optional)</span>}
       </h3>
       <div class="nhsuk-hint">
         @if (Model.ScoringInstructions != null)
@@ -22,10 +23,10 @@
       {
         <div class="nhsuk-radios__item">
           <input class="nhsuk-radios__input select-all-checkbox"
-               name="[@ViewData["index"]].Result" id="radio-@Model.Id-@levelDescriptor.LevelValue"
-               data-group="group@(Model.Id)"
-               checked="@(Model.Result == @levelDescriptor.LevelValue)" type="radio" value="@levelDescriptor.LevelValue"
-               aria-describedby="radio-@Model.Id-@levelDescriptor.LevelValue-item-hint">
+                 name="[@ViewData["index"]].Result" id="radio-@Model.Id-@levelDescriptor.LevelValue"
+                 data-group="group@(Model.Id)"
+                 checked="@(Model.Result == @levelDescriptor.LevelValue)" type="radio" value="@levelDescriptor.LevelValue"
+                 aria-describedby="radio-@Model.Id-@levelDescriptor.LevelValue-item-hint">
           <label class="nhsuk-label nhsuk-radios__label" for="radio-@Model.Id-@levelDescriptor.LevelValue">
             @levelDescriptor.LevelLabel
           </label>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SliderQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SliderQuestion.cshtml
@@ -3,7 +3,7 @@
 
 <label for="@Model.Id-input">
   <h3 class="nhsuk-u-margin-bottom-1">@Model.Question @if (!Model.Required)
-  {<span>(Optional)</span>}</h3>
+  {<span>(optional)</span>}</h3>
 </label>
 @if (Model.ScoringInstructions != null)
 {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SliderQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SliderQuestion.cshtml
@@ -2,19 +2,20 @@
 @model AssessmentQuestion
 
 <label for="@Model.Id-input">
-  <h3 class="nhsuk-u-margin-bottom-1">@Model.Question</h3>
+  <h3 class="nhsuk-u-margin-bottom-1">@Model.Question @if (!Model.Required)
+  {<span>(Optional)</span>}</h3>
 </label>
-  @if (Model.ScoringInstructions != null)
-  {
-    <div class="nhsuk-hint">
-      @(Html.Raw(Model.ScoringInstructions))
-    </div>
-  }
+@if (Model.ScoringInstructions != null)
+{
+  <div class="nhsuk-hint">
+    @(Html.Raw(Model.ScoringInstructions))
+  </div>
+}
 
-  <div class="nhsuk-grid-row">
-    <div class="grid-column-85">
-      <span class="left-label">@Model.MinValueDescription</span>
-      <span class="right-label">@Model.MaxValueDescription</span>
+<div class="nhsuk-grid-row">
+  <div class="grid-column-85">
+    <span class="left-label">@Model.MinValueDescription</span>
+    <span class="right-label">@Model.MaxValueDescription</span>
   </div>
 </div>
 <div class="nhsuk-grid-row range-input-row nhsuk-u-margin-bottom-5">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionOverviewCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionOverviewCells.cshtml
@@ -10,10 +10,11 @@
 
 <td class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">@ViewData["QuestionLabel"]</span>
-  @Model.Question
+  @Model.Question @if (!Model.Required)
+  {<span>(Optional)</span>}
 </td>
 <td class="nhsuk-table__cell nhsuk-u-font-size-16">
-  <span class="nhsuk-table-responsive__heading">Self-assessment status </span>
+  <span class="nhsuk-table-responsive__heading">Self-assessment status</span>
   <partial name="../../Supervisor/Shared/_AssessmentQuestionResponse" model="Model" />
 </td>
 @if (((CurrentSelfAssessment)ViewData["selfAssessment"])?.IsSupervisorResultsReviewed ?? true)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionOverviewCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionOverviewCells.cshtml
@@ -11,7 +11,7 @@
 <td class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">@ViewData["QuestionLabel"]</span>
   @Model.Question @if (!Model.Required)
-  {<span>(Optional)</span>}
+  {<span>(optional)</span>}
 </td>
 <td class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Self-assessment status</span>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
@@ -3,7 +3,8 @@
 
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Question </span>
-  @Model.Question
+  @Model.Question @if (!Model.Required)
+  {<span>(Optional)</span>}
 </td>
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Self-assessment </span>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_AssessmentQuestionCells.cshtml
@@ -4,7 +4,7 @@
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Question </span>
   @Model.Question @if (!Model.Required)
-  {<span>(Optional)</span>}
+  {<span>(optional)</span>}
 </td>
 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
   <span class="nhsuk-table-responsive__heading">Self-assessment </span>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-584

### Description
Competency assessment questions that are marked as optional in the database should have “ (optional)” appended to their name.

### Screenshots
https://hee-tis.atlassian.net/browse/TD-584

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
