### PR TITLE
TD-265 Show which centre self-assessments were enrolled by

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -29,7 +29,9 @@
                         CA.UnprocessedUpdates,
                         CA.LaunchCount,
                         1 AS IsSelfAssessment,
-                        CA.SubmittedDate
+                        CA.SubmittedDate,
+                        (SELECT CentreName FROM Centres
+                        WHERE CentreID=MAX(CA.CentreID)) AS CentreName
                     FROM CandidateAssessments CA
                         JOIN SelfAssessments SA
                         ON CA.SelfAssessmentID = SA.ID

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -30,8 +30,7 @@
                         CA.LaunchCount,
                         1 AS IsSelfAssessment,
                         CA.SubmittedDate,
-                        (SELECT CentreName FROM Centres
-                        WHERE CentreID=MAX(CA.CentreID)) AS CentreName
+                        CR.CentreName AS CentreName
                     FROM CandidateAssessments CA
                         JOIN SelfAssessments SA
                         ON CA.SelfAssessmentID = SA.ID
@@ -39,13 +38,15 @@
                         ON CA.SelfAssessmentID = SAS.SelfAssessmentID
                     INNER JOIN Competencies AS C
                         ON SAS.CompetencyID = C.ID
+                    INNER JOIN Centres AS CR
+                        ON CA.CentreID = CR.CentreID
                     WHERE CA.DelegateUserID = @delegateUserId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
                         COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID,
-                        CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate",
+                        CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName",
                 new { delegateUserId }
             );
         }

--- a/DigitalLearningSolutions.Data/Models/StartedLearningItem.cs
+++ b/DigitalLearningSolutions.Data/Models/StartedLearningItem.cs
@@ -10,5 +10,6 @@
         public int Passes { get; set; }
         public int Sections { get; set; }
         public int ProgressID { get; set; }
+        public string CentreName { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/StartedLearningItemViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/StartedLearningItemViewModel.cs
@@ -12,6 +12,7 @@
         public int PassedSections { get; }
         public int Sections { get; }
         public int ProgressId { get; }
+        public string? CentreName { get; }
 
         protected StartedLearningItemViewModel(StartedLearningItem course) : base(course)
         {
@@ -21,6 +22,7 @@
             PassedSections = course.Passes;
             Sections = course.Sections;
             ProgressId = course.ProgressID;
+            CentreName = course.CentreName;
         }
 
         public bool HasDiagnosticScore()

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentCard.cshtml
@@ -2,36 +2,45 @@
 @model SelfAssessmentCardViewModel
 
 <div class="searchable-element nhsuk-panel @Model.DateStyle()" id="@Model.Id-sa-card">
-  <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
-    <summary class="nhsuk-details__summary nhsuk-u-padding-top-0 nhsuk-u-padding-left-0">
-      <span class="nhsuk-u-visually-hidden">@Model.DueByDescription()</span>
-      <span class="nhsuk-details__summary-text searchable-element-title"
-            id="@Model.Id-name-sa"
-            role="heading"
-            aria-level="2">
-        @Model.Name
-      </span>
-    </summary>
-    <div class="nhsuk-details__text nhsuk-u-padding-left-0">
-      <div class="nhsuk-u-padding-left-3">
-        <div class="nhsuk-grid-row">
-          <partial name="Shared/_TagRow" model="@Model" />
+    <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
+        <summary class="nhsuk-details__summary nhsuk-u-padding-top-0 nhsuk-u-padding-left-0">
+            <span class="nhsuk-u-visually-hidden">@Model.DueByDescription()</span>
+            <span class="nhsuk-details__summary-text searchable-element-title"
+                  id="@Model.Id-name-sa"
+                  role="heading"
+                  aria-level="2">
+                @Model.Name
+            </span>
+
+        </summary>
+        <div class="nhsuk-details__text nhsuk-u-padding-left-0">
+            <div class="nhsuk-u-padding-left-3">
+                <div class="nhsuk-grid-row">
+                    <partial name="Shared/_TagRow" model="@Model" />
+                </div>
+                <div class="nhsuk-u-padding-bottom-3">
+                    <span>
+                        <label><b>Enrolled by:  </b></label>
+                        <span>
+                            @Model.CentreName
+                        </span>
+                    </span>
+                </div>
+                <dl class="nhsuk-summary-list">
+                    <partial name="Shared/_Dates" model="@Model" />
+                </dl>
+            </div>
         </div>
-        <dl class="nhsuk-summary-list">
-          <partial name="Shared/_Dates" model="@Model" />
-        </dl>
-      </div>
+    </details>
+    <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full">
+            <a class="nhsuk-button nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-0"
+               aria-describedby="@Model.Id-name-sa"
+               asp-action="SelfAssessment"
+               asp-route-selfAssessmentId="@Model.Id"
+               role="button">
+                Launch self assessment
+            </a>
+        </div>
     </div>
-  </details>
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <a class="nhsuk-button nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-0"
-         aria-describedby="@Model.Id-name-sa"
-         asp-action="SelfAssessment"
-         asp-route-selfAssessmentId="@Model.Id"
-         role="button">
-        Launch self assessment
-      </a>
-    </div>
-  </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentCard.cshtml
@@ -20,7 +20,7 @@
                 </div>
                 <div class="nhsuk-u-padding-bottom-3">
                     <span>
-                        <label><b>Enrolled by:  </b></label>
+                        <label><b>Enrolled at:  </b></label>
                         <span>
                             @Model.CentreName
                         </span>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-265

### Description
The Delegates are shown all of their self-assessments for each centre. Currently the centre's are not displayed.

### Screenshots
https://hee-tis.atlassian.net/browse/TD-265

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
