### PR TITLE
TD-912-Modify SelfAssessmentResults to link to DelegateUser instead of CandidateID

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202301101342_AddSelfAssessmentResultDelegateUserID.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202301101342_AddSelfAssessmentResultDelegateUserID.cs
@@ -1,0 +1,37 @@
+﻿using FluentMigrator;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    [Migration(202301101342)]
+    public class AddSelfAssessmentResultDelegateUserID : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessmentResults").AddColumn("DelegateUserID").AsInt32().NotNullable().WithDefaultValue(0);
+
+            Execute.Sql("UPDATE SAR SET SAR.DelegateUserID = DA.UserID FROM SelfAssessmentResults SAR " +
+            "INNER JOIN DelegateAccounts DA ON SAR.CandidateID = DA.ID");
+
+            Create.ForeignKey("FK_SelfAssessmentResults_DelegateUserID_Users_ID")
+            .FromTable("SelfAssessmentResults").ForeignColumn("DelegateUserID").ToTable("Users").PrimaryColumn("ID");
+
+
+            Delete.ForeignKey("FK_SelfAssessmentResults_CandidateID_Candidates_CandidateID").OnTable("SelfAssessmentResults");
+            Rename.Column("CandidateID").OnTable("SelfAssessmentResults").To("CandidateID_deprecated");
+            Alter.Table("SelfAssessmentResults").AlterColumn("CandidateID_deprecated").AsInt32().Nullable();
+
+        }
+
+        public override void Down()
+        {
+            Delete.ForeignKey("FK_SelfAssessmentResults_DelegateUserID_Users_ID").OnTable("SelfAssessmentResults");
+            Delete.Column("DelegateUserID").FromTable("SelfAssessmentResults");
+
+            Rename.Column("CandidateID_deprecated").OnTable("SelfAssessmentResults").To("CandidateID");
+            Create.ForeignKey("FK_SelfAssessmentResults_CandidateID_Candidates_CandidateID")
+            .FromTable("SelfAssessmentResults").ForeignColumn("CandidateID").ToTable("DelegateAccounts").PrimaryColumn("ID");
+            Alter.Table("SelfAssessmentResults").AlterColumn("CandidateID").AsInt32().NotNullable();
+
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202301101342_AddSelfAssessmentResultDelegateUserID.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202301101342_AddSelfAssessmentResultDelegateUserID.cs
@@ -24,10 +24,14 @@ namespace DigitalLearningSolutions.Data.Migrations
 
         public override void Down()
         {
+            Rename.Column("CandidateID_deprecated").OnTable("SelfAssessmentResults").To("CandidateID");
+
+            Execute.Sql("UPDATE SAR SET SAR.CandidateID = DA.ID FROM SelfAssessmentResults SAR " +
+            "INNER JOIN DelegateAccounts DA ON SAR.DelegateUserID = DA.UserID Where SAR.CandidateID Is Null");
+
             Delete.ForeignKey("FK_SelfAssessmentResults_DelegateUserID_Users_ID").OnTable("SelfAssessmentResults");
             Delete.Column("DelegateUserID").FromTable("SelfAssessmentResults");
 
-            Rename.Column("CandidateID_deprecated").OnTable("SelfAssessmentResults").To("CandidateID");
             Create.ForeignKey("FK_SelfAssessmentResults_CandidateID_Candidates_CandidateID")
             .FromTable("SelfAssessmentResults").ForeignColumn("CandidateID").ToTable("DelegateAccounts").PrimaryColumn("ID");
             Alter.Table("SelfAssessmentResults").AlterColumn("CandidateID").AsInt32().NotNullable();

--- a/DigitalLearningSolutions.Data.Tests/DataServices/LearningLogItemsDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/LearningLogItemsDataServiceTests.cs
@@ -155,6 +155,7 @@
             const int learningResourceReferenceId = 1;
             const int learningHubResourceReferenceId = 2;
             const int delegateId = 2;
+            const int delegateUserId = 2;
             const int differentDelegateId = 3;
             const string firstActivityName = "activity 1";
             const string secondActivityName = "activity 2";
@@ -199,7 +200,7 @@
                 );
 
                 // When
-                var result = service.GetLearningLogItems(delegateId).ToList();
+                var result = service.GetLearningLogItems(delegateUserId).ToList();
 
                 // Then
                 using (new AssertionScope())

--- a/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CompetencyDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/SelfAssessmentDataServiceTests/CompetencyDataServiceTests.cs
@@ -144,7 +144,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     result + 1,
@@ -153,7 +152,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     result,
@@ -182,7 +180,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     result,
@@ -191,7 +188,7 @@
                 var insertedResult = GetAssessmentResults(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     assessmentQuestionId
                 ).First();
 
@@ -215,7 +212,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     firstResult,
@@ -224,7 +220,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     secondResult,
@@ -233,7 +228,7 @@
                 var insertedResults = GetAssessmentResults(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     assessmentQuestionId
                 ).ToList();
 
@@ -260,7 +255,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    invalidCandidateId,
                     invalidDelegateUserId,
                     assessmentQuestionId,
                     result,
@@ -269,7 +263,7 @@
                 var insertedResults = GetAssessmentResults(
                     competencyId,
                     SelfAssessmentId,
-                    invalidCandidateId,
+                    invalidDelegateUserId,
                     assessmentQuestionId
                 );
 
@@ -293,7 +287,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     invalidSelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     result,
@@ -302,7 +295,7 @@
                 var insertedResults = GetAssessmentResults(
                     competencyId,
                     invalidSelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     assessmentQuestionId
                 );
 
@@ -325,7 +318,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     invalidCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     result,
@@ -334,7 +326,7 @@
                 var insertedResults = GetAssessmentResults(
                     invalidCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     assessmentQuestionId
                 );
 
@@ -357,7 +349,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     invalidAssessmentQuestionId,
                     result,
@@ -366,7 +357,7 @@
                 var insertedResults = GetAssessmentResults(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     invalidAssessmentQuestionId
                 );
 
@@ -389,7 +380,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     invalidResult,
@@ -398,7 +388,7 @@
                 var insertedResults = GetAssessmentResults(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     assessmentQuestionId
                 );
 
@@ -421,7 +411,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     invalidResult,
@@ -430,7 +419,7 @@
                 var insertedResults = GetAssessmentResults(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
+                    delegateUserId,
                     assessmentQuestionId
                 );
 
@@ -460,7 +449,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     firstCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     firstAssessmentQuestionId,
                     firstResult,
@@ -469,7 +457,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     firstCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     secondAssessmentQuestionId,
                     secondResult,
@@ -478,7 +465,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     secondCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     thirdAssessmentQuestionId,
                     thirdResult,
@@ -487,7 +473,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     secondCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     fourthAssessmentQuestionId,
                     fourthResult,
@@ -531,7 +516,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     firstCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     firstAssessmentQuestionId,
                     firstResult,
@@ -540,7 +524,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     firstCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     secondAssessmentQuestionId,
                     secondResult,
@@ -549,7 +532,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     secondCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     thirdAssessmentQuestionId,
                     9,
@@ -558,7 +540,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     secondCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     fourthAssessmentQuestionId,
                     9,
@@ -567,7 +548,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     secondCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     thirdAssessmentQuestionId,
                     thirdResult,
@@ -576,7 +556,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     secondCompetencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     fourthAssessmentQuestionId,
                     fourthResult,
@@ -632,7 +611,6 @@
                 selfAssessmentDataService.SetResultForCompetency(
                     competencyId,
                     SelfAssessmentId,
-                    CandidateId,
                     delegateUserId,
                     assessmentQuestionId,
                     result,
@@ -642,7 +620,7 @@
                 // When
                 var results =
 selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-                        CandidateId,
+                        delegateUserId,
                         SelfAssessmentId,
                         competencyId
                     ).ToList();
@@ -651,7 +629,7 @@ selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompe
                 using (new AssertionScope())
                 {
                     results.Should().HaveCount(1);
-                    results.First().CandidateId.Should().Be(CandidateId);
+                    results.First().DelegateUserId.Should().Be(delegateUserId);
                     results.First().SelfAssessmentId.Should().Be(SelfAssessmentId);
                     results.First().AssessmentQuestionId.Should().Be(assessmentQuestionId);
                     results.First().CompetencyId.Should().Be(competencyId);
@@ -663,7 +641,7 @@ selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompe
         private IEnumerable<int> GetAssessmentResults(
             int competencyId,
             int selfAssessmentId,
-            int candidateId,
+            int delegateUserId,
             int assessmentQuestionId
         )
         {
@@ -671,9 +649,9 @@ selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompe
                 @"SELECT Result FROM SelfAssessmentResults WHERE
                         CompetencyID = @competencyId AND
                         SelfAssessmentID = @selfAssessmentId AND
-                        CandidateID = @candidateId AND
+                        DelegateUserID = @delegateUserId AND
                         AssessmentQuestionID = @assessmentQuestionId",
-                new { competencyId, selfAssessmentId, candidateId, assessmentQuestionId }
+                new { competencyId, selfAssessmentId, delegateUserId, assessmentQuestionId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
@@ -9,7 +9,7 @@
 
     public interface ILearningLogItemsDataService
     {
-        IEnumerable<LearningLogItem> GetLearningLogItems(int delegateId);
+        IEnumerable<LearningLogItem> GetLearningLogItems(int delegateUserId);
 
         LearningLogItem? GetLearningLogItem(int learningLogItemId);
 
@@ -73,7 +73,7 @@
             this.logger = logger;
         }
 
-        public IEnumerable<LearningLogItem> GetLearningLogItems(int delegateId)
+        public IEnumerable<LearningLogItem> GetLearningLogItems(int delegateUserId)
         {
             return connection.Query<LearningLogItem>(
                 $@"SELECT
@@ -81,9 +81,9 @@
                     FROM LearningLogItems l
                     INNER JOIN ActivityTypes a ON a.ID = l.ActivityTypeID
                     INNER JOIN LearningResourceReferences AS lrr ON lrr.ID = l.LearningResourceReferenceID
-                    WHERE LoggedById = @delegateId
+                    WHERE LoggedById = @delegateUserId
                     AND a.TypeLabel = '{LearningHubResourceActivityLabel}'",
-                new { delegateId }
+                new { delegateUserId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
@@ -23,7 +23,7 @@
                               SelfAssessmentResults AS sar1 ON sar1.ID =
                                   (SELECT MAX(ID) AS Expr1
                                   FROM    SelfAssessmentResults AS sar2
-                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -37,7 +37,7 @@
                               CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                                   (SELECT MAX(ID) AS Expr1
                                   FROM    SelfAssessmentResults AS sar2
-                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -53,7 +53,7 @@
                               CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                                   (SELECT MAX(ID) AS Expr1
                                   FROM    SelfAssessmentResults AS sar2
-                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_4.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_4.SignedOff = 1) AND (caqrr1.ID IS NULL) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -69,7 +69,7 @@
                               CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                                   (SELECT MAX(ID) AS Expr1
                                   FROM    SelfAssessmentResults AS sar2
-                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_3.SignedOff = 1) AND (caqrr1.LevelRAG = 1) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_3.SignedOff = 1) AND (caqrr1.LevelRAG = 1) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -85,7 +85,7 @@
                               CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                                   (SELECT MAX(ID) AS Expr1
                                   FROM    SelfAssessmentResults AS sar2
-                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_2.SignedOff = 1) AND (caqrr1.LevelRAG = 2) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_2.SignedOff = 1) AND (caqrr1.LevelRAG = 2) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -101,7 +101,7 @@
                               CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                                   (SELECT MAX(ID) AS Expr1
                                   FROM    SelfAssessmentResults AS sar2
-                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                                  WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_1.SignedOff = 1) AND (caqrr1.LevelRAG = 3) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications_1.SignedOff = 1) AND (caqrr1.LevelRAG = 3) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -146,12 +146,12 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.DelegateUserID  = @delegateUserID)
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM CandidateAssessments ca
                 INNER JOIN SelfAssessmentResults s
-                    ON s.CandidateID = ca.CandidateID AND s.SelfAssessmentID = ca.SelfAssessmentID
+                    ON s.DelegateUserID = ca.DelegateUserID AND s.SelfAssessmentID = ca.SelfAssessmentID
                 INNER JOIN (
                     SELECT MAX(s1.ID) as ID
                     FROM SelfAssessmentResults AS s1
                     INNER JOIN CandidateAssessments AS ca1
-                        ON  s1.CandidateID = ca1.CandidateID AND s1.SelfAssessmentID = ca1.SelfAssessmentID
+                        ON  s1.DelegateUserID = ca1.DelegateUserID AND s1.SelfAssessmentID = ca1.SelfAssessmentID
                     WHERE ca1.ID = @candidateAssessmentId
                     GROUP BY CompetencyID, AssessmentQuestionID
                 ) t

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -31,7 +31,6 @@
         void SetResultForCompetency(
             int competencyId,
             int selfAssessmentId,
-            int candidateId,
             int delegateUserId,
             int assessmentQuestionId,
             int? result,
@@ -61,7 +60,7 @@
         );
 
         IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-            int delegateId,
+            int delegateUserId,
             int selfAssessmentId,
             int competencyId
         );

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -213,8 +213,7 @@
                     SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
                     AdminUsers AS au ON sd.SupervisorAdminID = au.AdminID INNER JOIN
                     SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
-                    INNER JOIN DelegateAccounts AS da ON sar.CandidateID = da.ID
-                    WHERE (da.UserID = @delegateUserId) AND (sasv.SelfAssessmentResultId = @resultId)",
+                    WHERE (sar.DelegateUserID = @delegateUserId) AND (sasv.SelfAssessmentResultId = @resultId)",
                 new { delegateUserId, resultId }
             ).FirstOrDefault();
         }

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -792,25 +792,54 @@ WHERE (cas.CandidateAssessmentID = @candidateAssessmentId) AND (cas.SupervisorDe
         public IEnumerable<CandidateAssessmentSupervisorVerificationSummary> GetCandidateAssessmentSupervisorVerificationSummaries(int candidateAssessmentId)
         {
             return connection.Query<CandidateAssessmentSupervisorVerificationSummary>(
-                @"SELECT ca1.ID, AdminUsers.Forename, AdminUsers.Surname, AdminUsers.Email, COUNT(sas1.CompetencyID) AS VerifiedCount
-FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
-             SelfAssessmentResults AS sar1 ON SelfAssessmentResultSupervisorVerifications.SelfAssessmentResultId = sar1.ID INNER JOIN
-             CandidateAssessmentSupervisors ON SelfAssessmentResultSupervisorVerifications.CandidateAssessmentSupervisorID = CandidateAssessmentSupervisors.ID INNER JOIN
-             SupervisorDelegates ON CandidateAssessmentSupervisors.SupervisorDelegateId = SupervisorDelegates.ID INNER JOIN
-             AdminUsers ON SupervisorDelegates.SupervisorAdminID = AdminUsers.AdminID RIGHT OUTER JOIN
-             SelfAssessmentStructure AS sas1 INNER JOIN
-             CandidateAssessments AS ca1 ON sas1.SelfAssessmentID = ca1.SelfAssessmentID INNER JOIN
-             CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
-                 (SELECT MAX(ID) AS Expr1
-                 FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
-             CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
-WHERE (ca1.ID = @candidateAssessmentId) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
-             (ca1.ID = @candidateAssessmentId) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
-             (ca1.ID = @candidateAssessmentId) AND (sas1.Optional = 0) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
-             (ca1.ID = @candidateAssessmentId) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.SupportingComments IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1)
-GROUP BY AdminUsers.Forename, AdminUsers.Surname, AdminUsers.Email, caoc1.CandidateAssessmentID, ca1.ID
-ORDER BY AdminUsers.Surname, AdminUsers.Forename", new { candidateAssessmentId });
+                @"SELECT	ca1.ID, 
+		                    AdminUsers.Forename, 
+		                    AdminUsers.Surname, 
+		                    AdminUsers.Email, 
+		                    COUNT(sas1.CompetencyID) AS VerifiedCount
+                    FROM   SelfAssessmentResultSupervisorVerifications 
+                    INNER JOIN SelfAssessmentResults AS sar1 
+	                    ON SelfAssessmentResultSupervisorVerifications.SelfAssessmentResultId = sar1.ID 
+                    INNER JOIN CandidateAssessmentSupervisors 
+	                    ON SelfAssessmentResultSupervisorVerifications.CandidateAssessmentSupervisorID = CandidateAssessmentSupervisors.ID 
+                    INNER JOIN SupervisorDelegates sd
+	                    ON CandidateAssessmentSupervisors.SupervisorDelegateId = sd.ID 
+                    INNER JOIN AdminUsers 
+	                    ON sd.SupervisorAdminID = AdminUsers.AdminID 
+                    RIGHT OUTER JOIN SelfAssessmentStructure AS sas1 
+                    INNER JOIN CandidateAssessments AS ca1 
+	                    ON sas1.SelfAssessmentID = ca1.SelfAssessmentID 
+                    INNER JOIN CompetencyAssessmentQuestions AS caq1 
+	                    ON sas1.CompetencyID = caq1.CompetencyID 
+	                    ON sar1.ID =
+		                    (SELECT MAX(ID) AS Expr1
+		                    FROM    SelfAssessmentResults AS sar2
+		                    WHERE (CompetencyID = caq1.CompetencyID) 
+			                    AND (AssessmentQuestionID = caq1.AssessmentQuestionID) 
+			                    AND (sd.DelegateUserID = ca1.DelegateUserID) 
+			                    AND (SelfAssessmentID = ca1.SelfAssessmentID)) 
+                    LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS caoc1 
+	                    ON sas1.CompetencyID = caoc1.CompetencyID 
+	                    AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID 
+	                    AND ca1.ID = caoc1.CandidateAssessmentID
+                    WHERE (ca1.ID = @candidateAssessmentId) 
+	                    AND (sas1.Optional = 0) 
+	                    AND (NOT (sar1.Result IS NULL)) 
+	                    AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) 
+	                    OR (ca1.ID = @candidateAssessmentId) 
+	                    AND (caoc1.IncludedInSelfAssessment = 1) 
+	                    AND (NOT (sar1.Result IS NULL)) 
+	                    AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) 
+	                    OR (ca1.ID = @candidateAssessmentId) 
+	                    AND (sas1.Optional = 0) 
+	                    AND (NOT (sar1.SupportingComments IS NULL)) 
+	                    AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) 
+	                    OR (ca1.ID = @candidateAssessmentId)
+	                    AND (caoc1.IncludedInSelfAssessment = 1) 
+	                    AND (NOT (sar1.SupportingComments IS NULL)) 
+	                    AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1)
+                    GROUP BY AdminUsers.Forename, AdminUsers.Surname, AdminUsers.Email, caoc1.CandidateAssessmentID, ca1.ID
+                    ORDER BY AdminUsers.Surname, AdminUsers.Forename", new { candidateAssessmentId });
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -685,7 +685,7 @@ FROM   SelfAssessmentStructure AS sas1 INNER JOIN
              SelfAssessmentResults AS sar1 ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) OR
              (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (caoc1.IncludedInSelfAssessment = 1) OR
@@ -699,7 +699,7 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
              (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
@@ -715,7 +715,7 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
              (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.ID IS NULL) OR
@@ -731,7 +731,7 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.LevelRAG = 1) OR
              (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.LevelRAG = 1) OR
@@ -747,7 +747,7 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.LevelRAG = 2) OR
              (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.LevelRAG = 2) OR
@@ -763,7 +763,7 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.LevelRAG = 3) OR
              (ca1.ID = ca.ID) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) AND (caqrr1.LevelRAG = 3) OR
@@ -803,7 +803,7 @@ FROM   SelfAssessmentResultSupervisorVerifications INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.ID =
                  (SELECT MAX(ID) AS Expr1
                  FROM    SelfAssessmentResults AS sar2
-                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (CandidateID = ca1.CandidateID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
+                 WHERE (CompetencyID = caq1.CompetencyID) AND (AssessmentQuestionID = caq1.AssessmentQuestionID) AND (DelegateUserID = ca1.DelegateUserID) AND (SelfAssessmentID = ca1.SelfAssessmentID)) LEFT OUTER JOIN
              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
 WHERE (ca1.ID = @candidateAssessmentId) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR
              (ca1.ID = @candidateAssessmentId) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (SelfAssessmentResultSupervisorVerifications.SignedOff = 1) OR

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentResult.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentResult.cs
@@ -6,8 +6,6 @@
     {
         public int Id { get; set; }
 
-        public int CandidateId { get; set; }
-
         public int SelfAssessmentId { get; set; }
 
         public int CompetencyId { get; set; }
@@ -19,5 +17,8 @@
         public DateTime DateTime { get; set; }
 
         public string? SupportingComments { get; set; }
+
+        public int DelegateUserId { get; set; }
+
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CompletedTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CompletedTests.cs
@@ -36,7 +36,7 @@
                 completedActionPlanResources.Select(r => new CompletedActionPlanResource(r));
             var bannerText = "bannerText";
             A.CallTo(() => courseDataService.GetCompletedCourses(CandidateId)).Returns(completedCourses);
-            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(CandidateId))
+            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(DelegateUserId))
                 .Returns((completedActionPlanResources, apiIsAccessible));
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);
             var allItems = completedCourses.Cast<CompletedLearningItem>().ToList();
@@ -92,7 +92,7 @@
             await controller.Completed();
 
             // Then
-            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(CandidateId)).MustNotHaveHappened();
+            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(DelegateUserId)).MustNotHaveHappened();
         }
 
         [Test]
@@ -106,7 +106,7 @@
             await controller.Completed();
 
             // Then
-            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(CandidateId))
+            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(DelegateUserId))
                 .MustHaveHappenedOnceExactly();
         }
 
@@ -121,7 +121,7 @@
             await controller.AllCompletedItems();
 
             // Then
-            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(CandidateId)).MustNotHaveHappened();
+            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(DelegateUserId)).MustNotHaveHappened();
         }
 
         [Test]
@@ -135,7 +135,7 @@
             await controller.AllCompletedItems();
 
             // Then
-            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(CandidateId))
+            A.CallTo(() => actionPlanService.GetCompletedActionPlanResources(DelegateUserId))
                 .MustHaveHappenedOnceExactly();
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -45,7 +45,7 @@
             var bannerText = "bannerText";
             A.CallTo(() => courseDataService.GetCurrentCourses(CandidateId)).Returns(currentCourses);
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(DelegateUserId)).Returns(selfAssessments);
-            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId))
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId))
                 .Returns((actionPlanResources, apiIsAccessible));
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);
             A.CallTo(() => config["FeatureManagement:UseSignposting"]).Returns("true");
@@ -87,7 +87,7 @@
             await controller.Current();
 
             // Then
-            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).MustNotHaveHappened();
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId)).MustNotHaveHappened();
         }
 
         [Test]
@@ -101,7 +101,7 @@
             await controller.Current();
 
             // Then
-            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId))
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId))
                 .MustHaveHappenedOnceExactly();
         }
 
@@ -116,7 +116,7 @@
             await controller.AllCurrentItems();
 
             // Then
-            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId)).MustNotHaveHappened();
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId)).MustNotHaveHappened();
         }
 
         [Test]
@@ -130,7 +130,7 @@
             await controller.AllCurrentItems();
 
             // Then
-            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(CandidateId))
+            A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId))
                 .MustHaveHappenedOnceExactly();
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/RecommendedLearningControllerTests.cs
@@ -97,7 +97,7 @@
                 A.CallTo(
                     () => recommendedLearningService.GetRecommendedLearningForSelfAssessment(
                         SelfAssessmentId,
-                        DelegateId
+                        DelegateUserId
                     )
                 ).MustHaveHappenedOnceExactly();
                 result.Should().BeViewResult().WithViewName("RecommendedLearning");
@@ -109,7 +109,7 @@
         {
             // Given
             const int resourceReferenceId = 1;
-            A.CallTo(() => actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, DelegateId))
+            A.CallTo(() => actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, DelegateUserId))
                 .Returns(false);
 
             // When
@@ -131,7 +131,7 @@
         {
             // Given
             const int resourceReferenceId = 1;
-            A.CallTo(() => actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, DelegateId))
+            A.CallTo(() => actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, DelegateUserId))
                 .Returns(true);
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -224,7 +224,6 @@
                     () => selfAssessmentService.SetResultForCompetency(
                         competencyId,
                         selfAssessment.Id,
-                        CandidateId,
                         DelegateUserId,
                         assessmentQuestionId,
                         assessmentQuestionResult,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Signposting/SignpostingControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Signposting/SignpostingControllerTests.cs
@@ -14,6 +14,7 @@
     public class SignpostingControllerTests
     {
         private const int DelegateId = 5;
+        private const int DelegateUserId = 2;
         private const int ResourceReferenceId = 10;
         private IActionPlanService actionPlanService = null!;
         private SignpostingController controller = null!;
@@ -52,7 +53,7 @@
             A.CallTo(
                     () => actionPlanService.UpdateActionPlanResourcesLastAccessedDateIfPresent(
                         ResourceReferenceId,
-                        DelegateId
+                        DelegateUserId
                     )
                 )
                 .MustHaveHappenedOnceExactly();

--- a/DigitalLearningSolutions.Web.Tests/Services/ActionPlanServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ActionPlanServiceTests.cs
@@ -23,6 +23,7 @@
     {
         private const int GenericLearningLogItemId = 1;
         private const int GenericDelegateId = 2;
+        private const int delegateUserId = 2;
         private const int GenericLearningHubResourceReferenceId = 3;
         private const int GenericLearningResourceReferenceId = 33;
 
@@ -160,7 +161,7 @@
             GetIncompleteActionPlanResources_returns_empty_list_if_no_incomplete_learning_log_items_found()
         {
             // Given
-            const int delegateId = 1;
+            const int delegateUserId = 2;
             var invalidLearningLogItems = Builder<LearningLogItem>.CreateListOfSize(3)
                 .All().With(i => i.CompletedDate = null).And(i => i.ArchivedDate = null)
                 .And(i => i.LearningHubResourceReferenceId = 1)
@@ -168,11 +169,11 @@
                 .TheNext(1).With(i => i.Activity = "removed").And(i => i.ArchivedDate = DateTime.UtcNow)
                 .TheNext(1).With(i => i.Activity = "no resource link").And(i => i.LearningHubResourceReferenceId = null)
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(invalidLearningLogItems);
 
             // When
-            var result = await actionPlanService.GetIncompleteActionPlanResources(delegateId);
+            var result = await actionPlanService.GetIncompleteActionPlanResources(delegateUserId);
 
             // Then
             result.resources.Should().BeEmpty();
@@ -185,7 +186,7 @@
         public async Task GetIncompleteActionPlanResources_returns_correctly_matched_action_plan_items()
         {
             // Given
-            const int delegateId = 1;
+            const int delegateUserId = 2;
             var learningLogIds = new List<int> { 4, 5, 6, 7, 8 };
             var learningResourceIds = new List<int> { 15, 21, 33, 48, 51 };
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(5).All()
@@ -194,12 +195,12 @@
                 .And((i, index) => i.LearningHubResourceReferenceId = learningResourceIds[index])
                 .And((i, index) => i.LearningLogItemId = learningLogIds[index])
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(learningLogItems);
             GivenLearningHubResourceServiceBulkResponseReturnsExpectedResources(learningResourceIds);
 
             // When
-            var result = await actionPlanService.GetIncompleteActionPlanResources(delegateId);
+            var result = await actionPlanService.GetIncompleteActionPlanResources(delegateUserId);
 
             // Then
             result.apiIsAccessible.Should().BeFalse();
@@ -210,7 +211,7 @@
         public async Task GetCompletedActionPlanResources_returns_empty_list_if_no_completed_learning_log_items_found()
         {
             // Given
-            const int delegateId = 1;
+            const int delegateUserId = 2;
             var invalidLearningLogItems = Builder<LearningLogItem>.CreateListOfSize(3)
                 .All().With(i => i.CompletedDate = DateTime.UtcNow).And(i => i.ArchivedDate = null)
                 .And(i => i.LearningHubResourceReferenceId = 1)
@@ -218,11 +219,11 @@
                 .TheNext(1).With(i => i.Activity = "removed").And(i => i.ArchivedDate = DateTime.UtcNow)
                 .TheNext(1).With(i => i.Activity = "no resource link").And(i => i.LearningHubResourceReferenceId = null)
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(invalidLearningLogItems);
 
             // When
-            var result = await actionPlanService.GetCompletedActionPlanResources(delegateId);
+            var result = await actionPlanService.GetCompletedActionPlanResources(delegateUserId);
 
             // Then
             result.resources.Should().BeEmpty();
@@ -235,7 +236,7 @@
         public async Task GetCompleteActionPlanResources_returns_correctly_matched_action_plan_items()
         {
             // Given
-            const int delegateId = 1;
+            const int delegateUserId = 2;
             var learningLogIds = new List<int> { 4, 5, 6, 7, 8 };
             var learningResourceIds = new List<int> { 15, 21, 33, 48, 51 };
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(5).All()
@@ -244,12 +245,12 @@
                 .And((i, index) => i.LearningHubResourceReferenceId = learningResourceIds[index])
                 .And((i, index) => i.LearningLogItemId = learningLogIds[index])
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(learningLogItems);
             GivenLearningHubResourceServiceBulkResponseReturnsExpectedResources(learningResourceIds);
 
             // When
-            var result = await actionPlanService.GetCompletedActionPlanResources(delegateId);
+            var result = await actionPlanService.GetCompletedActionPlanResources(delegateUserId);
 
             // Then
             result.apiIsAccessible.Should().BeFalse();
@@ -261,7 +262,7 @@
             GetCompleteActionPlanResources_returns_correctly_matched_action_plan_items_with_repeated_resource()
         {
             // Given
-            const int delegateId = 1;
+            const int delegateUserId = 2;
             var learningLogIds = new List<int> { 4, 5, 6 };
             var learningResourceIds = new List<int> { 15, 26, 15 };
             var expectedLearningResourceIdsUsedInApiCall = new List<int> { 15, 26 };
@@ -271,7 +272,7 @@
                 .And((i, index) => i.LearningHubResourceReferenceId = learningResourceIds[index])
                 .And((i, index) => i.LearningLogItemId = learningLogIds[index])
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(learningLogItems);
             var matchedResources = Builder<ResourceReferenceWithResourceDetails>.CreateListOfSize(2).All()
                 .With((r, index) => r.RefId = learningResourceIds[index])
@@ -290,7 +291,7 @@
                 .Returns((bulkReturnedItems, false));
 
             // When
-            var result = await actionPlanService.GetCompletedActionPlanResources(delegateId);
+            var result = await actionPlanService.GetCompletedActionPlanResources(delegateUserId);
 
             // Then
             List<(int id, string title)> resultIdsAndTitles = result.resources.Select(r => (r.Id, r.Name)).ToList();
@@ -317,7 +318,7 @@
             // Given
             var testDate = new DateTime(2021, 12, 2);
             A.CallTo(() => clockUtility.UtcNow).Returns(testDate);
-            const int delegateId = 2;
+            const int delegateUserId = 2;
             const int resourceReferenceId = 3;
             var expectedLearningLogItemIdsToUpdate = new[] { 1, 4 };
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(4).All()
@@ -329,14 +330,14 @@
                 .TheNext(1).With(i => i.ArchivedDate = DateTime.UtcNow)
                 .TheNext(1).With(i => i.LearningHubResourceReferenceId = resourceReferenceId + 100)
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(learningLogItems);
 
             // When
-            actionPlanService.UpdateActionPlanResourcesLastAccessedDateIfPresent(resourceReferenceId, delegateId);
+            actionPlanService.UpdateActionPlanResourcesLastAccessedDateIfPresent(resourceReferenceId, delegateUserId);
 
             // Then
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .MustHaveHappenedOnceExactly();
             foreach (var id in expectedLearningLogItemIdsToUpdate)
             {
@@ -537,11 +538,11 @@
         public void ResourceCanBeAddedToActionPlan_returns_true_with_no_learning_log_records()
         {
             // Given
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(GenericDelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(new List<LearningLogItem>());
 
             // When
-            var result = actionPlanService.ResourceCanBeAddedToActionPlan(1, GenericDelegateId);
+            var result = actionPlanService.ResourceCanBeAddedToActionPlan(1, delegateUserId);
 
             // Then
             result.Should().BeTrue();
@@ -557,13 +558,13 @@
                 .And(i => i.LearningResourceReferenceId = GenericLearningResourceReferenceId)
                 .And(i => i.ArchivedDate = null)
                 .And(i => i.CompletedDate = DateTime.UtcNow).Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(GenericDelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(learningLogItems);
 
             // When
             var result = actionPlanService.ResourceCanBeAddedToActionPlan(
                 GenericLearningResourceReferenceId,
-                GenericDelegateId
+                delegateUserId
             );
 
             // Then
@@ -585,13 +586,13 @@
                 .And(i => i.LearningResourceReferenceId = GenericLearningResourceReferenceId)
                 .And(i => i.ArchivedDate = null)
                 .And(i => i.CompletedDate = DateTime.UtcNow).Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(GenericDelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(delegateUserId))
                 .Returns(learningLogItems);
 
             // When
             var result = actionPlanService.ResourceCanBeAddedToActionPlan(
                 GenericLearningResourceReferenceId,
-                GenericDelegateId
+                delegateUserId
             );
 
             // Then

--- a/DigitalLearningSolutions.Web.Tests/Services/RecommendedLearningServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/RecommendedLearningServiceTests.cs
@@ -23,6 +23,7 @@
         private const int LearningResourceReferenceId = 3;
         private const int LearningHubResourceReferenceId = 4;
         private const int DelegateId = 5;
+        private const int DelegateUserId = 2;
         private const int LearningLogId = 6;
         private const int CompetencyLearningResourceId = 1;
         private const int SecondCompetencyLearningResourceId = 2;
@@ -68,14 +69,14 @@
             GivenQuestionParametersAreReturned(true, true, 1, 10);
             GivenSelfAssessmentHasResultsForFirstCompetency(5, 5);
 
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateUserId))
                 .Returns(new List<LearningLogItem>());
 
             var expectedResource = GetExpectedResource(false, false, null, 175);
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -95,14 +96,14 @@
             var learningLogItems = Builder<LearningLogItem>.CreateListOfSize(5).All()
                 .With(i => i.LearningHubResourceReferenceId = LearningHubResourceReferenceId + 1)
                 .And(i => i.ArchivedDate = null).Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateUserId))
                 .Returns(learningLogItems);
 
             var expectedResource = GetExpectedResource(false, false, null, 175);
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -124,14 +125,14 @@
                 .And(i => i.CompletedDate = DateTime.UtcNow)
                 .And(i => i.LearningLogItemId = LearningLogId)
                 .And(i => i.ArchivedDate = null).Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateUserId))
                 .Returns(new List<LearningLogItem> { learningLogItem });
 
             var expectedResource = GetExpectedResource(false, true, null, 175);
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -153,14 +154,14 @@
                 .And(i => i.CompletedDate = null)
                 .And(i => i.LearningLogItemId = LearningLogId)
                 .And(i => i.ArchivedDate = null).Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateUserId))
                 .Returns(new List<LearningLogItem> { learningLogItem });
 
             var expectedResource = GetExpectedResource(true, false, LearningLogId, 175);
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -187,14 +188,14 @@
                 .TheRest()
                 .With(i => i.CompletedDate = null)
                 .Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateUserId))
                 .Returns(learningLogItems);
 
             var expectedResource = GetExpectedResource(true, true, LearningLogId, 175);
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -222,7 +223,7 @@
             GivenLearningHubApiReturnsResources(0);
 
             // When
-            await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId);
+            await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId);
 
             // Then
             A.CallTo(
@@ -277,7 +278,7 @@
             ).Returns(competencyLearningResources);
 
             // When
-            await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId);
+            await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId);
 
             // Then
             A.CallTo(
@@ -313,7 +314,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -354,7 +355,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -382,7 +383,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -423,7 +424,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -460,7 +461,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -487,7 +488,7 @@
 
             A.CallTo(
                 () => selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-                    DelegateId,
+                    DelegateUserId,
                     SelfAssessmentId,
                     CompetencyId
                 )
@@ -495,7 +496,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -543,7 +544,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -573,7 +574,7 @@
 
             // When
             var result =
-                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateId))
+                (await recommendedLearningService.GetRecommendedLearningForSelfAssessment(SelfAssessmentId, DelegateUserId))
                 .recommendedResources.ToList();
 
             // Then
@@ -667,7 +668,7 @@
                 .And(i => i.CompletedDate = null)
                 .And(i => i.LearningLogItemId = LearningLogId)
                 .And(i => i.ArchivedDate = null).Build();
-            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateId))
+            A.CallTo(() => learningLogItemsDataService.GetLearningLogItems(DelegateUserId))
                 .Returns(new List<LearningLogItem> { learningLogItem });
         }
 
@@ -717,7 +718,7 @@
             var assessmentResults = Builder<SelfAssessmentResult>.CreateListOfSize(2)
                 .All()
                 .With(r => r.SelfAssessmentId = SelfAssessmentId)
-                .And(r => r.CandidateId = DelegateId)
+                .And(r => r.DelegateUserId = DelegateUserId)
                 .And(r => r.CompetencyId = CompetencyId)
                 .TheFirst(1)
                 .With(r => r.AssessmentQuestionId = CompetencyAssessmentQuestionId)
@@ -728,7 +729,7 @@
                 .Build();
             A.CallTo(
                 () => selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-                    DelegateId,
+                    DelegateUserId,
                     SelfAssessmentId,
                     CompetencyId
                 )

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Completed.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Completed.cs
@@ -27,9 +27,10 @@
         {
             sortBy ??= CourseSortByOptions.CompletedDate.PropertyName;
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
             var completedCourses = courseDataService.GetCompletedCourses(delegateId);
             var (completedLearningResources, apiIsAccessible) =
-                await GetCompletedLearningResourcesIfSignpostingEnabled(delegateId);
+                await GetCompletedLearningResourcesIfSignpostingEnabled(delegateUserId);
             var bannerText = GetBannerText();
 
             var allItems = completedCourses.Cast<CompletedLearningItem>().ToList();
@@ -59,14 +60,15 @@
         public async Task<IActionResult> AllCompletedItems()
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
             var completedCourses = courseDataService.GetCompletedCourses(delegateId);
-            var (completedLearningResources, _) = await GetCompletedLearningResourcesIfSignpostingEnabled(delegateId);
+            var (completedLearningResources, _) = await GetCompletedLearningResourcesIfSignpostingEnabled(delegateUserId);
             var model = new AllCompletedItemsPageViewModel(completedCourses, completedLearningResources, config);
             return View("Completed/AllCompletedItems", model);
         }
 
         private async Task<(IList<CompletedActionPlanResource>, bool apiIsAccessible)>
-            GetCompletedLearningResourcesIfSignpostingEnabled(int delegateId)
+            GetCompletedLearningResourcesIfSignpostingEnabled(int delegateUserId)
         {
             if (!config.IsSignpostingUsed())
             {
@@ -74,7 +76,7 @@
             }
 
             var (resources, apiIsAccessible) =
-                await actionPlanService.GetCompletedActionPlanResources(delegateId);
+                await actionPlanService.GetCompletedActionPlanResources(delegateUserId);
             return (resources.Select(r => new CompletedActionPlanResource(r)).ToList(), apiIsAccessible);
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -37,7 +37,7 @@
             var selfAssessments =
                 selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId);
             var (learningResources, apiIsAccessible) =
-                await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
+                await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
 
             var allItems = currentCourses.Cast<CurrentLearningItem>().ToList();
             allItems.AddRange(selfAssessments);
@@ -70,7 +70,7 @@
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var selfAssessment =
                 selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId);
-            var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateId);
+            var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);
             return View("Current/AllCurrentItems", model);
         }
@@ -315,7 +315,7 @@
 
         private async Task<(IList<ActionPlanResource>, bool apiIsAccessible)>
             GetIncompleteActionPlanResourcesIfSignpostingEnabled(
-                int delegateId
+                int delegateUserId
             )
         {
             if (!config.IsSignpostingUsed())
@@ -324,7 +324,7 @@
             }
 
             var (resources, apiIsAccessible) =
-                await actionPlanService.GetIncompleteActionPlanResources(delegateId);
+                await actionPlanService.GetIncompleteActionPlanResources(delegateUserId);
             return (resources.ToList(), apiIsAccessible);
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/RecommendedLearningController.cs
@@ -97,10 +97,10 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/AllRecommendedLearningItems")]
         public async Task<IActionResult> AllRecommendedLearningItems(int selfAssessmentId)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
+            var delegateUserId = User.GetUserIdKnownNotNull();
             var (recommendedResources, _) = await recommendedLearningService.GetRecommendedLearningForSelfAssessment(
                 selfAssessmentId,
-                candidateId
+                delegateUserId
             );
 
             var model = new AllRecommendedLearningItemsViewModel(recommendedResources, selfAssessmentId);
@@ -120,7 +120,7 @@
             var delegateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
 
-            if (!actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, delegateId))
+            if (!actionPlanService.ResourceCanBeAddedToActionPlan(resourceReferenceId, delegateUserId))
             {
                 return NotFound();
             }
@@ -310,10 +310,9 @@
             string? searchString
         )
         {
-            var delegateId = User.GetCandidateIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId)!;
             var (recommendedResources, apiIsAccessible) =
-                await recommendedLearningService.GetRecommendedLearningForSelfAssessment(selfAssessmentId, delegateId);
+                await recommendedLearningService.GetRecommendedLearningForSelfAssessment(selfAssessmentId, delegateUserId);
 
             var searchSortPaginationOptions = new SearchSortFilterAndPaginateOptions(
                 new SearchOptions(searchString),

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -148,7 +148,6 @@
             int? competencyGroupId
         )
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             if (assessment == null)
@@ -171,7 +170,7 @@
             }
             else
             {
-                return SubmitSelfAssessment(assessment, selfAssessmentId, competencyNumber, competencyId, competencyGroupId, candidateId, assessmentQuestions, delegateUserId);
+                return SubmitSelfAssessment(assessment, selfAssessmentId, competencyNumber, competencyId, competencyGroupId, assessmentQuestions, delegateUserId);
             }
         }
 
@@ -220,11 +219,10 @@
         {
             if (model.IsChecked)
             {
-                var candidateId = User.GetCandidateIdKnownNotNull();
                 var delegateUserId = User.GetUserIdKnownNotNull();
                 var assessmentQuestions = JsonSerializer.Deserialize<List<AssessmentQuestion>>(TempData["assessmentQuestions"] as string);
                 var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
-                return SubmitSelfAssessment(assessment, selfAssessmentId, competencyNumber, competencyId, competencyGroupId, candidateId, assessmentQuestions, delegateUserId);
+                return SubmitSelfAssessment(assessment, selfAssessmentId, competencyNumber, competencyId, competencyGroupId, assessmentQuestions, delegateUserId);
             }
             else
             {
@@ -246,7 +244,7 @@
             }
         }
 
-        IActionResult SubmitSelfAssessment(CurrentSelfAssessment assessment, int selfAssessmentId, int competencyNumber, int competencyId, int? competencyGroupId, int candidateId, ICollection<AssessmentQuestion> assessmentQuestions,int delegateUserId)
+        IActionResult SubmitSelfAssessment(CurrentSelfAssessment assessment, int selfAssessmentId, int competencyNumber, int competencyId, int? competencyGroupId, ICollection<AssessmentQuestion> assessmentQuestions,int delegateUserId)
         {
             if (assessment == null)
             {
@@ -272,7 +270,6 @@
                     selfAssessmentService.SetResultForCompetency(
                         competencyId,
                         assessment.Id,
-                        candidateId,
                         delegateUserId,
                         assessmentQuestion.Id,
                         assessmentQuestion.Result,

--- a/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Signposting/SignpostingController.cs
@@ -35,7 +35,8 @@
         public async Task<IActionResult> LaunchLearningResource(int resourceReferenceId)
         {
             var delegateId = User.GetCandidateIdKnownNotNull();
-            actionPlanService.UpdateActionPlanResourcesLastAccessedDateIfPresent(resourceReferenceId, delegateId);
+            var delegateUserId = User.GetUserIdKnownNotNull();
+            actionPlanService.UpdateActionPlanResourcesLastAccessedDateIfPresent(resourceReferenceId, delegateUserId);
 
             var delegateUser = userService.GetDelegateUserById(delegateId);
 

--- a/DigitalLearningSolutions.Web/Services/ActionPlanService.cs
+++ b/DigitalLearningSolutions.Web/Services/ActionPlanService.cs
@@ -19,18 +19,18 @@
         Task AddResourceToActionPlan(int learningResourceReferenceId, int delegateId, int selfAssessmentId);
 
         Task<(IEnumerable<ActionPlanResource> resources, bool apiIsAccessible)> GetIncompleteActionPlanResources(
-            int delegateId
+            int delegateUserId
         );
 
         Task<(IEnumerable<ActionPlanResource> resources, bool apiIsAccessible)> GetCompletedActionPlanResources(
-            int delegateId
+            int delegateUserId
         );
 
         Task<(ActionPlanResource? actionPlanResource, bool apiIsAccessible)> GetActionPlanResource(
             int learningLogItemId
         );
 
-        void UpdateActionPlanResourcesLastAccessedDateIfPresent(int resourceReferenceId, int delegateId);
+        void UpdateActionPlanResourcesLastAccessedDateIfPresent(int resourceReferenceId, int delegateUserId);
 
         public void SetCompletionDate(int learningLogItemId, DateTime completedDate);
 
@@ -40,7 +40,7 @@
 
         bool? VerifyDelegateCanAccessActionPlanResource(int learningLogItemId, int delegateId);
 
-        bool ResourceCanBeAddedToActionPlan(int resourceReferenceId, int delegateId);
+        bool ResourceCanBeAddedToActionPlan(int resourceReferenceId, int delegateUserId);
     }
 
     public class ActionPlanService : IActionPlanService
@@ -148,9 +148,9 @@
         }
 
         public async Task<(IEnumerable<ActionPlanResource> resources, bool apiIsAccessible)>
-            GetIncompleteActionPlanResources(int delegateId)
+            GetIncompleteActionPlanResources(int delegateUserId)
         {
-            var incompleteLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId)
+            var incompleteLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateUserId)
                 .Where(
                     i => i.CompletedDate == null && i.ArchivedDate == null
                 ).ToList();
@@ -159,9 +159,9 @@
         }
 
         public async Task<(IEnumerable<ActionPlanResource> resources, bool apiIsAccessible)>
-            GetCompletedActionPlanResources(int delegateId)
+            GetCompletedActionPlanResources(int delegateUserId)
         {
-            var completedLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId)
+            var completedLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateUserId)
                 .Where(
                     i => i.CompletedDate != null && i.ArchivedDate == null
                 ).ToList();
@@ -187,10 +187,10 @@
 
         public void UpdateActionPlanResourcesLastAccessedDateIfPresent(
             int resourceReferenceId,
-            int delegateId
+            int delegateUserId
         )
         {
-            var actionPlanResourcesToUpdate = learningLogItemsDataService.GetLearningLogItems(delegateId).Where(
+            var actionPlanResourcesToUpdate = learningLogItemsDataService.GetLearningLogItems(delegateUserId).Where(
                 r =>
                     r.ArchivedDate == null &&
                     r.LearningHubResourceReferenceId == resourceReferenceId
@@ -239,9 +239,9 @@
             return actionPlanResource.LoggedById == delegateId;
         }
 
-        public bool ResourceCanBeAddedToActionPlan(int resourceReferenceId, int delegateId)
+        public bool ResourceCanBeAddedToActionPlan(int resourceReferenceId, int delegateUserId)
         {
-            var incompleteLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId)
+            var incompleteLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateUserId)
                 .Where(
                     i => i.CompletedDate == null && i.ArchivedDate == null && i.LearningHubResourceReferenceId != null
                 ).ToList();

--- a/DigitalLearningSolutions.Web/Services/RecommendedLearningService.cs
+++ b/DigitalLearningSolutions.Web/Services/RecommendedLearningService.cs
@@ -16,7 +16,7 @@
         Task<(IEnumerable<RecommendedResource> recommendedResources, bool apiIsAccessible)>
             GetRecommendedLearningForSelfAssessment(
                 int selfAssessmentId,
-                int delegateId
+                int delegateUserId
             );
     }
 
@@ -46,7 +46,7 @@
         public async Task<(IEnumerable<RecommendedResource> recommendedResources, bool apiIsAccessible)>
             GetRecommendedLearningForSelfAssessment(
                 int selfAssessmentId,
-                int delegateId
+                int delegateUserId
             )
         {
             var hasMaxSignpostedResources = Int32.TryParse(
@@ -81,12 +81,12 @@
             var resources =
                 learningHubResourceService.GetResourceReferenceDetailsByReferenceIds(uniqueLearningHubReferenceIds);
 
-            var delegateLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateId);
+            var delegateLearningLogItems = learningLogItemsDataService.GetLearningLogItems(delegateUserId);
 
             var recommendedResources = resources.Select(
                     rr => GetPopulatedRecommendedResource(
                         selfAssessmentId,
-                        delegateId,
+                        delegateUserId,
                         resourceReferences[rr.RefId],
                         delegateLearningLogItems,
                         rr,
@@ -116,7 +116,7 @@
 
         private RecommendedResource? GetPopulatedRecommendedResource(
             int selfAssessmentId,
-            int delegateId,
+            int delegateUserId,
             int learningHubResourceReferenceId,
             IEnumerable<LearningLogItem> delegateLearningLogItems,
             ResourceReferenceWithResourceDetails rr,
@@ -142,7 +142,7 @@
                 clrsForResource,
                 competencyResourceAssessmentQuestionParameters,
                 selfAssessmentId,
-                delegateId
+                delegateUserId
             ))
             {
                 return null;
@@ -158,7 +158,7 @@
                     clrsForResource,
                     competencyResourceAssessmentQuestionParameters,
                     selfAssessmentId,
-                    delegateId
+                    delegateUserId
                 )
             );
         }
@@ -167,14 +167,14 @@
             List<CompetencyLearningResource> clrsForResource,
             List<CompetencyResourceAssessmentQuestionParameter> competencyResourceAssessmentQuestionParameters,
             int selfAssessmentId,
-            int delegateId
+            int delegateUserId
         )
         {
             foreach (var competencyLearningResource in clrsForResource)
             {
                 var delegateResults = selfAssessmentDataService
                     .GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-                        delegateId,
+                        delegateUserId,
                         selfAssessmentId,
                         competencyLearningResource.CompetencyId
                     ).ToList();
@@ -213,7 +213,7 @@
             List<CompetencyLearningResource> clrsForResource,
             List<CompetencyResourceAssessmentQuestionParameter> competencyResourceAssessmentQuestionParameters,
             int selfAssessmentId,
-            int delegateId
+            int delegateUserId
         )
         {
             var essentialnessValue = CalculateEssentialnessValue(competencyResourceAssessmentQuestionParameters);
@@ -224,7 +224,7 @@
                 clrsForResource,
                 competencyResourceAssessmentQuestionParameters,
                 selfAssessmentId,
-                delegateId
+                delegateUserId
             );
 
             return essentialnessValue + learningHubRating * 4 + requirementAdjuster;
@@ -242,7 +242,7 @@
             List<CompetencyLearningResource> competencyLearningResources,
             List<CompetencyResourceAssessmentQuestionParameter> competencyResourceAssessmentQuestionParameters,
             int selfAssessmentId,
-            int delegateId
+            int delegateUserId
         )
         {
             var requirementAdjusters = new List<decimal>();
@@ -261,7 +261,7 @@
 
                 var delegateResults = selfAssessmentDataService
                     .GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
-                        delegateId,
+                        delegateUserId,
                         selfAssessmentId,
                         competencyLearningResource.CompetencyId
                     ).ToList();

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -53,7 +53,6 @@
         void SetResultForCompetency(
             int competencyId,
             int selfAssessmentId,
-            int candidateId,
             int delegateUserId,
             int assessmentQuestionId,
             int? result,
@@ -362,7 +361,6 @@
         public void SetResultForCompetency(
             int competencyId,
             int selfAssessmentId,
-            int candidateId,
             int delegateUserId,
             int assessmentQuestionId,
             int? result,
@@ -372,7 +370,6 @@
             selfAssessmentDataService.SetResultForCompetency(
                 competencyId,
                 selfAssessmentId,
-                candidateId,
                 delegateUserId,
                 assessmentQuestionId,
                 result,


### PR DESCRIPTION
JIRA link
https://hee-tis.atlassian.net/browse/TD-912

### Description
DelegateUserId column added to SelfAssessmentResults populated with userId based on CandidateID
Code modified to replace CandidateID

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
