### PR TITLE
TD-1051: Educator/Manager Sign off - Send reminder option results in …

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -284,7 +284,8 @@
                         casv.EmailSent,
                         casv.Verified,
                         casv.Comments,
-                        casv.SignedOff
+                        casv.SignedOff,
+                        sd.Removed
                     FROM CandidateAssessmentSupervisorVerifications AS casv
                     INNER JOIN CandidateAssessmentSupervisors AS cas
                         ON casv.CandidateAssessmentSupervisorID = cas.ID

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SupervisorSignOff.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SupervisorSignOff.cs
@@ -13,5 +13,6 @@
         public DateTime? Verified { get; set; }
         public string? Comments { get; set; }
         public bool SignedOff { get; set; }
+        public DateTime? Removed { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -6,88 +6,88 @@
 @if (Model.Any())
 {
   <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      @Model.FirstOrDefault().SupervisorRoleName
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-      @Model.FirstOrDefault().SupervisorName (@Model.FirstOrDefault().SupervisorEmail)
-    </dd>
-    @if ((Model.Count() - 1) > 0)
-    {
-      <dd class="nhsuk-summary-list__actions">
-
-      </dd>
-    }
-    </div>
-
-    <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Status
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-      @if (Model.FirstOrDefault().Verified == null)
-      {
-        <span class="nhsuk-tag">Requested @Model.FirstOrDefault().Requested.Value.ToShortDateString()</span>
-      }
-      else if (Model.FirstOrDefault().SignedOff && Model.FirstOrDefault().Verified != null)
-      {
-        <span class="nhsuk-tag nhsuk-tag--green">Signed off @Model.FirstOrDefault().Verified.Value.ToShortDateString()</span>
-      }
-      else
-      {
-        <span class="nhsuk-tag nhsuk-tag--red">Rejected @Model.FirstOrDefault().Verified.Value.ToShortDateString()</span>
-      }
-    </dd>
-    @if ((Model.Count() - 1) > 0)
-    {
-  <dd class="nhsuk-summary-list__actions">
-    @if ((Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString()))
-    {
-      if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
-      {
-        <a asp-action="SendRequestSignOffReminder" asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-candidateAssessmentSupervisorId="@Model.FirstOrDefault().CandidateAssessmentSupervisorID" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">Send reminder</a>
-
-      }
-    }
-  </dd>
-    }
-
-    </div>
-    <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Comments
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-      @Model.FirstOrDefault().Comments
-    </dd>
-    @if ((Model.Count() - 1) > 0)
-    {
-      <dd class="nhsuk-summary-list__actions">
-
-      </dd>
-    }
-    </div>
-    @if ((Model.Count() - 1) > 0)
-    {
       <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Previous sign off requests
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @(Model.Count() - 1)
-      </dd>
-      <dd class="nhsuk-summary-list__actions">
-        @if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
-        {
-          <a asp-action="SignOffHistory" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">View</a>
-        }
-        else if (ViewContext.RouteData.Values.ContainsKey("supervisorDelegateId"))
-        {
-        <a asp-action="SignOffHistory" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">View</a>
-        }
-      </dd>
+          <dt class="nhsuk-summary-list__key">
+        @Model.FirstOrDefault().SupervisorRoleName
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+        @Model.FirstOrDefault().SupervisorName (@Model.FirstOrDefault().SupervisorEmail)
+          </dd>
+      @if ((Model.Count() - 1) > 0)
+      {
+            <dd class="nhsuk-summary-list__actions">
+
+            </dd>
+      }
       </div>
+
+      <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+              Status
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+        @if (Model.FirstOrDefault().Verified == null)
+        {
+                <span class="nhsuk-tag">Requested @Model.FirstOrDefault().Requested.Value.ToShortDateString()</span>
+        }
+        else if (Model.FirstOrDefault().SignedOff && Model.FirstOrDefault().Verified != null)
+        {
+                <span class="nhsuk-tag nhsuk-tag--green">Signed off @Model.FirstOrDefault().Verified.Value.ToShortDateString()</span>
+        }
+        else
+        {
+                <span class="nhsuk-tag nhsuk-tag--red">Rejected @Model.FirstOrDefault().Verified.Value.ToShortDateString()</span>
+        }
+          </dd>
+      @if ((Model.Count() - 1) > 0)
+      {
+            <dd class="nhsuk-summary-list__actions">
+          @if (((Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString()) && Model.FirstOrDefault().Removed == null))
+          {
+            if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
+            {
+                    <a asp-action="SendRequestSignOffReminder" asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-candidateAssessmentSupervisorId="@Model.FirstOrDefault().CandidateAssessmentSupervisorID" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">Send reminder</a>
+
+            }
+          }
+            </dd>
+      }
+
+      </div>
+      <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">
+              Comments
+          </dt>
+          <dd class="nhsuk-summary-list__value">
+        @Model.FirstOrDefault().Comments
+          </dd>
+      @if ((Model.Count() - 1) > 0)
+      {
+            <dd class="nhsuk-summary-list__actions">
+
+            </dd>
+      }
+      </div>
+    @if ((Model.Count() - 1) > 0)
+    {
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Previous sign off requests
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+          @(Model.Count() - 1)
+            </dd>
+            <dd class="nhsuk-summary-list__actions">
+          @if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
+          {
+                  <a asp-action="SignOffHistory" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">View</a>
+          }
+          else if (ViewContext.RouteData.Values.ContainsKey("supervisorDelegateId"))
+          {
+                  <a asp-action="SignOffHistory" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">View</a>
+          }
+            </dd>
+        </div>
     }
   </dl>
 }


### PR DESCRIPTION
…error

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1051

### Description
Hide the Send Reminder button when the educator or manager was previously included in the passport but is no longer included.

### Screenshots
Before Changes:
![image](https://user-images.githubusercontent.com/121869435/216950730-25d7b9a3-778e-474e-860a-470a53ac4e48.png)
![image](https://user-images.githubusercontent.com/121869435/216950818-d8b9a61c-7bd9-471a-b099-984d2f6d95cb.png)

After Changes:
![image](https://user-images.githubusercontent.com/121869435/216950922-14ec12a4-dd71-44ff-a955-99baa8b36961.png)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
