### PR TITLE
TD-1139 Removes DLSRole column and excludes learners with admin roles…

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
@@ -11,7 +11,6 @@
         public string? ProgrammeCourse { get; set; }
         public string? Organisation { get; set; }
         public string? DepartmentTeam { get; set; }
-        public string? DLSRole { get; set; }
         public DateTime? Registered { get; set; }
         public DateTime? Started { get; set; }
         public DateTime? LastAccessed { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
@@ -104,7 +104,6 @@
                           x.ProgrammeCourse,
                           x.Organisation,
                           x.DepartmentTeam,
-                          x.DLSRole,
                           x.Registered,
                           x.Started,
                           x.LastAccessed,


### PR DESCRIPTION
### JIRA link
[TD-1139](https://hee-tis.atlassian.net/browse/TD-1139)

### Description
Removes DLSRole column and excludes learners with admin roles from the Self Assessment reports

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/220154175-9fc8c9fd-7c57-4049-b46f-99e417814bfc.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). 
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
