### PR TITLE
Added security headers to http responses

### DIFF
--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -341,6 +341,24 @@ namespace DigitalLearningSolutions.Web
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)
         {
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("content-security-policy",
+                    "default-src 'self'; " +
+                    "script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='; " +
+                    "style-src 'self' 'unsafe-inline'; " +
+                    "font-src https://assets.nhs.uk/; " +
+                    "connect-src 'self' http: ws:; " +
+                    "img-src 'self' data: https:; " +
+                    "frame-src 'self' https:");
+                context.Response.Headers.Add("Referrer-Policy", "no-referrer");
+                context.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                context.Response.Headers.Add("X-Frame-Options", "deny");
+                context.Response.Headers.Add("X-XSS-protection", "0");
+                await next();
+            });
+
             app.UseForwardedHeaders(
                 new ForwardedHeadersOptions
                 {


### PR DESCRIPTION
### JIRA link
[TD-276](https://hee-tis.atlassian.net/browse/TD-276)

### Description
A number of missing Security Headers are missing from the application. This branch adds the required headers.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-276]: https://hee-tis.atlassian.net/browse/TD-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ