### PR TITLE
Removed new-password, current-password and username from autocomplete…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/ChangePassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ChangePassword/Index.cshtml
@@ -29,7 +29,7 @@
         type="password"
         spell-check="false"
         hint-text=""
-        autocomplete="current-password"
+        autocomplete="off"
         css-class="nhsuk-u-width-one-half"
         required="true" />
 

--- a/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Login/Index.cshtml
@@ -27,7 +27,7 @@
                      type="text"
                      spell-check="false"
                      hint-text=""
-                     autocomplete="username"
+                     autocomplete="off"
                      css-class="nhsuk-u-width-one-half"
                      required="true" />
 
@@ -37,7 +37,7 @@
                      type="password"
                      spell-check="false"
                      hint-text=""
-                     autocomplete="current-password"
+                     autocomplete="off"
                      css-class="nhsuk-u-width-one-half"
                      required="true" />
 

--- a/DigitalLearningSolutions.Web/Views/Shared/_SetPasswordFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_SetPasswordFields.cshtml
@@ -8,7 +8,7 @@
   type="password"
   spell-check="false"
   hint-text="Your new password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
-  autocomplete="new-password"
+  autocomplete="off"
   css-class="nhsuk-u-width-one-half"
   required="true"/>
 
@@ -19,6 +19,6 @@
   type="password"
   spell-check="false"
   hint-text=""
-  autocomplete="new-password"
+  autocomplete="off"
   css-class="nhsuk-u-width-one-half"
   required="true"/>


### PR DESCRIPTION
### JIRA link
[TD-277](https://hee-tis.atlassian.net/browse/TD-277)

### Description
autocomplete attribute in password fields has been set to off. This should assist with keeping user passwords safe from attackers.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [X] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-277]: https://hee-tis.atlassian.net/browse/TD-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ