### PR TITLE
Corrected ValidatePassword call to check Password rather than Current…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/ChangePasswordController.cs
@@ -44,13 +44,8 @@
         public async Task<IActionResult> Index(ChangePasswordFormData formData, DlsSubApplication dlsSubApplication)
         {
             var userId = User.GetUserId();
-            var password = formData.CurrentPassword;
-            if (TempData != null)
-            { 
-                var data = TempData.Peek<DelegateRegistrationData>()!;
-                var user = userVerificationService.GetUserAccountById((int)userId);
-                RegistrationPasswordValidator.ValidatePassword(password, user.FirstName, user.LastName, ModelState);
-            }
+            var user = userVerificationService.GetUserAccountById((int)userId);
+            RegistrationPasswordValidator.ValidatePassword(formData.Password, user.FirstName, user.LastName, ModelState);
 
             if (!ModelState.IsValid)
             {
@@ -58,7 +53,7 @@
                 return View(model);
             }
 
-            if (!userVerificationService.IsPasswordValid(password, userId))
+            if (!userVerificationService.IsPasswordValid(formData.CurrentPassword, userId))
             {
                 ModelState.AddModelError(
                     nameof(ChangePasswordFormData.CurrentPassword),


### PR DESCRIPTION
…Password

### JIRA link
[TD-274](https://hee-tis.atlassian.net/browse/TD-274)

### Description
Modified code to ensure that Password was being checked against the users name, rather than CurrentPassword. Password is the new password in this scenario, currentpassword is the existing password.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-274]: https://hee-tis.atlassian.net/browse/TD-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ