### PR TITLE
TD-1153-On "Activity Supervisors" list, show first 3 supervisors with "+X more"

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_SupervisorsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_SupervisorsCard.cshtml
@@ -9,9 +9,13 @@
       @if (Model.Any())
       {
         <ul>
-          @foreach (var supervisor in Model)
+          @foreach (var supervisor in Model.Take(3))
           {
             <li>@supervisor.SupervisorName, @supervisor.RoleName (@supervisor.CentreName)</li>
+          }
+          @if(Model.Count()>3)
+          {
+            <li style="list-style-type: none">+@(Model.Count() - 3) more</li>
           }
         </ul>
       }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1153

**Description**
Supervisor count check added in the view.

**Screenshots**
Updated in the Jira ticket.

-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
