### PR TITLE
TD-1284 Fixes excel export query to resolve problems identified by testers

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
@@ -54,9 +54,9 @@
                     FROM   SelfAssessmentResults AS s INNER JOIN
                                      (SELECT MAX(sar1.ID) AS ID
                                      FROM    SelfAssessmentResults as sar1 INNER JOIN
-                    				 DelegateAccounts AS da ON sar1.DelegateUserID = da.UserID AND da.CentreID = @centreId
+                    				 DelegateAccounts AS da1 ON sar1.DelegateUserID = da1.UserID AND da1.CentreID = @centreId
                                      WHERE (SelfAssessmentID = @selfAssessmentId)
-                                     GROUP BY da.ID, CompetencyID, AssessmentQuestionID) AS t ON s.ID = t.ID INNER JOIN
+                                     GROUP BY da1.ID, CompetencyID, AssessmentQuestionID) AS t ON s.ID = t.ID INNER JOIN
                                  SelfAssessmentStructure AS sas ON s.SelfAssessmentID = sas.SelfAssessmentID AND s.CompetencyID = sas.CompetencyID LEFT OUTER JOIN
                                  SelfAssessmentResultSupervisorVerifications AS sv ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0 LEFT OUTER JOIN
                                  CompetencyAssessmentQuestionRoleRequirements AS rr ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
@@ -65,7 +65,7 @@
                     SELECT 
                         sa.Name AS SelfAssessment
                     	, u.LastName + ', ' + u.FirstName AS Learner
-						, da.Active
+						, da.Active AS LearnerActive
                     	, u.ProfessionalRegistrationNumber AS PRN
                         , jg.JobGroupName AS JobGroup
                     	, CASE WHEN c.CustomField1PromptID = 10 THEN da.Answer1 WHEN c.CustomField2PromptID = 10 THEN da.Answer2 WHEN c.CustomField3PromptID = 10 THEN da.Answer3 WHEN c.CustomField4PromptID = 10 THEN da.Answer4 WHEN c.CustomField5PromptID = 10 THEN da.Answer5 WHEN c.CustomField6PromptID = 10 THEN da.Answer6 ELSE '' END AS 'ProgrammeCourse'
@@ -81,7 +81,7 @@
                     	, da.DateRegistered AS Registered
                         , ca.StartedDate AS Started
                         , ca.LastAccessed
-                    	, COALESCE(COUNT(DISTINCT LAR.Optional), NULL) AS [OptionalProficiencies]
+                    	, COALESCE(COUNT(DISTINCT LAR.Optional), NULL) AS [OptionalProficienciesAssessed]
                     	, COALESCE(COUNT(DISTINCT LAR.SelfAssessed), NULL) AS [SelfAssessedAchieved]
                     	, COALESCE(COUNT(DISTINCT LAR.Confirmed), NULL) AS [ConfirmedResults]
                         , max(casv.Requested) AS SignOffRequested
@@ -99,7 +99,7 @@
                         CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID left JOIN
                         CandidateAssessmentSupervisorVerifications AS casv ON casv.CandidateAssessmentSupervisorID = cas.ID LEFT JOIN
 	                    SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID 
-	                    LEFT OUTER JOIN LatestAssessmentResults AS LAR ON LAR.DelegateUserID = da.ID
+	                    LEFT OUTER JOIN LatestAssessmentResults AS LAR ON LAR.DelegateUserID = ca.DelegateUserID
                     WHERE
                         (sa.ID = @SelfAssessmentID) AND (sa.ArchivedDate IS NULL) AND (c.Active = 1) AND (ca.RemovedDate IS NULL)
                     Group by sa.Name


### PR DESCRIPTION
### JIRA link
[TD-1284](https://hee-tis.atlassian.net/browse/TD-1284)

### Description
Fixes query to join between latest assessment results (LAR) and main query to fix competency counts. Sets the field alias for delegate account Active to 'LearnerActive' to ensure it maps properly.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1284]: https://hee-tis.atlassian.net/browse/TD-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ