### PR TITLE
TD-849 Promote delegate to Admin doesn't display validation message w…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/Components/Checkboxes/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/Checkboxes/Default.cshtml
@@ -4,7 +4,7 @@
 
 <div class="nhsuk-form-group">
 
-  <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
+  <fieldset class="nhsuk-fieldset" >
     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
       <label class="nhsuk-fieldset__heading">
         @Model.Label

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/Radios/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/Radios/Default.cshtml
@@ -3,46 +3,47 @@
 @model RadiosViewModel
 
 <div class="nhsuk-form-group">
+    <fieldset class="nhsuk-fieldset">
+        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
+            <label class="nhsuk-fieldset__heading">
+                @Model.Label
+            </label>
+        </legend>
 
-  <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
-    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-      <label class="nhsuk-fieldset__heading">
-        @Model.Label
-      </label>
-    </legend>
-
-    @if (Model.HintText != null)
-    {
-      <div class="nhsuk-hint" id="@Model.Label.RemoveWhitespace()-hint">
-        @Html.Raw(Model.HintText)
-      </div>
-    }
-
-    <div class="nhsuk-radios" aria-required="@(Model.Required ? "true" : "false" )">
-      @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
-      {
-        var radioId = $"{radio.Value}-{index}";
-        <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input"
-               id="@radioId"
-               name="@Model.AspFor"
-               type="radio"
-               value="@radio.Value"
-               aria-describedby="@radio.Value-item-hint"
-               @(radio.Selected ? "checked" : string.Empty) />
-          <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
-            @radio.Label
-          </label>
-          @if (radio.HintText != null)
-          {
-            <div class="nhsuk-hint nhsuk-radios__hint" id="@radio.Value-item-hint">
-              @radio.HintText
+        @if (Model.HintText != null)
+        {
+            <div class="nhsuk-hint" id="@Model.Label.RemoveWhitespace()-hint">
+                @Html.Raw(Model.HintText)
             </div>
-          }
-        </div>
-      }
+        }
 
-    </div>
-  </fieldset>
+        <div class="nhsuk-radios" aria-required="@(Model.Required ? "true" : "false" )">
+            @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
+            {
+                var radioId = $"{radio.Value}-{index}";
+                <div class="nhsuk-radios__item">
+                    <input class="nhsuk-radios__input"
+                       id="@radioId"
+                       name="@Model.AspFor"
+                       type="radio"
+                       value="@radio.Value"
+                       aria-describedby="@radio.Value-item-hint"
+                       @(radio.Selected ? "checked" : string.Empty) />
+                    <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
+                        @radio.Label
+                    </label>
+
+                    <div class="nhsuk-hint nhsuk-radios__hint" id="@radio.Value-item-hint">
+                        @if (radio.HintText != null)
+                        {
+                            @radio.HintText
+                        }
+                    </div>
+
+                </div>
+            }
+
+        </div>
+    </fieldset>
 
 </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_CheckboxItem.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_CheckboxItem.cshtml
@@ -37,7 +37,7 @@
     </label>
     @if (Model.HintText != null)
     {
-      <div class="nhsuk-hint nhsuk-checkboxes__hint" id="@Model.Id-item-hint">
+      <div class="nhsuk-hint nhsuk-checkboxes__hint" id="@Model.Id-hint">
         @Model.HintText
       </div>
     }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/PromoteToAdmin/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/PromoteToAdmin/Index.cshtml
@@ -2,6 +2,7 @@
 @model PromoteToAdminViewModel
 
 @{
+   var errorHasOccurred = !ViewData.ModelState.IsValid;
   ViewData["Title"] = "Promote centre delegate to admin";
   var cancelRouteData = new Dictionary<string, string> { { "delegateId", Model.DelegateId.ToString() } };
 }
@@ -9,6 +10,10 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
+     @if (errorHasOccurred) {
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Checkboxes) })" />
+    }
+
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
         <div class="nhsuk-u-font-weight-bold">


### PR DESCRIPTION
…hen user roles are not selected and it promoted to admin

### JIRA link
https://hee-tis.atlassian.net/browse/TD-849

### Description
The validation error is now displayed when the user promotes a delegate to Admin without selecting user roles

### Screenshots
https://hee-tis.atlassian.net/browse/TD-849

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
