### PR TITLE
TD-850: Enrol delegate on activity/assessment tempdata model Id problem

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SessionData/Supervisor/SessionEnrolOnRoleProfile.cs
+++ b/DigitalLearningSolutions.Data/Models/SessionData/Supervisor/SessionEnrolOnRoleProfile.cs
@@ -3,11 +3,6 @@
     using System;
     public class SessionEnrolOnRoleProfile
     {
-        public SessionEnrolOnRoleProfile()
-        {
-            Id = new Guid();
-        }
-        public Guid Id { get; set; }
         public int? SelfAssessmentID { get; set; }
         public DateTime? CompleteByDate { get; set; }
         public int? SelfAssessmentSupervisorRoleId { get; set; }

--- a/DigitalLearningSolutions.Data/Models/SessionData/Tracking/Deligate/Enrol/SessionEnrolDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SessionData/Tracking/Deligate/Enrol/SessionEnrolDelegate.cs
@@ -3,11 +3,6 @@
     using System;
     public class SessionEnrolDelegate
     {
-        public SessionEnrolDelegate()
-        {
-            Id = new Guid();
-        }
-        public Guid Id { get; set; }
         public int? AssessmentID { get; set; }
         public string? AssessmentName { get; set; }
         public DateTime? CompleteByDate { get; set; }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-850

### Description
Id column has been removed from below models
1. SessionEnrolDelegate
2. SessionEnrolOnRoleProfile

### Screenshots
1.  Supervise → Enrol staff member on self assessment transaction

Before:
![image](https://user-images.githubusercontent.com/120369940/214279231-7fe18235-e044-4fde-9b47-87b1ed86b01c.png)

After:
![image](https://user-images.githubusercontent.com/120369940/214279262-2f11c727-bc16-4071-9d85-3902e328da56.png)


2. Tracking System → Delegates → Enrol on activity transaction.

Before:
![image](https://user-images.githubusercontent.com/120369940/214279120-6017f452-c017-4c80-a8fb-0331df2c2a7d.png)
 
After:
![image](https://user-images.githubusercontent.com/120369940/214279207-d30d2d8b-7efa-400c-afb8-7530228f0eb0.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
