### PR TITLE
TD-260-Passporting - Fix Learning Portal and Self Assessment functionality broken by migration

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CandidateAssessmentsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CandidateAssessmentsDataServiceTests.cs
@@ -22,7 +22,7 @@
                "to build up a picture of digital capability across the workforce to help with service design and learning provision.";
 
             // When
-            var result = selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId);
+            var result = selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId);
 
             // Then
             var expectedSelfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment(
@@ -45,7 +45,7 @@
         public void GetSelfAssessmentForCandidateById_should_return_null_when_there_are_no_matching_assessments()
         {
             // When
-            var result = selfAssessmentDataService.GetSelfAssessmentForCandidateById(2, SelfAssessmentId);
+            var result = selfAssessmentDataService.GetSelfAssessmentForUserById(1, SelfAssessmentId);
 
             // Then
             result.Should().BeNull();
@@ -57,9 +57,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.UpdateLastAccessed(SelfAssessmentId, CandidateId);
+                selfAssessmentDataService.UpdateLastAccessed(SelfAssessmentId, UserId);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.LastAccessed.Should().NotBeNull();
@@ -76,8 +76,8 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.UpdateLastAccessed(invalidSelfAssessmentId, CandidateId);
-                var updatedSelfAssessment =  selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                selfAssessmentDataService.UpdateLastAccessed(invalidSelfAssessmentId, UserId);
+                var updatedSelfAssessment =  selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.LastAccessed.Should().BeNull();
@@ -93,9 +93,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetCompleteByDate(SelfAssessmentId, CandidateId, expectedCompleteByDate);
+                selfAssessmentDataService.SetCompleteByDate(SelfAssessmentId, UserId, expectedCompleteByDate);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.CompleteByDate.Should().Be(expectedCompleteByDate);
@@ -108,9 +108,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetCompleteByDate(SelfAssessmentId, CandidateId, null);
+                selfAssessmentDataService.SetCompleteByDate(SelfAssessmentId, UserId, null);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.CompleteByDate.Should().BeNull();
@@ -126,9 +126,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetCompleteByDate(invalidSelfAssessmentId, CandidateId, DateTime.UtcNow);
+                selfAssessmentDataService.SetCompleteByDate(invalidSelfAssessmentId, UserId, DateTime.UtcNow);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.CompleteByDate.Should().BeNull();
@@ -141,9 +141,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetUpdatedFlag(SelfAssessmentId, CandidateId, true);
+                selfAssessmentDataService.SetUpdatedFlag(SelfAssessmentId, UserId, true);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.UnprocessedUpdates.Should().BeTrue();
@@ -159,10 +159,10 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetUpdatedFlag(SelfAssessmentId, CandidateId, false);
-                selfAssessmentDataService.SetUpdatedFlag(invalidSelfAssessmentId, CandidateId, true);
+                selfAssessmentDataService.SetUpdatedFlag(SelfAssessmentId, UserId, false);
+                selfAssessmentDataService.SetUpdatedFlag(invalidSelfAssessmentId, UserId, true);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.UnprocessedUpdates.Should().BeFalse();
@@ -175,9 +175,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetBookmark(SelfAssessmentId, CandidateId, "");
+                selfAssessmentDataService.SetBookmark(SelfAssessmentId, UserId, "");
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.UserBookmark.Should().Be("");
@@ -193,9 +193,9 @@
             using (new TransactionScope())
             {
                 // When
-                selfAssessmentDataService.SetBookmark(invalidSelfAssessmentId, CandidateId, "test");
+                selfAssessmentDataService.SetBookmark(invalidSelfAssessmentId, UserId, "test");
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.UserBookmark.Should().NotBe("test");
@@ -209,11 +209,11 @@
             {
                 // When
                 var originalSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
                 var originalLaunchCount = originalSelfAssessment.LaunchCount;
-                selfAssessmentDataService.IncrementLaunchCount(SelfAssessmentId, CandidateId);
+                selfAssessmentDataService.IncrementLaunchCount(SelfAssessmentId, UserId);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.LaunchCount.Should().BeGreaterThan(originalLaunchCount);
@@ -230,11 +230,11 @@
             {
                 // When
                 var originalSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
                 var originalLaunchCount = originalSelfAssessment.LaunchCount;
-                selfAssessmentDataService.IncrementLaunchCount(invalidSelfAssessmentId, CandidateId);
+                selfAssessmentDataService.IncrementLaunchCount(invalidSelfAssessmentId, UserId);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.LaunchCount.Should().Be(originalLaunchCount);
@@ -248,11 +248,11 @@
             {
                 // When
                 var originalSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
                 var originalSubmittedDate = originalSelfAssessment.SubmittedDate;
-                selfAssessmentDataService.SetSubmittedDateNow(SelfAssessmentId, CandidateId);
+                selfAssessmentDataService.SetSubmittedDateNow(SelfAssessmentId, UserId);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 originalSubmittedDate.Should().BeNull();
@@ -270,11 +270,11 @@
             {
                 // When
                 var originalSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
                 var originalSubmittedDate = originalSelfAssessment.SubmittedDate;
-                selfAssessmentDataService.SetSubmittedDateNow(invalidSelfAssessmentId, CandidateId);
+                selfAssessmentDataService.SetSubmittedDateNow(invalidSelfAssessmentId, UserId);
                 var updatedSelfAssessment =
-                    selfAssessmentDataService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId)!;
+                    selfAssessmentDataService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId)!;
 
                 // Then
                 updatedSelfAssessment.SubmittedDate.Should().Be(originalSubmittedDate);
@@ -292,11 +292,12 @@
                 DelegateId = delegateId,
                 SelfAssessmentId = SelfAssessmentId,
                 CompletedDate = null,
-                RemovedDate = null
+                RemovedDate = null,
+                
             };
 
             // When
-            var result = selfAssessmentDataService.GetCandidateAssessments(delegateId, SelfAssessmentId).ToList();
+            var result = selfAssessmentDataService.GetCandidateAssessments(UserId, SelfAssessmentId).ToList();
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CompetencyDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CompetencyDataServiceTests.cs
@@ -43,7 +43,7 @@
             );
 
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(1, SelfAssessmentId, CandidateId);
+            var result = selfAssessmentDataService.GetNthCompetency(1, SelfAssessmentId, UserId);
 
             // Then
             result.Should().BeEquivalentTo(expectedCompetency);
@@ -74,7 +74,7 @@
             );
 
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(32, SelfAssessmentId, CandidateId);
+            var result = selfAssessmentDataService.GetNthCompetency(32, SelfAssessmentId, UserId);
 
             // Then
             result.Should().BeEquivalentTo(expectedCompetency);
@@ -84,7 +84,7 @@
         public void GetNthCompetency_returns_null_when_reached_end_of_assessment()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(33, SelfAssessmentId, CandidateId);
+            var result = selfAssessmentDataService.GetNthCompetency(33, SelfAssessmentId, UserId);
 
             // Then
             result.Should().BeNull();
@@ -94,7 +94,7 @@
         public void GetNthCompetency_returns_null_when_n_zero()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(0, SelfAssessmentId, CandidateId);
+            var result = selfAssessmentDataService.GetNthCompetency(0, SelfAssessmentId, UserId);
 
             // Then
             result.Should().BeNull();
@@ -104,7 +104,7 @@
         public void GetNthCompetency_returns_null_when_n_negative()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(-1, SelfAssessmentId, CandidateId);
+            var result = selfAssessmentDataService.GetNthCompetency(-1, SelfAssessmentId, UserId);
 
             // Then
             result.Should().BeNull();
@@ -159,7 +159,7 @@
                 );
 
                 // Then
-                var competency = selfAssessmentDataService.GetNthCompetency(2, SelfAssessmentId, CandidateId);
+                var competency = selfAssessmentDataService.GetNthCompetency(2, SelfAssessmentId, UserId);
                 var actualResult = competency.AssessmentQuestions.First(question => question.Id == assessmentQuestionId)
                     .Result;
                 result.Should().Be(actualResult);
@@ -479,7 +479,7 @@
                 );
 
                 // Then
-                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, CandidateId).ToList();
+                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, UserId).ToList();
 
                 results.Count.Should().Be(32);
                 SelfAssessmentHelper.GetQuestionResult(results, firstCompetencyId, firstAssessmentQuestionId).Should()
@@ -562,7 +562,7 @@
                 );
 
                 // Then
-                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, CandidateId).ToList();
+                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, UserId).ToList();
 
                 results.Count.Should().Be(32);
                 SelfAssessmentHelper.GetQuestionResult(results, secondCompetencyId, thirdAssessmentQuestionId).Should()

--- a/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/SelfAssessmentDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/SelfAssessmentDataServiceTests.cs
@@ -11,6 +11,7 @@
     {
         private const int SelfAssessmentId = 1;
         private const int CandidateId = 11;
+        private const int UserId = 1;
         private ISelfAssessmentDataService selfAssessmentDataService = null!;
         private SqlConnection connection = null!;
         private CompetencyTestHelper competencyTestHelper = null!;

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
@@ -6,7 +6,7 @@
 
     public partial class SelfAssessmentDataService
     {
-        public CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(int candidateAssessmentId, int candidateId)
+        public CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(int candidateAssessmentId, int userId)
         {
             return connection.QuerySingle<CandidateAssessmentExportSummary>(
                 @"SELECT sa.Name AS SelfAssessment, c.FirstName + ' ' + c.LastName AS CandidateName, c.ProfessionalRegistrationNumber AS CandidatePrn, ca.StartedDate AS StartDate,
@@ -118,13 +118,13 @@ FROM   CandidateAssessmentSupervisorVerifications AS casv RIGHT OUTER JOIN
              SupervisorDelegates AS sd LEFT OUTER JOIN
              AdminUsers as au ON sd.SupervisorAdminID = au.AdminID LEFT OUTER JOIN
              CandidateAssessmentSupervisors AS cas ON sd.ID = cas.SupervisorDelegateId ON casv.CandidateAssessmentSupervisorID = cas.ID
-WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
-                new { candidateAssessmentId, candidateId }
+WHERE (ca.ID = @candidateAssessmentId  AND ca.DelegateUserID = @userId)",
+                new { candidateAssessmentId, userId }
             );
         }
 
         public List<CandidateAssessmentExportDetail> GetCandidateAssessmentExportDetails(
-            int candidateAssessmentId, int candidateId
+            int candidateAssessmentId, int userId
         )
         {
             return connection.Query<CandidateAssessmentExportDetail>(
@@ -168,7 +168,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
                
 				LEFT OUTER JOIN AdminUsers as au
 					ON sd.SupervisorAdminID = au.AdminID
-                 WHERE ca.ID = @candidateAssessmentId AND ca.CandidateID = @candidateId
+                 WHERE ca.ID = @candidateAssessmentId AND ca.DelegateUserID = @userId
             )
                     SELECT 
 					CG.Name AS [Group],
@@ -199,7 +199,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
             INNER JOIN AssessmentQuestions AS AQ
                 ON AQ.ID = CAQ.AssessmentQuestionID
             INNER JOIN CandidateAssessments AS CA
-                ON CA.ID = @candidateAssessmentId AND CA.CandidateID = @candidateId
+                ON CA.ID = @candidateAssessmentId AND CA.DelegateUserID = @userId
             LEFT OUTER JOIN LatestAssessmentResults AS LAR
                 ON LAR.CompetencyID = C.ID AND LAR.AssessmentQuestionID = AQ.ID
             INNER JOIN SelfAssessmentStructure AS SAS
@@ -210,7 +210,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
                 ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
                     WHERE (CAOC.IncludedInSelfAssessment = 1) OR (SAS.Optional = 0)
                     ORDER BY SAS.Ordering, CAQ.Ordering",
-                new { candidateAssessmentId, candidateId }
+                new { candidateAssessmentId, userId }
             ).AsList();
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -8,7 +8,7 @@
 
     public partial class SelfAssessmentDataService
     {
-        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int candidateId)
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForUser(int userId)
         {
             return connection.Query<CurrentSelfAssessment>(
                 @"SELECT
@@ -37,18 +37,18 @@
                         ON CA.SelfAssessmentID = SAS.SelfAssessmentID
                     INNER JOIN Competencies AS C
                         ON SAS.CompetencyID = C.ID
-                    WHERE CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
+                    WHERE CA.DelegateUserID = @userId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
                         COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID,
                         CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate",
-                new { candidateId }
+                new { userId }
             );
         }
 
-        public CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int candidateId, int selfAssessmentId)
+        public CurrentSelfAssessment? GetSelfAssessmentForUserById(int userId, int selfAssessmentId)
         {
             return connection.QueryFirstOrDefault<CurrentSelfAssessment>(
                 @"SELECT
@@ -108,7 +108,7 @@
                             ON SAS.CompetencyGroupID = CG.ID AND SAS.SelfAssessmentID = @selfAssessmentId
                     LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
                             ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
-                    WHERE CA.CandidateID = @candidateId AND CA.SelfAssessmentID = @selfAssessmentId AND CA.RemovedDate IS NULL
+                    WHERE CA.DelegateUserID = @userId AND CA.SelfAssessmentID = @selfAssessmentId AND CA.RemovedDate IS NULL
                         AND CA.CompletedDate IS NULL AND ((SAS.Optional = 0) OR (CAOC.IncludedInSelfAssessment = 1))
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description,
@@ -119,119 +119,119 @@
                         CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders,
                         SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel,SA.EnforceRoleRequirementsForSignOff, SA.ManageSupervisorsDescription",
-                new { candidateId, selfAssessmentId }
+                new { userId, selfAssessmentId }
             );
         }
 
-        public void UpdateLastAccessed(int selfAssessmentId, int candidateId)
+        public void UpdateLastAccessed(int selfAssessmentId, int userId)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessments SET LastAccessed = GETUTCDATE()
-                      WHERE SelfAssessmentID = @selfAssessmentId AND CandidateID = @candidateId",
-                new { selfAssessmentId, candidateId }
+                      WHERE SelfAssessmentID = @selfAssessmentId AND DelegateUserID = @userId",
+                new { selfAssessmentId, userId }
             );
 
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not updating self assessment last accessed date as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}"
+                    $"Self assessment id: {selfAssessmentId}, user id: {userId}"
                 );
             }
         }
 
-        public void SetCompleteByDate(int selfAssessmentId, int candidateId, DateTime? completeByDate)
+        public void SetCompleteByDate(int selfAssessmentId, int userId, DateTime? completeByDate)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessments
                         SET CompleteByDate = @date
                         WHERE SelfAssessmentID = @selfAssessmentId
-                          AND CandidateID = @candidateId",
-                new { date = completeByDate, selfAssessmentId, candidateId }
+                          AND DelegateUserID = @userId",
+                new { date = completeByDate, selfAssessmentId, userId }
             );
 
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not setting self assessment complete by date as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}, complete by date: {completeByDate}"
+                    $"Self assessment id: {selfAssessmentId}, user id: {userId}, complete by date: {completeByDate}"
                 );
             }
         }
 
-        public void SetUpdatedFlag(int selfAssessmentId, int candidateId, bool status)
+        public void SetUpdatedFlag(int selfAssessmentId, int userId, bool status)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessments
                         SET UnprocessedUpdates = @status
                         WHERE SelfAssessmentID = @selfAssessmentId
-                          AND CandidateID = @candidateId",
-                new { status, selfAssessmentId, candidateId }
+                          AND DelegateUserID = @userId",
+                new { status, selfAssessmentId, userId }
             );
 
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not setting self assessment updated flag as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}, status: {status}"
+                    $"Self assessment id: {selfAssessmentId}, user id: {userId}, status: {status}"
                 );
             }
         }
 
-        public void SetBookmark(int selfAssessmentId, int candidateId, string bookmark)
+        public void SetBookmark(int selfAssessmentId, int userId, string bookmark)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessments
                         SET UserBookmark = @bookmark
                         WHERE SelfAssessmentID = @selfAssessmentId
-                          AND CandidateID = @candidateId",
-                new { bookmark, selfAssessmentId, candidateId }
+                          AND DelegateUserID = @userId",
+                new { bookmark, selfAssessmentId, userId }
             );
 
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not setting self assessment bookmark as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}, bookmark: {bookmark}"
+                    $"Self assessment id: {selfAssessmentId}, user id: {userId}, bookmark: {bookmark}"
                 );
             }
         }
 
-        public void IncrementLaunchCount(int selfAssessmentId, int candidateId)
+        public void IncrementLaunchCount(int selfAssessmentId, int userId)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessments SET LaunchCount = LaunchCount+1
-                      WHERE SelfAssessmentID = @selfAssessmentId AND CandidateID = @candidateId",
-                new { selfAssessmentId, candidateId }
+                      WHERE SelfAssessmentID = @selfAssessmentId AND DelegateUserID = @userId",
+                new { selfAssessmentId, userId }
             );
 
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not updating self assessment launch count as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}"
+                    $"Self assessment id: {selfAssessmentId}, user id: {userId}"
                 );
             }
         }
 
-        public void SetSubmittedDateNow(int selfAssessmentId, int candidateId)
+        public void SetSubmittedDateNow(int selfAssessmentId, int userId)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessments SET SubmittedDate = GETUTCDATE()
-                      WHERE SelfAssessmentID = @selfAssessmentId AND CandidateID = @candidateId AND SubmittedDate IS NULL",
-                new { selfAssessmentId, candidateId }
+                      WHERE SelfAssessmentID = @selfAssessmentId AND DelegateUserID = @userId AND SubmittedDate IS NULL",
+                new { selfAssessmentId, userId }
             );
 
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not setting self assessment submitted date as db update failed. " +
-                    $"Self assessment id: {selfAssessmentId}, candidate id: {candidateId}"
+                    $"Self assessment id: {selfAssessmentId}, user id: {userId}"
                 );
             }
         }
 
-        public IEnumerable<CandidateAssessment> GetCandidateAssessments(int delegateId, int selfAssessmentId)
+        public IEnumerable<CandidateAssessment> GetCandidateAssessments(int userId, int selfAssessmentId)
         {
             return connection.Query<CandidateAssessment>(
                 @"SELECT
@@ -242,8 +242,8 @@
                         RemovedDate
                     FROM CandidateAssessments
                     WHERE SelfAssessmentID = @selfAssessmentId
-                        AND CandidateId = @delegateId",
-                new { selfAssessmentId, delegateId }
+                        AND DelegateUserID = @userId",
+                new { selfAssessmentId, userId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -32,19 +32,21 @@
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM SelfAssessmentResults s
                 INNER JOIN (
-                    SELECT MAX(ID) as ID
-                    FROM SelfAssessmentResults
-                    WHERE CandidateID = @candidateId
-                        AND SelfAssessmentID = @selfAssessmentId
-                    GROUP BY CompetencyID, AssessmentQuestionID
+                    SELECT MAX(sar1.ID) as ID
+                    FROM SelfAssessmentResults AS sar1 
+                    INNER JOIN DelegateAccounts AS da1 ON sar1.CandidateID = da1.ID
+                    WHERE da1.UserID = @userId
+                    AND sar1.SelfAssessmentID = @selfAssessmentId
+                    GROUP BY sar1.CompetencyID, sar1.AssessmentQuestionID
                 ) t
                     ON s.ID = t.ID
+                INNER JOIN DelegateAccounts AS da ON s.CandidateID = da.ID
                 LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
                     ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
                 LEFT OUTER JOIN CompetencyAssessmentQuestionRoleRequirements rr
                     ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID
                         AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
-                WHERE CandidateID = @candidateId
+                WHERE da.UserID = @userId
                 AND s.SelfAssessmentID = @selfAssessmentId
             )";
 
@@ -145,7 +147,7 @@
             INNER JOIN AssessmentQuestions AS AQ
                 ON AQ.ID = CAQ.AssessmentQuestionID
             INNER JOIN CandidateAssessments AS CA
-                ON CA.SelfAssessmentID = @selfAssessmentId AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL
+                ON CA.SelfAssessmentID = @selfAssessmentId AND CA.DelegateUserID = @userId AND CA.RemovedDate IS NULL
             LEFT OUTER JOIN LatestAssessmentResults AS LAR
                 ON LAR.CompetencyID = C.ID AND LAR.AssessmentQuestionID = AQ.ID
             INNER JOIN SelfAssessmentStructure AS SAS
@@ -183,7 +185,7 @@
             );
         }
 
-        public Competency? GetNthCompetency(int n, int selfAssessmentId, int candidateId)
+        public Competency? GetNthCompetency(int n, int selfAssessmentId, int userId)
         {
             Competency? competencyResult = null;
             return connection.Query<Competency, AssessmentQuestion, Competency>(
@@ -193,7 +195,7 @@
                             DENSE_RANK() OVER (ORDER BY SAS.Ordering) as RowNo,
                             sas.CompetencyID
                         FROM            SelfAssessmentStructure AS sas INNER JOIN
-                                         CandidateAssessments AS CA ON CA.SelfAssessmentID = @selfAssessmentId AND CA.CandidateID = @candidateId INNER JOIN
+                                         CandidateAssessments AS CA ON CA.SelfAssessmentID = @selfAssessmentId AND CA.DelegateUserID = @userId INNER JOIN
                                          CompetencyAssessmentQuestions AS caq ON sas.CompetencyID = caq.CompetencyID LEFT OUTER JOIN
                                          CandidateAssessmentOptionalCompetencies AS CAOC ON CA.ID = CAOC.CandidateAssessmentID AND sas.CompetencyID = CAOC.CompetencyID AND 
                                          sas.CompetencyGroupID = CAOC.CompetencyGroupID
@@ -214,11 +216,11 @@
                     competencyResult.AssessmentQuestions.Add(assessmentQuestion);
                     return competencyResult;
                 },
-                new { n, selfAssessmentId, candidateId }
+                new { n, selfAssessmentId, userId }
             ).FirstOrDefault();
         }
 
-        public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int userId)
         {
             var result = connection.Query<Competency, AssessmentQuestion, Competency>(
                 $@"WITH {LatestAssessmentResults}
@@ -231,7 +233,7 @@
                     competency.AssessmentQuestions.Add(assessmentQuestion);
                     return competency;
                 },
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             );
             return GroupCompetencyAssessmentQuestions(result);
         }
@@ -278,7 +280,7 @@
             return GroupCompetencyAssessmentQuestions(result);
         }
 
-        public IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int userId)
         {
             const string supervisorFields = @"
                 LAR.EmailSent,
@@ -306,12 +308,12 @@
                     competency.AssessmentQuestions.Add(assessmentQuestion);
                     return competency;
                 },
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             );
             return result;
         }
 
-        public IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int userId)
         {
             var result = connection.Query<Competency, AssessmentQuestion, Competency>(
                 $@"WITH {LatestAssessmentResults}
@@ -327,7 +329,7 @@
                     competency.AssessmentQuestions.Add(assessmentQuestion);
                     return competency;
                 },
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             );
             return GroupCompetencyAssessmentQuestions(result);
         }
@@ -441,7 +443,7 @@
             }
         }
 
-        public IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int userId)
         {
             return connection.Query<Competency>(
                 @"SELECT
@@ -456,7 +458,7 @@
                         COALESCE (CAOC.IncludedInSelfAssessment, 0) AS IncludedInSelfAssessment
                     FROM Competencies AS C
                     INNER JOIN CandidateAssessments AS CA
-                        ON CA.SelfAssessmentID = @selfAssessmentId AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL
+                        ON CA.SelfAssessmentID = @selfAssessmentId AND CA.DelegateUserID = @userId AND CA.RemovedDate IS NULL
                     INNER JOIN SelfAssessmentStructure AS SAS
                         ON C.ID = SAS.CompetencyID AND SAS.SelfAssessmentID = @selfAssessmentId
                     INNER JOIN CompetencyGroups AS CG
@@ -465,11 +467,11 @@
                         ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
                     WHERE (SAS.Optional = 1)
                     ORDER BY SAS.Ordering",
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             );
         }
 
-        public void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int candidateId)
+        public void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int userId)
         {
             connection.Execute(
                 @"UPDATE CandidateAssessmentOptionalCompetencies
@@ -480,9 +482,9 @@
                     INNER JOIN SelfAssessmentStructure AS SAS
                         ON CA.SelfAssessmentID = SAS.SelfAssessmentID AND CAOC.CompetencyID = SAS.CompetencyID
                             AND CAOC.CompetencyGroupID = SAS.CompetencyGroupID
-                    WHERE (CA.CandidateID = @candidateId) AND (CA.RemovedDate IS NULL)
+                    WHERE (CA.DelegateUserID = @userId) AND (CA.RemovedDate IS NULL)
                                     ",
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             );
             connection.Execute(
                 @"INSERT INTO CandidateAssessmentOptionalCompetencies
@@ -492,14 +494,14 @@
                     FROM SelfAssessmentStructure AS SAS
                     INNER JOIN CandidateAssessments AS CA
                         ON SAS.SelfAssessmentID = CA.SelfAssessmentID AND CA.SelfAssessmentID = @selfAssessmentId
-                            AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL AND SAS.Optional = 1
+                            AND CA.DelegateUserID = @userId AND CA.RemovedDate IS NULL AND SAS.Optional = 1
                     WHERE NOT EXISTS (SELECT * FROM CandidateAssessmentOptionalCompetencies WHERE CandidateAssessmentID = CA.ID
                         AND CompetencyID = SAS.CompetencyID AND CompetencyGroupID = SAS.CompetencyGroupID)",
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             );
         }
 
-        public void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int candidateId)
+        public void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int userId)
         {
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE CandidateAssessmentOptionalCompetencies
@@ -510,14 +512,14 @@
                     INNER JOIN SelfAssessmentStructure AS SAS
                         ON CA.SelfAssessmentID = SAS.SelfAssessmentID AND CAOC.CompetencyID = SAS.CompetencyID
                             AND CAOC.CompetencyGroupID = SAS.CompetencyGroupID
-                    WHERE (SAS.ID = @selfAssessmentStructureId) AND (CA.CandidateID = @candidateId) AND (CA.RemovedDate IS NULL)",
-                new { selfAssessmentStructureId, candidateId }
+                    WHERE (SAS.ID = @selfAssessmentStructureId) AND (CA.DelegateUserID = @userId) AND (CA.RemovedDate IS NULL)",
+                new { selfAssessmentStructureId, userId }
             );
             if (numberOfAffectedRows < 1)
             {
                 logger.LogWarning(
                     "Not setting CandidateAssessmentOptionalCompetencies include state as db update failed. " +
-                    $"Self assessment id: {selfAssessmentStructureId}, candidate id: {candidateId} "
+                    $"Self assessment id: {selfAssessmentStructureId}, user id: {userId} "
                 );
             }
         }
@@ -548,7 +550,7 @@
             );
         }
 
-        public List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int candidateId)
+        public List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int userId)
         {
             return connection.Query<int>(
                 @"SELECT
@@ -556,12 +558,12 @@
                     FROM CandidateAssessmentOptionalCompetencies AS CAOC
                     INNER JOIN CandidateAssessments  AS CA
                         ON CAOC.CandidateAssessmentID = CA.ID AND CA.SelfAssessmentID = @selfAssessmentId
-                            AND CA.CandidateID = @candidateId AND CA.RemovedDate IS NULL
+                            AND CA.DelegateUserID = @userId AND CA.RemovedDate IS NULL
                     INNER JOIN SelfAssessmentStructure AS SAS
                             ON CAOC.CompetencyID = SAS.CompetencyID AND CAOC.CompetencyGroupID = SAS.CompetencyGroupID
                                 AND SAS.SelfAssessmentID = @selfAssessmentId
                     WHERE (CAOC.IncludedInSelfAssessment = 1)",
-                new { selfAssessmentId, candidateId }
+                new { selfAssessmentId, userId }
             ).ToList();
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -15,16 +15,16 @@
         // CompetencyDataService
         IEnumerable<int> GetCompetencyIdsForSelfAssessment(int selfAssessmentId);
 
-        Competency? GetNthCompetency(int n, int selfAssessmentId, int candidateId); // 1 indexed
+        Competency? GetNthCompetency(int n, int selfAssessmentId, int userId); // 1 indexed
 
-        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int candidateId);
+        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int userId);
 
         IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int adminId, int? selfAssessmentResultId = null);
 
         IEnumerable<Competency> GetCandidateAssessmentResultsForReviewById(int candidateAssessmentId, int adminId);
 
-        IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int candidateId);
-        IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int candidateId);
+        IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int userId);
+        IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int userId);
 
         Competency? GetCompetencyByCandidateAssessmentResultId(int resultId, int candidateAssessmentId, int adminId);
 
@@ -37,11 +37,11 @@
             string? supportingComments
         );
 
-        IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int candidateId);
+        IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int userId);
 
-        void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int candidateId);
+        void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int userId);
 
-        void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int candidateId);
+        void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int userId);
 
         IEnumerable<LevelDescriptor> GetLevelDescriptorsForAssessmentQuestion(
             int assessmentQuestionId,
@@ -50,7 +50,7 @@
             bool zeroBased
         );
 
-        List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int candidateId);
+        List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int userId);
 
         CompetencyAssessmentQuestionRoleRequirement? GetCompetencyAssessmentQuestionRoleRequirements(
             int competencyId,
@@ -66,44 +66,44 @@
         );
 
         // CandidateAssessmentsDataService
-        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int candidateId);
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForUser(int userId);
 
-        CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int candidateId, int selfAssessmentId);
+        CurrentSelfAssessment? GetSelfAssessmentForUserById(int userId, int selfAssessmentId);
 
-        void UpdateLastAccessed(int selfAssessmentId, int candidateId);
+        void UpdateLastAccessed(int selfAssessmentId, int userId);
 
-        void SetCompleteByDate(int selfAssessmentId, int candidateId, DateTime? completeByDate);
+        void SetCompleteByDate(int selfAssessmentId, int userId, DateTime? completeByDate);
 
-        void SetSubmittedDateNow(int selfAssessmentId, int candidateId);
+        void SetSubmittedDateNow(int selfAssessmentId, int userId);
 
-        void IncrementLaunchCount(int selfAssessmentId, int candidateId);
+        void IncrementLaunchCount(int selfAssessmentId, int userId);
 
-        void SetUpdatedFlag(int selfAssessmentId, int candidateId, bool status);
+        void SetUpdatedFlag(int selfAssessmentId, int userId, bool status);
 
-        void SetBookmark(int selfAssessmentId, int candidateId, string bookmark);
+        void SetBookmark(int selfAssessmentId, int userId, string bookmark);
 
-        IEnumerable<CandidateAssessment> GetCandidateAssessments(int delegateId, int selfAssessmentId);
+        IEnumerable<CandidateAssessment> GetCandidateAssessments(int userId, int selfAssessmentId);
 
         // SelfAssessmentSupervisorDataService
         SelfAssessmentSupervisor? GetSupervisorForSelfAssessmentId(int selfAssessmentId, int candidateId);
 
-        IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int candidateId);
+        IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int userId);
 
-        IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(int selfAssessmentId, int candidateId);
+        IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(int selfAssessmentId, int userId);
 
         IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
         IEnumerable<SelfAssessmentSupervisor> GetResultReviewSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
         IEnumerable<SelfAssessmentSupervisor> GetSignOffSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
         SelfAssessmentSupervisor? GetSelfAssessmentSupervisorByCandidateAssessmentSupervisorId(
@@ -114,15 +114,15 @@
 
         void UpdateCandidateAssessmentSupervisorVerificationEmailSent(int candidateAssessmentSupervisorVerificationId);
 
-        SupervisorComment? GetSupervisorComments(int candidateId, int resultId);
+        SupervisorComment? GetSupervisorComments(int userId, int resultId);
 
-        IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId, int candidateId);
+        IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId, int userId);
 
         Administrator GetSupervisorByAdminId(int supervisorAdminId);
 
         IEnumerable<SupervisorSignOff> GetSupervisorSignOffsForCandidateAssessment(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
         // FilteredDataService
@@ -135,12 +135,12 @@
         //Export Candidate Assessment
         CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(
             int candidateAssessmentId,
-            int candidateId
+            int userId
         );
 
         List<CandidateAssessmentExportDetail> GetCandidateAssessmentExportDetails(
             int candidateAssessmentId,
-            int candidateId
+            int userId
         );
     }
 

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -44,7 +44,7 @@
         //INSERT DATA
         int AddSuperviseDelegate(int? supervisorAdminId, int? delegateId, string delegateEmail, string supervisorEmail, int centreId);
         int EnrolDelegateOnAssessment(int delegateId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int? selfAssessmentSupervisorRoleId, int adminId);
-        int InsertCandidateAssessmentSupervisor(int delegateId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId);
+        int InsertCandidateAssessmentSupervisor(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId);
         bool InsertSelfAssessmentResultSupervisorVerification(int candidateAssessmentSupervisorId, int resultId);
         //DELETE DATA
         bool RemoveCandidateAssessmentSupervisor(int selfAssessmentId, int supervisorDelegateId);
@@ -544,14 +544,14 @@ WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
                 return existingId;
             }
         }
-        public int InsertCandidateAssessmentSupervisor(int delegateId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId)
+        public int InsertCandidateAssessmentSupervisor(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId)
         {
             int candidateAssessmentId = (int)connection.ExecuteScalar(
                  @"SELECT COALESCE
                  ((SELECT ID
                   FROM    CandidateAssessments
-                   WHERE (SelfAssessmentID = @selfAssessmentId) AND (CandidateID = @delegateId) AND (RemovedDate IS NULL) AND (CompletedDate IS NULL)), 0) AS CandidateAssessmentID",
-               new { selfAssessmentId, delegateId });
+                   WHERE (SelfAssessmentID = @selfAssessmentId) AND (DelegateUserID = @delegateUserId) AND (RemovedDate IS NULL) AND (CompletedDate IS NULL)), 0) AS CandidateAssessmentID",
+               new { selfAssessmentId, delegateUserId });
             if (candidateAssessmentId > 0)
             {
                 int numberOfAffectedRows = connection.Execute(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -44,7 +44,7 @@
 
             var bannerText = "bannerText";
             A.CallTo(() => courseDataService.GetCurrentCourses(CandidateId)).Returns(currentCourses);
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(CandidateId)).Returns(selfAssessments);
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForUser(UserId)).Returns(selfAssessments);
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId))
                 .Returns((actionPlanResources, apiIsAccessible));
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);
@@ -426,7 +426,7 @@
         private void GivenCurrentActivitiesAreEmptyLists()
         {
             A.CallTo(() => courseDataService.GetCurrentCourses(A<int>._)).Returns(new List<CurrentCourse>());
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(A<int>._))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForUser(A<int>._))
                 .Returns(new List<CurrentSelfAssessment>());
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(A<int>._))
                 .Returns((new List<ActionPlanResource>(), false));

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/LearningPortalControllerTests.cs
@@ -19,6 +19,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
     {
         private const string BaseUrl = "https://www.dls.nhs.uk";
         private const int CandidateId = 11;
+        private const int UserId = 1;
         private const int SelfAssessmentId = 1;
         private const string Vocabulary = "Capabilities";
         private const int CentreId = 2;
@@ -64,6 +65,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.LearningPortal
                     {
                         new Claim("learnCandidateID", CandidateId.ToString()),
                         new Claim("UserCentreID", CentreId.ToString()),
+                        new Claim("UserId", UserId.ToString()),
                     },
                     "mock"
                 )

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
@@ -19,6 +19,7 @@
     {
         private const int DelegateId = 2;
         private const int SelfAssessmentId = 1;
+        private const int UserId = 2;
 
         private IActionPlanService actionPlanService = null!;
         private IConfiguration configuration = null!;
@@ -87,9 +88,9 @@
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => selfAssessmentService.SetBookmark(SelfAssessmentId, DelegateId, expectedBookmarkString))
+                A.CallTo(() => selfAssessmentService.SetBookmark(SelfAssessmentId, UserId, expectedBookmarkString))
                     .MustHaveHappenedOnceExactly();
-                A.CallTo(() => selfAssessmentService.UpdateLastAccessed(SelfAssessmentId, DelegateId))
+                A.CallTo(() => selfAssessmentService.UpdateLastAccessed(SelfAssessmentId, UserId))
                     .MustHaveHappenedOnceExactly();
                 A.CallTo(() => filteredApiHelperService.GetUserAccessToken<AccessToken>(A<string>._))
                     .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -22,7 +22,7 @@
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
             var supervisors = new List<SelfAssessmentSupervisor>();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
             var expectedModel = new SelfAssessmentDescriptionViewModel(selfAssessment, supervisors);
 
@@ -40,14 +40,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
             controller.SelfAssessment(SelfAssessmentId);
 
             // Then
-            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, CandidateId)).MustHaveHappened();
+            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, UserId)).MustHaveHappened();
         }
 
         [Test]
@@ -55,14 +55,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
             controller.SelfAssessment(SelfAssessmentId);
 
             // Then
-            A.CallTo(() => selfAssessmentService.IncrementLaunchCount(selfAssessment.Id, CandidateId))
+            A.CallTo(() => selfAssessmentService.IncrementLaunchCount(selfAssessment.Id, UserId))
                 .MustHaveHappened();
         }
 
@@ -70,7 +70,7 @@
         public void SelfAssessment_action_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -91,9 +91,9 @@
             const int competencyNumber = 1;
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
             var competency = new Competency();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, CandidateId))
+            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, UserId))
                 .Returns(competency);
             A.CallTo(() => frameworkService.GetSelectedCompetencyFlagsByCompetecyId(competency.Id))
                 .Returns(new List<Data.Models.Frameworks.CompetencyFlag>() { });
@@ -118,14 +118,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
             controller.SelfAssessmentCompetency(SelfAssessmentId, 1);
 
             // Then
-            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, CandidateId)).MustHaveHappened();
+            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, UserId)).MustHaveHappened();
         }
 
         [Test]
@@ -133,14 +133,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
             string destUrl = "/LearningPortal/SelfAssessment/" + selfAssessment.Id + "/1";
             // When
             controller.SelfAssessmentCompetency(SelfAssessmentId, 1);
 
             // Then
-            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, CandidateId, destUrl))
+            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, UserId, destUrl))
                 .MustHaveHappened();
         }
 
@@ -150,9 +150,9 @@
             // Given
             const int competencyNumber = 3;
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, CandidateId))
+            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, UserId))
                 .Returns(null);
 
             // When
@@ -166,7 +166,7 @@
         public void SelfAssessmentCompetency_action_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -204,7 +204,7 @@
                     AssessmentQuestionInputTypeID = assessmentQuestionInputTypeID,
                 },
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -247,7 +247,7 @@
                     Result = assessmentQuestionResult,
                 },
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -269,7 +269,7 @@
         public void SelfAssessmentCompetency_Post_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -303,9 +303,9 @@
                 SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
                 AllQuestionsVerifiedOrNotRequired = false
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, CandidateId))
+            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, UserId))
                 .Returns(competencies);
 
             // When
@@ -322,16 +322,16 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetMostRecentResults(SelfAssessmentId, CandidateId))
+            A.CallTo(() => selfAssessmentService.GetMostRecentResults(SelfAssessmentId, UserId))
                 .Returns(new List<Competency>() { });
 
             // When
             controller.SelfAssessmentOverview(SelfAssessmentId, selfAssessment.Vocabulary);
 
             // Then
-            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, CandidateId)).MustHaveHappened();
+            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, UserId)).MustHaveHappened();
         }
 
         [Test]
@@ -339,14 +339,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
             string destUrl = $"/LearningPortal/SelfAssessment/{selfAssessment.Id}/{selfAssessment.Vocabulary}";
             // When
             controller.SelfAssessmentOverview(SelfAssessmentId, selfAssessment.Vocabulary);
 
             // Then
-            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, CandidateId, destUrl))
+            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, UserId, destUrl))
                 .MustHaveHappened();
         }
 
@@ -366,9 +366,9 @@
                 SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
                 AllQuestionsVerifiedOrNotRequired = false
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, CandidateId))
+            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, UserId))
                 .Returns(competencies);
 
             // When
@@ -384,7 +384,7 @@
         public void SelfAssessmentOverview_action_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -409,7 +409,7 @@
             var newDate = new DateTime(newYear, newMonth, newDay);
             var formData = new EditCompleteByDateFormData { Day = newDay, Month = newMonth, Year = newYear };
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -417,7 +417,7 @@
 
             // Then
             A.CallTo(
-                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, CandidateId, newDate)
+                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, UserId, newDate)
             ).MustHaveHappened();
         }
 
@@ -428,7 +428,7 @@
             const int selfAssessmentId = 1;
             var formData = new EditCompleteByDateFormData { Day = null, Month = null, Year = null };
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -436,7 +436,7 @@
 
             // Then
             A.CallTo(
-                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, CandidateId, null)
+                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, UserId, null)
             ).MustHaveHappened();
         }
 
@@ -451,7 +451,7 @@
             const int year = 3020;
             var formData = new EditCompleteByDateFormData { Day = day, Month = month, Year = year };
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -473,7 +473,7 @@
             var formData = new EditCompleteByDateFormData { Day = day, Month = month, Year = year };
             controller.ModelState.AddModelError("year", "message");
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -481,7 +481,7 @@
 
             // Then
             A.CallTo(
-                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, CandidateId, A<DateTime>._)
+                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, UserId, A<DateTime>._)
             ).MustNotHaveHappened();
         }
 
@@ -493,7 +493,7 @@
             const int month = 2;
             const int year = 2020;
             var formData = new EditCompleteByDateFormData { Day = day, Month = month, Year = year };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForUserById(UserId, SelfAssessmentId))
                 .Returns(null);
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ActionPlanServiceTests.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
@@ -34,6 +35,7 @@
         private ILearningLogItemsDataService learningLogItemsDataService = null!;
         private ILearningResourceReferenceDataService learningResourceReferenceDataService = null!;
         private ISelfAssessmentDataService selfAssessmentDataService = null!;
+        private IUserDataService userDataService = null!;
 
         [SetUp]
         public void Setup()
@@ -45,6 +47,7 @@
             learningHubResourceService = A.Fake<ILearningHubResourceService>();
             selfAssessmentDataService = A.Fake<ISelfAssessmentDataService>();
             learningResourceReferenceDataService = A.Fake<ILearningResourceReferenceDataService>();
+            userDataService = A.Fake<IUserDataService>();
             config = A.Fake<IConfiguration>();
 
             actionPlanService = new ActionPlanService(
@@ -54,7 +57,8 @@
                 learningHubResourceService,
                 selfAssessmentDataService,
                 config,
-                learningResourceReferenceDataService
+                learningResourceReferenceDataService,
+                userDataService
             );
         }
 
@@ -70,9 +74,12 @@
             const string resourceLink = "www.test.com";
             const int learningLogId = 4;
             const int learningHubResourceId = 6;
+            const int userId = 1;
 
             var addedDate = new DateTime(2021, 11, 1);
             A.CallTo(() => clockUtility.UtcNow).Returns(addedDate);
+
+            A.CallTo(() => userDataService.GetUserIdFromDelegateId(delegateId)).Returns(userId);
 
             A.CallTo(
                 () => learningResourceReferenceDataService.GetLearningHubResourceReferenceById(
@@ -95,7 +102,7 @@
             A.CallTo(() => selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(selfAssessmentId))
                 .Returns(assessmentCompetencies);
 
-            A.CallTo(() => selfAssessmentDataService.GetCandidateAssessments(delegateId, selfAssessmentId))
+            A.CallTo(() => selfAssessmentDataService.GetCandidateAssessments(userId, selfAssessmentId))
                 .Returns(
                     new[] { Builder<CandidateAssessment>.CreateNew().With(ca => ca.Id = candidateAssessmentId).Build() }
                 );

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -31,10 +31,11 @@
         {
             sortBy ??= CourseSortByOptions.LastAccessed.PropertyName;
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var userId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var bannerText = GetBannerText();
             var selfAssessments =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateId);
+                selfAssessmentService.GetSelfAssessmentsForUser(userId);
             var (learningResources, apiIsAccessible) =
                 await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
 
@@ -65,9 +66,10 @@
         public async Task<IActionResult> AllCurrentItems()
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var userId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var selfAssessment =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateId);
+                selfAssessmentService.GetSelfAssessmentsForUser(userId);
             var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);
             return View("Current/AllCurrentItems", model);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
@@ -59,9 +59,9 @@
         public async Task<IActionResult> SelfAssessmentResults(int selfAssessmentId)
         {
             var candidateId = User.GetCandidateIdKnownNotNull();
-
-            selfAssessmentService.SetSubmittedDateNow(selfAssessmentId, candidateId);
-            selfAssessmentService.SetUpdatedFlag(selfAssessmentId, candidateId, false);
+            var userId = User.GetUserIdKnownNotNull();
+            selfAssessmentService.SetSubmittedDateNow(selfAssessmentId, userId);
+            selfAssessmentService.SetUpdatedFlag(selfAssessmentId, userId, false);
 
             if (!configuration.IsSignpostingUsed())
             {
@@ -85,12 +85,12 @@
                 return RedirectToAction("FilteredDashboard", new { selfAssessmentId });
             }
 
-            var candidateId = User.GetCandidateIdKnownNotNull();
+            var userId = User.GetUserIdKnownNotNull();
             var destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId + "/RecommendedLearning";
-            selfAssessmentService.SetBookmark(selfAssessmentId, candidateId, destUrl);
-            selfAssessmentService.UpdateLastAccessed(selfAssessmentId, candidateId);
+            selfAssessmentService.SetBookmark(selfAssessmentId, userId, destUrl);
+            selfAssessmentService.UpdateLastAccessed(selfAssessmentId, userId);
 
-            return await ReturnSignpostingRecommendedLearningView(selfAssessmentId, candidateId, page, searchString);
+            return await ReturnSignpostingRecommendedLearningView(selfAssessmentId, userId, page, searchString);
         }
 
         [FeatureGate(FeatureFlags.UseSignposting)]
@@ -118,6 +118,7 @@
         )
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var userId = User.GetUserIdKnownNotNull();
 
             if (!actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, delegateId))
             {
@@ -135,7 +136,7 @@
                     return NotFound();
                 }
 
-                var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateId, selfAssessmentId);
+                var assessment = selfAssessmentService.GetSelfAssessmentForUserById(userId, selfAssessmentId);
                 var model = new ResourceRemovedViewModel(assessment!);
                 return View("ResourceRemovedErrorPage", model);
             }
@@ -153,12 +154,12 @@
                 return RedirectToAction("RecommendedLearning", new { selfAssessmentId });
             }
 
-            var candidateId = User.GetCandidateIdKnownNotNull();
+            var userId = User.GetUserIdKnownNotNull();
             var destUrl = $"/LearningPortal/SelfAssessment/{selfAssessmentId}/Filtered/Dashboard";
-            selfAssessmentService.SetBookmark(selfAssessmentId, candidateId, destUrl);
-            selfAssessmentService.UpdateLastAccessed(selfAssessmentId, candidateId);
+            selfAssessmentService.SetBookmark(selfAssessmentId, userId, destUrl);
+            selfAssessmentService.UpdateLastAccessed(selfAssessmentId, userId);
 
-            return await ReturnFilteredResultsView(selfAssessmentId, candidateId);
+            return await ReturnFilteredResultsView(selfAssessmentId, userId);
         }
 
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Filtered/PlayList/{playListId}")]
@@ -170,7 +171,7 @@
             }
 
             var destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId + "/Filtered/PlayList/" + playListId;
-            selfAssessmentService.SetBookmark(selfAssessmentId, User.GetCandidateIdKnownNotNull(), destUrl);
+            selfAssessmentService.SetBookmark(selfAssessmentId, User.GetUserIdKnownNotNull(), destUrl);
             var filteredToken = await GetFilteredToken();
             var model = await filteredApiHelperService.GetPlayList<PlayList>(
                 filteredToken,
@@ -190,7 +191,7 @@
 
             var destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId + "/Filtered/LearningAsset/" +
                           assetId;
-            selfAssessmentService.SetBookmark(selfAssessmentId, User.GetCandidateIdKnownNotNull(), destUrl);
+            selfAssessmentService.SetBookmark(selfAssessmentId, User.GetUserIdKnownNotNull(), destUrl);
             var filteredToken = await GetFilteredToken();
             var asset = await filteredApiHelperService.GetLearningAsset<LearningAsset>(
                 filteredToken,
@@ -278,10 +279,10 @@
             var response = await filteredApiHelperService.UpdateProfileAndGoals(filteredToken, profile, goals);
         }
 
-        private async Task<IActionResult> ReturnFilteredResultsView(int selfAssessmentId, int candidateId)
+        private async Task<IActionResult> ReturnFilteredResultsView(int selfAssessmentId, int userId)
         {
             var filteredToken = await GetFilteredToken();
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId)!;
+            var assessment = selfAssessmentService.GetSelfAssessmentForUserById(userId, selfAssessmentId)!;
             var model = new SelfAssessmentFilteredResultsViewModel
             {
                 SelfAssessment = assessment,
@@ -304,14 +305,15 @@
 
         private async Task<IActionResult> ReturnSignpostingRecommendedLearningView(
             int selfAssessmentId,
-            int candidateId,
+            int userId,
             int page,
             string? searchString
         )
         {
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId)!;
+            var delegateId = User.GetCandidateIdKnownNotNull();
+            var assessment = selfAssessmentService.GetSelfAssessmentForUserById(userId, selfAssessmentId)!;
             var (recommendedResources, apiIsAccessible) =
-                await recommendedLearningService.GetRecommendedLearningForSelfAssessment(selfAssessmentId, candidateId);
+                await recommendedLearningService.GetRecommendedLearningForSelfAssessment(selfAssessmentId, delegateId);
 
             var searchSortPaginationOptions = new SearchSortFilterAndPaginateOptions(
                 new SearchOptions(searchString),

--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyDelegateUserCanAccessSelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyDelegateUserCanAccessSelfAssessment.cs
@@ -30,14 +30,14 @@
             }
 
             var selfAssessmentId = int.Parse(context.RouteData.Values["selfAssessmentId"].ToString()!);
-            var delegateId = controller.User.GetCandidateIdKnownNotNull();
+            var userId = controller.User.GetUserIdKnownNotNull();
             var canAccessSelfAssessment =
-                selfAssessmentService.CanDelegateAccessSelfAssessment(delegateId, selfAssessmentId);
+                selfAssessmentService.CanDelegateAccessSelfAssessment(userId, selfAssessmentId);
 
             if (!canAccessSelfAssessment)
             {
                 logger.LogWarning(
-                    $"Attempt to display self assessment results for candidate {delegateId} with no self assessment"
+                    $"Attempt to display self assessment results for user {userId} with no self assessment"
                 );
                 context.Result = new RedirectToActionResult("AccessDenied", "LearningSolutions", new { });
             }

--- a/DigitalLearningSolutions.Web/Services/CandidateAssessmentDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/CandidateAssessmentDownloadFileService.cs
@@ -12,7 +12,7 @@
 
     public interface ICandidateAssessmentDownloadFileService
     {
-        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId, bool isProtected);
+        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int userId, bool isProtected);
     }
 
     public class CandidateAssessmentDownloadFileService : ICandidateAssessmentDownloadFileService
@@ -28,10 +28,10 @@
             this.selfAssessmentDataService = selfAssessmentDataService;
             this.config = config;
         }
-        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId, bool isProtected)
+        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int userId, bool isProtected)
         {
-            var summaryData = selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, candidateId);
-            var detailData = selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, candidateId);
+            var summaryData = selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, userId);
+            var detailData = selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, userId);
             var details = detailData.Select(
                 x => new
                 {

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -13,31 +13,31 @@
     public interface ISelfAssessmentService
     {
         // Candidate Assessments
-        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int candidateId);
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForUser(int userId);
 
-        CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int candidateId, int selfAssessmentId);
+        CurrentSelfAssessment? GetSelfAssessmentForUserById(int userId, int selfAssessmentId);
 
-        void SetBookmark(int selfAssessmentId, int candidateId, string bookmark);
+        void SetBookmark(int selfAssessmentId, int userId, string bookmark);
 
-        void SetSubmittedDateNow(int selfAssessmentId, int candidateId);
+        void SetSubmittedDateNow(int selfAssessmentId, int userId);
 
-        void SetUpdatedFlag(int selfAssessmentId, int candidateId, bool status);
+        void SetUpdatedFlag(int selfAssessmentId, int userId, bool status);
 
-        void UpdateLastAccessed(int selfAssessmentId, int candidateId);
+        void UpdateLastAccessed(int selfAssessmentId, int userId);
 
-        void IncrementLaunchCount(int selfAssessmentId, int candidateId);
+        void IncrementLaunchCount(int selfAssessmentId, int userId);
 
-        void SetCompleteByDate(int selfAssessmentId, int candidateId, DateTime? completeByDate);
+        void SetCompleteByDate(int selfAssessmentId, int userId, DateTime? completeByDate);
 
-        bool CanDelegateAccessSelfAssessment(int delegateId, int selfAssessmentId);
+        bool CanDelegateAccessSelfAssessment(int userId, int selfAssessmentId);
 
         // Competencies
         IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int adminId, int? selfAssessmentResultId = null);
 
         IEnumerable<Competency> GetCandidateAssessmentResultsForReviewById(int candidateAssessmentId, int adminId);
 
-        IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int candidateId);
-        IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int candidateId);
+        IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int userId);
+        IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int userId);
 
         IEnumerable<LevelDescriptor> GetLevelDescriptorsForAssessmentQuestion(
             int assessmentQuestionId,
@@ -48,7 +48,7 @@
 
         Competency? GetCompetencyByCandidateAssessmentResultId(int resultId, int candidateAssessmentId, int adminId);
 
-        Competency? GetNthCompetency(int n, int selfAssessmentId, int candidateId); // 1 indexed
+        Competency? GetNthCompetency(int n, int selfAssessmentId, int userId); // 1 indexed
 
         void SetResultForCompetency(
             int competencyId,
@@ -59,40 +59,40 @@
             string? supportingComments
         );
 
-        IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int candidateId);
+        IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int userId);
 
-        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int candidateId);
+        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int userId);
 
-        List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int candidateId);
+        List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int userId);
 
-        void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int candidateId);
+        void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int userId);
 
-        void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int candidateId);
+        void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int userId);
 
         // Supervisor
-        IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int candidateId);
+        IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int userId);
 
         IEnumerable<SupervisorSignOff> GetSupervisorSignOffsForCandidateAssessment(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
-        SupervisorComment? GetSupervisorComments(int candidateId, int resultId);
+        SupervisorComment? GetSupervisorComments(int userId, int resultId);
 
         IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
-        IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(int selfAssessmentId, int candidateId);
+        IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(int selfAssessmentId, int userId);
 
-        IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId, int candidateId);
+        IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId, int userId);
 
         Administrator GetSupervisorByAdminId(int supervisorAdminId);
 
         IEnumerable<SelfAssessmentSupervisor> GetResultReviewSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
         SelfAssessmentSupervisor? GetSelfAssessmentSupervisorByCandidateAssessmentSupervisorId(
@@ -101,7 +101,7 @@
 
         IEnumerable<SelfAssessmentSupervisor> GetSignOffSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         );
 
         void InsertCandidateAssessmentSupervisorVerification(int candidateAssessmentSupervisorId);
@@ -118,12 +118,12 @@
         // Export Self Assessment
         CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(
             int candidateAssessmentId,
-            int candidateId
+            int userId
         );
 
         IEnumerable<CandidateAssessmentExportDetail> GetCandidateAssessmentExportDetails(
             int candidateAssessmentId,
-            int candidateId
+            int userId
         );
     }
 
@@ -136,39 +136,39 @@
             this.selfAssessmentDataService = selfAssessmentDataService;
         }
 
-        public CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int candidateId, int selfAssessmentId)
+        public CurrentSelfAssessment? GetSelfAssessmentForUserById(int userId, int selfAssessmentId)
         {
-            return selfAssessmentDataService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId);
+            return selfAssessmentDataService.GetSelfAssessmentForUserById(userId, selfAssessmentId);
         }
 
-        public void SetBookmark(int selfAssessmentId, int candidateId, string bookmark)
+        public void SetBookmark(int selfAssessmentId, int userId, string bookmark)
         {
-            selfAssessmentDataService.SetBookmark(selfAssessmentId, candidateId, bookmark);
+            selfAssessmentDataService.SetBookmark(selfAssessmentId, userId, bookmark);
         }
 
-        public void SetSubmittedDateNow(int selfAssessmentId, int candidateId)
+        public void SetSubmittedDateNow(int selfAssessmentId, int userId)
         {
-            selfAssessmentDataService.SetSubmittedDateNow(selfAssessmentId, candidateId);
+            selfAssessmentDataService.SetSubmittedDateNow(selfAssessmentId, userId);
         }
 
-        public void SetUpdatedFlag(int selfAssessmentId, int candidateId, bool status)
+        public void SetUpdatedFlag(int selfAssessmentId, int userId, bool status)
         {
-            selfAssessmentDataService.SetUpdatedFlag(selfAssessmentId, candidateId, status);
+            selfAssessmentDataService.SetUpdatedFlag(selfAssessmentId, userId, status);
         }
 
-        public void UpdateLastAccessed(int selfAssessmentId, int candidateId)
+        public void UpdateLastAccessed(int selfAssessmentId, int userId)
         {
-            selfAssessmentDataService.UpdateLastAccessed(selfAssessmentId, candidateId);
+            selfAssessmentDataService.UpdateLastAccessed(selfAssessmentId, userId);
         }
 
-        public void IncrementLaunchCount(int selfAssessmentId, int candidateId)
+        public void IncrementLaunchCount(int selfAssessmentId, int userId)
         {
-            selfAssessmentDataService.IncrementLaunchCount(selfAssessmentId, candidateId);
+            selfAssessmentDataService.IncrementLaunchCount(selfAssessmentId, userId);
         }
 
-        public void SetCompleteByDate(int selfAssessmentId, int candidateId, DateTime? completeByDate)
+        public void SetCompleteByDate(int selfAssessmentId, int userId, DateTime? completeByDate)
         {
-            selfAssessmentDataService.SetCompleteByDate(selfAssessmentId, candidateId, completeByDate);
+            selfAssessmentDataService.SetCompleteByDate(selfAssessmentId, userId, completeByDate);
         }
 
         public IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int adminId, int? selfAssessmentResultId = null)
@@ -184,60 +184,60 @@
             return selfAssessmentDataService.GetCandidateAssessmentResultsForReviewById(candidateAssessmentId, adminId);
         }
 
-        public IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetCandidateAssessmentResultsToVerifyById(int selfAssessmentId, int userId)
         {
-            return selfAssessmentDataService.GetCandidateAssessmentResultsToVerifyById(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetCandidateAssessmentResultsToVerifyById(selfAssessmentId, userId);
         }
 
-        public IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int userId)
         {
-            return selfAssessmentDataService.GetResultSupervisorVerifications(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetResultSupervisorVerifications(selfAssessmentId, userId);
         }
 
         public IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetSupervisorsForSelfAssessmentId(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetSupervisorsForSelfAssessmentId(selfAssessmentId, userId);
         }
 
         public IEnumerable<SupervisorSignOff> GetSupervisorSignOffsForCandidateAssessment(
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetSupervisorSignOffsForCandidateAssessment(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetSupervisorSignOffsForCandidateAssessment(selfAssessmentId, userId);
         }
 
-        public SupervisorComment? GetSupervisorComments(int candidateId, int resultId)
+        public SupervisorComment? GetSupervisorComments(int userId, int resultId)
         {
-            return selfAssessmentDataService.GetSupervisorComments(candidateId, resultId);
+            return selfAssessmentDataService.GetSupervisorComments(userId, resultId);
         }
 
         public IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetAllSupervisorsForSelfAssessmentId(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetAllSupervisorsForSelfAssessmentId(selfAssessmentId, userId);
         }
 
         public IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetOtherSupervisorsForCandidate(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetOtherSupervisorsForCandidate(selfAssessmentId, userId);
         }
 
         public IEnumerable<Administrator> GetValidSupervisorsForActivity(
             int centreId,
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetValidSupervisorsForActivity(centreId, selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetValidSupervisorsForActivity(centreId, selfAssessmentId, userId);
         }
 
         public Administrator GetSupervisorByAdminId(int supervisorAdminId)
@@ -247,12 +247,12 @@
 
         public IEnumerable<SelfAssessmentSupervisor> GetResultReviewSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
             return selfAssessmentDataService.GetResultReviewSupervisorsForSelfAssessmentId(
                 selfAssessmentId,
-                candidateId
+                userId
             );
         }
 
@@ -267,10 +267,10 @@
 
         public IEnumerable<SelfAssessmentSupervisor> GetSignOffSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetSignOffSupervisorsForSelfAssessmentId(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetSignOffSupervisorsForSelfAssessmentId(selfAssessmentId, userId);
         }
 
         public void InsertCandidateAssessmentSupervisorVerification(int candidateAssessmentSupervisorId)
@@ -304,23 +304,23 @@
 
         public CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(
             int candidateAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, candidateId);
+            return selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, userId);
         }
 
         public IEnumerable<CandidateAssessmentExportDetail> GetCandidateAssessmentExportDetails(
             int candidateAssessmentId,
-            int candidateId
+            int userId
         )
         {
-            return selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, candidateId);
+            return selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, userId);
         }
 
-        public bool CanDelegateAccessSelfAssessment(int delegateId, int selfAssessmentId)
+        public bool CanDelegateAccessSelfAssessment(int userId, int selfAssessmentId)
         {
-            var candidateAssessments = selfAssessmentDataService.GetCandidateAssessments(delegateId, selfAssessmentId);
+            var candidateAssessments = selfAssessmentDataService.GetCandidateAssessments(userId, selfAssessmentId);
 
             return candidateAssessments.Any(ca => ca.CompletedDate == null && ca.RemovedDate == null);
         }
@@ -353,9 +353,9 @@
             );
         }
 
-        public Competency? GetNthCompetency(int n, int selfAssessmentId, int candidateId)
+        public Competency? GetNthCompetency(int n, int selfAssessmentId, int userId)
         {
-            return selfAssessmentDataService.GetNthCompetency(n, selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetNthCompetency(n, selfAssessmentId, userId);
         }
 
         public void SetResultForCompetency(
@@ -377,42 +377,42 @@
             );
         }
 
-        public IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int userId)
         {
-            return selfAssessmentDataService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, userId);
         }
 
-        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int candidateId)
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForUser(int userId)
         {
-            return selfAssessmentDataService.GetSelfAssessmentsForCandidate(candidateId);
+            return selfAssessmentDataService.GetSelfAssessmentsForUser(userId);
         }
 
-        public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int candidateId)
+        public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int userId)
         {
-            return selfAssessmentDataService.GetMostRecentResults(selfAssessmentId, candidateId);
+            return selfAssessmentDataService.GetMostRecentResults(selfAssessmentId, userId);
         }
 
-        public List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int candidateId)
+        public List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int userId)
         {
             return selfAssessmentDataService.GetCandidateAssessmentIncludedSelfAssessmentStructureIds(
                 selfAssessmentId,
-                candidateId
+                userId
             );
         }
 
-        public void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int candidateId)
+        public void InsertCandidateAssessmentOptionalCompetenciesIfNotExist(int selfAssessmentId, int userId)
         {
             selfAssessmentDataService.InsertCandidateAssessmentOptionalCompetenciesIfNotExist(
                 selfAssessmentId,
-                candidateId
+                userId
             );
         }
 
-        public void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int candidateId)
+        public void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int userId)
         {
             selfAssessmentDataService.UpdateCandidateAssessmentOptionalCompetencies(
                 selfAssessmentStructureId,
-                candidateId
+                userId
             );
         }
     }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-260

**Description**
Service methods used 'UserId' instead of CandidateId or DelegateId. SQL queries updated accordingly.

**Screenshots**
N/A

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
