### PR TITLE
TD-1106 Allow supervisor self enrolment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -100,14 +100,15 @@
             var supervisorEmail = GetUserEmail();
 
             ModelState.Remove("Page");
-            if (ModelState.IsValid && supervisorEmail != model.DelegateEmail)
+            //if (ModelState.IsValid && supervisorEmail != model.DelegateEmail)
+            if (ModelState.IsValid)
             {
                 AddSupervisorDelegateAndReturnId(adminId, model.DelegateEmail ?? String.Empty, supervisorEmail, centreId);
                 return RedirectToAction("MyStaffList", model.Page);
             }
             else
             {
-                if (supervisorEmail == model.DelegateEmail) { ModelState.AddModelError("DelegateEmail", "The email address must not match the email address you are logged in with."); }
+                // if (supervisorEmail == model.DelegateEmail) { ModelState.AddModelError("DelegateEmail", "The email address must not match the email address you are logged in with."); }
                 ModelState.ClearErrorsForAllFieldsExcept("DelegateEmail");
                 return MyStaffList(model.SearchString, model.SortBy, model.SortDirection, model.Page);
             }
@@ -133,7 +134,8 @@
                 var delegateEmailsList = NewlineSeparatedStringListHelper.SplitNewlineSeparatedList(model.DelegateEmails);
                 foreach (var delegateEmail in delegateEmailsList)
                 {
-                    if (delegateEmail.Length > 0 && supervisorEmail != delegateEmail)
+                    //if (delegateEmail.Length > 0 && supervisorEmail != delegateEmail)
+                    if (delegateEmail.Length > 0)
                     {
                         if (RegexStringValidationHelper.IsValidEmail(delegateEmail))
                         {
@@ -867,11 +869,11 @@
                     SupervisorDelegateDetail = supervisorDelegate,
                     SupervisorRoleName = supervisorRole.SelfAssessmentSupervisorRoleId == null
                     ? "Supervisor" : supervisorService.GetSupervisorRoleById((int)supervisorRole.SelfAssessmentSupervisorRoleId).RoleName,
-                                        SupervisorRoleCount = supervisorRole.SelfAssessmentSupervisorRoleId == null
+                    SupervisorRoleCount = supervisorRole.SelfAssessmentSupervisorRoleId == null
                         ? 0 : supervisorService.GetSupervisorRolesForSelfAssessment((int)supervisorRole.SelfAssessmentSupervisorRoleId).Count()
 
                 };
-                return View("SelectDelegateSupervisorRoleSummary",new Tuple<EnrolDelegateSummaryViewModel,int?>(model, supervisorRole.SelfAssessmentSupervisorRoleId));
+                return View("SelectDelegateSupervisorRoleSummary", new Tuple<EnrolDelegateSummaryViewModel, int?>(model, supervisorRole.SelfAssessmentSupervisorRoleId));
             }
         }
 


### PR DESCRIPTION
### JIRA link
[TD-1106](https://hee-tis.atlassian.net/browse/TD-1106)

### Description
We added code to prevent supervisors from adding themselves as a member of staff (same email address validation). This reverts that change (leaving code in comments to allow easy reinstatement).

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they aren't appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1106]: https://hee-tis.atlassian.net/browse/TD-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ