### PR TITLE
Reinstated the keepAlivePingPath hidden input

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -169,6 +169,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         <script src="@Url.Content("~/js/cookiesbanner.js")" asp-append-version="true"></script>
 
+        <input type="hidden" id="keepAlivePingPath" value="@Url.Action("ping","keepSessionAlive")" />
+
     </div>
 
 </body>


### PR DESCRIPTION
### JIRA link
[TD-296](https://hee-tis.atlassian.net/browse/TD-269)

### Description
The hidden input ID=keepAlivePingPath has been re added to _Layout.cshtml.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-296]: https://hee-tis.atlassian.net/browse/TD-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ