### PR TITLE
TD-1105- UAR: 'Deactivate admin account' button is not visible

### DIFF
--- a/DigitalLearningSolutions.Data/Helpers/UserPermissionsHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/UserPermissionsHelper.cs
@@ -18,7 +18,6 @@
             if (loggedInAdminAccount.IsCentreManager)
             {
                 return !adminAccount.IsSuperAdmin
-                       && !adminAccount.IsCentreManager
                        && adminAccount.Id != loggedInAdminAccount.Id;
             }
 


### PR DESCRIPTION
 **JIRA link**
https://hee-tis.atlassian.net/browse/TD-1105

**Description**
Deactivate button made available for adminAccount having centre manager role.

**Screenshots**
N/A

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
