### PR TITLE
TD-260-Passporting - Fix Learning Portal and Self Assessment functionality broken by migration

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CompetencyDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CompetencyDataServiceTests.cs
@@ -43,7 +43,7 @@
             );
 
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(1, SelfAssessmentId, CandidateId,delegateUserId);
+            var result = selfAssessmentDataService.GetNthCompetency(1, SelfAssessmentId, delegateUserId);
 
             // Then
             result.Should().BeEquivalentTo(expectedCompetency);
@@ -74,7 +74,7 @@
             );
 
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(32, SelfAssessmentId, CandidateId, delegateUserId);
+            var result = selfAssessmentDataService.GetNthCompetency(32, SelfAssessmentId, delegateUserId);
 
             // Then
             result.Should().BeEquivalentTo(expectedCompetency);
@@ -84,7 +84,7 @@
         public void GetNthCompetency_returns_null_when_reached_end_of_assessment()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(33, SelfAssessmentId, CandidateId, delegateUserId);
+            var result = selfAssessmentDataService.GetNthCompetency(33, SelfAssessmentId, delegateUserId);
 
             // Then
             result.Should().BeNull();
@@ -94,7 +94,7 @@
         public void GetNthCompetency_returns_null_when_n_zero()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(0, SelfAssessmentId, CandidateId, delegateUserId);
+            var result = selfAssessmentDataService.GetNthCompetency(0, SelfAssessmentId, delegateUserId);
 
             // Then
             result.Should().BeNull();
@@ -104,7 +104,7 @@
         public void GetNthCompetency_returns_null_when_n_negative()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(-1, SelfAssessmentId, CandidateId, delegateUserId);
+            var result = selfAssessmentDataService.GetNthCompetency(-1, SelfAssessmentId, delegateUserId);
 
             // Then
             result.Should().BeNull();
@@ -114,7 +114,7 @@
         public void GetNthCompetency_returns_null_when_invalid_candidate()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(1, SelfAssessmentId, 1, 2);
+            var result = selfAssessmentDataService.GetNthCompetency(1, SelfAssessmentId, 2);
 
             // Then
             result.Should().BeNull();
@@ -124,7 +124,7 @@
         public void GetNthCompetency_returns_null_when_invalid_assessment()
         {
             // When
-            var result = selfAssessmentDataService.GetNthCompetency(1, 2, 1,2);
+            var result = selfAssessmentDataService.GetNthCompetency(1, 2, 2);
 
             // Then
             result.Should().BeNull();
@@ -161,7 +161,7 @@
                 );
 
                 // Then
-                var competency = selfAssessmentDataService.GetNthCompetency(2, SelfAssessmentId, CandidateId, delegateUserId);
+                var competency = selfAssessmentDataService.GetNthCompetency(2, SelfAssessmentId, delegateUserId);
                 var actualResult = competency.AssessmentQuestions.First(question => question.Id == assessmentQuestionId)
                     .Result;
                 result.Should().Be(actualResult);
@@ -495,7 +495,7 @@
                 );
 
                 // Then
-                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, CandidateId,delegateUserId).ToList();
+                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, delegateUserId).ToList();
 
                 results.Count.Should().Be(32);
                 SelfAssessmentHelper.GetQuestionResult(results, firstCompetencyId, firstAssessmentQuestionId).Should()
@@ -584,7 +584,7 @@
                 );
 
                 // Then
-                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId,CandidateId, delegateUserId).ToList();
+                var results = selfAssessmentDataService.GetMostRecentResults(SelfAssessmentId, delegateUserId).ToList();
 
                 results.Count.Should().Be(32);
                 SelfAssessmentHelper.GetQuestionResult(results, secondCompetencyId, thirdAssessmentQuestionId).Should()

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
@@ -6,7 +6,7 @@
 
     public partial class SelfAssessmentDataService
     {
-        public CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(int candidateAssessmentId, int candidateId)
+        public CandidateAssessmentExportSummary GetCandidateAssessmentExportSummary(int candidateAssessmentId, int delegateUserID)
         {
             return connection.QuerySingle<CandidateAssessmentExportSummary>(
                 @"SELECT sa.Name AS SelfAssessment, c.FirstName + ' ' + c.LastName AS CandidateName, c.ProfessionalRegistrationNumber AS CandidatePrn, ca.StartedDate AS StartDate,
@@ -118,13 +118,13 @@ FROM   CandidateAssessmentSupervisorVerifications AS casv RIGHT OUTER JOIN
              SupervisorDelegates AS sd LEFT OUTER JOIN
              AdminUsers as au ON sd.SupervisorAdminID = au.AdminID LEFT OUTER JOIN
              CandidateAssessmentSupervisors AS cas ON sd.ID = cas.SupervisorDelegateId ON casv.CandidateAssessmentSupervisorID = cas.ID
-WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
-                new { candidateAssessmentId, candidateId }
+WHERE (ca.ID = @candidateAssessmentId  AND ca.DelegateUserID  = @delegateUserID)",
+                new { candidateAssessmentId, delegateUserID }
             );
         }
 
         public List<CandidateAssessmentExportDetail> GetCandidateAssessmentExportDetails(
-            int candidateAssessmentId, int candidateId
+            int candidateAssessmentId, int delegateUserID
         )
         {
             return connection.Query<CandidateAssessmentExportDetail>(
@@ -168,7 +168,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
                
 				LEFT OUTER JOIN AdminUsers as au
 					ON sd.SupervisorAdminID = au.AdminID
-                 WHERE ca.ID = @candidateAssessmentId AND ca.CandidateID = @candidateId
+                 WHERE ca.ID = @candidateAssessmentId AND ca.DelegateUserID = @delegateUserID
             )
                     SELECT 
 					CG.Name AS [Group],
@@ -199,7 +199,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
             INNER JOIN AssessmentQuestions AS AQ
                 ON AQ.ID = CAQ.AssessmentQuestionID
             INNER JOIN CandidateAssessments AS CA
-                ON CA.ID = @candidateAssessmentId AND CA.CandidateID = @candidateId
+                ON CA.ID = @candidateAssessmentId AND CA.DelegateUserID = @delegateUserID
             LEFT OUTER JOIN LatestAssessmentResults AS LAR
                 ON LAR.CompetencyID = C.ID AND LAR.AssessmentQuestionID = AQ.ID
             INNER JOIN SelfAssessmentStructure AS SAS
@@ -210,7 +210,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.CandidateID = @candidateId)",
                 ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
                     WHERE (CAOC.IncludedInSelfAssessment = 1) OR (SAS.Optional = 0)
                     ORDER BY SAS.Ordering, CAQ.Ordering",
-                new { candidateAssessmentId, candidateId }
+                new { candidateAssessmentId, delegateUserID }
             ).AsList();
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -15,9 +15,9 @@
         // CompetencyDataService
         IEnumerable<int> GetCompetencyIdsForSelfAssessment(int selfAssessmentId);
 
-        Competency? GetNthCompetency(int n, int selfAssessmentId,int candidateId, int delegateUserId); // 1 indexed
+        Competency? GetNthCompetency(int n, int selfAssessmentId, int delegateUserId); // 1 indexed
 
-        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId,int candidateId, int delegateUserId);
+        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateUserId);
 
         IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int delegateUserId, int? selfAssessmentResultId = null);
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -83,7 +83,7 @@
         {
             return connection.Query<SelfAssessmentSupervisor>(
                 @$"{SelectSelfAssessmentSupervisorQuery}
-                    WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (sd.DelegateUserID = @delegateUserId) AND (ca.SelfAssessmentID = @selfAssessmentId)",
+                    WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (ca.DelegateUserID = @delegateUserId) AND (ca.SelfAssessmentID = @selfAssessmentId)",
                 new { selfAssessmentId, delegateUserId }
             );
         }
@@ -183,7 +183,7 @@
             );
         }
 
-        public SupervisorComment? GetSupervisorComments(int candidateId, int resultId)
+        public SupervisorComment? GetSupervisorComments(int delegateUserId, int resultId)
         {
             return connection.Query<SupervisorComment>(
                 @"SELECT
@@ -213,8 +213,9 @@
                     SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
                     AdminUsers AS au ON sd.SupervisorAdminID = au.AdminID INNER JOIN
                     SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
-                    WHERE (sar.CandidateID = @candidateId) AND (sasv.SelfAssessmentResultId = @resultId)",
-                new { candidateId, resultId }
+                    INNER JOIN DelegateAccounts AS da ON sar.CandidateID = da.ID
+                    WHERE (da.UserID = @delegateUserId) AND (sasv.SelfAssessmentResultId = @resultId)",
+                new { delegateUserId, resultId }
             ).FirstOrDefault();
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -44,7 +44,7 @@
         //INSERT DATA
         int AddSuperviseDelegate(int? supervisorAdminId, int? delegateId, string delegateEmail, string supervisorEmail, int centreId);
         int EnrolDelegateOnAssessment(int delegateId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int? selfAssessmentSupervisorRoleId, int adminId);
-        int InsertCandidateAssessmentSupervisor(int delegateId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId);
+        int InsertCandidateAssessmentSupervisor(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId);
         bool InsertSelfAssessmentResultSupervisorVerification(int candidateAssessmentSupervisorId, int resultId);
         //DELETE DATA
         bool RemoveCandidateAssessmentSupervisor(int selfAssessmentId, int supervisorDelegateId);
@@ -544,14 +544,14 @@ WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
                 return existingId;
             }
         }
-        public int InsertCandidateAssessmentSupervisor(int delegateId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId)
+        public int InsertCandidateAssessmentSupervisor(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, int? selfAssessmentSupervisorRoleId)
         {
             int candidateAssessmentId = (int)connection.ExecuteScalar(
                  @"SELECT COALESCE
                  ((SELECT ID
                   FROM    CandidateAssessments
-                   WHERE (SelfAssessmentID = @selfAssessmentId) AND (CandidateID = @delegateId) AND (RemovedDate IS NULL) AND (CompletedDate IS NULL)), 0) AS CandidateAssessmentID",
-               new { selfAssessmentId, delegateId });
+                   WHERE (SelfAssessmentID = @selfAssessmentId) AND (DelegateUserID = @delegateUserId) AND (RemovedDate IS NULL) AND (CompletedDate IS NULL)), 0) AS CandidateAssessmentID",
+               new { selfAssessmentId, delegateUserId });
             if (candidateAssessmentId > 0)
             {
                 int numberOfAffectedRows = connection.Execute(

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -44,7 +44,7 @@
 
             var bannerText = "bannerText";
             A.CallTo(() => courseDataService.GetCurrentCourses(CandidateId)).Returns(currentCourses);
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(CandidateId)).Returns(selfAssessments);
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(DelegateUserId)).Returns(selfAssessments);
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId))
                 .Returns((actionPlanResources, apiIsAccessible));
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
@@ -19,6 +19,7 @@
     {
         private const int DelegateId = 2;
         private const int SelfAssessmentId = 1;
+        private const int DelegateUserId = 2;
 
         private IActionPlanService actionPlanService = null!;
         private IConfiguration configuration = null!;
@@ -87,9 +88,9 @@
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => selfAssessmentService.SetBookmark(SelfAssessmentId, DelegateId, expectedBookmarkString))
+                A.CallTo(() => selfAssessmentService.SetBookmark(SelfAssessmentId, DelegateUserId, expectedBookmarkString))
                     .MustHaveHappenedOnceExactly();
-                A.CallTo(() => selfAssessmentService.UpdateLastAccessed(SelfAssessmentId, DelegateId))
+                A.CallTo(() => selfAssessmentService.UpdateLastAccessed(SelfAssessmentId, DelegateUserId))
                     .MustHaveHappenedOnceExactly();
                 A.CallTo(() => filteredApiHelperService.GetUserAccessToken<AccessToken>(A<string>._))
                     .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -22,7 +22,7 @@
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
             var supervisors = new List<SelfAssessmentSupervisor>();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
             var expectedModel = new SelfAssessmentDescriptionViewModel(selfAssessment, supervisors);
 
@@ -40,14 +40,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
             controller.SelfAssessment(SelfAssessmentId);
 
             // Then
-            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, CandidateId)).MustHaveHappened();
+            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, DelegateUserId)).MustHaveHappened();
         }
 
         [Test]
@@ -70,7 +70,7 @@
         public void SelfAssessment_action_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -91,9 +91,9 @@
             const int competencyNumber = 1;
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
             var competency = new Competency();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, CandidateId,DelegateUserId))
+            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, DelegateUserId))
                 .Returns(competency);
             A.CallTo(() => frameworkService.GetSelectedCompetencyFlagsByCompetecyId(competency.Id))
                 .Returns(new List<Data.Models.Frameworks.CompetencyFlag>() { });
@@ -118,14 +118,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
             controller.SelfAssessmentCompetency(SelfAssessmentId, 1);
 
             // Then
-            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, CandidateId)).MustHaveHappened();
+            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, DelegateUserId)).MustHaveHappened();
         }
 
         [Test]
@@ -133,14 +133,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
             string destUrl = "/LearningPortal/SelfAssessment/" + selfAssessment.Id + "/1";
             // When
             controller.SelfAssessmentCompetency(SelfAssessmentId, 1);
 
             // Then
-            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, CandidateId, destUrl))
+            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, DelegateUserId, destUrl))
                 .MustHaveHappened();
         }
 
@@ -150,9 +150,9 @@
             // Given
             const int competencyNumber = 3;
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, CandidateId, DelegateUserId))
+            A.CallTo(() => selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, DelegateUserId))
                 .Returns(null);
 
             // When
@@ -166,7 +166,7 @@
         public void SelfAssessmentCompetency_action_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -207,7 +207,7 @@
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id,candidateId, DelegateUserId);
+            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, selfAssessment.Id, DelegateUserId);
             if (!competency.AssessmentQuestions.Any(x => x.SignedOff == true))
             {
                 // When
@@ -252,7 +252,7 @@
                     Result = assessmentQuestionResult,
                 },
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -274,7 +274,7 @@
         public void SelfAssessmentCompetency_Post_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -308,9 +308,9 @@
                 SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
                 AllQuestionsVerifiedOrNotRequired = false
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, CandidateId,DelegateUserId))
+            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, DelegateUserId))
                 .Returns(competencies);
 
             // When
@@ -327,16 +327,16 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetMostRecentResults(SelfAssessmentId, CandidateId, DelegateUserId))
+            A.CallTo(() => selfAssessmentService.GetMostRecentResults(SelfAssessmentId, DelegateUserId))
                 .Returns(new List<Competency>() { });
 
             // When
             controller.SelfAssessmentOverview(SelfAssessmentId, selfAssessment.Vocabulary);
 
             // Then
-            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, CandidateId)).MustHaveHappened();
+            A.CallTo(() => selfAssessmentService.UpdateLastAccessed(selfAssessment.Id, DelegateUserId)).MustHaveHappened();
         }
 
         [Test]
@@ -344,14 +344,14 @@
         {
             // Given
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
             string destUrl = $"/LearningPortal/SelfAssessment/{selfAssessment.Id}/{selfAssessment.Vocabulary}";
             // When
             controller.SelfAssessmentOverview(SelfAssessmentId, selfAssessment.Vocabulary);
 
             // Then
-            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, CandidateId, destUrl))
+            A.CallTo(() => selfAssessmentService.SetBookmark(selfAssessment.Id, DelegateUserId, destUrl))
                 .MustHaveHappened();
         }
 
@@ -371,9 +371,9 @@
                 SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
                 AllQuestionsVerifiedOrNotRequired = false
             };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
-            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, CandidateId, DelegateUserId))
+            A.CallTo(() => selfAssessmentService.GetMostRecentResults(selfAssessment.Id, DelegateUserId))
                 .Returns(competencies);
 
             // When
@@ -389,7 +389,7 @@
         public void SelfAssessmentOverview_action_without_self_assessment_should_return_403()
         {
             // Given
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(null);
 
             // When
@@ -414,7 +414,7 @@
             var newDate = new DateTime(newYear, newMonth, newDay);
             var formData = new EditCompleteByDateFormData { Day = newDay, Month = newMonth, Year = newYear };
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -422,7 +422,7 @@
 
             // Then
             A.CallTo(
-                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, CandidateId, newDate)
+                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, DelegateUserId, newDate)
             ).MustHaveHappened();
         }
 
@@ -433,7 +433,7 @@
             const int selfAssessmentId = 1;
             var formData = new EditCompleteByDateFormData { Day = null, Month = null, Year = null };
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -441,7 +441,7 @@
 
             // Then
             A.CallTo(
-                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, CandidateId, null)
+                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, DelegateUserId, null)
             ).MustHaveHappened();
         }
 
@@ -456,7 +456,7 @@
             const int year = 3020;
             var formData = new EditCompleteByDateFormData { Day = day, Month = month, Year = year };
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -478,7 +478,7 @@
             var formData = new EditCompleteByDateFormData { Day = day, Month = month, Year = year };
             controller.ModelState.AddModelError("year", "message");
             var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
 
             // When
@@ -486,7 +486,7 @@
 
             // Then
             A.CallTo(
-                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, CandidateId, A<DateTime>._)
+                () => selfAssessmentService.SetCompleteByDate(selfAssessmentId, DelegateUserId, A<DateTime>._)
             ).MustNotHaveHappened();
         }
 
@@ -498,7 +498,7 @@
             const int month = 2;
             const int year = 2020;
             var formData = new EditCompleteByDateFormData { Day = day, Month = month, Year = year };
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(null);
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ActionPlanServiceTests.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Models.External.LearningHubApiClient;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
@@ -34,6 +35,7 @@
         private ILearningLogItemsDataService learningLogItemsDataService = null!;
         private ILearningResourceReferenceDataService learningResourceReferenceDataService = null!;
         private ISelfAssessmentDataService selfAssessmentDataService = null!;
+        private IUserDataService userDataService = null!;
 
         [SetUp]
         public void Setup()
@@ -45,6 +47,7 @@
             learningHubResourceService = A.Fake<ILearningHubResourceService>();
             selfAssessmentDataService = A.Fake<ISelfAssessmentDataService>();
             learningResourceReferenceDataService = A.Fake<ILearningResourceReferenceDataService>();
+            userDataService = A.Fake<IUserDataService>();
             config = A.Fake<IConfiguration>();
 
             actionPlanService = new ActionPlanService(
@@ -54,7 +57,8 @@
                 learningHubResourceService,
                 selfAssessmentDataService,
                 config,
-                learningResourceReferenceDataService
+                learningResourceReferenceDataService,
+                userDataService
             );
         }
 
@@ -70,9 +74,12 @@
             const string resourceLink = "www.test.com";
             const int learningLogId = 4;
             const int learningHubResourceId = 6;
+            const int delegateUserId = 1;
 
             var addedDate = new DateTime(2021, 11, 1);
             A.CallTo(() => clockUtility.UtcNow).Returns(addedDate);
+
+            A.CallTo(() => userDataService.GetUserIdFromDelegateId(delegateId)).Returns(delegateUserId);
 
             A.CallTo(
                 () => learningResourceReferenceDataService.GetLearningHubResourceReferenceById(
@@ -95,7 +102,7 @@
             A.CallTo(() => selfAssessmentDataService.GetCompetencyIdsForSelfAssessment(selfAssessmentId))
                 .Returns(assessmentCompetencies);
 
-            A.CallTo(() => selfAssessmentDataService.GetCandidateAssessments(delegateId, selfAssessmentId))
+            A.CallTo(() => selfAssessmentDataService.GetCandidateAssessments(delegateUserId, selfAssessmentId))
                 .Returns(
                     new[] { Builder<CandidateAssessment>.CreateNew().With(ca => ca.Id = candidateAssessmentId).Build() }
                 );

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -31,10 +31,11 @@
         {
             sortBy ??= CourseSortByOptions.LastAccessed.PropertyName;
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var bannerText = GetBannerText();
             var selfAssessments =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId);
             var (learningResources, apiIsAccessible) =
                 await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
 
@@ -65,9 +66,10 @@
         public async Task<IActionResult> AllCurrentItems()
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var selfAssessment =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId);
             var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);
             return View("Current/AllCurrentItems", model);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
@@ -59,9 +59,9 @@
         public async Task<IActionResult> SelfAssessmentResults(int selfAssessmentId)
         {
             var candidateId = User.GetCandidateIdKnownNotNull();
-            var userId = User.GetUserIdKnownNotNull();
-            selfAssessmentService.SetSubmittedDateNow(selfAssessmentId, candidateId);
-            selfAssessmentService.SetUpdatedFlag(selfAssessmentId, userId, false);
+            var delegateUserId = User.GetUserIdKnownNotNull();
+            selfAssessmentService.SetSubmittedDateNow(selfAssessmentId, delegateUserId);
+            selfAssessmentService.SetUpdatedFlag(selfAssessmentId, delegateUserId, false);
 
             if (!configuration.IsSignpostingUsed())
             {
@@ -85,13 +85,12 @@
                 return RedirectToAction("FilteredDashboard", new { selfAssessmentId });
             }
 
-            var candidateId = User.GetCandidateIdKnownNotNull();
-            var delegateUserId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
             var destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId + "/RecommendedLearning";
             selfAssessmentService.SetBookmark(selfAssessmentId, delegateUserId, destUrl);
             selfAssessmentService.UpdateLastAccessed(selfAssessmentId, delegateUserId);
 
-            return await ReturnSignpostingRecommendedLearningView(selfAssessmentId, candidateId, page, searchString);
+            return await ReturnSignpostingRecommendedLearningView(selfAssessmentId, delegateUserId, page, searchString);
         }
 
         [FeatureGate(FeatureFlags.UseSignposting)]
@@ -119,6 +118,7 @@
         )
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
 
             if (!actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, delegateId))
             {
@@ -136,7 +136,7 @@
                     return NotFound();
                 }
 
-                var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateId, selfAssessmentId);
+                var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
                 var model = new ResourceRemovedViewModel(assessment!);
                 return View("ResourceRemovedErrorPage", model);
             }
@@ -154,13 +154,12 @@
                 return RedirectToAction("RecommendedLearning", new { selfAssessmentId });
             }
 
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var destUrl = $"/LearningPortal/SelfAssessment/{selfAssessmentId}/Filtered/Dashboard";
             selfAssessmentService.SetBookmark(selfAssessmentId, delegateUserId, destUrl);
             selfAssessmentService.UpdateLastAccessed(selfAssessmentId, delegateUserId);
 
-            return await ReturnFilteredResultsView(selfAssessmentId, candidateId);
+            return await ReturnFilteredResultsView(selfAssessmentId, delegateUserId);
         }
 
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Filtered/PlayList/{playListId}")]
@@ -280,10 +279,10 @@
             var response = await filteredApiHelperService.UpdateProfileAndGoals(filteredToken, profile, goals);
         }
 
-        private async Task<IActionResult> ReturnFilteredResultsView(int selfAssessmentId, int candidateId)
+        private async Task<IActionResult> ReturnFilteredResultsView(int selfAssessmentId, int delegateUserId)
         {
             var filteredToken = await GetFilteredToken();
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId)!;
+            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId)!;
             var model = new SelfAssessmentFilteredResultsViewModel
             {
                 SelfAssessment = assessment,
@@ -306,14 +305,15 @@
 
         private async Task<IActionResult> ReturnSignpostingRecommendedLearningView(
             int selfAssessmentId,
-            int candidateId,
+            int delegateUserId,
             int page,
             string? searchString
         )
         {
-            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, selfAssessmentId)!;
+            var delegateId = User.GetCandidateIdKnownNotNull();
+            var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId)!;
             var (recommendedResources, apiIsAccessible) =
-                await recommendedLearningService.GetRecommendedLearningForSelfAssessment(selfAssessmentId, candidateId);
+                await recommendedLearningService.GetRecommendedLearningForSelfAssessment(selfAssessmentId, delegateId);
 
             var searchSortPaginationOptions = new SearchSortFilterAndPaginateOptions(
                 new SearchOptions(searchString),

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -49,7 +49,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}")]
         public IActionResult SelfAssessment(int selfAssessmentId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
 
             var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
@@ -57,7 +56,7 @@
             if (selfAssessment == null)
             {
                 logger.LogWarning(
-                    $"Attempt to display self assessment description for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to display self assessment description for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
@@ -75,7 +74,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{competencyNumber:int}")]
         public IActionResult SelfAssessmentCompetency(int selfAssessmentId, int competencyNumber)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId + "/" + competencyNumber;
             selfAssessmentService.SetBookmark(selfAssessmentId, delegateUserId, destUrl);
@@ -86,12 +84,12 @@
             if (assessment == null)
             {
                 logger.LogWarning(
-                    $"Attempt to display self assessment competency for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to display self assessment competency for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
-            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id,candidateId, delegateUserId);
+            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id, delegateUserId);
             if (competency == null)
             {
                 return RedirectToAction(
@@ -156,11 +154,11 @@
             if (assessment == null)
             {
                 logger.LogWarning(
-                    $"Attempt to set self assessment competency for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to set self assessment competency for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id,candidateId, delegateUserId);
+            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id, delegateUserId);
             if (competency.AssessmentQuestions.Any(x => x.SignedOff == true))
             {
 
@@ -257,7 +255,7 @@
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id,candidateId, delegateUserId);
+            var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id, delegateUserId);
 
             var unansweredRadioQuestion = assessmentQuestions.FirstOrDefault(q => q.AssessmentQuestionInputTypeID != 2 && q.Result == null && q.SupportingComments != null);
             if (unansweredRadioQuestion?.SupportingComments != null)
@@ -307,7 +305,6 @@
     )]
         public IActionResult SupervisorComments(int selfAssessmentId, int competencyNumber, int resultId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var destUrl = "/LearningPortal/SelfAssessment/" + selfAssessmentId + "/Proficiencies/" + competencyNumber +
                           "/Viewnotes";
@@ -319,7 +316,7 @@
             if (assessment == null)
             {
                 logger.LogWarning(
-                    $"Attempt to display self assessment overview for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to display self assessment overview for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
@@ -416,7 +413,6 @@
         [Route("LearningPortal/SelfAssessment/{selfAssessmentId:int}/{vocabulary}")]
         public IActionResult SelfAssessmentOverview(int selfAssessmentId, string vocabulary, int? competencyGroupId = null, SearchSelfAssessmentOvervieviewViewModel searchModel = null)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var destUrl = $"/LearningPortal/SelfAssessment/{selfAssessmentId}/{vocabulary}";
             selfAssessmentService.SetBookmark(selfAssessmentId, delegateUserId, destUrl);
@@ -424,7 +420,7 @@
             if (assessment == null)
             {
                 logger.LogWarning(
-                    $"Attempt to display self assessment overview for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to display self assessment overview for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
@@ -433,7 +429,7 @@
             selfAssessmentService.UpdateLastAccessed(assessment.Id, delegateUserId);
             var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(selfAssessmentId, delegateUserId);
 
-            var recentResults = selfAssessmentService.GetMostRecentResults(assessment.Id, candidateId,delegateUserId).ToList();
+            var recentResults = selfAssessmentService.GetMostRecentResults(assessment.Id, delegateUserId).ToList();
             var competencyIds = recentResults.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
             var competencies = CompetencyFilterHelper.FilterCompetencies(recentResults, competencyFlags, searchModel);
@@ -480,7 +476,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/CompleteBy")]
         public IActionResult SetSelfAssessmentCompleteByDate(int selfAssessmentId, EditCompleteByDateFormData formData)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(
                 delegateUserId,
@@ -490,7 +485,7 @@
             if (assessment is { Id: 0 })
             {
                 logger.LogWarning(
-                    $"Attempt to set complete by date for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to set complete by date for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
@@ -517,7 +512,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/CompleteBy")]
         public IActionResult SetSelfAssessmentCompleteByDate(int selfAssessmentId, ReturnPageQuery returnPageQuery)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(
                 delegateUserId,
@@ -526,7 +520,7 @@
             if (assessment == null)
             {
                 logger.LogWarning(
-                    $"Attempt to view self assessment complete by date edit page for candidate {delegateUserId} with no self assessment"
+                    $"Attempt to view self assessment complete by date edit page for user {delegateUserId} with no self assessment"
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
@@ -545,7 +539,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Supervisors")]
         public IActionResult ManageSupervisors(int selfAssessmentId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(
                 delegateUserId,
@@ -553,7 +546,7 @@
             );
             if (assessment == null)
             {
-                logger.LogWarning($"Attempt to manage supervisors for candidate {delegateUserId} with no self assessment");
+                logger.LogWarning($"Attempt to manage supervisors for user {delegateUserId} with no self assessment");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
@@ -587,7 +580,7 @@
 
             int? supervisorRoleId = roles.First().ID;
             supervisorService.InsertCandidateAssessmentSupervisor(
-                User.GetCandidateIdKnownNotNull(),
+                User.GetUserIdKnownNotNull(),
                 supervisorDelegateId,
                 selfAssessmentId,
                 supervisorRoleId
@@ -641,7 +634,7 @@
             var supervisors = selfAssessmentService.GetValidSupervisorsForActivity(
                 User.GetCentreIdKnownNotNull(),
                 selfAssessmentId,
-                User.GetCandidateIdKnownNotNull()
+                User.GetUserIdKnownNotNull()
             );
             var model = new AddSupervisorViewModel
             {
@@ -666,7 +659,7 @@
                 var supervisors = selfAssessmentService.GetValidSupervisorsForActivity(
                User.GetCentreIdKnownNotNull(),
                sessionAddSupervisor.SelfAssessmentID,
-               User.GetCandidateIdKnownNotNull()
+               User.GetUserIdKnownNotNull()
            );
                 model.Supervisors = supervisors;
                 return View("SelfAssessments/AddSupervisor", model);
@@ -735,9 +728,9 @@
             }
             else
             {
-                var userId = User.GetUserIdKnownNotNull();
+                var delegateUserId = User.GetUserIdKnownNotNull();
                 var selfAssessment =
-                    selfAssessmentService.GetSelfAssessmentForCandidateById(userId, selfAssessmentId);
+                    selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
                 if (selfAssessment == null)
                 {
                     return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
@@ -805,7 +798,7 @@
             }
 
             supervisorService.InsertCandidateAssessmentSupervisor(
-                User.GetCandidateIdKnownNotNull(),
+                User.GetUserIdKnownNotNull(),
                 (int)model.SupervisorDelegateId,
                 model.SelfAssessmentID,
                 model.SelfAssessmentSupervisorRoleId
@@ -878,7 +871,7 @@
             var delegateEntity = userDataService.GetDelegateById(candidateId);
             var supervisorDelegateId = supervisorService.AddSuperviseDelegate(
                 sessionAddSupervisor.SupervisorAdminId,
-                delegateUserId,
+                candidateId,
                 delegateEntity!.EmailForCentreNotifications,
                 sessionAddSupervisor.SupervisorEmail ?? throw new InvalidOperationException(),
                 User.GetCentreIdKnownNotNull()
@@ -892,7 +885,7 @@
             frameworkNotificationService.SendDelegateSupervisorNominated(
                 supervisorDelegateId,
                 sessionAddSupervisor.SelfAssessmentID,
-                delegateUserId
+                candidateId
             );
             return RedirectToAction("ManageSupervisors", new { sessionAddSupervisor.SelfAssessmentID });
         }
@@ -917,7 +910,7 @@
         {
             TempData.Clear();
             var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(
-                User.GetCandidateIdKnownNotNull(),
+                User.GetUserIdKnownNotNull(),
                 selfAssessmentId
             );
             if (selfAssessment == null)
@@ -943,7 +936,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/ConfirmationRequests")]
         public IActionResult ReviewConfirmationRequests(int selfAssessmentId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             if (selfAssessment == null)
@@ -952,7 +944,7 @@
             }
 
             var competencies = PopulateCompetencyLevelDescriptors(
-                selfAssessmentService.GetResultSupervisorVerifications(selfAssessmentId, User.GetCandidateIdKnownNotNull()).ToList()
+                selfAssessmentService.GetResultSupervisorVerifications(selfAssessmentId, delegateUserId).ToList()
             );
             var model = new ReviewConfirmationRequestsViewModel
             {
@@ -985,7 +977,6 @@
                 MultiPageFormDataFeature.AddSelfAssessmentRequestVerification,
                 TempData
             );
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var supervisors = selfAssessmentService
@@ -1018,7 +1009,6 @@
                 MultiPageFormDataFeature.AddSelfAssessmentRequestVerification,
                 TempData
             );
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             if (!ModelState.IsValid)
             {
@@ -1068,7 +1058,7 @@
             var competencies = PopulateCompetencyLevelDescriptors(
                 selfAssessmentService.GetCandidateAssessmentResultsToVerifyById(
                     selfAssessmentId,
-                    User.GetCandidateIdKnownNotNull()
+                    User.GetUserIdKnownNotNull()
                 ).ToList()
             );
             var model = new VerificationPickResultsViewModel
@@ -1101,7 +1091,7 @@
                 var competencies = PopulateCompetencyLevelDescriptors(
                     selfAssessmentService.GetCandidateAssessmentResultsToVerifyById(
                         selfAssessmentId,
-                        User.GetCandidateIdKnownNotNull()
+                        User.GetUserIdKnownNotNull()
                     ).ToList()
                 );
                 model.CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup);
@@ -1252,7 +1242,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{vocabulary}/Optional")]
         public IActionResult ManageOptionalCompetencies(int selfAssessmentId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var optionalCompetencies =
@@ -1279,7 +1268,6 @@
             ManageOptionalCompetenciesViewModel model
         )
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             selfAssessmentService.InsertCandidateAssessmentOptionalCompetenciesIfNotExist(
                 selfAssessmentId,
@@ -1302,7 +1290,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{vocabulary}/RequestSignOff")]
         public IActionResult RequestSignOff(int selfAssessmentId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var supervisors =
@@ -1340,7 +1327,7 @@
             frameworkNotificationService.SendSignOffRequest(
                 model.CandidateAssessmentSupervisorId,
                 selfAssessmentId,
-                delegateUserId
+                candidateId
             );
             return RedirectToAction("SelfAssessmentOverview", new { selfAssessmentId, vocabulary });
         }
@@ -1366,7 +1353,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{vocabulary}/SignOffHistory")]
         public IActionResult SignOffHistory(int selfAssessmentId, string vocabulary)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var supervisorSignOffs =
@@ -1380,7 +1366,7 @@
         }
         public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string vocabulary)
         {
-            var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, GetCandidateId(), true);
+            var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, User.GetUserIdKnownNotNull(), true);
             var fileName = $"DLS {vocabulary} Assessment Export {clockUtility.UtcNow:yyyy-MM-dd}.xlsx";
             return File(
                 content,

--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyDelegateUserCanAccessSelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyDelegateUserCanAccessSelfAssessment.cs
@@ -30,14 +30,14 @@
             }
 
             var selfAssessmentId = int.Parse(context.RouteData.Values["selfAssessmentId"].ToString()!);
-            var delegateId = controller.User.GetCandidateIdKnownNotNull();
+            var delegateUserId = controller.User.GetUserIdKnownNotNull();
             var canAccessSelfAssessment =
-                selfAssessmentService.CanDelegateAccessSelfAssessment(delegateId, selfAssessmentId);
+                selfAssessmentService.CanDelegateAccessSelfAssessment(delegateUserId, selfAssessmentId);
 
             if (!canAccessSelfAssessment)
             {
                 logger.LogWarning(
-                    $"Attempt to display self assessment results for candidate {delegateId} with no self assessment"
+                    $"Attempt to display self assessment results for user {delegateUserId} with no self assessment"
                 );
                 context.Result = new RedirectToActionResult("AccessDenied", "LearningSolutions", new { });
             }

--- a/DigitalLearningSolutions.Web/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Web/Services/ActionPlanService.cs
@@ -7,6 +7,7 @@
     using System.Transactions;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Utilities;
@@ -51,6 +52,7 @@
         private readonly ILearningLogItemsDataService learningLogItemsDataService;
         private readonly ILearningResourceReferenceDataService learningResourceReferenceDataService;
         private readonly ISelfAssessmentDataService selfAssessmentDataService;
+        private readonly IUserDataService userDataService;
 
         public ActionPlanService(
             ICompetencyLearningResourcesDataService competencyLearningResourcesDataService,
@@ -59,7 +61,8 @@
             ILearningHubResourceService learningHubResourceService,
             ISelfAssessmentDataService selfAssessmentDataService,
             IConfiguration config,
-            ILearningResourceReferenceDataService learningResourceReferenceDataService
+            ILearningResourceReferenceDataService learningResourceReferenceDataService,
+            IUserDataService userDataService
         )
         {
             this.competencyLearningResourcesDataService = competencyLearningResourcesDataService;
@@ -69,6 +72,7 @@
             this.selfAssessmentDataService = selfAssessmentDataService;
             this.config = config;
             this.learningResourceReferenceDataService = learningResourceReferenceDataService;
+            this.userDataService = userDataService;
         }
 
         public async Task AddResourceToActionPlan(int learningResourceReferenceId, int delegateId, int selfAssessmentId)
@@ -114,14 +118,15 @@
 
             // We can assume a single Candidate Assessment because we'll be adding a uniqueness constraint
             // on CandidateAssessments (candidateId, selfAssessmentId) before releasing (see HEEDLS-932)
+            var delegateUserId = userDataService.GetUserIdFromDelegateId(delegateId);
             var candidateAssessmentIdIfAny = selfAssessmentDataService
-                .GetCandidateAssessments(delegateId, selfAssessmentId)
+                .GetCandidateAssessments(delegateUserId, selfAssessmentId)
                 .SingleOrDefault()?.Id;
 
             if (candidateAssessmentIdIfAny == null)
             {
                 throw new InvalidOperationException(
-                    $"Cannot add resource to action plan as user {delegateId} is not enrolled on self assessment {selfAssessmentId}"
+                    $"Cannot add resource to action plan as user {delegateUserId} is not enrolled on self assessment {selfAssessmentId}"
                 );
             }
 

--- a/DigitalLearningSolutions.Web/Services/CandidateAssessmentDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/CandidateAssessmentDownloadFileService.cs
@@ -12,7 +12,7 @@
 
     public interface ICandidateAssessmentDownloadFileService
     {
-        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId, bool isProtected);
+        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int delegateUserId, bool isProtected);
     }
 
     public class CandidateAssessmentDownloadFileService : ICandidateAssessmentDownloadFileService
@@ -28,10 +28,10 @@
             this.selfAssessmentDataService = selfAssessmentDataService;
             this.config = config;
         }
-        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int candidateId, bool isProtected)
+        public byte[] GetCandidateAssessmentDownloadFileForCentre(int candidateAssessmentId, int delegateUserId, bool isProtected)
         {
-            var summaryData = selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, candidateId);
-            var detailData = selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, candidateId);
+            var summaryData = selfAssessmentDataService.GetCandidateAssessmentExportSummary(candidateAssessmentId, delegateUserId);
+            var detailData = selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, delegateUserId);
             var details = detailData.Select(
                 x => new
                 {

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -29,7 +29,7 @@
 
         void SetCompleteByDate(int selfAssessmentId, int delegateUserId, DateTime? completeByDate);
 
-        bool CanDelegateAccessSelfAssessment(int delegateId, int selfAssessmentId);
+        bool CanDelegateAccessSelfAssessment(int delegateUserId, int selfAssessmentId);
 
         // Competencies
         IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int adminId, int? selfAssessmentResultId = null);
@@ -48,7 +48,7 @@
 
         Competency? GetCompetencyByCandidateAssessmentResultId(int resultId, int candidateAssessmentId, int adminId);
 
-        Competency? GetNthCompetency(int n, int selfAssessmentId,int candidateId, int delegateUserId); // 1 indexed
+        Competency? GetNthCompetency(int n, int selfAssessmentId, int delegateUserId); // 1 indexed
 
         void SetResultForCompetency(
             int competencyId,
@@ -62,7 +62,7 @@
 
         IEnumerable<Competency> GetCandidateAssessmentOptionalCompetencies(int selfAssessmentId, int delegateUserId);
 
-        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId,int candidateId, int delegateUserId);
+        IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateUserId);
 
         List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int delegateUserId);
 
@@ -319,9 +319,9 @@
             return selfAssessmentDataService.GetCandidateAssessmentExportDetails(candidateAssessmentId, delegateUserId);
         }
 
-        public bool CanDelegateAccessSelfAssessment(int delegateId, int selfAssessmentId)
+        public bool CanDelegateAccessSelfAssessment(int delegateUserId, int selfAssessmentId)
         {
-            var candidateAssessments = selfAssessmentDataService.GetCandidateAssessments(delegateId, selfAssessmentId);
+            var candidateAssessments = selfAssessmentDataService.GetCandidateAssessments(delegateUserId, selfAssessmentId);
 
             return candidateAssessments.Any(ca => ca.CompletedDate == null && ca.RemovedDate == null);
         }
@@ -354,9 +354,9 @@
             );
         }
 
-        public Competency? GetNthCompetency(int n, int selfAssessmentId,int candidateId, int delegateUserId)
+        public Competency? GetNthCompetency(int n, int selfAssessmentId, int delegateUserId)
         {
-            return selfAssessmentDataService.GetNthCompetency(n, selfAssessmentId, candidateId,delegateUserId);
+            return selfAssessmentDataService.GetNthCompetency(n, selfAssessmentId, delegateUserId);
         }
 
         public void SetResultForCompetency(
@@ -390,9 +390,9 @@
             return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId);
         }
 
-        public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId,int candidateId, int delegateUserId)
+        public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateUserId)
         {
-            return selfAssessmentDataService.GetMostRecentResults(selfAssessmentId, candidateId,delegateUserId);
+            return selfAssessmentDataService.GetMostRecentResults(selfAssessmentId, delegateUserId);
         }
 
         public List<int> GetCandidateAssessmentIncludedSelfAssessmentStructureIds(int selfAssessmentId, int delegateUserId)


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-260

**Description**
For self assessment, service methods used 'delegateUserId' instead of CandidateId or DelegateId. SQL queries updated accordingly.

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**
I have:
- [ ] Run the formatter and made sure there are no IDE errors 
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-260]: https://hee-tis.atlassian.net/browse/TD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ