### PR TITLE
TD-1104 Promote to nominated supervisor notification email guid

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffMemberCard.cshtml
@@ -77,7 +77,8 @@
       @if ((Model.SupervisorDelegateDetail.DlsRole == DlsRole.Learner
            && !Model.SupervisorDelegateDetail.DelegateIsNominatedSupervisor
            && Model.SupervisorDelegateDetail.DelegateUserID != null)
-          && !(Model.SupervisorDelegateDetail.DelegateEmail == String.Empty || Guid.TryParse(Model.SupervisorDelegateDetail.DelegateEmail, out _)))
+           && !(Model.SupervisorDelegateDetail.DelegateEmail == String.Empty || Guid.TryParse(Model.SupervisorDelegateDetail.DelegateEmail, out _))
+           && !Guid.TryParse(Model.SupervisorDelegateDetail.CandidateEmail, out _))
       {
         <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-4 button-small"
          data-return-page-enabled="true"


### PR DESCRIPTION
### JIRA link
[TD-1104](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-1104)

### Description
Updated MyStaff view to hide 'Promote to nominated supervisor' button if the delegate email is a guid (ie the user has not logged in yet).

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![td_1104](https://user-images.githubusercontent.com/113513647/219369569-bb70c7fa-b3c4-4824-9fd6-6d2c8ff625af.PNG)
