### PR TITLE
Develop/fix/td 260 passporting fix learning portal bug fix

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -305,7 +305,7 @@
                 PreviousCompetencyNumber = 2,
                 SupervisorSignOffs = supervisorSignOffs,
                 SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
-                AllQuestionsVerifiedOrNotRequired = false
+                AllQuestionsVerifiedOrNotRequired = true
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);
@@ -368,7 +368,7 @@
                 PreviousCompetencyNumber = 1,
                 SupervisorSignOffs = supervisorSignOffs,
                 SearchViewModel = new SearchSelfAssessmentOvervieviewViewModel(null, SelfAssessmentId, selfAssessment.Vocabulary, false, false, null),
-                AllQuestionsVerifiedOrNotRequired = false
+                AllQuestionsVerifiedOrNotRequired = true
             };
             A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(DelegateUserId, SelfAssessmentId))
                 .Returns(selfAssessment);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -737,7 +737,7 @@
                 var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(
                     (int)supervisorDelegateId,
                     0,
-                    GetCandidateId()
+                    delegateUserId
                 );
                 if (supervisorDelegate.SupervisorAdminID != null)
                 {
@@ -868,7 +868,7 @@
             var delegateEntity = userDataService.GetDelegateById(candidateId);
             var supervisorDelegateId = supervisorService.AddSuperviseDelegate(
                 sessionAddSupervisor.SupervisorAdminId,
-                candidateId,
+                delegateUserId,
                 delegateEntity!.EmailForCentreNotifications,
                 sessionAddSupervisor.SupervisorEmail ?? throw new InvalidOperationException(),
                 User.GetCentreIdKnownNotNull()
@@ -882,7 +882,7 @@
             frameworkNotificationService.SendDelegateSupervisorNominated(
                 supervisorDelegateId,
                 sessionAddSupervisor.SelfAssessmentID,
-                candidateId
+                delegateUserId
             );
             return RedirectToAction("ManageSupervisors", new { sessionAddSupervisor.SelfAssessmentID });
         }
@@ -898,7 +898,7 @@
             frameworkNotificationService.SendDelegateSupervisorNominated(
                 supervisorDelegateId,
                 selfAssessmentId,
-                User.GetCandidateIdKnownNotNull()
+                User.GetUserIdKnownNotNull()
             );
             return RedirectToAction("ManageSupervisors", new { selfAssessmentId });
         }
@@ -1165,7 +1165,7 @@
                 candidateAssessmentSupervisorId,
                 selfAssessmentId,
                 1,
-                User.GetCandidateIdKnownNotNull(),
+                User.GetUserIdKnownNotNull(),
                 selfAssessmentResultId
             );
             supervisorService.UpdateSelfAssessmentResultSupervisorVerificationsEmailSent(supervisorVerificationId);
@@ -1221,7 +1221,7 @@
                     candidateAssessmentSupervisorId,
                     sessionRequestVerification.SelfAssessmentID,
                     resultCount,
-                    User.GetCandidateIdKnownNotNull()
+                    User.GetUserIdKnownNotNull()
                 );
             }
 
@@ -1304,7 +1304,6 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{vocabulary}/RequestSignOff")]
         public IActionResult RequestSignOff(int selfAssessmentId, string vocabulary, RequestSignOffViewModel model)
         {
-            var candidateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             if (!ModelState.IsValid)
             {
@@ -1325,7 +1324,7 @@
             frameworkNotificationService.SendSignOffRequest(
                 model.CandidateAssessmentSupervisorId,
                 selfAssessmentId,
-                candidateId
+                delegateUserId
             );
             return RedirectToAction("SelfAssessmentOverview", new { selfAssessmentId, vocabulary });
         }
@@ -1340,7 +1339,7 @@
             frameworkNotificationService.SendSignOffRequest(
                 candidateAssessmentSupervisorId,
                 selfAssessmentId,
-                User.GetCandidateIdKnownNotNull()
+                User.GetUserIdKnownNotNull()
             );
             selfAssessmentService.UpdateCandidateAssessmentSupervisorVerificationEmailSent(
                 candidateAssessmentSupervisorVerificationId

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -461,6 +461,9 @@
                 SupervisorSignOffs = supervisorSignOffs,
                 SearchViewModel = searchViewModel
             };
+
+            model.Initialise(recentResults);
+
             if (searchModel != null)
             {
                 searchModel.IsSupervisorResultsReviewed = assessment.IsSupervisorResultsReviewed;

--- a/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
@@ -15,14 +15,14 @@
         void SendReviewRequest(int id, int invitedByAdminId, bool required, bool reminder);
         void SendReviewOutcomeNotification(int reviewId);
         void SendSupervisorDelegateInvite(int supervisorDelegateId, int adminId);
-        void SendSupervisorDelegateConfirmed(int superviseDelegateId, int adminId, int delegateId);
+        void SendSupervisorDelegateConfirmed(int superviseDelegateId, int adminId, int delegateUserId);
         void SendSupervisorResultReviewed(int adminId, int supervisorDelegateId, int candidateAssessmentId, int resultId);
         void SendSupervisorEnroledDelegate(int adminId, int supervisorDelegateId, int candidateAssessmentId, DateTime? completeByDate);
         void SendReminderDelegateSelfAssessment(int adminId, int supervisorDelegateId, int candidateAssessmentId);
         void SendSupervisorMultipleResultsReviewed(int adminId, int supervisorDelegateId, int candidateAssessmentId, int countResults);
-        void SendDelegateSupervisorNominated(int supervisorDelegateId, int selfAssessmentID, int delegateId, int? selfAssessmentResultId = null);
-        void SendResultVerificationRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int resultCount, int delegateId, int? selfAssessmentResultId = null);
-        void SendSignOffRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int delegateId);
+        void SendDelegateSupervisorNominated(int supervisorDelegateId, int selfAssessmentID, int delegateUserId, int? selfAssessmentResultId = null);
+        void SendResultVerificationRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int resultCount, int delegateUserId, int? selfAssessmentResultId = null);
+        void SendSignOffRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int delegateUserId);
         void SendProfileAssessmentSignedOff(int supervisorDelegateId, int candidateAssessmentId, string? supervisorComments, bool signedOff, int adminId);
     }
 
@@ -218,9 +218,9 @@
             }
         }
 
-        public void SendSupervisorDelegateConfirmed(int supervisorDelegateId, int adminId, int delegateId)
+        public void SendSupervisorDelegateConfirmed(int supervisorDelegateId, int adminId, int delegateUserId)
         {
-            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, adminId, delegateId);
+            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, adminId, delegateUserId);
             string emailSubjectLine = "Supervisor Confirmed - Digital Learning Solutions";
             var builder = new BodyBuilder();
             builder.TextBody = $@"Dear {supervisorDelegate.FirstName}
@@ -298,9 +298,9 @@ If this looks like a mistake, please contact {supervisorDelegate.SupervisorName}
             emailService.SendEmail(new Email(emailSubjectLine, builder, supervisorDelegate.DelegateEmail));
         }
 
-        public void SendDelegateSupervisorNominated(int supervisorDelegateId, int selfAssessmentID, int delegateId, int? selfAssessmentResultId = null)
+        public void SendDelegateSupervisorNominated(int supervisorDelegateId, int selfAssessmentID, int delegateUserId, int? selfAssessmentResultId = null)
         {
-            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateId);
+            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateUserId);
             if (supervisorDelegate == null || supervisorDelegate.DelegateUserID == null || supervisorDelegate.SupervisorAdminID == null)
             {
                 return;
@@ -327,12 +327,12 @@ If this looks like a mistake, please contact {supervisorDelegate.SupervisorName}
             return dlsUrlBuilder.Uri.ToString();
         }
 
-        public void SendResultVerificationRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int resultCount, int delegateId, int? selfAssessmentResultId)
+        public void SendResultVerificationRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int resultCount, int delegateUserId, int? selfAssessmentResultId)
         {
             var candidateAssessmentSupervisor = supervisorService.GetCandidateAssessmentSupervisorById(candidateAssessmentSupervisorId);
             int supervisorDelegateId = candidateAssessmentSupervisor.SupervisorDelegateId;
             int candidateAssessmentId = candidateAssessmentSupervisor.CandidateAssessmentID;
-            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateId);
+            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateUserId);
             var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID);
             string emailSubjectLine = $"{delegateSelfAssessment.SupervisorRoleTitle} Self Assessment Results Review Request - Digital Learning Solutions";
             string? profileReviewUrl = GetSupervisorProfileReviewUrl(supervisorDelegateId, candidateAssessmentId, selfAssessmentResultId);
@@ -344,12 +344,12 @@ If this looks like a mistake, please contact {supervisorDelegate.SupervisorName}
             emailService.SendEmail(new Email(emailSubjectLine, builder, supervisorDelegate.SupervisorEmail));
         }
 
-        public void SendSignOffRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int delegateId)
+        public void SendSignOffRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int delegateUserId)
         {
             var candidateAssessmentSupervisor = supervisorService.GetCandidateAssessmentSupervisorById(candidateAssessmentSupervisorId);
             int supervisorDelegateId = candidateAssessmentSupervisor.SupervisorDelegateId;
             int candidateAssessmentId = candidateAssessmentSupervisor.CandidateAssessmentID;
-            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateId);
+            var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateUserId);
             var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID);
             string emailSubjectLine = $"{delegateSelfAssessment.SupervisorRoleTitle} Self Assessment Sign-off Request - Digital Learning Solutions";
             string? profileReviewUrl = GetSupervisorProfileReviewUrl(supervisorDelegateId, candidateAssessmentId);


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-260

**Description**
CandidateId replaced with DelegateUserId.

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
