### PR TITLE
TD-1315 Tutorial menu Next section bug fix

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/TutorialContentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/TutorialContentDataService.cs
@@ -91,6 +91,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                          INNER JOIN Sections
                          ON Tutorials.SectionID = Sections.SectionID
                             AND Sections.ArchivedDate IS NULL
+							AND Sections.ApplicationID = Customisations.ApplicationID
 
                          INNER JOIN CustomisationTutorials
                          ON CustomisationTutorials.CustomisationID = @customisationId


### PR DESCRIPTION
### JIRA link
[TD-1315](https://hee-tis.atlassian.net/browse/TD-1315)

### Description
Fixes query returning data for the tutorial screen by ensuring that the OtherTutorials section of the query only returns tutorials for the course (ApplicationID) referenced in the Customisation.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1315]: https://hee-tis.atlassian.net/browse/TD-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ