### PR TITLE
TD-876-Self-assessment - Proficiency Confirmation request page displays blank

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -944,7 +944,8 @@
             }
 
             var competencies = PopulateCompetencyLevelDescriptors(
-                selfAssessmentService.GetResultSupervisorVerifications(selfAssessmentId, delegateUserId).ToList()
+                selfAssessmentService.GetResultSupervisorVerifications(selfAssessmentId, delegateUserId)
+                .Where(s=>s.SupervisorName !=null).ToList()
             );
             var model = new ReviewConfirmationRequestsViewModel
             {


### PR DESCRIPTION
JIRA link
https://hee-tis.atlassian.net/browse/TD-876

**Description**
Retrieved competencies having supervisor names (not empty)

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
