### PR TITLE
TD-844-UAR: Console '404' error when deactivating an admin account and clicking browser back button

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
@@ -126,7 +126,7 @@
             );
 
             // Then
-            result.Should().BeNotFoundResult();
+            result.Should().BeStatusCodeResult().WithStatusCode(410);
         }
 
         [Test]
@@ -203,7 +203,7 @@
             using (new AssertionScope())
             {
                 A.CallTo(() => userDataService.DeactivateAdmin(adminUser.Id)).MustNotHaveHappened();
-                result.Should().BeNotFoundResult();
+                result.Should().BeStatusCodeResult().WithStatusCode(410);
             }
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessAdminUserTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanAccessAdminUserTests.cs
@@ -52,7 +52,7 @@
             new VerifyAdminUserCanAccessAdminUser(userDataService).OnActionExecuting(context);
 
             // Then
-            context.Result.Should().BeNotFoundResult();
+            context.Result.Should().BeStatusCodeResult().WithStatusCode(410);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Administrator
 {
     using System.Linq;
+    using System.Net;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
@@ -213,7 +214,7 @@
 
             if (!CurrentUserCanDeactivateAdmin(admin!.AdminAccount))
             {
-                return NotFound();
+                return StatusCode((int)HttpStatusCode.Gone);
             }
 
             var model = new DeactivateAdminViewModel(admin, returnPageQuery);
@@ -229,7 +230,7 @@
 
             if (!CurrentUserCanDeactivateAdmin(admin!.AdminAccount))
             {
-                return NotFound();
+                return StatusCode((int)HttpStatusCode.Gone);
             }
 
             if (!ModelState.IsValid)

--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessAdminUser.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessAdminUser.cs
@@ -1,9 +1,10 @@
 ﻿namespace DigitalLearningSolutions.Web.ServiceFilter
 {
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
-    using DigitalLearningSolutions.Web.Helpers;
+    using System.Net;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Filters;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Web.Helpers;    
 
     public class VerifyAdminUserCanAccessAdminUser : IActionFilter
     {
@@ -29,7 +30,7 @@
 
             if (adminAccount == null)
             {
-                context.Result = new NotFoundResult();
+                context.Result = new StatusCodeResult((int)HttpStatusCode.Gone);
             }
             else if (adminAccount.CentreId != centreId)
             {


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-844

**Description**
HttpStatusCode changed to 410. Test cases result updated to 410 status code.

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors 
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin] and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-844]: https://hee-tis.atlassian.net/browse/TD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ