### PR TITLE
TD-262 Supervisor passporting fixes

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -264,6 +264,14 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                     WHERE (sd.ID = @supervisorDelegateId) AND (sd.DelegateUserID = @delegateUserId OR sd.SupervisorAdminID = @adminId) AND (Removed IS NULL)", new { supervisorDelegateId, adminId, delegateUserId }
             ).FirstOrDefault();
 
+            if (delegateUserId == 0)
+            {
+                if (supervisorDelegateDetail != null && supervisorDelegateDetail.DelegateUserID != null)
+                {
+                    delegateUserId = (int)supervisorDelegateDetail!.DelegateUserID!;
+                }
+            }
+
             var delegateDetails = connection.Query<SupervisorDelegateDetail>(
                $@"SELECT u.ID AS DelegateUserId, u.FirstName, u.LastName, u.ProfessionalRegistrationNumber, u.PrimaryEmail AS CandidateEmail, da.CandidateNumber
                     FROM   Users u
@@ -274,6 +282,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 
             if (supervisorDelegateDetail != null && delegateDetails != null)
             {
+                supervisorDelegateDetail.DelegateUserID = delegateUserId;
                 supervisorDelegateDetail.FirstName = delegateDetails.FirstName;
                 supervisorDelegateDetail.LastName = delegateDetails.LastName;
                 supervisorDelegateDetail.ProfessionalRegistrationNumber = delegateDetails.ProfessionalRegistrationNumber;

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -506,7 +506,7 @@
             );
         }
 
-        public IActionResult StartEnrolDelegateOnProfileAssessment(int supervisorDelegateId) //, int delegateUserId
+        public IActionResult StartEnrolDelegateOnProfileAssessment(int supervisorDelegateId)
         {
             TempData.Clear();
 
@@ -519,18 +519,15 @@
             return RedirectToAction(
                 "EnrolDelegateOnProfileAssessment",
                 "Supervisor",
-                //new { supervisorDelegateId = supervisorDelegateId, delegateUserId = delegateUserId }
-            new { supervisorDelegateId = supervisorDelegateId }
+                new { supervisorDelegateId = supervisorDelegateId }
             );
         }
 
-        //[Route("/Supervisor/Staff/{supervisorDelegateId}/{delegateUserId}/ProfileAssessment/Enrol/Profile")]
         [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessment/Enrol/Profile")]
         [TypeFilter(
             typeof(RedirectToErrorEmptySessionData),
             Arguments = new object[] { nameof(MultiPageFormDataFeature.EnrolDelegateOnProfileAssessment) }
         )]
-        //public IActionResult EnrolDelegateOnProfileAssessment(int supervisorDelegateId, int delegateUserId)
         public IActionResult EnrolDelegateOnProfileAssessment(int supervisorDelegateId)
         {
             var sessionEnrolOnRoleProfile = multiPageFormService.GetMultiPageFormData<SessionEnrolOnRoleProfile>(

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -505,7 +505,7 @@
             );
         }
 
-        public IActionResult StartEnrolDelegateOnProfileAssessment(int supervisorDelegateId)
+        public IActionResult StartEnrolDelegateOnProfileAssessment(int supervisorDelegateId) //, int delegateUserId
         {
             TempData.Clear();
 
@@ -518,15 +518,18 @@
             return RedirectToAction(
                 "EnrolDelegateOnProfileAssessment",
                 "Supervisor",
-                new { supervisorDelegateId = supervisorDelegateId }
+                //new { supervisorDelegateId = supervisorDelegateId, delegateUserId = delegateUserId }
+            new { supervisorDelegateId = supervisorDelegateId }
             );
         }
 
+        //[Route("/Supervisor/Staff/{supervisorDelegateId}/{delegateUserId}/ProfileAssessment/Enrol/Profile")]
         [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessment/Enrol/Profile")]
         [TypeFilter(
             typeof(RedirectToErrorEmptySessionData),
             Arguments = new object[] { nameof(MultiPageFormDataFeature.EnrolDelegateOnProfileAssessment) }
         )]
+        //public IActionResult EnrolDelegateOnProfileAssessment(int supervisorDelegateId, int delegateUserId)
         public IActionResult EnrolDelegateOnProfileAssessment(int supervisorDelegateId)
         {
             var sessionEnrolOnRoleProfile = multiPageFormService.GetMultiPageFormData<SessionEnrolOnRoleProfile>(

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -230,8 +230,9 @@
             }
         }
 
+        [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessments")]
         [Route("/Supervisor/Staff/{supervisorDelegateId}/{delegateUserId}/ProfileAssessments")]
-        public IActionResult DelegateProfileAssessments(int supervisorDelegateId, int delegateUserId)
+        public IActionResult DelegateProfileAssessments(int supervisorDelegateId, int delegateUserId = 0)
         {
             var adminId = GetAdminId();
             var superviseDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, adminId, delegateUserId);

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -230,11 +230,11 @@
             }
         }
 
-        [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessments")]
-        public IActionResult DelegateProfileAssessments(int supervisorDelegateId)
+        [Route("/Supervisor/Staff/{supervisorDelegateId}/{delegateUserId}/ProfileAssessments")]
+        public IActionResult DelegateProfileAssessments(int supervisorDelegateId, int delegateUserId)
         {
             var adminId = GetAdminId();
-            var superviseDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, adminId, 0);
+            var superviseDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, adminId, delegateUserId);
             var loggedInUserId = User.GetAdminId();
             var loggedInAdminUser = userDataService.GetAdminUserById(loggedInUserId!.GetValueOrDefault());
             var delegateSelfAssessments = supervisorService.GetSelfAssessmentsForSupervisorDelegateId(supervisorDelegateId, adminId);

--- a/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
@@ -44,10 +44,6 @@ else
 }
 @if (!Model.IsNominatedSupervisor)
 {
-@*  <a class="nhsuk-button nhsuk-u-margin-top-4"
-     role="button"
-     asp-action="StartEnrolDelegateOnProfileAssessment">
-*@
   <a class="nhsuk-button nhsuk-u-margin-top-4"
        role="button"
        asp-action="StartEnrolDelegateOnProfileAssessment"

--- a/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/DelegateProfileAssessments.cshtml
@@ -44,7 +44,16 @@ else
 }
 @if (!Model.IsNominatedSupervisor)
 {
-  <a class="nhsuk-button nhsuk-u-margin-top-4" role="button" asp-action="StartEnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-    Enrol on new assessment
+@*  <a class="nhsuk-button nhsuk-u-margin-top-4"
+     role="button"
+     asp-action="StartEnrolDelegateOnProfileAssessment">
+*@
+  <a class="nhsuk-button nhsuk-u-margin-top-4"
+       role="button"
+       asp-action="StartEnrolDelegateOnProfileAssessment"
+       asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID"
+       asp-route-delegateUserId="@Model.SupervisorDelegateDetail.DelegateUserID"
+       >
+            Enrol on new assessment
   </a>
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -120,7 +120,8 @@
         aria-describedby="@Model.SupervisorDelegateDetail.ID-name"
         asp-controller="Supervisor"
         asp-action="DelegateProfileAssessments"
-        asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+        asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID"
+        asp-route-delegateUserId="@Model.SupervisorDelegateDetail.DelegateUserID">
       View self assessments (@Model.SupervisorDelegateDetail.CandidateAssessmentCount)
     </a>
   }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -120,8 +120,7 @@
         aria-describedby="@Model.SupervisorDelegateDetail.ID-name"
         asp-controller="Supervisor"
         asp-action="DelegateProfileAssessments"
-        asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID"
-        asp-route-delegateUserId="@Model.SupervisorDelegateDetail.DelegateUserID">
+        asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
       View self assessments (@Model.SupervisorDelegateDetail.CandidateAssessmentCount)
     </a>
   }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -97,6 +97,8 @@
           </button>
           @Html.Hidden("Id", Model.SupervisorDelegateDetail.ID)
           @Html.Hidden("DelegateEmail", Model.SupervisorDelegateDetail.DelegateEmail)
+          @Html.Hidden("FirstName", Model.SupervisorDelegateDetail.FirstName)
+          @Html.Hidden("LastName", Model.SupervisorDelegateDetail.LastName)
           @Html.Hidden("ConfirmedRemove", true)
           @Html.HiddenFor(m => m.ReturnPageQuery)
         </form>


### PR DESCRIPTION
### JIRA link
[TD-262](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-262)

### Description
Added sql call to ensure delegate details are retrieved and delegate name/job details correctly displayed in all supervisor views.

### Screenshots
Screenshots below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-262]: https://hee-tis.atlassian.net/browse/TD-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
![td-262a](https://user-images.githubusercontent.com/113513647/219336333-4628a6d1-de21-4c0d-a80b-fb6aa37141de.PNG)
![td-262b](https://user-images.githubusercontent.com/113513647/219336338-b5e8293a-91b3-4758-b143-6e8d9d23617b.PNG)
![td-262c](https://user-images.githubusercontent.com/113513647/219336340-b2fd0c47-ac37-41c0-8d77-130166e59f67.PNG)

