### PR TITLE
TD-275 Moved the storage of AdminSessionID from TempData to User.Claims

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
@@ -1,9 +1,9 @@
 ﻿namespace DigitalLearningSolutions.Data.DataServices
 {
-    using System;
-    using System.Data;
     using Dapper;
     using DigitalLearningSolutions.Data.Models;
+    using System;
+    using System.Data;
 
     public interface ISessionDataService
     {
@@ -20,6 +20,8 @@
         void StopAllAdminSessions(int adminId);
 
         bool HasAdminGotSessions(int adminId);
+
+        bool HasAdminGotActiveSessions(int adminId);
 
         bool HasDelegateGotSessions(int delegateId);
 
@@ -105,6 +107,14 @@
                 "SELECT 1 WHERE EXISTS (SELECT AdminSessionId FROM AdminSessions WHERE AdminID = @adminId)",
                 new { adminId }
             );
+        }
+
+        public bool HasAdminGotActiveSessions(int adminId)
+        {
+            return connection.ExecuteScalar<bool>(
+                "SELECT 1 WHERE EXISTS (SELECT adminSessionId FROM AdminSessions WHERE AdminID = @adminId AND Active = 1)",
+                new { adminId }
+                );
         }
 
         public bool HasDelegateGotSessions(int delegateId)

--- a/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanProceedTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ServiceFilter/VerifyAdminUserCanProceedTests.cs
@@ -116,9 +116,10 @@ namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
             var homeController = new HomeController(A.Fake<IConfiguration>(), A.Fake<IBrandsService>()).WithDefaultContext().WithMockTempData()
                .WithMockUser(true, 101);
             var httpContext = new DefaultHttpContext();
-            Claim[] claims = new Claim[2];
+            Claim[] claims = new Claim[3];
             claims[0] = new Claim("UserUserAdmin", "True");
             claims[1] = new Claim("UserID", "7");
+            claims[2] = new Claim("AdminSessionID", "123456");
             ClaimsIdentity claimsIdentity = new ClaimsIdentity(claims);
             httpContext.User = new ClaimsPrincipal(claimsIdentity);
             context = new ActionExecutingContext(
@@ -132,7 +133,6 @@ namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
                homeController
             );
 
-            homeController.TempData["AdminSessionID"] = 123456;
             var adminSession = new Data.Models.AdminSession(123456, 7, DateTime.Now, 0, true);
             A.CallTo(() => sessionDataService.GetAdminSessionById(123456)).Returns(adminSession);
 
@@ -151,9 +151,10 @@ namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
             var homeController = new HomeController(A.Fake<IConfiguration>(), A.Fake<IBrandsService>()).WithDefaultContext().WithMockTempData()
                .WithMockUser(true, 101);
             var httpContext = new DefaultHttpContext();
-            Claim[] claims = new Claim[2];
+            Claim[] claims = new Claim[3];
             claims[0] = new Claim("UserUserAdmin", "True");
             claims[1] = new Claim("UserID", "7");
+            claims[2] = new Claim("AdminSessionID", "123456");
             ClaimsIdentity claimsIdentity = new ClaimsIdentity(claims);
             httpContext.User = new ClaimsPrincipal(claimsIdentity);
             context = new ActionExecutingContext(
@@ -167,7 +168,6 @@ namespace DigitalLearningSolutions.Web.Tests.ServiceFilter
                homeController
             );
 
-            homeController.TempData["AdminSessionID"] = 123456;
             var adminSession = new Data.Models.AdminSession(123456, 7, DateTime.Now, 0, false);
             A.CallTo(() => sessionDataService.GetAdminSessionById(123456)).Returns(adminSession);
 

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -1,9 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
-    using System;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Threading.Tasks;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.User;
@@ -19,6 +15,10 @@
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using System;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
 
     [SetDlsSubApplication(nameof(DlsSubApplication.Main))]
     [SetSelectedTab(nameof(NavMenuTab.LogIn))]
@@ -209,11 +209,17 @@
 
             if (adminAccount?.Active == true)
             {
-                logger.LogWarning($"Concurrent login detected for admin user {adminAccount.Id}.");
-                sessionService.StopAllAdminSessions(adminAccount.Id);
+                if (sessionService.hasAdminGotActiveSessions(adminAccount.Id))
+                {
+                    logger.LogWarning($"Concurrent login detected for admin user {adminAccount.Id}.");
+                    sessionService.StopAllAdminSessions(adminAccount.Id);
+                }
                 var adminSessionId = sessionService.StartAdminSession(adminAccount.Id);
-                TempData["AdminSessionId"] = adminSessionId;
+                Claim adminSessionClaim = new Claim("AdminSessionID", adminSessionId.ToString());
+                claimsIdentity.AddClaim(adminSessionClaim);
             }
+
+
 
             await HttpContext.SignInAsync("Identity.Application", new ClaimsPrincipal(claimsIdentity), authProperties);
 

--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanProceed.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanProceed.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.Filters;
+﻿using DigitalLearningSolutions.Data.DataServices;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using System.Linq;
-using DigitalLearningSolutions.Data.DataServices;
 
 namespace DigitalLearningSolutions.Web.ServiceFilter
 {
@@ -35,11 +35,11 @@ namespace DigitalLearningSolutions.Web.ServiceFilter
 
             if (adminUserId > 0)
             {
-
-                if (controller.TempData.Peek("AdminSessionID") != null)
+                var adminSessionId = context.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "AdminSessionID");
+                if (adminSessionId != null)
                 {
-                    var session = sessionDataService.GetAdminSessionById((int)controller.TempData.Peek("AdminSessionID"));
-                    if (session.Active)
+                    var session = sessionDataService.GetAdminSessionById(int.Parse(adminSessionId.Value));
+                    if (session != null && session.Active)
                     {
                         return;
                     }

--- a/DigitalLearningSolutions.Web/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Web/Services/SessionService.cs
@@ -15,6 +15,8 @@
         void StopAdminSession(int? adminId, int adminSessionId);
 
         void StopAllAdminSessions(int? adminId);
+
+        bool hasAdminGotActiveSessions(int? adminId);
     }
 
     public class SessionService : ISessionService
@@ -75,6 +77,15 @@
             {
                 sessionDataService.StopAllAdminSessions((int)adminId);
             }
+        }
+
+        public bool hasAdminGotActiveSessions(int? adminId)
+        {
+            if (adminId != null)
+            {
+                return sessionDataService.HasAdminGotActiveSessions((int)adminId);
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-275](https://hee-tis.atlassian.net/browse/TD-275)

### Description
The admin user session information has been moved from TempData to a User claim. This gets around the issue that we were having where several controllers were performing a TempData.Clear() operation.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-275]: https://hee-tis.atlassian.net/browse/TD-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ