### PR TITLE
TD-1222 Fix self assessment report counts

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
@@ -76,9 +76,9 @@
                     	, can.DateRegistered AS Registered
                         , ca.StartedDate AS Started
                         , ca.LastAccessed
-                    	, COALESCE(COUNT(DISTINCT LAR.Optional), 0) AS [OptionalProficiencies]
-                    	, COALESCE(COUNT(DISTINCT LAR.SelfAssessed),0) AS [SelfAssessedAchieved]
-                    	, COALESCE(COUNT(DISTINCT LAR.Confirmed), 0) AS [ConfirmedResults]
+                    	, COALESCE(COUNT(DISTINCT LAR.Optional), NULL) AS [OptionalProficiencies]
+                    	, COALESCE(COUNT(DISTINCT LAR.SelfAssessed), NULL) AS [SelfAssessedAchieved]
+                    	, COALESCE(COUNT(DISTINCT LAR.Confirmed), NULL) AS [ConfirmedResults]
                         , max(casv.Requested) AS SignOffRequested
                         , max(1*casv.SignedOff) AS SignOffAchieved
                         , min(casv.Verified) AS ReviewedDate

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
@@ -76,7 +76,7 @@
                     	, can.DateRegistered AS Registered
                         , ca.StartedDate AS Started
                         , ca.LastAccessed
-                    	, COALESCE(COUNT(DISTINCT LAR.Optional), NULL) AS [OptionalProficiencies]
+                    	, COALESCE(COUNT(DISTINCT LAR.Optional), NULL) AS [OptionalProficienciesAssessed]
                     	, COALESCE(COUNT(DISTINCT LAR.SelfAssessed), NULL) AS [SelfAssessedAchieved]
                     	, COALESCE(COUNT(DISTINCT LAR.Confirmed), NULL) AS [ConfirmedResults]
                         , max(casv.Requested) AS SignOffRequested

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
@@ -14,7 +14,7 @@
         public DateTime? Registered { get; set; }
         public DateTime? Started { get; set; }
         public DateTime? LastAccessed { get; set; }
-        public int? OptionalProficiencies { get; set; }
+        public int?OptionalProficienciesAssessed { get; set; }
         public int? SelfAssessedAchieved { get; set; }
         public int? ConfirmedResults { get; set; }
         public DateTime? SignOffRequested { get; set; }

--- a/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Data/Services/SelfAssessmentReportService.cs
@@ -107,7 +107,7 @@
                           x.Registered,
                           x.Started,
                           x.LastAccessed,
-                          x.OptionalProficiencies,
+                          x.OptionalProficienciesAssessed,
                           x.SelfAssessedAchieved,
                           x.ConfirmedResults,
                           x.SignOffRequested,


### PR DESCRIPTION
### JIRA link
[TD-1222](https://hee-tis.atlassian.net/browse/TD-1222)

### Description
Report counts were returning a number that was always 1 too many because `COUNT DISTINCT` was including 0 in the count. This fixes that problem. Also renames the OptionalProficiencies column in the report to OptionalProficienciesAssessed because they are only included in the count if they have been self assessed.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1222]: https://hee-tis.atlassian.net/browse/TD-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ