### PR TITLE
TD-1313 Implement site-wide alert banner

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -335,3 +335,18 @@ nav, .nhsuk-header__navigation, #header-navigation {
     color: $color_nhsuk-dark-pink;
   }
 }
+.dls-alert-banner {
+  background-color: $color_nhsuk-dark-pink;
+  color: #FFFFFF;
+  a {
+    color: #FFFFFF;
+
+    &:hover {
+      color: #FFFFFF;
+    }
+
+    &:visited {
+      color: #FFFFFF;
+    }
+  }
+}

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -50,10 +50,19 @@
 </head>
 
 <body>
+
+    
     <div id="pagewrapper">
         <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
         <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
+        <div class="dls-alert-banner">
+            <div class="nhsuk-width-container">
+                <div class="hee-banner__message nhsuk-u-padding-top-4">
+                    <p class="nhsuk-body-s"> Creating a new NHS England: Health Education England, NHS Digital and NHS England have merged. <a href="https://hee.nhs.uk/hee-merges-with-nhs-england" target="_parent">Learn more.</a></p>
+                </div>
+            </div>
+        </div>
         <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white">
             <div class="nhsuk-width-container nhsuk-header__container">
                 <div class="nhsuk-header__logo">

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -56,13 +56,17 @@
         <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
         <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
-        <div class="dls-alert-banner">
-            <div class="nhsuk-width-container">
-                <div class="hee-banner__message nhsuk-u-padding-top-4">
-                    <p class="nhsuk-body-s"> Creating a new NHS England: Health Education England, NHS Digital and NHS England have merged. <a href="https://hee.nhs.uk/hee-merges-with-nhs-england" target="_parent">Learn more.</a></p>
+        @if(Configuration["ShowAlertBanner"] == "True")
+        {
+            <div class="dls-alert-banner">
+                <div class="nhsuk-width-container">
+                    <div class="hee-banner__message nhsuk-u-padding-top-4">
+                        @Html.Raw(Configuration["AlertBannerContent"])
+                    </div>
                 </div>
             </div>
-        </div>
+        }
+        
         <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white">
             <div class="nhsuk-width-container nhsuk-header__container">
                 <div class="nhsuk-header__logo">

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -19,4 +19,6 @@
     "RefactoredFindYourCentrePage": true
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
+  "ShowAlertBanner": "True",
+  "AlertBannerContent": "<p class='nhsuk-body-s'>Creating a new NHS England: Health Education England, NHS Digital and NHS England have merged. <a href='https://hee.nhs.uk/hee-merges-with-nhs-england' target='_parent'>Learn more.</a></p>"
 }

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
     "PricingPage": true,
     "RefactoredFindYourCentrePage": true
   },
-  "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
+  "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "ShowAlertBanner": "True",
   "AlertBannerContent": "<p class='nhsuk-body-s'>Creating a new NHS England: Health Education England, NHS Digital and NHS England have merged. <a href='https://hee.nhs.uk/hee-merges-with-nhs-england' target='_parent'>Learn more.</a></p>"
 }

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -18,7 +18,5 @@
     "PricingPage": true,
     "RefactoredFindYourCentrePage": true
   },
-  "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
-  "ShowAlertBanner": "True",
-  "AlertBannerContent": "<p class='nhsuk-body-s'>Creating a new NHS England: Health Education England, NHS Digital and NHS England have merged. <a href='https://hee.nhs.uk/hee-merges-with-nhs-england' target='_parent'>Learn more.</a></p>"
+  "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -28,5 +28,7 @@
     "LinkingEndpoint": "/create-user",
     "ClientCode": "DigitalLearningSolutions"
   },
-  "ExcelPassword": "0f8cc6f0-9f21-4f0f-9cb9-365675490458"
+  "ExcelPassword": "0f8cc6f0-9f21-4f0f-9cb9-365675490458",
+  "ShowAlertBanner": "True",
+  "AlertBannerContent": "<p class='nhsuk-body-s'>Creating a new NHS England: Health Education England, NHS Digital and NHS England have merged. <a href='https://hee.nhs.uk/hee-merges-with-nhs-england' target='_parent'>Learn more.</a></p>"
 }


### PR DESCRIPTION
### JIRA link
[TD-1313](https://hee-tis.atlassian.net/browse/TD-1313)

### Description
Implements a site-wide alert banner in the layout template. Visibility and content of this banner are set in appsettings.  This will be used to display the NHS England merger banner content initially.

### Screenshots
![image](https://user-images.githubusercontent.com/67740339/229553775-12b68ee4-10a4-4062-a511-9c8b583f5945.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1313]: https://hee-tis.atlassian.net/browse/TD-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ