### PR TITLE
TD-1143 Hide unpublished for centre self assessments

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -8,7 +8,7 @@
 
     public partial class SelfAssessmentDataService
     {
-        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId)
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
         {
             return connection.Query<CurrentSelfAssessment>(
                 @"SELECT
@@ -40,16 +40,72 @@
                         ON SAS.CompetencyID = C.ID
                     INNER JOIN Centres AS CR
                         ON CA.CentreID = CR.CentreID
+
+inner join CentreSelfAssessments csa
+	on csa.CentreID = ca.CentreID
+
                     WHERE CA.DelegateUserID = @delegateUserId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
+                        and ca.CentreId = @centreId
+
+
+
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
                         COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID,
                         CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName",
-                new { delegateUserId }
+                new { delegateUserId, centreId }
             );
         }
+
+
+        //public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId)
+        //{
+        //    return connection.Query<CurrentSelfAssessment>(
+        //        @"SELECT
+        //                CA.SelfAssessmentID AS Id,
+        //                SA.Name,
+        //                SA.Description,
+        //                SA.IncludesSignposting,
+        //                SA.IncludeRequirementsFilters,
+        //                SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
+        //                SA.ReviewerCommentsLabel,
+        //                COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
+        //                COUNT(C.ID) AS NumberOfCompetencies,
+        //                CA.StartedDate,
+        //                CA.LastAccessed,
+        //                CA.CompleteByDate,
+        //                CA.ID AS CandidateAssessmentId,
+        //                CA.UserBookmark,
+        //                CA.UnprocessedUpdates,
+        //                CA.LaunchCount,
+        //                1 AS IsSelfAssessment,
+        //                CA.SubmittedDate,
+        //                CR.CentreName AS CentreName
+        //            FROM CandidateAssessments CA
+        //                JOIN SelfAssessments SA
+        //                ON CA.SelfAssessmentID = SA.ID
+        //            INNER JOIN SelfAssessmentStructure AS SAS
+        //                ON CA.SelfAssessmentID = SAS.SelfAssessmentID
+        //            INNER JOIN Competencies AS C
+        //                ON SAS.CompetencyID = C.ID
+        //            INNER JOIN Centres AS CR
+        //                ON CA.CentreID = CR.CentreID
+        //            WHERE CA.DelegateUserID = @delegateUserId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
+        //                and csa.CentreId = @centreId
+        //            GROUP BY
+        //                CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
+        //                SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
+        //                COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
+        //                CA.ID,
+        //                CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName",
+        //        new { delegateUserId }
+        //    );
+        //}
+
+
+
 
         public CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId)
         {

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -40,15 +40,10 @@
                         ON SAS.CompetencyID = C.ID
                     INNER JOIN Centres AS CR
                         ON CA.CentreID = CR.CentreID
-
-inner join CentreSelfAssessments csa
-	on csa.CentreID = ca.CentreID
-
+                    INNER JOIN CentreSelfAssessments csa
+	                    ON csa.CentreID = ca.CentreID
                     WHERE CA.DelegateUserID = @delegateUserId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
-                        and ca.CentreId = @centreId
-
-
-
+                        AND ca.CentreId = @centreId
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
@@ -58,54 +53,6 @@ inner join CentreSelfAssessments csa
                 new { delegateUserId, centreId }
             );
         }
-
-
-        //public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId)
-        //{
-        //    return connection.Query<CurrentSelfAssessment>(
-        //        @"SELECT
-        //                CA.SelfAssessmentID AS Id,
-        //                SA.Name,
-        //                SA.Description,
-        //                SA.IncludesSignposting,
-        //                SA.IncludeRequirementsFilters,
-        //                SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
-        //                SA.ReviewerCommentsLabel,
-        //                COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
-        //                COUNT(C.ID) AS NumberOfCompetencies,
-        //                CA.StartedDate,
-        //                CA.LastAccessed,
-        //                CA.CompleteByDate,
-        //                CA.ID AS CandidateAssessmentId,
-        //                CA.UserBookmark,
-        //                CA.UnprocessedUpdates,
-        //                CA.LaunchCount,
-        //                1 AS IsSelfAssessment,
-        //                CA.SubmittedDate,
-        //                CR.CentreName AS CentreName
-        //            FROM CandidateAssessments CA
-        //                JOIN SelfAssessments SA
-        //                ON CA.SelfAssessmentID = SA.ID
-        //            INNER JOIN SelfAssessmentStructure AS SAS
-        //                ON CA.SelfAssessmentID = SAS.SelfAssessmentID
-        //            INNER JOIN Competencies AS C
-        //                ON SAS.CompetencyID = C.ID
-        //            INNER JOIN Centres AS CR
-        //                ON CA.CentreID = CR.CentreID
-        //            WHERE CA.DelegateUserID = @delegateUserId AND CA.RemovedDate IS NULL AND CA.CompletedDate IS NULL
-        //                and csa.CentreId = @centreId
-        //            GROUP BY
-        //                CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
-        //                SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
-        //                COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
-        //                CA.ID,
-        //                CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName",
-        //        new { delegateUserId }
-        //    );
-        //}
-
-
-
 
         public CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId)
         {

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -66,7 +66,7 @@
         );
 
         // CandidateAssessmentsDataService
-        //IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId);
+
         IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
 
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -66,7 +66,8 @@
         );
 
         // CandidateAssessmentsDataService
-        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId);
+        //IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId);
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
 
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -44,7 +44,7 @@
 
             var bannerText = "bannerText";
             A.CallTo(() => courseDataService.GetCurrentCourses(CandidateId)).Returns(currentCourses);
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(DelegateUserId)).Returns(selfAssessments);
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(DelegateUserId, A<int>._)).Returns(selfAssessments);
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId))
                 .Returns((actionPlanResources, apiIsAccessible));
             A.CallTo(() => centresDataService.GetBannerText(CentreId)).Returns(bannerText);
@@ -426,7 +426,7 @@
         private void GivenCurrentActivitiesAreEmptyLists()
         {
             A.CallTo(() => courseDataService.GetCurrentCourses(A<int>._)).Returns(new List<CurrentCourse>());
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(A<int>._))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(A<int>._, A<int>._))
                 .Returns(new List<CurrentSelfAssessment>());
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(A<int>._))
                 .Returns((new List<ActionPlanResource>(), false));

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -35,8 +35,12 @@
             var delegateUserId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
             var bannerText = GetBannerText();
+
+            var centreId = User.GetCentreIdKnownNotNull();
             var selfAssessments =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
+
+
             var (learningResources, apiIsAccessible) =
                 await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
 
@@ -69,8 +73,13 @@
             var delegateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
+
+
+            var centreId = User.GetCentreIdKnownNotNull();
             var selfAssessment =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
+
+
             var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);
             return View("Current/AllCurrentItems", model);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -40,7 +40,6 @@
             var selfAssessments =
                 selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
 
-
             var (learningResources, apiIsAccessible) =
                 await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
 
@@ -73,12 +72,10 @@
             var delegateId = User.GetCandidateIdKnownNotNull();
             var delegateUserId = User.GetUserIdKnownNotNull();
             var currentCourses = courseDataService.GetCurrentCourses(delegateId);
-
-
             var centreId = User.GetCentreIdKnownNotNull();
+
             var selfAssessment =
                 selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
-
 
             var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -13,7 +13,8 @@
     public interface ISelfAssessmentService
     {
         // Candidate Assessments
-        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId);
+        //IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId);
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
 
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
 
@@ -382,10 +383,20 @@
             return selfAssessmentDataService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
         }
 
-        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId)
+        //public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId)
+        //{
+
+        //    return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId);
+
+        //}
+
+
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
         {
-            return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId);
+            return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
         }
+
+
 
         public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateId)
         {

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -13,7 +13,6 @@
     public interface ISelfAssessmentService
     {
         // Candidate Assessments
-        //IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId);
         IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
 
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
@@ -383,21 +382,11 @@
             return selfAssessmentDataService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
         }
 
-        //public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId)
-        //{
-
-        //    return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId);
-
-        //}
-
-
         public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
         {
             return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
         }
-
-
-
+        
         public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateId)
         {
             return selfAssessmentDataService.GetMostRecentResults(selfAssessmentId, delegateId);


### PR DESCRIPTION
### JIRA link
[TD-1143](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-1143)

### Description
Added the centreId for the currently logged in user as a filter for the self-assessment list population. Also joined to table CentreSelfAssessments in the same SQL expression.

### Screenshots
Screenshots below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1143]: https://hee-tis.atlassian.net/browse/TD-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![td-1143a](https://user-images.githubusercontent.com/113513647/221625430-c91b0af5-eaee-4757-849d-73b8bf817bbb.JPG)
![td-1143b](https://user-images.githubusercontent.com/113513647/221625459-da35c3f9-8458-45b4-92df-680b3ce24a23.JPG)
![td-1143c2](https://user-images.githubusercontent.com/113513647/221629499-a466bd57-fa43-418d-85a7-46ec591ba7dd.JPG)

