### PR TITLE
TD-264-Passporting - LearningPortal: Show supervisors' centres on self assessments

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -20,7 +20,8 @@
                 COALESCE(sasr.RoleName, 'Supervisor') AS RoleName,
                 sasr.SelfAssessmentReview,
                 sasr.ResultsReview,
-                sd.AddedByDelegate
+                sd.AddedByDelegate,
+                au.CentreName
             FROM SupervisorDelegates AS sd
             INNER JOIN CandidateAssessmentSupervisors AS cas
                 ON sd.ID = cas.SupervisorDelegateId

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -325,10 +325,13 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         public IEnumerable<SupervisorForEnrolDelegate> GetSupervisorForEnrolDelegate(int CustomisationID, int CentreID)
         {
             return connection.Query<SupervisorForEnrolDelegate>(
-                $@"SELECT AdminID, Forename + ' ' + Surname AS Name, Email FROM AdminUsers AS au
+                $@"SELECT AdminID, Forename + ' ' + Surname + ' (' + CentreName +')' AS Name, Email FROM AdminUsers AS au
                     WHERE (Supervisor = 1) AND (CentreID = @CentreID) AND (CategoryID = 0 OR
                          CategoryID = (SELECT au.CategoryID FROM Applications AS a INNER JOIN
-                           Customisations AS c ON a.ApplicationID = c.ApplicationID WHERE        (c.CustomisationID = @CustomisationID))) AND (Active = 1) AND (Approved = 1) GROUP BY AdminID, Surname, Forename, Email ORDER BY Surname, Forename",
+                           Customisations AS c ON a.ApplicationID = c.ApplicationID
+                            WHERE (c.CustomisationID = @CustomisationID))) AND (Active = 1) AND (Approved = 1)
+                            GROUP BY AdminID, Surname, Forename, Email, CentreName
+                            ORDER BY Surname, Forename",
                 new { CentreID, CustomisationID });
         }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickSupervisor.cshtml
@@ -48,7 +48,7 @@
               <div class="nhsuk-radios__item">
                 <input class="nhsuk-radios__input" id="radio-@supervisor.ID" asp-for="CandidateAssessmentSupervisorId" type="radio" value="@supervisor.ID">
                 <label class="nhsuk-label nhsuk-radios__label" for="radio-@supervisor.ID">
-                  @supervisor.SupervisorName (@supervisor.SupervisorEmail) - @supervisor.RoleName
+                  @supervisor.SupervisorName - @supervisor.SupervisorEmail - @supervisor.RoleName (@supervisor.CentreName)
                 </label>
               </div>
             }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_SupervisorsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_SupervisorsCard.cshtml
@@ -11,7 +11,7 @@
         <ul>
           @foreach (var supervisor in Model)
           {
-            <li>@supervisor.SupervisorName, @supervisor.RoleName</li>
+            <li>@supervisor.SupervisorName, @supervisor.RoleName (@supervisor.CentreName)</li>
           }
         </ul>
       }


### PR DESCRIPTION
**JIRA link**
[TD-264](https://hee-tis.atlassian.net/browse/TD-264)

**Description**
Centre name added for Activity supervisors and Request proficiency confirmation.

**Screenshots**
Updated in the Jira ticket.

-----
**Developer checks**
I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-264]: https://hee-tis.atlassian.net/browse/TD-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ