### PR TITLE
TD-1154-Centre Email address should not be same as Primary email address

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/MyAccount/MyAccountControllerTests.cs
@@ -354,14 +354,17 @@
                 .ValidationState.Should().Be
                     (ModelValidationState.Invalid);
 
-            myAccountController.ModelState.Count.Should().Be(1); // The values for centres 2 and 3 are not invalid
-
+            //myAccountController.ModelState.Count.Should().Be(1); // The values for centres 2 and 3 are not invalid
+            myAccountController.ModelState.Count().Should().Be(2); //Since we are expecting 2 errors
             result.As<ViewResult>().Model.As<MyAccountEditDetailsViewModel>().Should()
                 .BeEquivalentTo(expectedModel);
 
-            var errorMessage = result.As<ViewResult>().ViewData.ModelState.Select(x => x.Value.Errors)
+            var errorMessageSameEmail = result.As<ViewResult>().ViewData.ModelState.Select(x => x.Value.Errors)
                 .Where(y => y.Count > 0).ToList().First().First().ErrorMessage;
-            errorMessage.Should().BeEquivalentTo("This email is already in use by another user at the centre");
+            var errorMessageEmailAlreadyInUse = result.As<ViewResult>().ViewData.ModelState.Select(x => x.Value.Errors)
+                .Where(y => y.Count > 0).ToList().Last().Last().ErrorMessage;
+            errorMessageSameEmail.Should().BeEquivalentTo("Centre email is the same as primary email");
+            errorMessageEmailAlreadyInUse.Should().BeEquivalentTo("This email is already in use by another user at the centre");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -299,6 +299,7 @@
             }
             else
             {
+                ValidateCentreEmailIsSameAsPrimaryIfCentreIsNotSelected(formData);
                 ValidateCentreEmailsDictionary(formData.CentreSpecificEmailsByCentreId, userId);
             }
         }
@@ -609,6 +610,19 @@
                     CommonValidationErrorMessages.CenterEmailIsSameAsPrimary
                 );
                 formData.CentreSpecificEmail = null;
+            }
+        }
+        private void ValidateCentreEmailIsSameAsPrimaryIfCentreIsNotSelected(MyAccountEditDetailsFormData formData)
+        {
+            foreach (var centreIdAndEmail in formData.AllCentreSpecificEmailsDictionary)
+            {
+                if (centreIdAndEmail.Value == formData.Email)
+                {
+                    ModelState.AddModelError(
+                    "AllCentreSpecificEmailsDictionary_" + centreIdAndEmail.Key,
+                CommonValidationErrorMessages.CenterEmailIsSameAsPrimary);
+                    break;
+                }
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using System.Globalization;
@@ -616,7 +617,7 @@
         {
             foreach (var centreIdAndEmail in formData.AllCentreSpecificEmailsDictionary)
             {
-                if (centreIdAndEmail.Value == formData.Email)
+                if (string.Compare(centreIdAndEmail.Value, formData.Email, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     ModelState.AddModelError(
                     "AllCentreSpecificEmailsDictionary_" + centreIdAndEmail.Key,

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -411,6 +411,12 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
 
         private void ValidateEmailAddresses(PersonalInformationViewModel model)
         {
+            if (!string.IsNullOrEmpty(model.PrimaryEmail) &&
+                string.Compare(model.CentreSpecificEmail, model.PrimaryEmail, StringComparison.OrdinalIgnoreCase) == 0) //Ignoring the case since email addresses are case insensitive
+            {
+                ModelState.AddModelError("CentreSpecificEmail",
+                CommonValidationErrorMessages.CenterEmailIsSameAsPrimary);
+            }
             RegistrationEmailValidator.ValidatePrimaryEmailIfNecessary(
                 model.PrimaryEmail,
                 nameof(PersonalInformationViewModel.PrimaryEmail),


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1154

### Description
Added validation for email address uniqueness for primary email and centre email in register page and my account page

### Screenshots
![image](https://user-images.githubusercontent.com/126668828/228902142-32430d6b-b09a-4c46-9747-e34090f52c3a.png)
![image](https://user-images.githubusercontent.com/126668828/228902322-045e0476-0f39-4c3d-b13a-ed29ad8ff828.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
