### PR TITLE
TD-1168 Promote nominated supervisor rework

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -208,7 +208,7 @@
 
         void SetCentreEmailVerified(int userId, string email, DateTime verifiedDateTime);
 
-        void DeleteUserCentreDetail(int userId,int centreId);
+        void DeleteUserCentreDetail(int userId, int centreId);
     }
 
     public partial class UserDataService : IUserDataService

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/PromoteToAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/PromoteToAdminControllerTests.cs
@@ -70,7 +70,7 @@
                 UserId = 2,
                 CentreId = 101,
             };
-            A.CallTo(() => registrationService.PromoteDelegateToAdmin(A<AdminRoles>._, A<int>._, A<int>._, A<int>._))
+            A.CallTo(() => registrationService.PromoteDelegateToAdmin(A<AdminRoles>._, A<int>._, A<int>._, A<int>._, false))
                 .DoesNothing();
 
             DelegateEntity delegateEntity = A.Fake<DelegateEntity>();
@@ -116,7 +116,8 @@
                             ),
                             null,
                             formData.UserId,
-                            formData.CentreId
+                            formData.CentreId,
+                            false
                         )
                 )
                 .MustHaveHappened();
@@ -139,7 +140,7 @@
                 ContentManagementRole = ContentManagementRole.NoContentManagementRole,
                 LearningCategory = 0
             };
-            A.CallTo(() => registrationService.PromoteDelegateToAdmin(A<AdminRoles>._, A<int?>._, A<int>._, A<int>._))
+            A.CallTo(() => registrationService.PromoteDelegateToAdmin(A<AdminRoles>._, A<int?>._, A<int>._, A<int>._, A<bool>._))
                 .Throws(new AdminCreationFailedException());
 
             // When

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -981,7 +981,7 @@
                 var adminRoles = new AdminRoles(false, false, true, false, false, false, false, false);
                 if (supervisorDelegateDetail.DelegateUserID != null)
                 {
-                    registrationService.PromoteDelegateToAdmin(adminRoles, categoryId, (int)supervisorDelegateDetail.DelegateUserID, (int)User.GetCentreId());
+                    registrationService.PromoteDelegateToAdmin(adminRoles, categoryId, (int)supervisorDelegateDetail.DelegateUserID, (int)User.GetCentreId(), true);
 
                     if (delegateUser != null && adminUser != null)
                     {

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -134,7 +134,8 @@
                     adminRoles,
                     AdminCategoryHelper.AdminCategoryToCategoryId(formData.LearningCategory),
                     formData.UserId,
-                    formData.CentreId
+                    formData.CentreId,
+                    false
                 );
 
                 var delegateUserEmailDetails = userDataService.GetDelegateById(delegateId);

--- a/DigitalLearningSolutions.Web/Services/RegistrationService.cs
+++ b/DigitalLearningSolutions.Web/Services/RegistrationService.cs
@@ -48,7 +48,7 @@ namespace DigitalLearningSolutions.Web.Services
 
         void CreateCentreManagerForExistingUser(int userId, int centreId, string? centreSpecificEmail);
 
-        void PromoteDelegateToAdmin(AdminRoles adminRoles, int? categoryId, int userId, int centreId);
+        void PromoteDelegateToAdmin(AdminRoles adminRoles, int? categoryId, int userId, int centreId, bool mergeWithExistingRoles);
 
         (int delegateId, string candidateNumber, int delegateUserId) CreateAccountAndReturnCandidateNumberAndDelegateId(
             DelegateRegistrationModel delegateRegistrationModel,
@@ -426,29 +426,54 @@ namespace DigitalLearningSolutions.Web.Services
             transaction.Complete();
         }
 
-        public void PromoteDelegateToAdmin(AdminRoles adminRoles, int? categoryId, int userId, int centreId)
+        public void PromoteDelegateToAdmin(AdminRoles newAdminRoles, int? categoryId, int userId, int centreId, bool mergeWithExistingRoles = true)
         {
-            var adminAtCentre = userDataService.GetAdminAccountsByUserId(userId)
+            var existingAdminDetails = userDataService.GetAdminAccountsByUserId(userId)
                 .SingleOrDefault(a => a.CentreId == centreId);
 
-            if (adminAtCentre != null)
+            if (existingAdminDetails != null)
             {
-                if (adminAtCentre.Active == false)
+                if (existingAdminDetails.Active == false)
                 {
-                    userDataService.ReactivateAdmin(adminAtCentre.Id);
+                    userDataService.ReactivateAdmin(existingAdminDetails.Id);
+                }
+
+                var mergedAdminDetails = existingAdminDetails;
+
+                if (mergeWithExistingRoles)
+                {
+                    mergedAdminDetails.IsCentreAdmin = existingAdminDetails.IsCentreAdmin || newAdminRoles.IsCentreAdmin;
+                    mergedAdminDetails.IsSupervisor = existingAdminDetails.IsSupervisor || newAdminRoles.IsSupervisor;
+                    mergedAdminDetails.IsNominatedSupervisor = existingAdminDetails.IsNominatedSupervisor || newAdminRoles.IsNominatedSupervisor;
+                    mergedAdminDetails.IsTrainer = existingAdminDetails.IsTrainer || newAdminRoles.IsTrainer;
+                    mergedAdminDetails.IsContentCreator = existingAdminDetails.IsContentCreator || newAdminRoles.IsContentCreator;
+                    mergedAdminDetails.IsContentManager = existingAdminDetails.IsContentManager || newAdminRoles.IsContentManager;
+                    mergedAdminDetails.ImportOnly = existingAdminDetails.ImportOnly || newAdminRoles.ImportOnly;
+                    mergedAdminDetails.IsCentreManager = existingAdminDetails.IsCentreManager || newAdminRoles.IsCentreManager;
+                }
+                else
+                {
+                    mergedAdminDetails.IsCentreAdmin = newAdminRoles.IsCentreAdmin;
+                    mergedAdminDetails.IsSupervisor = newAdminRoles.IsSupervisor;
+                    mergedAdminDetails.IsNominatedSupervisor = newAdminRoles.IsNominatedSupervisor;
+                    mergedAdminDetails.IsTrainer = newAdminRoles.IsTrainer;
+                    mergedAdminDetails.IsContentCreator = newAdminRoles.IsContentCreator;
+                    mergedAdminDetails.IsContentManager = newAdminRoles.IsContentManager;
+                    mergedAdminDetails.ImportOnly = newAdminRoles.ImportOnly;
+                    mergedAdminDetails.IsCentreManager = newAdminRoles.IsCentreManager;
                 }
 
                 userDataService.UpdateAdminUserPermissions(
-                    adminAtCentre.Id,
-                    adminRoles.IsCentreAdmin,
-                    adminRoles.IsSupervisor,
-                    adminRoles.IsNominatedSupervisor,
-                    adminRoles.IsTrainer,
-                    adminRoles.IsContentCreator,
-                    adminRoles.IsContentManager,
-                    adminRoles.ImportOnly,
+                    existingAdminDetails.Id,
+                    mergedAdminDetails.IsCentreAdmin,
+                    mergedAdminDetails.IsSupervisor,
+                    mergedAdminDetails.IsNominatedSupervisor,
+                    mergedAdminDetails.IsTrainer,
+                    mergedAdminDetails.IsContentCreator,
+                    mergedAdminDetails.IsContentManager,
+                    mergedAdminDetails.ImportOnly,
                     categoryId,
-                    adminRoles.IsCentreManager
+                    mergedAdminDetails.IsCentreManager
                 );
             }
             else
@@ -458,14 +483,14 @@ namespace DigitalLearningSolutions.Web.Services
                     null,
                     centreId,
                     categoryId,
-                    adminRoles.IsCentreAdmin,
-                    adminRoles.IsCentreManager,
-                    adminRoles.IsContentManager,
-                    adminRoles.IsContentCreator,
-                    adminRoles.IsTrainer,
-                    adminRoles.ImportOnly,
-                    adminRoles.IsSupervisor,
-                    adminRoles.IsNominatedSupervisor,
+                    newAdminRoles.IsCentreAdmin,
+                    newAdminRoles.IsCentreManager,
+                    newAdminRoles.IsContentManager,
+                    newAdminRoles.IsContentCreator,
+                    newAdminRoles.IsTrainer,
+                    newAdminRoles.ImportOnly,
+                    newAdminRoles.IsSupervisor,
+                    newAdminRoles.IsNominatedSupervisor,
                     true
                 );
 


### PR DESCRIPTION
### JIRA link
[TD-1168](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-1168)

### Description
Added param to promote method so now Promote To Nominated Supervisor merges the new admin role with any existing roles for the delegate.

### Screenshots
Screenshots below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![td-1168reworkA](https://user-images.githubusercontent.com/113513647/222742916-60a7820e-d3d6-4d0d-b915-3101eca18c20.jpg)
![td-1168reworkB](https://user-images.githubusercontent.com/113513647/222742936-67363ae4-40ea-4fb3-9333-ba25bf7c9b3d.jpg)
![td-1168reworkC](https://user-images.githubusercontent.com/113513647/222742947-b1b96ca7-cc1c-4fc1-adeb-2a056df8331f.jpg)




[TD-1168]: https://hee-tis.atlassian.net/browse/TD-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ