### PR TITLE
TD-1198 added a condition for approved centres so that only approved centres …

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -246,7 +246,7 @@
                         CentreID IN (SELECT DA.CentreID FROM DelegateAccounts DA
                         INNER JOIN CentreSelfAssessments CSA on csa.CentreID = DA.CentreID
                         where DA.UserID = @delegateUserId And DA.Active = 1
-                        AND CSA.SelfAssessmentID=@selfAssessmentId)
+                        AND CSA.SelfAssessmentID=@selfAssessmentId AND DA.Approved=1)
                         AND ((COALESCE(CategoryID, 0) = 0) OR (CategoryID IN (select CategoryID from SelfAssessments where ID=@selfAssessmentId)))
                         AND AdminID NOT IN (
                         SELECT sd.SupervisorAdminID


### PR DESCRIPTION
…are shown

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1198

### Description
Changed the SQL query by placing an additional where clause to return only the centres which are approved.

### Screenshots
![image](https://user-images.githubusercontent.com/126668828/231143550-1766717b-9b64-4ebe-a8b5-49e3375c484e.png)
![image](https://user-images.githubusercontent.com/126668828/231143617-51b437a8-8a90-4472-ae9c-fe198e57d073.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
