### PR TITLE
TD-798 Error message missing on 'Confirm Remove Staff Member' when cl…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/RemoveConfirm.cshtml
@@ -15,7 +15,7 @@
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
+  <div class="nhsuk-grid-column-full word-break">
     @if (errorHasOccurred)
     {
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />


### PR DESCRIPTION
…icked Remove' button before confirming it

### JIRA link
https://hee-tis.atlassian.net/browse/TD-798

### Description
The page is not properly displayed in mobile view when the email address is longer.

### Screenshots

![Error-My-Staff-Confirm-Remove-Digital-Learning-Solutions](https://user-images.githubusercontent.com/111436026/214824643-29c6c2b3-33ed-44e2-a56e-876ba3865677.png)
![WavePlugin](https://user-images.githubusercontent.com/111436026/214824645-24b98e6b-eac3-46e1-92a1-0c90e57dce81.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
