### PR TITLE
TD-899 allow supervisors to supervise self assessments a user is already enrolled on (TD-202 for UAR)

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/Services/SupervisorServiceTest.cs
+++ b/DigitalLearningSolutions.Data.Tests/Services/SupervisorServiceTest.cs
@@ -1,0 +1,33 @@
+﻿using DigitalLearningSolutions.Data.DataServices;
+using DigitalLearningSolutions.Data.Tests.TestHelpers;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace DigitalLearningSolutions.Data.Tests.Services
+{
+    public class SupervisorServiceTest
+    {
+        private ISupervisorService supervisorService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var connection = ServiceTestHelper.GetDatabaseConnection();
+            var logger = A.Fake<ILogger<SupervisorService>>();
+            supervisorService = new SupervisorService(connection, logger);
+        }
+
+
+        [Test]
+        public void GetNonNationalSupervisorDelegateAssessmentWithoutAssignedSupervisor_returns_empty_record()
+        {
+            // When
+            var result = supervisorService.GetSelfAssessmentsForSupervisorDelegateId(8, 1);
+
+            // Then
+            result.Should().BeEmpty();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -55,12 +55,13 @@
         private readonly IDbConnection connection;
         private readonly ILogger<SupervisorService> logger;
         private const string supervisorDelegateDetailFields = @"
-            sd.ID, sd.SupervisorEmail, sd.SupervisorAdminID, sd.DelegateEmail, sd.DelegateUserID, sd.Added, sd.AddedByDelegate, sd.NotificationSent, sd.Removed, sd.InviteHash, u.FirstName, u.LastName, jg.JobGroupName, da.Answer1, da.Answer2, da.Answer3, da.Answer4, da.Answer5,
-            da.Answer6, da.CandidateNumber, u.ProfessionalRegistrationNumber, u.PrimaryEmail AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2, cp3.CustomPrompt AS CustomPrompt3, cp4.CustomPrompt AS CustomPrompt4,
-            cp5.CustomPrompt AS CustomPrompt5, cp6.CustomPrompt AS CustomPrompt6, COALESCE (au.CentreID, da.CentreID) AS CentreID, au.Forename + ' ' + au.Surname AS SupervisorName,
-            (SELECT COUNT(ca.ID) AS Expr1
+           sd.ID, sd.SupervisorEmail, sd.SupervisorAdminID, sd.DelegateEmail, sd.DelegateUserID, sd.Added, sd.AddedByDelegate, sd.NotificationSent, sd.Removed, sd.InviteHash, du.FirstName, du.LastName, jg.JobGroupName, da.Answer1, da.Answer2, da.Answer3, da.Answer4, 
+             da.Answer5, da.Answer6, da.CandidateNumber, du.ProfessionalRegistrationNumber, du.PrimaryEmail AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2, cp3.CustomPrompt AS CustomPrompt3, 
+             cp4.CustomPrompt AS CustomPrompt4, cp5.CustomPrompt AS CustomPrompt5, cp6.CustomPrompt AS CustomPrompt6, COALESCE (aa.CentreID, da.CentreID) AS CentreID, u.FirstName + ' ' + u.LastName AS SupervisorName,
+                 (SELECT COUNT(ca.ID) AS Expr1
             FROM CandidateAssessments AS ca INNER JOIN SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID LEFT JOIN CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID 
-            WHERE (ca.DelegateUserID = sd.DelegateUserID) AND (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = sd.ID  OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID AND sa.[National] = 1))) AS CandidateAssessmentCount, CAST(COALESCE (au2.NominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, CAST(COALESCE (au2.Supervisor, 0) AS Bit) AS DelegateIsSupervisor ";
+            WHERE (ca.DelegateUserID = sd.DelegateUserID) AND (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = sd.ID  OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = aa.CentreID AND sa.[National] = 1))) AS CandidateAssessmentCount, CAST(COALESCE (au2.IsNominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, CAST(COALESCE (au2.IsSupervisor, 0) AS Bit) 
+             AS DelegateIsSupervisor ";
         private const string supervisorDelegateDetailTables = @"
             CustomPrompts AS cp2 RIGHT OUTER JOIN
              CustomPrompts AS cp3 RIGHT OUTER JOIN

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -58,10 +58,9 @@
             sd.ID, sd.SupervisorEmail, sd.SupervisorAdminID, sd.DelegateEmail, sd.DelegateUserID, sd.Added, sd.AddedByDelegate, sd.NotificationSent, sd.Removed, sd.InviteHash, u.FirstName, u.LastName, jg.JobGroupName, da.Answer1, da.Answer2, da.Answer3, da.Answer4, da.Answer5,
             da.Answer6, da.CandidateNumber, u.ProfessionalRegistrationNumber, u.PrimaryEmail AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2, cp3.CustomPrompt AS CustomPrompt3, cp4.CustomPrompt AS CustomPrompt4,
             cp5.CustomPrompt AS CustomPrompt5, cp6.CustomPrompt AS CustomPrompt6, COALESCE (au.CentreID, da.CentreID) AS CentreID, au.Forename + ' ' + au.Surname AS SupervisorName,
-            (SELECT COUNT(cas.ID) AS Expr1
-            FROM    CandidateAssessmentSupervisors AS cas INNER JOIN
-                      CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL
-            WHERE (cas.SupervisorDelegateId = sd.ID) AND (ca.RemovedDate IS NULL)) AS CandidateAssessmentCount, CAST(COALESCE (au2.NominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, CAST(COALESCE (au2.Supervisor, 0) AS Bit) AS DelegateIsSupervisor ";
+            (SELECT COUNT(ca.ID) AS Expr1
+            FROM CandidateAssessments AS ca LEFT JOIN CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID
+            WHERE (ca.DelegateUserID = sd.DelegateUserID) AND (ca.RemovedDate IS NULL) AND (ca.CentreID = au.CentreID OR cas.CandidateAssessmentID IS NULL OR cas.SupervisorDelegateId = sd.ID)) AS CandidateAssessmentCount, CAST(COALESCE (au2.NominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, CAST(COALESCE (au2.Supervisor, 0) AS Bit) AS DelegateIsSupervisor ";
         private const string supervisorDelegateDetailTables = @"
             JobGroups AS jg INNER JOIN
             Users AS u ON jg.JobGroupID = u.JobGroupID INNER JOIN
@@ -145,13 +144,9 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 		                cp5.CustomPrompt AS CustomPrompt5, cp6.CustomPrompt AS CustomPrompt6, 
 		                COALESCE (au.CentreID, da.CentreID) AS CentreID, 
 		                au.Forename + ' ' + au.Surname AS SupervisorName,                 
-		                (SELECT COUNT(cas.ID) AS Expr1
-			                FROM    CandidateAssessmentSupervisors AS cas 
-			                INNER JOIN CandidateAssessments AS ca 
-				                ON cas.CandidateAssessmentID = ca.ID 
-				                AND cas.Removed IS NULL                 
-			                WHERE (cas.SupervisorDelegateId = sd.ID) 
-				                AND (ca.RemovedDate IS NULL)) AS CandidateAssessmentCount, 
+		                (SELECT COUNT(ca.ID) AS Expr1
+                        FROM CandidateAssessments AS ca LEFT JOIN CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID
+                        WHERE (ca.DelegateUserID = sd.DelegateUserID) AND (ca.RemovedDate IS NULL) AND (ca.CentreID = au.CentreID OR cas.CandidateAssessmentID IS NULL OR cas.SupervisorDelegateId = sd.ID)) AS CandidateAssessmentCount, 
 		                CAST(COALESCE (au2.IsNominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, 
 		                CAST(COALESCE (au2.IsSupervisor, 0) AS Bit) AS DelegateIsSupervisor,             
 		                da.ID AS Expr1
@@ -393,22 +388,24 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         public IEnumerable<DelegateSelfAssessment> GetSelfAssessmentsForSupervisorDelegateId(int supervisorDelegateId, int adminId)
         {
             return connection.Query<DelegateSelfAssessment>(
-                @$"SELECT {delegateSelfAssessmentFields}, COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup,
+                @$"SELECT {delegateSelfAssessmentFields}, COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup,CONVERT(BIT, IIF(cas.CandidateAssessmentID IS NULL, 0, 1)) AS IsAssignedToSupervisor,ca.DelegateUserID,
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
                 {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
-FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
-WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (sarsv.Superceded = 0)) AS ResultsVerificationRequests
-                 FROM   CandidateAssessmentSupervisors AS cas INNER JOIN
-                 CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID  AND cas.Removed IS NULL INNER JOIN
+                 FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
+                 WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (sarsv.Superceded = 0)) AS ResultsVerificationRequests
+                 FROM   CandidateAssessments AS ca  LEFT JOIN
+                 CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL INNER JOIN
                  SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID LEFT OUTER JOIN
                  NRPProfessionalGroups AS pg ON sa.NRPProfessionalGroupID = pg.ID LEFT OUTER JOIN
                  NRPSubGroups AS sg ON sa.NRPSubGroupID = sg.ID LEFT OUTER JOIN
                  NRPRoles AS r ON sa.NRPRoleID = r.ID
                  LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
-                 WHERE (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = @supervisorDelegateId)", new { supervisorDelegateId }
+                 RIGHT OUTER JOIN SupervisorDelegates AS sd ON sd.ID=@supervisorDelegateId
+                 RIGHT OUTER JOIN AdminAccounts AS au ON au.ID = sd.SupervisorAdminID
+                 WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (ca.CentreID = au.CentreID) AND (sa.[National] = 1 OR cas.SupervisorDelegateId = @supervisorDelegateId OR cas.CandidateAssessmentID IS NULL)", new { supervisorDelegateId }
                 );
         }
         public DelegateSelfAssessment GetSelfAssessmentBySupervisorDelegateSelfAssessmentId(int selfAssessmentId, int supervisorDelegateId)

--- a/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
@@ -5,6 +5,7 @@
     {
         public int ID { get; set; }
         public int SelfAssessmentID { get; set; }
+        public int DelegateUserID { get; set; }
         public string? RoleName { get; set; }
         public bool SupervisorSelfAssessmentReview { get; set; }
         public bool SupervisorResultsReview { get; set; }
@@ -25,5 +26,6 @@
         public int SignOffRequested { get; set; }
         public int ResultsVerificationRequests { get; set; }
         public bool IsSupervisorResultsReviewed { get; set; }
+        public bool IsAssignedToSupervisor { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -832,6 +832,103 @@
             return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = supervisorDelegateId });
         }
 
+        public IActionResult QuickAddSupervisor(int selfAssessmentId, int supervisorDelegateId, int delegateUserId)
+        {
+            var supervisorDelegate =
+                supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
+            var roleProfile = supervisorService.GetRoleProfileById(selfAssessmentId);
+            var supervisorRoles = supervisorService.GetSupervisorRolesForSelfAssessment(selfAssessmentId);
+
+            if (supervisorRoles.Any() && supervisorRoles.Count() > 1)
+            {
+                var model = new EnrolDelegateSupervisorRoleViewModel()
+                {
+                    SupervisorDelegateDetail = supervisorDelegate,
+                    RoleProfile = roleProfile,
+                    SelfAssessmentSupervisorRoleId = null,
+                    SelfAssessmentSupervisorRoles = supervisorRoles
+                };
+                return View("SelectDelegateSupervisorRole", model);
+            }
+            else
+            {
+                supervisorService.InsertCandidateAssessmentSupervisor(
+                    delegateUserId,
+                    supervisorDelegateId,
+                    selfAssessmentId,
+                    supervisorRoles.FirstOrDefault()?.ID
+                );
+                return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = supervisorDelegateId });
+            }
+        }
+
+        [HttpPost]
+        public IActionResult QuickAddSupervisor(EnrolDelegateSupervisorRoleViewModel supervisorRole, int selfAssessmentId, int supervisorDelegateId, int delegateUserId)
+        {
+            var roleProfile = supervisorService.GetRoleProfileById(selfAssessmentId);
+            var supervisorDelegate =
+                supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
+            if (supervisorRole.SelfAssessmentSupervisorRoleId == null)
+            {
+                var supervisorRoles = supervisorService.GetSupervisorRolesForSelfAssessment(selfAssessmentId);
+                var model = new EnrolDelegateSupervisorRoleViewModel()
+                {
+                    SupervisorDelegateDetail = supervisorDelegate,
+                    RoleProfile = roleProfile,
+                    SelfAssessmentSupervisorRoleId = null,
+                    SelfAssessmentSupervisorRoles = supervisorRoles
+                };
+                return View("SelectDelegateSupervisorRole", model);
+            }
+            else
+            {
+                var model = new EnrolDelegateSummaryViewModel
+                {
+                    RoleProfile = roleProfile,
+                    SupervisorDelegateDetail = supervisorDelegate,
+                    SupervisorRoleName = supervisorRole.SelfAssessmentSupervisorRoleId == null
+                    ? "Supervisor" : supervisorService.GetSupervisorRoleById((int)supervisorRole.SelfAssessmentSupervisorRoleId).RoleName,
+                    SupervisorRoleCount = supervisorRole.SelfAssessmentSupervisorRoleId == null
+                        ? 0 : supervisorService.GetSupervisorRolesForSelfAssessment((int)supervisorRole.SelfAssessmentSupervisorRoleId).Count()
+
+                };
+                return View("SelectDelegateSupervisorRoleSummary", new Tuple<EnrolDelegateSummaryViewModel, int?>(model, supervisorRole.SelfAssessmentSupervisorRoleId));
+            }
+        }
+
+
+        [HttpGet]
+        public IActionResult QuickAddSupervisorConfirm(int? selfAssessmentSupervisorRoleId, int selfAssessmentId, int supervisorDelegateId, int delegateUserId)
+        {
+            if (!selfAssessmentSupervisorRoleId.HasValue)
+            {
+                var roleProfile = supervisorService.GetRoleProfileById(selfAssessmentId);
+                var supervisorDelegate =
+                    supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
+                var supervisorRoles = supervisorService.GetSupervisorRolesForSelfAssessment(selfAssessmentId);
+                var model = new EnrolDelegateSupervisorRoleViewModel()
+                {
+                    SupervisorDelegateDetail = supervisorDelegate,
+                    RoleProfile = roleProfile,
+                    SelfAssessmentSupervisorRoleId = null,
+                    SelfAssessmentSupervisorRoles = supervisorRoles
+                };
+                return View("SelectDelegateSupervisorRole", model);
+            }
+            else
+            {
+                supervisorService.InsertCandidateAssessmentSupervisor(
+                    delegateUserId,
+                    supervisorDelegateId,
+                    selfAssessmentId,
+                    selfAssessmentSupervisorRoleId.Value
+                );
+                return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = supervisorDelegateId });
+            }
+        }
+
+
+
         public IActionResult RemoveDelegateSelfAssessment(int candidateAssessmentId, int supervisorDelegateId)
         {
             supervisorService.RemoveCandidateAssessment(candidateAssessmentId);

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRole.cshtml
@@ -1,0 +1,100 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+@model EnrolDelegateSupervisorRoleViewModel
+@{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Select Supervisor Role for Profile Assessment" : "Select Supervisor Role for Profile Assessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
+}
+<link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+    @section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+                        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    Supervise
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="DelegateProfileAssessments"
+           asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+                Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+            </a>
+        </p>
+    </nav>
+}
+    <details class="nhsuk-details nhsuk-expander">
+        <summary class="nhsuk-details__summary">
+            <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+                @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+            </h1>
+        </summary>
+        <div class="nhsuk-details__text">
+            <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+        </div>
+    </details>
+@if (errorHasOccurred)
+{
+    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SelfAssessmentSupervisorRoleId) })" />
+}
+<form method="post">
+    <div class="nhsuk-form-group">
+        <fieldset class="nhsuk-fieldset">
+            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                <h2 class="nhsuk-fieldset__heading">
+                    Choose your supervisor role
+                </h2>
+            </legend>
+            <nhs-form-group nhs-validation-for="SelfAssessmentSupervisorRoleId">
+                <div class="nhsuk-radios">
+                    @foreach (var role in Model.SelfAssessmentSupervisorRoles)
+                    {
+                        <div class="nhsuk-radios__item">
+                            <input class="nhsuk-radios__input" id="role-@role.ID" name="SelfAssessmentSupervisorRoleId" asp-for="SelfAssessmentSupervisorRoleId" type="radio" value="@role.ID">
+                            <label class="nhsuk-label nhsuk-radios__label" for="role-@role.ID">
+                                @role.RoleName
+                            </label>
+                            @if (role.RoleDescription != null)
+                            {
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="role-@role.ID-hint">
+                                    @role.RoleDescription
+                                </div>
+                            }
+
+                        </div>
+                    }
+
+                </div>
+            </nhs-form-group>
+        </fieldset>
+        <div class=" nhsuk-u-margin-top-5">
+
+            <button class="nhsuk-button" id="save-button" type="submit">Submit</button>
+        </div>
+    </div>
+</form>
+<div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRoleSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRoleSummary.cshtml
@@ -1,0 +1,117 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+@model Tuple<EnrolDelegateSummaryViewModel,int?>;
+@{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = "Select Supervisor Role for Profile Assessment Summary";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
+}
+<link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+    @section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@Model.Item1.SupervisorDelegateDetail.ID">@Model.Item1.SupervisorDelegateDetail.FirstName @Model.Item1.SupervisorDelegateDetail.LastName</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    Supervise
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="DelegateProfileAssessments"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                Back to @Model.Item1.SupervisorDelegateDetail.FirstName @Model.Item1.SupervisorDelegateDetail.LastName
+            </a>
+        </p>
+    </nav>
+}
+
+    <details class="nhsuk-details nhsuk-expander">
+        <summary class="nhsuk-details__summary">
+            <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+                @Model.Item1.SupervisorDelegateDetail.FirstName @Model.Item1.SupervisorDelegateDetail.LastName
+            </h1>
+        </summary>
+        <div class="nhsuk-details__text">
+            <partial name="Shared/_StaffDetails" model="Model.Item1.SupervisorDelegateDetail" />
+        </div>
+    </details>
+    <h2>Supervision Summary</h2>
+    <dl class="nhsuk-summary-list">
+
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Self Assessment
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @Model.Item1.RoleProfile.RoleProfileName
+            </dd>
+
+            <dd class="nhsuk-summary-list__actions">
+
+
+            </dd>
+
+        </div>
+
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Complete by date
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @(Model.Item1.CompleteByDate == null ? "Not set" : Model.Item1.CompleteByDate.Value.ToShortDateString())
+        </dd>
+
+        <dd class="nhsuk-summary-list__actions">
+
+
+        </dd>
+
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Supervisor role
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.Item1.SupervisorRoleName
+        </dd>
+
+        <dd class="nhsuk-summary-list__actions">
+            @if (Model.Item1.SupervisorRoleCount > 1)
+            {
+                <a asp-action="QuickAddSupervisor" asp-route-delegateUserId="@Model.Item1.SupervisorDelegateDetail.DelegateUserID.Value" asp-route-selfAssessmentId="@Model.Item1.RoleProfile.ID" asp-route-supervisorDelegateId="@Model.Item1.SupervisorDelegateDetail.ID">
+                    Change<span class="nhsuk-u-visually-hidden"> supervisor role</span>
+                </a>
+            }
+
+
+        </dd>
+
+    </div>
+
+</dl>
+<a class="nhsuk-button" role="button" asp-action="QuickAddSupervisorConfirm" asp-route-delegateUserId="@Model.Item1.SupervisorDelegateDetail.DelegateUserID.Value" asp-route-selfAssessmentId="@Model.Item1.RoleProfile.ID" asp-route-supervisorDelegateId="@Model.Item1.SupervisorDelegateDetail.ID" asp-route-selfAssessmentSupervisorRoleId="@Model.Item2.GetValueOrDefault()">
+    Confirm
+</a>
+<div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId=@Model.Item1.SupervisorDelegateDetail.ID>
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
@@ -44,18 +44,25 @@
         </td>
         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
           <span class="nhsuk-table-responsive__heading">Actions </span>
-          @if (delegateSelfAssessment.SignOffRequested == 0 && delegateSelfAssessment.LastAccessed < ClockUtility.UtcNow.AddDays(-7))
-          {
-            <a class="status-tag" asp-action="SendReminderDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Send reminder</a>
-          }
-          @if (delegateSelfAssessment.LaunchCount > 0)
-          {
-            <a asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">@(delegateSelfAssessment.SignOffRequested > 0 | delegateSelfAssessment.ResultsVerificationRequests > 0 ? "Review" : "View")</a>
-          }
-          @if (delegateSelfAssessment.CompletedDate != null | delegateSelfAssessment.LaunchCount == 0)
-          {
-            <a asp-action="RemoveDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Remove</a>
-          }
+                    @if (delegateSelfAssessment.IsAssignedToSupervisor)
+                    {
+                        @if (delegateSelfAssessment.SignOffRequested == 0 && delegateSelfAssessment.LastAccessed < ClockUtility.UtcNow.AddDays(-7))
+                        {
+                            <a class="status-tag" asp-action="SendReminderDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Send reminder</a>
+                        }
+                        @if (delegateSelfAssessment.LaunchCount > 0)
+                        {
+                            <a asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">@(delegateSelfAssessment.SignOffRequested > 0 | delegateSelfAssessment.ResultsVerificationRequests > 0 ? "Review" : "View")</a>
+                        }
+                        @if (delegateSelfAssessment.CompletedDate != null | delegateSelfAssessment.LaunchCount == 0)
+                        {
+                            <a asp-action="RemoveDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Remove</a>
+                        }
+                    }
+                    else
+                    {
+                        <a asp-action="QuickAddSupervisor" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-delegateUserId="@delegateSelfAssessment.DelegateUserID" asp-route-selfAssessmentId="@delegateSelfAssessment.SelfAssessmentID">Supervise</a>
+                    }
         </td>
       </tr>
     }


### PR DESCRIPTION
### JIRA link
[TD-899](https://hee-tis.atlassian.net/browse/TD-899)

### Description
Merge TD-202 changes, as well as further query changes(centre check, supervisor check and SelfAssessments.National check)

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-899]: https://hee-tis.atlassian.net/browse/TD-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ