### PR TITLE
TD-1131-UAR: Delegates details enrolled on 'Digital Capability Self assessment' not showing on the Self Assessment Report

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -35,63 +35,75 @@
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1) AND (sar.CandidateID = ca.CandidateID)) AS DataInformationAndContentConfidence,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1) AND (sar.CandidateID = ca.CandidateID)) AS DataInformationAndContentRelevance,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2) AND (sar.CandidateID = ca.CandidateID)) AS TeachingLearningAndSelfDevelopmentConfidence,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2) AND (sar.CandidateID = ca.CandidateID)) AS TeachingLearningAndSelfDevelopmentRelevance,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3) AND (sar.CandidateID = ca.CandidateID)) AS CommunicationCollaborationParticipationConfidence,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationParticipationConfidence,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3) AND (sar.CandidateID = ca.CandidateID)) AS CommunicationCollaborationParticipationRelevance,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationParticipationRelevance,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4) AND (sar.CandidateID = ca.CandidateID)) AS TechnicalProficiencyConfidence,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4) AND (sar.CandidateID = ca.CandidateID)) AS TechnicalProficiencyRelevance,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5) AND (sar.CandidateID = ca.CandidateID)) AS CreationInnovationResearchConfidence,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationResearchConfidence,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5) AND (sar.CandidateID = ca.CandidateID)) AS CreationInnovationResearchRelevance,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationResearchRelevance,
                                  (SELECT AVG(sar.Result) AS AvgConfidence
                                  FROM    SelfAssessmentResults AS sar INNER JOIN
                                               Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6) AND (sar.CandidateID = ca.CandidateID)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
                                 (SELECT AVG(sar.Result) AS AvgConfidence
                                 FROM    SelfAssessmentResults AS sar INNER JOIN
                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                             SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6) AND (sar.CandidateID = ca.CandidateID)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
+                                             SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+											  DelegateAccounts as da ON ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
                 FROM   Candidates AS ca INNER JOIN
                              CandidateAssessments AS caa ON ca.CandidateID = caa.CandidateID INNER JOIN
                              JobGroups AS jg ON ca.JobGroupID = jg.JobGroupID


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1131

**Description**
UAR Issue - Sql query modified to remove deprecated candidateID.

**Screenshots**
N/A

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
