### PR TITLE
TD-274 Added code to enforce stronger passwords

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Attributes/CommonPasswordsAttributeTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Attributes/CommonPasswordsAttributeTests.cs
@@ -1,0 +1,27 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Attributes
+{
+    using DigitalLearningSolutions.Web.Attributes;
+    using NUnit.Framework;
+
+    public class CommonPasswordsAttributeTests
+    {
+        private const string ErrorMessage = "error message";
+
+        [Test]
+        [TestCase("kducj&123JUJJJ", true)]
+        [TestCase("monkey", false)]
+        [TestCase("OpenSunshine123", false)]
+        public void Password_might_contain_common_element(string password, bool expectedResult)
+        {
+            // Given
+            const string value = "kducj&123JUJJJ";
+            var attribute = new CommonPasswordsAttribute(ErrorMessage);
+
+            // When
+            var result = attribute.IsValid(value);
+
+            // Then
+            result.Equals(expectedResult);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Attributes/UserNameAttributeTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Attributes/UserNameAttributeTests.cs
@@ -1,0 +1,59 @@
+﻿namespace DigitalLearningSolutions.Web.Tests.Attributes
+{
+    using System;
+    using System.Security.Claims;
+    using System.Collections.Generic;
+
+    using NUnit.Framework;
+    using DigitalLearningSolutions.Web.Attributes;
+    using FakeItEasy;
+    using Microsoft.AspNetCore.Http;
+    using System.ComponentModel.DataAnnotations;
+
+
+    public class UserNameAttributeTests
+    {
+        [Test]
+        [TestCase("Fred", "Bloggs", "R2d2$$c£PO", false)]
+        [TestCase("Fred", "Bloggs", "fredbloggs", true)]
+        [TestCase("Fred", "Bloggs", "Bloggs1234", true)]
+        public void Password_might_contain_part_of_username(string forename, string surname, string password, bool expectedResult)
+        {
+            // Given
+            IList<Claim> claimCollection = new List<Claim>()
+            {
+                new Claim("UserForename", forename),
+                new Claim("UserSurname", surname)
+            };
+
+            var fakeClaimsPrincipal = A.Fake<ClaimsPrincipal>();
+            A.CallTo(() => fakeClaimsPrincipal.Claims).Returns(claimCollection);
+
+            var fakeHttpContext = A.Fake<HttpContext>();
+            A.CallTo(() => fakeHttpContext.User).Returns(fakeClaimsPrincipal);
+
+            var fakeService = A.Fake<IHttpContextAccessor>();
+            A.CallTo(() => fakeService.HttpContext).Returns(fakeHttpContext);
+
+            var fakeServiceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() => fakeServiceProvider.GetService(typeof(IHttpContextAccessor))).Returns(fakeService);
+
+            PasswordData passwordData = new PasswordData() { Password = password };
+            var validationContext = new ValidationContext(passwordData, fakeServiceProvider, null);
+
+            var validationResults = new List<ValidationResult>();
+
+            // When
+            Validator.TryValidateObject(passwordData, validationContext, validationResults, true);
+
+            // Then
+            Assert.AreEqual(expectedResult, (validationResults.Count > 0));
+        }
+
+        private class PasswordData
+        {
+            [UserName("error message")]
+            public string? Password { get; set; }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Attributes/CommonPasswordsAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/CommonPasswordsAttribute.cs
@@ -1,0 +1,65 @@
+﻿namespace DigitalLearningSolutions.Web.Attributes
+{
+    using Microsoft.AspNetCore.Http;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+
+    public class CommonPasswordsAttribute : ValidationAttribute
+    {
+        private readonly string? errorMessage;
+
+        private static readonly HashSet<string> Passwords;
+        public CommonPasswordsAttribute(string? errorMessage = null)
+        {
+            this.errorMessage = errorMessage;
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            string lowerCasePassword = value.ToString().ToLower();
+            foreach (var commonPassword in CommonPasswords.passwords)
+            {
+                if (lowerCasePassword.Contains(commonPassword))
+                {
+                    return new ValidationResult(this.errorMessage);
+                }
+            }
+            return ValidationResult.Success;
+        }
+    }
+
+    public static class CommonPasswords
+    {
+        public static readonly HashSet<string> passwords = new HashSet<string>();
+
+        static CommonPasswords()
+        {
+            // Password list taken from here https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/top-passwords-shortlist.txt
+            passwords.Add("password");
+            passwords.Add("123456");
+            passwords.Add("12345678");
+            passwords.Add("abc123");
+            passwords.Add("querty");
+            passwords.Add("monkey");
+            passwords.Add("letmein");
+            passwords.Add("dragon");
+            passwords.Add("111111");
+            passwords.Add("baseball");
+            passwords.Add("iloveyou");
+            passwords.Add("trustno1");
+            passwords.Add("1234567");
+            passwords.Add("sunshine");
+            passwords.Add("master");
+            passwords.Add("123123");
+            passwords.Add("welcome");
+            passwords.Add("shadow");
+            passwords.Add("ashley");
+            passwords.Add("footbal");
+            passwords.Add("jesus");
+            passwords.Add("michael");
+            passwords.Add("ninja");
+            passwords.Add("mustang");
+            passwords.Add("password1");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Attributes/UserNameAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/UserNameAttribute.cs
@@ -1,0 +1,38 @@
+﻿using DigitalLearningSolutions.Data.Models.User;
+using DigitalLearningSolutions.Web.Attributes;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Web;
+using System.Linq;
+
+namespace DigitalLearningSolutions.Web.Attributes
+{
+    public class UserNameAttribute : ValidationAttribute
+    {
+        private readonly string? errorMessage;
+
+        public UserNameAttribute(string? errorMessage = null)
+        {
+            this.errorMessage = errorMessage;
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var httpContextAccessor = (IHttpContextAccessor)validationContext.GetService(typeof(IHttpContextAccessor));
+            string userForename = httpContextAccessor.HttpContext.User.Claims.FirstOrDefault(x => x.Type == "UserForename")?.Value;
+            string userSurname = httpContextAccessor.HttpContext.User.Claims.FirstOrDefault(x => x.Type == "UserSurname")?.Value;
+
+            string passwordLowercase = value.ToString().ToLower();
+            userForename = userForename.ToLower();
+            userSurname = userSurname.ToLower();
+
+            if (passwordLowercase.Contains(userForename) || passwordLowercase.Contains(userSurname))
+            {
+                return new ValidationResult(this.errorMessage);
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -22,15 +22,14 @@
         public const string WrongEmailForCentreDuringAdminRegistration =
             "This email address does not match the one held by the centre; either your primary email or centre email must match the one held by the centre";
 
-        public const string PasswordRegex = @"(?=.*?[^\w\s])(?=.*?[0-9])(?=.*?[A-Za-z]).*";
-
-        public const string PasswordInvalidCharacters =
-            "Password must contain at least 1 letter, 1 number and 1 symbol";
-
+        public const string PasswordRegex = @"(?=.*?[^\w\s])(?=.*?[0-9])(?=.*?[A-Z])(?=.*?[a-z]).*";
+        public const string PasswordInvalidCharacters = "Password must contain at least 1 upper case and 1 lower case letter, 1 number and 1 symbol";
         public const string PasswordRequired = "Enter a password";
         public const string PasswordMinLength = "Password must be 8 characters or more";
         public const string PasswordMaxLength = "Password must be 100 characters or fewer";
         public const string StringMaxLengthValidation = "{0} must be {1} characters or fewer";
         public const string CenterEmailIsSameAsPrimary = "Centre email is the same as primary email";
+        public const string PasswordTooCommon = "Enter a less common password";
+        public const string PasswordSimilarUsername = "Enter a password which is less similar to your user name";
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -23,7 +23,7 @@
             "This email address does not match the one held by the centre; either your primary email or centre email must match the one held by the centre";
 
         public const string PasswordRegex = @"(?=.*?[^\w\s])(?=.*?[0-9])(?=.*?[A-Z])(?=.*?[a-z]).*";
-        public const string PasswordInvalidCharacters = "Password must contain at least 1 upper case and 1 lower case letter, 1 number and 1 symbol";
+        public const string PasswordInvalidCharacters = "Password must contain at least 1 uppercase and 1 lowercase letter, 1 number and 1 symbol";
         public const string PasswordRequired = "Enter a password";
         public const string PasswordMinLength = "Password must be 8 characters or more";
         public const string PasswordMaxLength = "Password must be 100 characters or fewer";

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -54,6 +54,8 @@ namespace DigitalLearningSolutions.Web
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHttpContextAccessor();
+
             services.AddDataProtection()
                 .PersistKeysToFileSystem(new DirectoryInfo($"C:\\keys\\{env.EnvironmentName}"))
                 .SetApplicationName("DLSSharedCookieApp");

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ConfirmPasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ConfirmPasswordViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System.ComponentModel.DataAnnotations;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Attributes;
 
     public class ConfirmPasswordViewModel
     {
@@ -12,6 +13,8 @@
             CommonValidationErrorMessages.PasswordRegex,
             ErrorMessage = CommonValidationErrorMessages.PasswordInvalidCharacters
         )]
+        [CommonPasswords(CommonValidationErrorMessages.PasswordTooCommon)]
+        [UserName(CommonValidationErrorMessages.PasswordSimilarUsername)]
         [DataType(DataType.Password)]
         public string? Password { get; set; }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Common/PasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/PasswordViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System.ComponentModel.DataAnnotations;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Attributes;
 
     public class PasswordViewModel
     {
@@ -11,6 +12,8 @@
             CommonValidationErrorMessages.PasswordRegex,
             ErrorMessage = CommonValidationErrorMessages.PasswordInvalidCharacters
         )]
+        [CommonPasswords(CommonValidationErrorMessages.PasswordTooCommon)]
+        [UserName(CommonValidationErrorMessages.PasswordSimilarUsername)]
         [DataType(DataType.Password)]
         public string? Password { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System.ComponentModel.DataAnnotations;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+    using DigitalLearningSolutions.Web.Attributes;
     using DigitalLearningSolutions.Web.Helpers;
 
     public class SetDelegatePasswordViewModel
@@ -34,6 +35,8 @@
             CommonValidationErrorMessages.PasswordRegex,
             ErrorMessage = CommonValidationErrorMessages.PasswordInvalidCharacters
         )]
+        [CommonPasswords(CommonValidationErrorMessages.PasswordTooCommon)]
+        [UserName(CommonValidationErrorMessages.PasswordSimilarUsername)]
         [DataType(DataType.Password)]
         public string? Password { get; set; }
 

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/Password.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/Password.cshtml
@@ -29,7 +29,7 @@
                      type="text"
                      spell-check="false"
                      autocomplete=""
-                     hint-text="Password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
+                     hint-text="Password should have a minimum of 8 characters with at least 1 uppercase and 1 lowercase letter, 1 number and 1 symbol."
                      css-class="nhsuk-u-width-one-half"
                      required="false" />
 

--- a/DigitalLearningSolutions.Web/Views/Shared/_SetPasswordFields.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_SetPasswordFields.cshtml
@@ -7,7 +7,7 @@
   populate-with-current-value="false"
   type="password"
   spell-check="false"
-  hint-text="Your new password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
+  hint-text="Your new password should have a minimum of 8 characters with at least 1 uppercase and 1 lowercase letter, 1 number and 1 symbol."
   autocomplete="off"
   css-class="nhsuk-u-width-one-half"
   required="true"/>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/SetDelegatePassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/SetDelegatePassword/Index.cshtml
@@ -27,7 +27,7 @@
                      type="text"
                      spell-check="false"
                      autocomplete="off"
-                     hint-text="Password should have a minimum of 8 characters with at least 1 letter, 1 number and 1 symbol."
+                     hint-text="Password should have a minimum of 8 characters with at least 1 uppercase and 1 lowercase letter, 1 number and 1 symbol."
                      css-class="nhsuk-u-width-one-half"
                      required="true" />
 


### PR DESCRIPTION
### JIRA link
[TD-274](https://hee-tis.atlassian.net/browse/TD-274)

### Description
Code has been modified to enforce ‘strong’ passwords standards - 8 characters or more, numbers, characters, mixed case characters.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-274]: https://hee-tis.atlassian.net/browse/TD-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ