### PR TITLE
TD-843-Console '404' error on the screen when clicking browser back button after remove delegate

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
@@ -374,7 +374,7 @@
             );
 
             // Then
-            result.Should().BeNotFoundResult();
+            result.Should().BeStatusCodeResult().WithStatusCode(410);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 {
     using System;
+    using System.Net;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Helpers;
@@ -266,7 +267,7 @@
             var progress = progressService.GetDetailedCourseProgress(progressId);
             if (!courseService.DelegateHasCurrentProgress(progressId) || progress == null)
             {
-                return new NotFoundResult();
+                return StatusCode((int)HttpStatusCode.Gone);
             }
 
             var model = new RemoveFromCourseViewModel(


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-843

**Description**
HttpStatusCode changed to 410.

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors 
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
