### PR TITLE
TD-1393-Issue with 'Back to signposting' link in Mobile view on 'Your cookie settings have been saved' page

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CookieConsent/CookieConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CookieConsent/CookieConfirmation.cshtml
@@ -15,7 +15,9 @@
                 <li class="nhsuk-breadcrumb__item">Cookie Consent</li>
             </ol>
             <p class="nhsuk-breadcrumb__back">
-                <a class="nhsuk-breadcrumb__backlink">Back to Signposting</a>
+                <a class="nhsuk-breadcrumb__link trigger-loader"
+                   asp-action="CookiePolicy"
+                   asp-controller="CookieConsent">Cookie Policy</a>
             </p>
         </div>
     </nav>

--- a/DigitalLearningSolutions.Web/Views/CookieConsent/CookieConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CookieConsent/CookieConfirmation.cshtml
@@ -15,9 +15,7 @@
                 <li class="nhsuk-breadcrumb__item">Cookie Consent</li>
             </ol>
             <p class="nhsuk-breadcrumb__back">
-                <a class="nhsuk-breadcrumb__link trigger-loader"
-                   asp-action="CookiePolicy"
-                   asp-controller="CookieConsent">Cookie Policy</a>
+                <a class="nhsuk-breadcrumb__backlink">Back to Signposting</a>
             </p>
         </div>
     </nav>


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1393

**Description**
mobile view back link updated to Cookie Policy.

**Screenshots**
Updated in Jira ticket.

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
