### PR TITLE
TD-1181 Fixed 410 error should be shown when clicked browser back but…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -1,5 +1,6 @@
 namespace DigitalLearningSolutions.Web.Controllers.Register
 {
+    using System;
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
@@ -78,7 +79,12 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         public IActionResult PersonalInformation()
         {
             var data = TempData.Peek<DelegateRegistrationByCentreData>()!;
-
+            var delegateRegistered = TempData.Peek("delegateRegistered")!;
+            if (Convert.ToBoolean(delegateRegistered))
+            {
+                TempData.Clear();
+                return RedirectToAction("LearningSolutions", "StatusCode", new { code = 410 });
+            }
             var model = new RegisterDelegatePersonalInformationViewModel(data);
 
             ValidateEmailAddress(model);
@@ -188,7 +194,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
         public IActionResult Password()
         {
             var model = new PasswordViewModel();
-
             return View(model);
         }
 
@@ -241,6 +246,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
                 TempData.Clear();
                 TempData.Add("delegateNumber", candidateNumber);
                 TempData.Add("passwordSet", data.IsPasswordSet);
+                TempData.Add("delegateRegistered", true);
                 return RedirectToAction("Confirmation");
             }
             catch (DelegateCreationFailedException e)


### PR DESCRIPTION
…tons

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1181

### Description
Fixed 410 error should be shown when clicked browser back buttons

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
