### PR TITLE
TD-1146 Sets SQL logging level to Error

### DIFF
--- a/DigitalLearningSolutions.Web/Program.cs
+++ b/DigitalLearningSolutions.Web/Program.cs
@@ -50,7 +50,7 @@ namespace DigitalLearningSolutions.Web
                 .WriteTo.MSSqlServer(
                     connectionString: config.GetConnectionString(ConfigHelper.DefaultConnectionStringName),
                     sinkOptions: new SinkOptions { TableName = "V2LogEvents", AutoCreateSqlTable = true },
-                    appConfiguration: config)
+                    appConfiguration: config, restrictedToMinimumLevel: LogEventLevel.Error)
                 .CreateLogger();
         }
     }


### PR DESCRIPTION
### JIRA link
[TD-1146](https://hee-tis.atlassian.net/browse/TD-1146)

### Description
Changes the SQL SeriLog logging minimum level to "Error" to avoid log table bloat.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [x] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md).
  - [Confluence - Tech stack notes](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3469443077/DLS+Tech+Stack+Notes)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1146]: https://hee-tis.atlassian.net/browse/TD-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ