### PR TITLE
TD-1204 Overwrite confirmed self assessment fix for live

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/SelfAssessmentTests.cs
@@ -288,6 +288,102 @@
         }
 
         [Test]
+        public void SelfAssessmentCompetency_Post_result_overriding_signedoff_question_should_redirect_to_confirmation_route()
+        {
+            // Given
+            var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
+
+            var existingAssessmentQuestions = new List<AssessmentQuestion>
+            {
+                new AssessmentQuestion
+                {
+                    Id = 1,
+                    Result = 0,
+                    SignedOff = true,
+                },
+            };
+            var competency = new Competency();
+            competency.AssessmentQuestions = existingAssessmentQuestions;
+
+            var userUpdatedAssessmentQuestions = new Collection<AssessmentQuestion>
+            {
+                new AssessmentQuestion
+                {
+                    Id = 1,
+                    Result = 1,
+                    SignedOff = true,
+                },
+            };
+
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+                .Returns(selfAssessment);
+
+            A.CallTo(() => selfAssessmentService.GetNthCompetency(A<int>._, A<int>._, A<int>._))
+                .Returns(competency);
+
+            // When
+            var result = controller.SelfAssessmentCompetency(1, userUpdatedAssessmentQuestions, 1, 1, 1);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithActionName("ConfirmOverwriteSelfAssessment");
+        }
+
+        [Test]
+        public void SelfAssessmentCompetency_Post_result_not_overriding_signedoff_question_should_redirect_to_confirmation_route()
+        {
+            // Given
+            var selfAssessment = SelfAssessmentHelper.CreateDefaultSelfAssessment();
+
+            var existingAssessmentQuestions = new List<AssessmentQuestion>
+            {
+                new AssessmentQuestion
+                {
+                    Id = 1,
+                    Result = 1,
+                    SignedOff = true,
+                },
+                new AssessmentQuestion
+                {
+                    Id = 2,
+                    Result = 0,
+                    SignedOff = false,
+                },
+            };
+            var competency = new Competency();
+            competency.AssessmentQuestions = existingAssessmentQuestions;
+
+            var userUpdatedAssessmentQuestions = new Collection<AssessmentQuestion>
+            {
+                new AssessmentQuestion
+                {
+                    Id = 1,
+                    Result = 1,
+                },
+                new AssessmentQuestion
+                {
+                    Id = 1,
+                    Result = 1,
+                },
+            };
+
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentForCandidateById(CandidateId, SelfAssessmentId))
+                .Returns(selfAssessment);
+
+            A.CallTo(() => selfAssessmentService.GetNthCompetency(A<int>._, A<int>._, A<int>._))
+                .Returns(competency);
+
+            // When
+            var result = controller.SelfAssessmentCompetency(1, userUpdatedAssessmentQuestions, 1, 1, 1);
+
+            // Then
+            result.Should()
+                .BeRedirectToActionResult()
+                .WithActionName("SelfAssessmentCompetency");
+        }
+
+        [Test]
         public void SelfAssessmentOverview_Should_Return_View()
         {
             // Given

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -169,7 +169,7 @@
                         TempData["competencyGroupId"] = competencyGroupId;
                         TempData["competencyName"] = competency.Name;
 
-                        return RedirectToAction("ConfirmOverwriteSelfAssessment", new { selfAssessmentId = selfAssessmentId, competencyNumber = competencyId });
+                        return RedirectToAction("ConfirmOverwriteSelfAssessment", new { selfAssessmentId = selfAssessmentId, competencyNumber = competencyNumber });
                     }
                 }
             }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -281,7 +281,7 @@
             selfAssessmentService.SetUpdatedFlag(selfAssessmentId, candidateId, true);
             if (assessment.LinearNavigation)
             {
-                return RedirectToAction("SelfAssessmentCompetency", new { competencyNumber = competencyNumber + 1 });
+                return RedirectToAction("SelfAssessmentCompetency", new { selfAssessmentId = selfAssessmentId, competencyNumber = competencyNumber + 1 });
             }
 
             return new RedirectResult(

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -139,7 +139,7 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/{competencyNumber:int}")]
         public IActionResult SelfAssessmentCompetency(
             int selfAssessmentId,
-            ICollection<AssessmentQuestion> assessmentQuestions,
+            ICollection<AssessmentQuestion> updatedAssessmentQuestions,
             int competencyNumber,
             int competencyId,
             int? competencyGroupId
@@ -155,20 +155,26 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
             var competency = selfAssessmentService.GetNthCompetency(competencyNumber, assessment.Id, candidateId);
-            if (competency.AssessmentQuestions.Any(x => x.SignedOff == true))
-            {
 
-                TempData["assessmentQuestions"] = JsonSerializer.Serialize(assessmentQuestions);
-                TempData["competencyId"] = competencyId;
-                TempData["competencyGroupId"] = competencyGroupId;
-                TempData["competencyName"] = competency.Name;
-
-                return RedirectToAction("ConfirmOverwriteSelfAssessment", new { selfAssessmentId = selfAssessmentId, competencyNumber = competencyId });
-            }
-            else
+            foreach (var updatedAssessmentQuestion in updatedAssessmentQuestions)
             {
-                return SubmitSelfAssessment(assessment, selfAssessmentId, competencyNumber, competencyId, competencyGroupId, candidateId, assessmentQuestions);
+                foreach (var originalAssessmentQuestion in competency.AssessmentQuestions)
+                {
+                    if (originalAssessmentQuestion.Id == updatedAssessmentQuestion.Id
+                        && originalAssessmentQuestion.SignedOff == true
+                        && updatedAssessmentQuestion.Result != originalAssessmentQuestion.Result)
+                    {
+                        TempData["assessmentQuestions"] = JsonSerializer.Serialize(updatedAssessmentQuestions);
+                        TempData["competencyId"] = competencyId;
+                        TempData["competencyGroupId"] = competencyGroupId;
+                        TempData["competencyName"] = competency.Name;
+
+                        return RedirectToAction("ConfirmOverwriteSelfAssessment", new { selfAssessmentId = selfAssessmentId, competencyNumber = competencyId });
+                    }
+                }
             }
+
+            return SubmitSelfAssessment(assessment, selfAssessmentId, competencyNumber, competencyId, competencyGroupId, candidateId, updatedAssessmentQuestions);
         }
 
         [Route(


### PR DESCRIPTION
### JIRA link
[TD-1204](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-1204)

### Description
When updating the answer to a self-assessment question, the system now only checks if the current question already has a confirmed/sign-off by the supervisor. Previously it checked if *any* of the answers in the group were signed-off, so redirected to the 'Confirm sign-off overwrite' page spuriously.

Also fixed existing issue where system threw 404 error due to incorrect routing after the user confirmed the sign-off override.

### Screenshots
Screenshots below.
-----
### Developer checks
I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1204]: https://hee-tis.atlassian.net/browse/TD-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
![TD-1204a](https://user-images.githubusercontent.com/113513647/226970264-e37d8f92-c829-4d08-9f83-f97725b8a0bd.jpg)
![TD-1204b](https://user-images.githubusercontent.com/113513647/226970291-7d932d4d-5dd5-4ad0-873a-338e7fb506cc.jpg)
![TD-1204c](https://user-images.githubusercontent.com/113513647/226970307-101893aa-a700-4290-89f8-b01763cc0161.jpg)
![TD-1204d](https://user-images.githubusercontent.com/113513647/226970326-69bd27ca-6c15-4186-a9cf-81dc8d0a8063.jpg)
