### PR TITLE
TD-1093: Edit Details - When Centre email address added same as Prima…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -133,7 +133,7 @@
                     : new List<EditDelegateRegistrationPromptViewModel>();
 
             var allCentreSpecificEmails = centreId == null
-                ? userService.GetAllActiveCentreEmailsForUser(userId,true).ToList()
+                ? userService.GetAllActiveCentreEmailsForUser(userId, true).ToList()
                 : new List<(int centreId, string centreName, string? centreSpecificEmail)>();
 
             var model = new MyAccountEditDetailsViewModel(
@@ -295,6 +295,7 @@
             if (centreId.HasValue)
             {
                 ValidateSingleCentreEmail(formData.CentreSpecificEmail, centreId.Value, userId);
+                ValidateCentreEmailIsSameAsPrimary(formData);
             }
             else
             {
@@ -582,10 +583,10 @@
             return delegateAccount is { Active: true } ? delegateAccount : null;
         }
 
-        private List<string>? GetRoles(AdminAccount? adminAccount, DelegateAccount? delegateAccount, UserEntity userEntity )
+        private List<string>? GetRoles(AdminAccount? adminAccount, DelegateAccount? delegateAccount, UserEntity userEntity)
         {
             var roles = new List<string>();
-            
+
             if (adminAccount != null)
             {
                 var adminentity = new AdminEntity(adminAccount, userEntity.UserAccount, null);
@@ -598,6 +599,17 @@
                 roles.Add("Delegate");
             }
             return roles;
+        }
+        private void ValidateCentreEmailIsSameAsPrimary(MyAccountEditDetailsFormData formData)
+        {
+            if (formData.CentreSpecificEmail == formData.Email)
+            {
+                ModelState.AddModelError(
+                    nameof(MyAccountEditDetailsFormData.CentreSpecificEmail),
+                    CommonValidationErrorMessages.CenterEmailIsSameAsPrimary
+                );
+                formData.CentreSpecificEmail = null;
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -10,7 +10,7 @@
         public const string WhitespaceInEmail = "Email must not contain any whitespace characters";
         public const string EmailsRegexWithNewLineSeparator = @"(([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)(\s*\r\n\s*|\s*$))*";
         public const string InvalidMultiLineEmail = "Enter an email in the correct format (like name@example.com). Note: Each email address should be on separate lines";
-	public const string EmailInUse = "This email is already in use";
+        public const string EmailInUse = "This email is already in use";
         public const string EmailInUseAtCentre = "This email is already in use by another user at the centre";
 
         public const string EmailInUseDuringDelegateRegistration =
@@ -31,5 +31,6 @@
         public const string PasswordMinLength = "Password must be 8 characters or more";
         public const string PasswordMaxLength = "Password must be 100 characters or fewer";
         public const string StringMaxLengthValidation = "{0} must be {1} characters or fewer";
+        public const string CenterEmailIsSameAsPrimary = "Centre email is the same as primary email";
     }
 }


### PR DESCRIPTION
…ry email address, it still send Verify email and Additional Registration prompt disappeared

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1093

### Description
Implemented the logic to display a validation message saying Centre email is the same as primary email and leave centre email blank if it is the same as primary email.

### Screenshots
Before Change:
![image](https://user-images.githubusercontent.com/121869435/217242536-247d5fea-e473-48a0-830b-2289b71c9f0e.png)
![image](https://user-images.githubusercontent.com/121869435/217242715-ecf72447-0dc2-48b0-b0c3-8e4e099217f5.png)
![image](https://user-images.githubusercontent.com/121869435/217242868-c0c474cd-8528-47d7-acac-fda2abca444b.png)

After Change:
![image](https://user-images.githubusercontent.com/121869435/217243558-363576b0-4bdf-41c9-b197-257ebc1cbebc.png)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
