### PR TITLE
TD-1047:Manage Supervisor page is in loading state when browser back …

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -539,7 +539,7 @@
 
             return View("Current/SetCompleteByDate", model);
         }
-
+        [NoCaching]
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Supervisors")]
         public IActionResult ManageSupervisors(int selfAssessmentId)
         {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1047

### Description
When hit back button from add supervisor page, its shows loading icon instead of moving to previous page.

### Screenshots
Before 
![image](https://user-images.githubusercontent.com/120369940/215799167-487b3ab8-e468-4e1f-b954-0a4d3ce43697.png)
After:
![image](https://user-images.githubusercontent.com/120369940/215799624-a7e4ad0a-bf0a-451f-8942-234347cf26ef.png)

Please note that, issue is not able to reproduce in local dev environment. The issue seems to be because of caching.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
