### PR TITLE
TD-1046-Passporting: Issue with the Completed/Available Activities links on the 'Learning Portal'

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/CloseTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/CloseTests.cs
@@ -10,8 +10,9 @@
         [Test]
         public void Close_should_close_sessions()
         {
+            var learningActivity = "Current";
             // When
-            controller.Close();
+            controller.Close(learningActivity);
 
             // Then
             A.CallTo(() => sessionService.StopDelegateSession(CandidateId, httpContextSession)).MustHaveHappenedOnceExactly();
@@ -23,8 +24,9 @@
         [Test]
         public void Close_should_redirect_to_Current_LearningPortal()
         {
+            var learningActivity = "Current";
             // When
-            var result = controller.Close();
+            var result = controller.Close(learningActivity);
 
             // Then
             result.Should()

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -154,11 +154,12 @@
             }
         }
             [Route("/LearningMenu/Close")]
-        public IActionResult Close()
+        public IActionResult Close(string learningActivity)
         {
+            var action = string.IsNullOrEmpty(learningActivity) ? "Current" : learningActivity;
             sessionService.StopDelegateSession(User.GetCandidateIdKnownNotNull(), HttpContext.Session);
 
-            return RedirectToAction("Current", "LearningPortal");
+            return RedirectToAction(action, "LearningPortal");
         }
 
         [Route("/LearningMenu/{customisationId:int}/{sectionId:int}")]

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Available.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Available.cs
@@ -16,6 +16,7 @@
             int page = 1
         )
         {
+            TempData["LearningActivity"] = "Available";
             sortBy ??= CourseSortByOptions.Name.PropertyName;
 
             var availableCourses = courseDataService.GetAvailableCourses(

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Completed.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Completed.cs
@@ -25,6 +25,7 @@
             int page = 1
         )
         {
+            TempData["LearningActivity"] = "Completed";
             sortBy ??= CourseSortByOptions.CompletedDate.PropertyName;
             var delegateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -29,6 +29,7 @@
             int page = 1
         )
         {
+            TempData["LearningActivity"] = "Current";
             sortBy ??= CourseSortByOptions.LastAccessed.PropertyName;
             var delegateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Completion/Completion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Completion/Completion.cshtml
@@ -17,12 +17,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item">Completion summary</li>
       </ol>
@@ -43,36 +44,36 @@
   @if (Model.ShowDiagnosticScore)
   {
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Diagnostic Score
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.DiagnosticScore%
-      </dd>
+    <dt class="nhsuk-summary-list__key">
+      Diagnostic Score
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.DiagnosticScore%
+    </dd>
     </div>
   }
 
   @if (Model.ShowPercentageTutorialsCompleted)
   {
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Learning Completed
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.PercentageTutorialsCompleted%
-      </dd>
+    <dt class="nhsuk-summary-list__key">
+      Learning Completed
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.PercentageTutorialsCompleted%
+    </dd>
     </div>
   }
 
   @if (Model.IsAssessed)
   {
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Assessments Passed
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.PostLearningPasses out of @Model.SectionCount
-      </dd>
+    <dt class="nhsuk-summary-list__key">
+      Assessments Passed
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      @Model.PostLearningPasses out of @Model.SectionCount
+    </dd>
     </div>
   }
 </dl>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
@@ -16,12 +16,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.Title</li>
       </ol>
       <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link" asp-action="Close">Return to current activities</a></p>
@@ -46,9 +47,9 @@
       </label>
       @if (Context.Request.Query["error"] == "True")
       {
-    <span class="nhsuk-error-message" id="password-error-error">
-      <span class="nhsuk-u-visually-hidden">Error:</span> The password was incorrect.
-    </span>
+        <span class="nhsuk-error-message" id="password-error-error">
+          <span class="nhsuk-u-visually-hidden">Error:</span> The password was incorrect.
+        </span>
       }
       <input required autofocus class="nhsuk-input nhsuk-input--width-20" id="Password" name="Password" type="password" aria-describedby="example-with-hint-text-hint">
     </div>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -16,12 +16,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item">Diagnostic assessment</li>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/DiagnosticContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/DiagnosticContent.cshtml
@@ -17,12 +17,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Diagnostic" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Diagnostic assessment</a></li>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -16,12 +16,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.Title</li>
       </ol>
       <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link" asp-action="Close">Return to current activities</a></p>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -13,6 +13,7 @@
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.CustomisationId}";
   ViewData["HeaderPathName"] = Model.CourseTitle;
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
@@ -22,7 +23,7 @@
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item">Post learning assessment</li>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearningContent.cshtml
@@ -17,12 +17,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="PostLearning" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">Post learning assessment</a></li>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -17,12 +17,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.SectionName</li>
       </ol>
@@ -44,7 +45,7 @@
     <h1 id="page-heading" class="nhsuk-heading-xl">@Model.SectionName</h1>
     @if (!Model.OtherSectionsExist)
     {
-  <p class="nhsuk-u-font-size-24">@Model.CourseDescription</p>
+      <p class="nhsuk-u-font-size-24">@Model.CourseDescription</p>
     }
     @if (Model.ShowPercentComplete)
     {

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/ContentViewer.cshtml
@@ -14,6 +14,7 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningMenu/contentViewer.css")" asp-append-version="true">
 
@@ -21,7 +22,7 @@
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Tutorial" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId" asp-route-tutorialId="@Model.TutorialId">@Model.TutorialName</a></li>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -17,12 +17,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.TutorialName</li>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/TutorialVideo.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/TutorialVideo.cshtml
@@ -16,12 +16,13 @@
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
 }
+@{var learningActivity = TempData["LearningActivity"]?.ToString(); TempData.Keep("LearningActivity");}
 
 @section NavBreadcrumbs {
   <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
     <div class="nhsuk-width-container">
       <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close">Current activities</a></li>
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Index" asp-route-customisationId="@Model.CustomisationId">@Model.CourseTitle</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Section" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId">@Model.SectionName</a></li>
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Tutorial" asp-route-customisationId="@Model.CustomisationId" asp-route-sectionId="@Model.SectionId" asp-route-tutorialId="@Model.TutorialId">@Model.TutorialName</a></li>


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1046

**Description**
Activity link updated for Current, Completed, and Available learning activities.

**Screenshots**
Updated in Jira ticket.

-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
