### PR TITLE
Fixed Export Delegate showing as 'Registered' for the delegates regis…

### DIFF
--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -259,7 +259,7 @@
                 }
             }
 
-            row[RegistrationComplete] = delegateRecord.IsPasswordSet;
+            row[RegistrationComplete] = delegateRecord.IsPasswordSet && string.IsNullOrEmpty(delegateRecord.RegistrationConfirmationHash);
             row[Active] = delegateRecord.Active;
             row[Approved] = delegateRecord.Approved;
             row[IsAdmin] = delegateRecord.IsAdmin;


### PR DESCRIPTION
…tered by the centre and not claimed their account

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1053

### Description
Fixed export delegate showing as 'Registered' for the delegates registered by the centre and not claimed their account

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
