### PR TITLE
TD-1096 Passporting: Additional error msg appeared on the screen when…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -74,7 +74,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
             return View(model);
         }
-
+        
         [HttpGet]
         public IActionResult Start(int? centreId = null, string? inviteId = null)
         {
@@ -416,13 +416,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
                 userDataService,
                 CommonValidationErrorMessages.EmailInUseDuringDelegateRegistration
             );
-
-            RegistrationEmailValidator.ValidatePrimaryEmailWithCentre(
-                model.PrimaryEmail,
-                model.Centre,
-                ModelState,
-                supervisorService
-                );
 
             RegistrationEmailValidator.ValidateCentreEmailIfNecessary(
                 model.CentreSpecificEmail,

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -26,22 +26,6 @@
             }
         }
 
-        public static void ValidatePrimaryEmailWithCentre(
-            string? primaryEmail,
-            int? centreId,
-            ModelStateDictionary modelState,
-            ISupervisorService supervisorService
-        )
-        {
-            string delegateEmail = primaryEmail ?? String.Empty;
-            int? approvedDelegateId = supervisorService.ValidateDelegate(Convert.ToInt16(centreId), delegateEmail);
-            if (approvedDelegateId != null && approvedDelegateId > 0)
-            {
-                modelState.AddModelError("DelegateEmail", "The email address must not match the email address which has approved delegate account.");
-
-            }
-        }
-
         public static void ValidateCentreEmailIfNecessary(
             string? centreEmail,
             int? centreId,


### PR DESCRIPTION
… try to register delegate externally using same email

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1096

### Description
Passporting: Additional error msg appeared on the screen when try to register delegate externally using same email

### Screenshots
https://hee-tis.atlassian.net/browse/TD-1096

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
