### PR TITLE
TD-707 Updated CourseSetup page status tags for consistency

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -72,13 +72,17 @@
         {
             var tags = new List<SearchableTagViewModel>();
 
-            if (courseStatistics.Active)
+            if (courseStatistics.Archived)
             {
-                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsActive));
+                tags.Add(new SearchableTagViewModel("Archived", string.Empty, CourseStatusFilterOptions.IsArchived.TagStatus));
+            }
+            else if (courseStatistics.Active)
+            {
+                tags.Add(new SearchableTagViewModel("Active", string.Empty, CourseStatusFilterOptions.IsActive.TagStatus));
             }
             else
             {
-                tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsInactive));
+                tags.Add(new SearchableTagViewModel("Inactive", string.Empty, CourseStatusFilterOptions.IsInactive.TagStatus));
             }
 
             if (courseStatistics.HideInLearnerPortal)
@@ -92,6 +96,7 @@
 
             return tags;
         }
+
 
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForDelegateCourses(
             CourseStatistics courseStatistics


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-707

### Description
Updated TrackingSystem/CourseSetup course status tags to be consistent with Delegates/Courses page. Previously the tags were displayed as a combined 'Inactive/archived' tag; now they are displayed individually (Active or Inactive or Archived).

### Screenshots
Screenshots below.

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
