### PR TITLE
Modified keep alive ping to use Url.Action

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/keepSessionAlive.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/keepSessionAlive.ts
@@ -2,6 +2,8 @@ export const heartbeatInterval = 60000;
 
 export function keepSessionAlive(): void {
   const request = new XMLHttpRequest();
-  request.open('GET', '/keepSessionAlive/ping', true);
+  const keepAlivePingPath = <HTMLInputElement>document.getElementById('keepAlivePingPath');
+  const path = keepAlivePingPath?.value;
+  request.open('GET', path, true);
   request.send();
 }

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -195,6 +195,7 @@
             })(window, document, 'script', 'dataLayer', 'GTM-5SKPRFQ');</script>
         <!-- End Google Tag Manager -->
 
+        <input type="hidden" id="keepAlivePingPath" value="@Url.Action("ping","keepSessionAlive")" />
     </div>
 
 </body>


### PR DESCRIPTION
### JIRA link
[TD-296](https://hee-tis.atlassian.net/browse/TD-269)

### Description
The ajax calls to the keep alive ping have been modified to ensure that they use the correct sub domain when making the call.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-296]: https://hee-tis.atlassian.net/browse/TD-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ