### PR TITLE
TD-1046-Passporting: Issue with the Completed/Available Activities links on the 'Learning Portal'

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
@@ -25,7 +25,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.Title</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link" asp-action="Close">Return to current activities</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>Return to @learningActivity activities</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Diagnostic/Diagnostic.cshtml
@@ -30,7 +30,7 @@
 
       @if (Model.OnlyItemInOnlySection)
       {
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close" asp-route-learningActivity=@learningActivity>Return to @learningActivity activities</a></p>
       }
       else if (Model.OnlyItemInThisSection)
       {

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -25,7 +25,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>@learningActivity activities</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.Title</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link" asp-action="Close">Return to current activities</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__link" asp-action="Close" asp-route-learningActivity=@learningActivity>Return to @learningActivity activities</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/PostLearning/PostLearning.cshtml
@@ -31,7 +31,7 @@
 
       @if (Model.OnlyItemInOnlySection)
       {
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close" asp-route-learningActivity=@learningActivity>Return to @learningActivity activities</a></p>
       }
       else if (Model.OnlyItemInThisSection)
       {

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Section/Section.cshtml
@@ -34,7 +34,7 @@
       }
       else
       {
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close" asp-route-learningActivity=@learningActivity>Return to @learningActivity activities</a></p>
       }
     </div>
   </nav>

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Tutorial/Tutorial.cshtml
@@ -31,7 +31,7 @@
 
       @if (Model.OnlyItemInOnlySection)
       {
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close">Return to current activities</a></p>
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="Close" asp-route-learningActivity=@learningActivity>Return to @learningActivity activities</a></p>
       }
       else if (Model.OnlyItemInThisSection)
       {


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1046

**Description**
Mobile view - Activity link updated for Current, Completed, and Available learning activities.

**Screenshots**
Updated in Jira ticket

-----
Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors 
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
