### PR TITLE
TD-1380-Back button error in mobile view returning to self assessment menu

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -798,6 +798,7 @@
                 MultiPageFormDataFeature.AddNewSupervisor,
                 TempData
             );
+            TempData["CentreID"]=model.CentreID.ToString();
             return RedirectToAction("AddNewSupervisor", new { model.SelfAssessmentID });
         }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
@@ -20,8 +20,14 @@
 @section mobilebacklink
     {
     <p class="nhsuk-breadcrumb__back">
-        <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
-       asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">Back</a>
+      @if(TempData["CentreID"] == null)
+      {
+        <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back</a>
+      }
+      else
+      {
+        <a class="nhsuk-breadcrumb__backlink" asp-action="SelectSupervisorCentre" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back</a>
+      }
     </p>
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelectSupervisorCentre.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelectSupervisorCentre.cshtml
@@ -20,8 +20,7 @@
   @section mobilebacklink
   {
   <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
-     asp-fragment="comp-@ViewContext.RouteData.Values["competencyNumber"]">Back</a>
+    <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back</a>
   </p>
 }
   <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1380

**Description**
Back button link updated.

**Screenshots**
N/A

-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
