### PR TITLE
TD-1128 Adds LearnerActive column to self assessment report

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
@@ -65,6 +65,7 @@
                     SELECT 
                         sa.Name AS SelfAssessment
                     	, can.LastName + ', ' + can.FirstName AS Learner
+                        , can.Active AS LearnerActive
                     	, can.ProfessionalRegistrationNumber AS PRN
                         , jg.JobGroupName AS JobGroup
                     	, CASE WHEN c.CustomField1PromptID = 10 THEN can.Answer1 WHEN c.CustomField2PromptID = 10 THEN can.Answer2 WHEN c.CustomField3PromptID = 10 THEN can.Answer3 WHEN c.CustomField4PromptID = 10 THEN can.Answer4 WHEN c.CustomField5PromptID = 10 THEN can.Answer5 WHEN c.CustomField6PromptID = 10 THEN can.Answer6 ELSE '' END AS 'ProgrammeCourse'
@@ -102,6 +103,7 @@
                         (sa.ID = @SelfAssessmentID) AND (sa.ArchivedDate IS NULL) AND (c.Active = 1) AND (ca.RemovedDate IS NULL)
                     Group by sa.Name
 	                    , can.LastName + ', ' + can.FirstName
+                        , can.Active
 	                    , can.ProfessionalRegistrationNumber
 	                    , c.CustomField1PromptID
 	                    , c.CustomField2PromptID

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
@@ -5,6 +5,7 @@
     {
         public string? SelfAssessment { get; set; }
         public string? Learner { get; set; }
+        public bool LearnerActive { get; set; }
         public string? PRN { get; set; }
         public string? JobGroup { get; set; }
         public string? ProgrammeCourse { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
@@ -98,6 +98,7 @@
                       {
                           x.SelfAssessment,
                           x.Learner,
+                          x.LearnerActive,
                           x.PRN,
                           x.JobGroup,
                           x.ProgrammeCourse,


### PR DESCRIPTION
### JIRA link
TD-1128

### Description
Adds LearnerActive column to self assessment report

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/219077874-bd56dea6-0b59-499e-8966-ad449ada0a98.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
