### PR TITLE
Added check for User Centre Admin when determining session status

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanProceed.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanProceed.cs
@@ -21,7 +21,9 @@ namespace DigitalLearningSolutions.Web.ServiceFilter
                 return;
             }
 
-            if (context.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "UserUserAdmin" && c.Value == "True") == null)
+            // If user does not have an AdminID then they must be a delegate user, so no need to check for concurrency.
+            var adminId = context.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "UserAdminID");
+            if (adminId == null || int.Parse(adminId.Value) == 0)
             {
                 return;
             }


### PR DESCRIPTION
### JIRA link
[TD-275](https://hee-tis.atlassian.net/browse/TD-275)

### Description
A check for a user being a Centre Admin has been added to the check to User Admin, when determining if an Admin User session should be logged out.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-275]: https://hee-tis.atlassian.net/browse/TD-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ