### PR TITLE
TD-1166 quick add same supervisors are added multiple times

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202303071200_AddUniqueConstraintToCandidateAssessmentSupervisors.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202303071200_AddUniqueConstraintToCandidateAssessmentSupervisors.cs
@@ -1,0 +1,47 @@
+﻿using FluentMigrator;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202303071200)]
+    public class AddUniqueConstraintToCandidateAssessmentSupervisors : Migration
+    {
+        public override void Down()
+        {
+            Delete.UniqueConstraint(
+                "IX_CandidateAssessmentSupervisors_CandidateAssessmentID_SupervisorDelegateId_SelfAssessmentSupervisorRoleID"
+            )
+            .FromTable("CandidateAssessmentSupervisors");
+        }
+
+        public override void Up()
+        {
+            Execute.Sql(@"DELETE CAS
+                          FROM CandidateAssessmentSupervisors CAS
+                          INNER JOIN
+                          (
+                            SELECT *, 
+                            RANK() OVER(PARTITION BY CandidateAssessmentID, 
+                                        SupervisorDelegateId, 
+                                        SelfAssessmentSupervisorRoleID
+                            ORDER BY id) rank
+                            FROM CandidateAssessmentSupervisors
+                           ) T ON CAS.ID = T.ID
+                        WHERE rank > 1");
+            Create.UniqueConstraint(
+                    "IX_CandidateAssessmentSupervisors_CandidateAssessmentID_SupervisorDelegateId_SelfAssessmentSupervisorRoleID"
+                )
+                .OnTable("CandidateAssessmentSupervisors").Columns(
+                    "CandidateAssessmentID",
+                    "SupervisorDelegateId",
+                    "SelfAssessmentSupervisorRoleID"
+                );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202303071200_AddUniqueConstraintToCandidateAssessmentSupervisors.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202303071200_AddUniqueConstraintToCandidateAssessmentSupervisors.cs
@@ -22,9 +22,18 @@ namespace DigitalLearningSolutions.Data.Migrations
 
         public override void Up()
         {
+            Execute.Sql(@" WITH CTEUpdate AS( SELECT ID, 
+                         RANK() OVER(PARTITION BY CandidateAssessmentID,SupervisorDelegateId,SelfAssessmentSupervisorRoleID ORDER BY id) rank
+                         FROM CandidateAssessmentSupervisors)
+                         UPDATE CandidateAssessmentSupervisorVerifications
+                         SET CandidateAssessmentSupervisorID = C.ID     
+                         FROM CandidateAssessmentSupervisorVerifications CASV
+                              INNER JOIN CTEUpdate C 
+                              ON C.ID  = CASV.CandidateAssessmentSupervisorID
+                         WHERE C.rank =1");
             Execute.Sql(@"DELETE CAS
                           FROM CandidateAssessmentSupervisors CAS
-                          INNER JOIN
+                          INNER JOIN    
                           (
                             SELECT *, 
                             RANK() OVER(PARTITION BY CandidateAssessmentID, 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1166

### Description
Quick Add - Same Supervisors are added multiple times : I can't replicate the issue locally. But there is a chance to insert duplicate records into the table CandidateAssessmentSupervisors if users click the add button multiple times due to network failure or delay. So I added unique constraints to eliminate the duplicate records.

### Screenshots
Before Change:
We can add duplicate entries to the table CandidateAssessmentSupervisors. If we add any duplicate entries to the table, then the Manage Supervisor page will display duplicate entries on the page.
![image](https://user-images.githubusercontent.com/121869435/223450680-428ea04d-6cd4-4613-93d7-5593a737fd5e.png)

After Change:
Added unique constraints to the table to eliminate the duplicate entries.
![image](https://user-images.githubusercontent.com/121869435/223450573-9f6b09bd-9158-439a-98fc-a295833e5050.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
