### PR TITLE
TD-849 validation message when user roles are not selected during promote to admin

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -90,13 +90,12 @@
         public IActionResult Index(AdminRolesFormData formData, int delegateId)
         {
             var adminRoles = formData.GetAdminRoles();
+
             if (!(adminRoles.IsCentreAdmin ||
                 adminRoles.IsSupervisor ||
                 adminRoles.IsNominatedSupervisor ||
                 adminRoles.IsContentCreator ||
                 adminRoles.IsTrainer ||
-                adminRoles.IsContentManager ||
-                adminRoles.ImportOnly ||
                 adminRoles.IsCentreManager))
             {
                 var centreId = User.GetCentreIdKnownNotNull();
@@ -116,7 +115,7 @@
                                 categories,
                                 numberOfAdmins
                             );
-
+                model.ContentManagementRole = formData.ContentManagementRole;
                 ModelState.Clear();
                 ModelState.AddModelError("IsCenterManager", $"Delegate must have one role to be promoted to Admin.");
                 return View(model);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-849

### Description
Implements validation message when user roles are not selected during promote to admin.

### Screenshots
https://hee-tis.atlassian.net/browse/TD-849

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
