### PR TITLE
TD-1046-Passporting: Issue with the Completed/Available Activities links on the 'Learning Portal'

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -98,6 +98,8 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail,
             int selfAssessmentSupervisorRoleId, DateTime completeByDate, int delegateUserId, int centreId);
+
+        bool IsCourseCompleted(int candidateId, int customisationId);
     }
 
     public class CourseDataService : ICourseDataService
@@ -1029,6 +1031,22 @@ namespace DigitalLearningSolutions.Data.DataServices
                         AND p.CustomisationID = @customisationId
                         AND ap.DefaultContentTypeID <> 4",
                 new { customisationId, centreId }
+            );
+        }
+
+        public bool IsCourseCompleted(int candidateId, int customisationId)
+        {
+            return connection.ExecuteScalar<bool>(
+                @"SELECT CASE WHEN EXISTS (
+                            SELECT p.Completed
+                                FROM  Progress AS p INNER JOIN
+                                                Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+                                                Applications AS a ON cu.ApplicationID = a.ApplicationID
+                                WHERE  (p.CandidateID = @candidateId) AND p.CustomisationID = @customisationId
+                                AND (NOT (p.Completed IS NULL)))
+                            THEN CAST(1 AS BIT)
+                            ELSE CAST(0 AS BIT) END",
+                new {candidateId, customisationId }
             );
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -32,6 +32,7 @@
         private ISectionContentDataService sectionContentDataService = null!;
         private ISessionService sessionService = null!;
         private ITutorialContentDataService tutorialContentDataService = null!;
+        private ICourseDataService courseDataService=null;
 
         [SetUp]
         public void SetUp()
@@ -46,6 +47,7 @@
             diagnosticAssessmentService = A.Fake<IDiagnosticAssessmentService>();
             postLearningAssessmentService = A.Fake<IPostLearningAssessmentService>();
             courseCompletionService = A.Fake<ICourseCompletionService>();
+            courseDataService = A.Fake<ICourseDataService>();
             clockUtility = A.Fake<IClockUtility>();
 
             controller = new LearningMenuController(
@@ -59,6 +61,7 @@
                     postLearningAssessmentService,
                     sessionService,
                     courseCompletionService,
+                    courseDataService,
                     clockUtility
                 ).WithDefaultContext()
                 .WithMockHttpContextSession()

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -29,6 +29,7 @@
         private readonly IDiagnosticAssessmentService diagnosticAssessmentService;
         private readonly IPostLearningAssessmentService postLearningAssessmentService;
         private readonly ICourseCompletionService courseCompletionService;
+        private readonly ICourseDataService courseDataService;
         private readonly IClockUtility clockUtility;
 
         public LearningMenuController(
@@ -42,6 +43,7 @@
             IPostLearningAssessmentService postLearningAssessmentService,
             ISessionService sessionService,
             ICourseCompletionService courseCompletionService,
+            ICourseDataService courseDataService,
             IClockUtility clockUtility
         )
         {
@@ -56,6 +58,7 @@
             this.postLearningAssessmentService = postLearningAssessmentService;
             this.courseCompletionService = courseCompletionService;
             this.clockUtility = clockUtility;
+            this.courseDataService = courseDataService;
         }
 
         [Route("/LearningMenu/{customisationId:int}")]
@@ -100,6 +103,9 @@
             }
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
+
+            SetTempData(candidateId, customisationId);
+
             var model = new InitialMenuViewModel(courseContent);
             return View(model);
         }
@@ -117,6 +123,12 @@
                     $"centre id: {centreId.ToString() ?? "null"}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
+            var isCompleted = courseDataService.IsCourseCompleted(candidateId, customisationId);
+            if (isCompleted)
+                TempData["LearningActivity"] = "Completed";
+            else
+                TempData["LearningActivity"] = "Available";
+
             var model = new InitialMenuViewModel(courseContent);
             return View(model);
         }
@@ -223,6 +235,8 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
+
             var model = new SectionContentViewModel(config, sectionContent, customisationId, sectionId);
             return View("Section/Section", model);
         }
@@ -260,6 +274,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new DiagnosticAssessmentViewModel(diagnosticAssessment, customisationId, sectionId);
             return View("Diagnostic/Diagnostic", model);
         }
@@ -293,6 +308,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new DiagnosticContentViewModel(
                 config,
                 diagnosticContent,
@@ -339,6 +355,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new PostLearningAssessmentViewModel(postLearningAssessment, customisationId, sectionId);
             return View("PostLearning/PostLearning", model);
         }
@@ -372,6 +389,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new PostLearningContentViewModel(
                 config,
                 postLearningContent,
@@ -422,6 +440,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             /* Course progress doesn't get updated if the auth token expires by the end of the tutorials.
               Some tutorials are longer than the default auth token lifetime of 1 hour, so we set the auth expiry to 8 hours.
               See HEEDLS-637 and HEEDLS-674 for more details */
@@ -464,6 +483,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new ContentViewerViewModel(
                 config,
                 tutorialContent,
@@ -507,6 +527,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new TutorialVideoViewModel(
                 config,
                 tutorialVideo,
@@ -547,6 +568,7 @@
             sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
             courseContentService.UpdateProgress(progressId.Value);
 
+            SetTempData(candidateId, customisationId);
             var model = new CourseCompletionViewModel(config, courseCompletion, progressId.Value);
             return View("Completion/Completion", model);
         }
@@ -560,6 +582,15 @@
                 ExpiresUtc = clockUtility.UtcNow.AddHours(8)
             };
             await HttpContext.SignInAsync("Identity.Application", User, authProperties);
+        }
+
+        private void SetTempData(int candidateId, int customisationId)
+        {
+            var isCompleted = courseDataService.IsCourseCompleted(candidateId, customisationId);
+            if (isCompleted)
+                TempData["LearningActivity"] = "Completed";
+            else
+                TempData["LearningActivity"] = "Current";
         }
     }
 }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1046

**Description**
code added to check completed activities.

**Screenshots**
N/A

-----
### Developer checks
I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
