### PR TITLE
TD-1134: After unlock click not expanding selected user issue fixed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Users/UsersController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Users/UsersController.cs
@@ -319,14 +319,14 @@
             return View("UserCentreAccounts", model);
         }
         [Route("SuperAdmin/Users/{UserId:int}/UnlockAccount")]
-        public IActionResult UnlockAccount(int UserId, string RequestUrl= null)
+        public IActionResult UnlockAccount(int userId, string RequestUrl= null)
         {
-            userService.ResetFailedLoginCountByUserId(UserId);
-
+            userService.ResetFailedLoginCountByUserId(userId);
+            TempData["UserId"] = userId;
             if (RequestUrl != null)
                 return Redirect(RequestUrl);
 
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", "Users", new { UserId = userId });
         }
 
         [Route("SuperAdmin/Users/{userId=0:int}/ActivateUser")]


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1134

### Description
After unlock click not expanding selected user issue fixed

### Screenshots
After issue fix:
![image](https://user-images.githubusercontent.com/120369940/232456352-6992fdc9-5f41-4fd2-adb7-d6a3ae9901f6.png)
![image](https://user-images.githubusercontent.com/120369940/232456416-51879080-6ba6-40fa-a64e-d086be355fd2.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
