### PR TITLE
TD-1390-Failed to show account is locked on login screen when users failed login count exceeds the expected count

### DIFF
--- a/DigitalLearningSolutions.Web/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Web/Services/LoginService.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.ViewModels;
@@ -58,7 +59,7 @@
                 userEntity.UserAccount.FailedLoginCount += 1;
                 userService.UpdateFailedLoginCount(userEntity.UserAccount);
 
-                return userEntity.IsLocked
+                return userEntity.UserAccount.FailedLoginCount >= AuthHelper.FailedLoginThreshold
                     ? new LoginResult(LoginAttemptResult.AccountLocked)
                     : new LoginResult(LoginAttemptResult.InvalidCredentials);
             }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1390

**Description**
check added to compare failed login count.

**Screenshots**
N/A
-----
**Developer checks**
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
