### PR TITLE
TD-1277 Changes site footer copyright notice to NHS England

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -3,100 +3,79 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
 
-  <title>@ViewData["Title"] - Digital Learning Solutions</title>
+    <title>@ViewData["Title"] - Digital Learning Solutions</title>
 
-  <!-- Styles -->
-  <link rel="stylesheet" href="@Url.Content("~/css/nhsuk.css")" asp-append-version="true">
-  <link rel="stylesheet" href="@Url.Content("~/css/index.css")" asp-append-version="true">
-  <link rel="stylesheet" href="@Url.Content("~/css/layout.css")" asp-append-version="true">
-  @await RenderSectionAsync("styles", false)
+    <!-- Styles -->
+    <link rel="stylesheet" href="@Url.Content("~/css/nhsuk.css")" asp-append-version="true">
+    <link rel="stylesheet" href="@Url.Content("~/css/index.css")" asp-append-version="true">
+    <link rel="stylesheet" href="@Url.Content("~/css/layout.css")" asp-append-version="true">
+    @await RenderSectionAsync("styles", false)
 
-  <!-- Scripts -->
-  <script src="@Url.Content("~/js/nhsuk.js")" asp-append-version="true"></script>
+    <!-- Scripts -->
+    <script src="@Url.Content("~/js/nhsuk.js")" asp-append-version="true"></script>
 
-  <!-- Favicons -->
-  <link rel="icon" href="@Url.Content("~/favicon.ico")">
+    <!-- Favicons -->
+    <link rel="icon" href="@Url.Content("~/favicon.ico")">
 
-  <!-- Open Graph -->
-  <meta property="og:url" content="@Context.Request.GetDisplayUrl()">
-  <meta property="og:title" content="@(ViewData["og:title"] ?? ViewData["Title"] ?? "Digital Learning Solutions")">
-  <meta property="og:description" content="@(ViewData["og:description"] ?? "")">
-  <meta property="og:type" content="@(ViewData["og:type"] ?? "article")">
-  <meta property="og:site_name" content="Digital Learning Solutions">
+    <!-- Open Graph -->
+    <meta property="og:url" content="@Context.Request.GetDisplayUrl()">
+    <meta property="og:title" content="@(ViewData["og:title"] ?? ViewData["Title"] ?? "Digital Learning Solutions")">
+    <meta property="og:description" content="@(ViewData["og:description"] ?? "")">
+    <meta property="og:type" content="@(ViewData["og:type"] ?? "article")">
+    <meta property="og:site_name" content="Digital Learning Solutions">
 
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="@(ViewData["twitter:title"] ?? ViewData["Title"] ?? "Digital Learning Solutions")">
-  <meta name="twitter:description" content="@(ViewData["twitter:description"] ?? "")">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="@(ViewData["twitter:title"] ?? ViewData["Title"] ?? "Digital Learning Solutions")">
+    <meta name="twitter:description" content="@(ViewData["twitter:description"] ?? "")">
 </head>
 
 <body>
-  <div id="pagewrapper">
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <div id="pagewrapper">
+        <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
+        <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
 
-    <header class="nhsuk-header nhsuk-header--transactional">
-      <div class="nhsuk-width-container nhsuk-header__container">
-        <div class="nhsuk-header__logo nhsuk-u-margin-right-3">
-          <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NHS Logo" focusable="false" viewBox="0 0 40 16">
-            <title>NHS</title>
-            <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
-            <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-            <image src="https://assets.nhs.uk/images/nhs-logo.png" width="40" height="16" xlink:href=""></image>
-          </svg>
+        <header class="nhsuk-header nhsuk-header--transactional">
+            <div class="nhsuk-width-container nhsuk-header__container">
+                <div class="nhsuk-header__logo nhsuk-u-margin-right-3">
+                    <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NHS Logo" focusable="false" viewBox="0 0 40 16">
+                        <title>NHS</title>
+                        <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
+                        <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+                        <image src="https://assets.nhs.uk/images/nhs-logo.png" width="40" height="16" xlink:href=""></image>
+                    </svg>
+                </div>
+                <div class="nhsuk-header__service-name">
+                    <span class="nhsuk-header__transactional-service-name--link">@ViewData["SelfAssessmentTitle"]</span>
+                    <sup class="header-beta">Beta</sup>
+                </div>
+            </div>
+        </header>
+        <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+            <div class="nhsuk-width-container">
+                <ol class="nhsuk-breadcrumb__list">
+                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="LearningPortal" asp-action="Current">Current activities</a></li>
+                    @RenderSection("breadcrumbs", required: false)
+                </ol>
+                @RenderSection("mobilebacklink", required: false)
+            </div>
+        </nav>
+        <div class="nhsuk-width-container" id="maincontentwrapper">
+            <main class="nhsuk-main-wrapper" id="maincontent" tabindex="-1">
+                @RenderBody()
+
+            </main>
+            <partial name="/Views/LearningPortal/Shared/_LoadingSpinner.cshtml" />
         </div>
-        <div class="nhsuk-header__service-name">
-          <span class="nhsuk-header__transactional-service-name--link">@ViewData["SelfAssessmentTitle"]</span>
-          <sup class="header-beta">Beta</sup>
-        </div>
-      </div>
-    </header>
-    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-      <div class="nhsuk-width-container">
-        <ol class="nhsuk-breadcrumb__list">
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="LearningPortal" asp-action="Current">Current activities</a></li>
-          @RenderSection("breadcrumbs", required: false)
-        </ol>
-        @RenderSection("mobilebacklink", required: false)
-      </div>
-    </nav>
-    <div class="nhsuk-width-container" id="maincontentwrapper">
-      <main class="nhsuk-main-wrapper" id="maincontent" tabindex="-1">
-        @RenderBody()
+        <partial name="_DlsFooter" />
+        @await RenderSectionAsync("scripts", false)
 
-      </main>
-      <partial name="/Views/LearningPortal/Shared/_LoadingSpinner.cshtml" />
     </div>
-    <footer>
-      <div class="nhsuk-footer" id="nhsuk-footer">
-        <div class="nhsuk-width-container">
-          <h2 class="nhsuk-u-visually-hidden">Support links</h2>
-          <ul class="nhsuk-footer__list">
-            <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Contact">Contact us <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-            </li>
-            <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-            </li>
-            <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-            </li>
-            <li class="nhsuk-footer__list-item">
-              <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-            </li>
-          </ul>
-          <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @DateTime.Now.Year</p>
-        </div>
-      </div>
-    </footer>
-    @await RenderSectionAsync("scripts", false)
-
-  </div>
 
 </body>
 </html>

--- a/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
@@ -1,0 +1,22 @@
+﻿<footer>
+    <div class="nhsuk-footer" id="nhsuk-footer">
+        <div class="nhsuk-width-container">
+            <h2 class="nhsuk-u-visually-hidden">Support links</h2>
+            <ul class="nhsuk-footer__list">
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Contact">Contact us <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
+                </li>
+            </ul>
+            <p class="nhsuk-footer__copyright">&copy; NHS England @DateTime.Now.Year</p>
+        </div>
+    </div>
+</footer>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -6,65 +6,66 @@
 @inject IConfiguration Configuration
 
 @{
-  var dlsSubApplication = (DlsSubApplication?)ViewData[LayoutViewDataKeys.DlsSubApplication];
-  if (dlsSubApplication != null) {
-    ViewData[LayoutViewDataKeys.Application] ??= dlsSubApplication.HeaderExtension;
-    ViewData[LayoutViewDataKeys.HeaderPath] ??= dlsSubApplication.HeaderPath;
-    ViewData[LayoutViewDataKeys.HeaderPathName] ??= dlsSubApplication.HeaderPathName;
-  }
-  var headerExtension = (string)ViewData[LayoutViewDataKeys.Application];
+    var dlsSubApplication = (DlsSubApplication?)ViewData[LayoutViewDataKeys.DlsSubApplication];
+    if (dlsSubApplication != null)
+    {
+        ViewData[LayoutViewDataKeys.Application] ??= dlsSubApplication.HeaderExtension;
+        ViewData[LayoutViewDataKeys.HeaderPath] ??= dlsSubApplication.HeaderPath;
+        ViewData[LayoutViewDataKeys.HeaderPathName] ??= dlsSubApplication.HeaderPathName;
+    }
+    var headerExtension = (string)ViewData[LayoutViewDataKeys.Application];
 }
 
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
 
-  <title>@ViewData[LayoutViewDataKeys.Title] - Digital Learning Solutions</title>
+    <title>@ViewData[LayoutViewDataKeys.Title] - Digital Learning Solutions</title>
 
-  <!-- Styles -->
-  <link rel="stylesheet" href="@Url.Content("~/css/nhsuk.css")" asp-append-version="true">
-  <link rel="stylesheet" href="@Url.Content("~/css/index.css")" asp-append-version="true">
-  <link rel="stylesheet" href="@Url.Content("~/css/layout.css")" asp-append-version="true">
-  @await RenderSectionAsync("styles", false)
+    <!-- Styles -->
+    <link rel="stylesheet" href="@Url.Content("~/css/nhsuk.css")" asp-append-version="true">
+    <link rel="stylesheet" href="@Url.Content("~/css/index.css")" asp-append-version="true">
+    <link rel="stylesheet" href="@Url.Content("~/css/layout.css")" asp-append-version="true">
+    @await RenderSectionAsync("styles", false)
 
-  <!-- Scripts -->
-  <script src="@Url.Content("~/js/nhsuk.js")" asp-append-version="true"></script>
+    <!-- Scripts -->
+    <script src="@Url.Content("~/js/nhsuk.js")" asp-append-version="true"></script>
 
-  <!-- Favicons -->
-  <link rel="icon" href="@Url.Content("~/favicon.ico")">
+    <!-- Favicons -->
+    <link rel="icon" href="@Url.Content("~/favicon.ico")">
 
-  <!-- Open Graph -->
-  <meta property="og:title" content="@(ViewData["og:title"] ?? ViewData[LayoutViewDataKeys.Title] ?? "Digital Learning Solutions")">
-  <meta property="og:description" content="@(ViewData["og:description"] ?? "")">
-  <meta property="og:type" content="@(ViewData["og:type"] ?? "article")">
-  <meta property="og:site_name" content="Digital Learning Solutions">
+    <!-- Open Graph -->
+    <meta property="og:title" content="@(ViewData["og:title"] ?? ViewData[LayoutViewDataKeys.Title] ?? "Digital Learning Solutions")">
+    <meta property="og:description" content="@(ViewData["og:description"] ?? "")">
+    <meta property="og:type" content="@(ViewData["og:type"] ?? "article")">
+    <meta property="og:site_name" content="Digital Learning Solutions">
 
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="@(ViewData["twitter:title"] ?? ViewData[LayoutViewDataKeys.Title] ?? "Digital Learning Solutions")">
-  <meta name="twitter:description" content="@(ViewData["twitter:description"] ?? "")">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="@(ViewData["twitter:title"] ?? ViewData[LayoutViewDataKeys.Title] ?? "Digital Learning Solutions")">
+    <meta name="twitter:description" content="@(ViewData["twitter:description"] ?? "")">
 </head>
 
 <body>
-<div id="pagewrapper">
-  <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <div id="pagewrapper">
+        <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-  <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
-  <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white">
-    <div class="nhsuk-width-container nhsuk-header__container">
-      <div class="nhsuk-header__logo">
-        <a class="nhsuk-header__link nhsuk-header__link--service"
-           href="@(ViewData[LayoutViewDataKeys.HeaderPath] ?? Configuration["AppRootPath"] + "/Home")"
-           aria-label="NHS Digital Learning Solutions - @(ViewData[LayoutViewDataKeys.HeaderPathName] ?? "Landing Page")">
-          <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NHS Logo" focusable="false" viewBox="0 0 40 16">
-            <title>NHS</title>
-            <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
-            <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-            <image src="https://assets.nhs.uk/images/nhs-logo.png" width="40" height="16" xlink:href=""></image>
-          </svg>
+        <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
+        <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white">
+            <div class="nhsuk-width-container nhsuk-header__container">
+                <div class="nhsuk-header__logo">
+                    <a class="nhsuk-header__link nhsuk-header__link--service"
+                       href="@(ViewData[LayoutViewDataKeys.HeaderPath] ?? Configuration["AppRootPath"] + "/Home")"
+                       aria-label="NHS Digital Learning Solutions - @(ViewData[LayoutViewDataKeys.HeaderPathName] ?? "Landing Page")">
+                        <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NHS Logo" focusable="false" viewBox="0 0 40 16">
+                            <title>NHS</title>
+                            <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
+                            <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+                            <image src="https://assets.nhs.uk/images/nhs-logo.png" width="40" height="16" xlink:href=""></image>
+                        </svg>
 
                         <span class="nhsuk-header__service-name">@(ViewData[LayoutViewDataKeys.HeaderPrefix] ?? "Digital Learning Solutions ")@(headerExtension)</span>
                         @if (ViewData[LayoutViewDataKeys.Application] != null)
@@ -75,86 +76,73 @@
                             }
                         }
                     </a>
-      </div>
+                </div>
 
-      @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true) {
-        <div class="nhsuk-header__content" id="content-header">
-          <div class="nhsuk-header__menu">
-            <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
-          </div>
-        </div>
-      }
-      <vc:logo customisation-id="@((int?)ViewData[LayoutViewDataKeys.CustomisationIdForHeaderLogo])" />
-    </div>
+                @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true)
+                {
+                    <div class="nhsuk-header__content" id="content-header">
+                        <div class="nhsuk-header__menu">
+                            <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+                        </div>
+                    </div>
+                }
+                <vc:logo customisation-id="@((int?)ViewData[LayoutViewDataKeys.CustomisationIdForHeaderLogo])" />
+            </div>
 
-    @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true) {
-      <nav class="nhsuk-header__navigation" id="header-navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
-        <div class="nhsuk-width-container">
-          <p class="nhsuk-header__navigation-title">
-            <span id="label-navigation">Menu</span>
-            <button class="nhsuk-header__navigation-close" id="close-menu">
-              <partial name="_NhsChevronRight" />
-              <span class="nhsuk-u-visually-hidden">Close menu</span>
-            </button>
-          </p>
-          <ul class="nhsuk-header__navigation-list">
-            @if (IsSectionDefined("NavMenuItems")) {
-              @RenderSection("NavMenuItems", true)
-            } else if (dlsSubApplication != null) {
-              <partial name="_AutoNavMenuItems.cshtml" model="@dlsSubApplication" />
+            @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true)
+            {
+                <nav class="nhsuk-header__navigation" id="header-navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
+                    <div class="nhsuk-width-container">
+                        <p class="nhsuk-header__navigation-title">
+                            <span id="label-navigation">Menu</span>
+                            <button class="nhsuk-header__navigation-close" id="close-menu">
+                                <partial name="_NhsChevronRight" />
+                                <span class="nhsuk-u-visually-hidden">Close menu</span>
+                            </button>
+                        </p>
+                        <ul class="nhsuk-header__navigation-list">
+                            @if (IsSectionDefined("NavMenuItems"))
+                            {
+                                @RenderSection("NavMenuItems", true)
+                            }
+                            else if (dlsSubApplication != null)
+                            {
+                                <partial name="_AutoNavMenuItems.cshtml" model="@dlsSubApplication" />
+                            }
+                            @if (User.Identity.IsAuthenticated && User.GetAdminId() != null)
+                            {
+                                <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
+                                    <a class="nhsuk-header__navigation-link" asp-controller="ApplicationSelector" asp-action="Index">
+                                        Switch application
+                                        <partial name="_NhsChevronRight" />
+                                    </a>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                </nav>
             }
-            @if (User.Identity.IsAuthenticated && User.GetAdminId() != null) {
-              <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
-                <a class="nhsuk-header__navigation-link" asp-controller="ApplicationSelector" asp-action="Index">
-                  Switch application
-                  <partial name="_NhsChevronRight" />
-                </a>
-              </li>
+
+            @{
+                var visualSeparatorNoNavBar = (bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] == true ? "visual-separator-no-nav-bar" : string.Empty;
             }
-          </ul>
+            <div class="visual-separator @visualSeparatorNoNavBar"></div>
+        </header>
+
+        @RenderSection("NavBreadcrumbs", false)
+
+        <div class="nhsuk-width-container" id="maincontentwrapper">
+            <main class="nhsuk-main-wrapper" id="maincontent" tabindex="-1">
+                @RenderBody()
+            </main>
+            <partial name="/Views/LearningPortal/Shared/_LoadingSpinner.cshtml" />
         </div>
-      </nav>
-    }
 
-    @{ var visualSeparatorNoNavBar = (bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] == true ? "visual-separator-no-nav-bar" : string.Empty; }
-    <div class="visual-separator @visualSeparatorNoNavBar"></div>
-  </header>
+        <partial name="_DlsFooter" />
 
-  @RenderSection("NavBreadcrumbs", false)
-
-  <div class="nhsuk-width-container" id="maincontentwrapper">
-    <main class="nhsuk-main-wrapper" id="maincontent" tabindex="-1">
-      @RenderBody()
-    </main>
-    <partial name="/Views/LearningPortal/Shared/_LoadingSpinner.cshtml" />
-  </div>
-
-  <footer>
-    <div class="nhsuk-footer" id="nhsuk-footer">
-      <div class="nhsuk-width-container">
-        <h2 class="nhsuk-u-visually-hidden">Support links</h2>
-        <ul class="nhsuk-footer__list">
-          <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Contact">Contact us <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-          </li>
-          <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="Terms">Terms of use <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-          </li>
-          <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" target="_blank" asp-controller="LearningSolutions" asp-action="AccessibilityHelp">Accessibility <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-          </li>
-          <li class="nhsuk-footer__list-item">
-            <a class="nhsuk-footer__list-item-link" href="https://www.hee.nhs.uk/about/privacy-notice">Privacy <span class="nhsuk-u-visually-hidden">(opens new browser window)</span></a>
-          </li>
-        </ul>
-        <p class="nhsuk-footer__copyright">&copy; Digital Learning Solutions, Health Education England @DateTime.Now.Year</p>
-      </div>
+        @await RenderSectionAsync("scripts", false)
+        <script src="@Url.Content("~/js/learningPortal/dlscommon.js")" asp-append-version="true"></script>
     </div>
-  </footer>
-
-  @await RenderSectionAsync("scripts", false)
-  <script src="@Url.Content("~/js/learningPortal/dlscommon.js")" asp-append-version="true"></script>
-</div>
 
 </body>
 </html>


### PR DESCRIPTION
### JIRA link
[TD-1277](https://hee-tis.atlassian.net/browse/TD-1277)

### Description
Moved the footer element of the layout pages to a shared partial and replaced the copyright notice with copyright NHS England in prep for transition.

### Screenshots
Change for master (live):
![image](https://user-images.githubusercontent.com/67740339/228566405-d7c68b55-f401-455f-9167-cf6d2e21aab6.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1277]: https://hee-tis.atlassian.net/browse/TD-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ