### PR TITLE
TD-1152 Reinstated check for empty delegate JobGroupName display.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -55,30 +55,44 @@
         private readonly IDbConnection connection;
         private readonly ILogger<SupervisorService> logger;
         private const string supervisorDelegateDetailFields = @"
-            sd.ID, sd.SupervisorEmail, sd.SupervisorAdminID, sd.DelegateEmail, sd.DelegateUserID, sd.Added, sd.AddedByDelegate, sd.NotificationSent, sd.Removed, sd.InviteHash, du.FirstName, du.LastName, jg.JobGroupName, da.ID AS DelegateID, da.Answer1, da.Answer2, da.Answer3, da.Answer4, 
-             da.Answer5, da.Answer6, da.CandidateNumber, du.ProfessionalRegistrationNumber, du.PrimaryEmail AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2, cp3.CustomPrompt AS CustomPrompt3, 
+            sd.ID, sd.SupervisorEmail, sd.SupervisorAdminID, sd.DelegateEmail, sd.DelegateUserID, sd.Added, sd.AddedByDelegate, sd.NotificationSent, sd.Removed, sd.InviteHash, u.FirstName, u.LastName, jg.JobGroupName, da.ID AS DelegateID, da.Answer1, da.Answer2, da.Answer3, da.Answer4, 
+             da.Answer5, da.Answer6, da.CandidateNumber, u.ProfessionalRegistrationNumber, u.PrimaryEmail AS CandidateEmail, cp1.CustomPrompt AS CustomPrompt1, cp2.CustomPrompt AS CustomPrompt2, cp3.CustomPrompt AS CustomPrompt3, 
              cp4.CustomPrompt AS CustomPrompt4, cp5.CustomPrompt AS CustomPrompt5, cp6.CustomPrompt AS CustomPrompt6, COALESCE (aa.CentreID, da.CentreID) AS CentreID, au.FirstName + ' ' + au.LastName AS SupervisorName,
                  (SELECT COUNT(ca.ID) AS Expr1
             FROM CandidateAssessments AS ca INNER JOIN SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID LEFT JOIN CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID 
             WHERE (ca.DelegateUserID = sd.DelegateUserID) AND (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = sd.ID  OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = aa.CentreID AND sa.[National] = 1))) AS CandidateAssessmentCount, CAST(COALESCE (au2.IsNominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, CAST(COALESCE (au2.IsSupervisor, 0) AS Bit)
              AS DelegateIsSupervisor ";
         private const string supervisorDelegateDetailTables = @"
-            CustomPrompts AS cp2 RIGHT OUTER JOIN
-             CustomPrompts AS cp3 RIGHT OUTER JOIN
-             CustomPrompts AS cp4 RIGHT OUTER JOIN
-             CustomPrompts AS cp5 RIGHT OUTER JOIN
-             CustomPrompts AS cp6 RIGHT OUTER JOIN
-             Centres AS ct ON cp6.CustomPromptID = ct.CustomField6PromptID ON cp5.CustomPromptID = ct.CustomField5PromptID ON cp4.CustomPromptID = ct.CustomField4PromptID ON cp3.CustomPromptID = ct.CustomField3PromptID ON 
-             cp2.CustomPromptID = ct.CustomField2PromptID LEFT OUTER JOIN
-             CustomPrompts AS cp1 ON ct.CustomField1PromptID = cp1.CustomPromptID FULL OUTER JOIN
-             DelegateAccounts AS da INNER JOIN
-             Users AS u ON da.UserID = u.ID ON ct.CentreID = da.CentreID FULL OUTER JOIN
-             Users AS du INNER JOIN
-             AdminAccounts AS au2 ON du.ID = au2.UserID RIGHT OUTER JOIN
-             JobGroups AS jg ON du.JobGroupID = jg.JobGroupID ON da.CentreID = au2.CentreID AND da.UserID = du.ID FULL OUTER JOIN
-             SupervisorDelegates AS sd INNER JOIN
-             AdminAccounts AS aa ON sd.SupervisorAdminID = aa.ID ON da.CentreID = aa.CentreID AND u.ID = sd.DelegateUserID
-             INNER JOIN Users AS au ON  aa.UserID = au.ID";
+            CustomPrompts AS cp2 
+            RIGHT OUTER JOIN CustomPrompts AS cp3 
+            RIGHT OUTER JOIN CustomPrompts AS cp4 
+            RIGHT OUTER JOIN CustomPrompts AS cp5 
+            RIGHT OUTER JOIN CustomPrompts AS cp6 
+            RIGHT OUTER JOIN Centres AS ct 
+	            ON cp6.CustomPromptID = ct.CustomField6PromptID 
+            ON cp5.CustomPromptID = ct.CustomField5PromptID 
+            ON cp4.CustomPromptID = ct.CustomField4PromptID 
+            ON cp3.CustomPromptID = ct.CustomField3PromptID 
+            ON cp2.CustomPromptID = ct.CustomField2PromptID 
+            LEFT OUTER JOIN CustomPrompts AS cp1 
+	            ON ct.CustomField1PromptID = cp1.CustomPromptID 
+            FULL OUTER JOIN DelegateAccounts AS da 
+            INNER JOIN Users AS u 
+	            ON da.UserID = u.ID 
+            ON ct.CentreID = da.CentreID 
+            RIGHT OUTER JOIN JobGroups AS jg 
+	            ON u.JobGroupID = jg.JobGroupID 			 
+            FULL OUTER JOIN Users AS du 
+            INNER JOIN AdminAccounts AS au2 
+	            ON du.ID = au2.UserID 
+            ON da.CentreID = au2.CentreID AND da.UserID = du.ID 			 
+            FULL OUTER JOIN SupervisorDelegates AS sd 
+            INNER JOIN AdminAccounts AS aa 
+	            ON sd.SupervisorAdminID = aa.ID 
+            ON da.CentreID = aa.CentreID 
+            AND u.ID = sd.DelegateUserID
+            INNER JOIN Users AS au ON  aa.UserID = au.ID
+            ";
 
         private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate";
         private const string signedOffFields = @"(SELECT TOP (1) casv.Verified

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
@@ -35,7 +35,6 @@
         </dd>
     </div>
 
-    @if (!string.IsNullOrEmpty(Model.JobGroupName)) {
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
             Job Group
@@ -44,7 +43,6 @@
             @Model.JobGroupName
         </dd>
     </div>
-    }
 
     @if (Model.CustomPrompt1 != null)
     {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_StaffDetails.cshtml
@@ -35,6 +35,7 @@
         </dd>
     </div>
 
+    @if (!string.IsNullOrEmpty(Model.JobGroupName)) {
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
             Job Group
@@ -43,6 +44,7 @@
             @Model.JobGroupName
         </dd>
     </div>
+    }
 
     @if (Model.CustomPrompt1 != null)
     {


### PR DESCRIPTION
### JIRA link
[TD-1152](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-1152)

### Description
The staff delegate panel was in some use cases displaying an empty Job Group Name row. This was previously hidden if customparam2 was empty, so this is effectively now reinstated for the new hardcoded JobGroupName html elements.

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1152]: https://hee-tis.atlassian.net/browse/TD-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
![td-1152](https://user-images.githubusercontent.com/113513647/228572752-2040da6b-e1e1-4165-8405-a431a9902d3e.jpg)

