### PR TITLE
TD-1185- Progress bar on supervisor review self assessment screen added

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -71,7 +71,7 @@
         <PackageReference Include="Microsoft.FeatureManagement" Version="2.5.1" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
         <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
         <PackageReference Include="NHSUKViewComponents.Web" Version="1.0.8" />
         <PackageReference Include="Npm" Version="3.5.2" />
         <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -71,7 +71,7 @@
         <PackageReference Include="Microsoft.FeatureManagement" Version="2.5.1" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
         <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
         <PackageReference Include="NHSUKViewComponents.Web" Version="1.0.8" />
         <PackageReference Include="Npm" Version="3.5.2" />
         <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -4,6 +4,17 @@
   ViewData["Title"] = "Review Profile Assessment";
   ViewData["Application"] = "Supervisor";
   ViewData["HeaderPathName"] = "Supervisor";
+    var competencySummaries = from g in Model.CompetencyGroups
+                              let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
+                              let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
+                              let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
+                              select new ViewDataDictionary(ViewData)
+{
+
+        { "questionsCount", questions.Count() },
+        { "selfAssessedCount", selfAssessedCount },
+        { "verifiedCount", verifiedCount }
+      };
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
@@ -50,6 +61,14 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h2>@Model.DelegateSelfAssessment.RoleName</h2>
+        @if (Model.CompetencyGroups.Count() > 5)
+        {
+            <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-">
+                <partial name="_ReviewSelfAssessmentOverallProgress"
+                     model="@competencySummaries"
+                     view-data="@(new ViewDataDictionary(ViewData))" />
+            </div>
+        }
     </div>
     <div class="nhsuk-grid-column-one-third">
       @if (Model.DelegateSelfAssessment.SignOffRequested > 0)

--- a/DigitalLearningSolutions.Web/Views/Supervisor/_ReviewSelfAssessmentOverallProgress.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/_ReviewSelfAssessmentOverallProgress.cshtml
@@ -1,0 +1,11 @@
+﻿@model IEnumerable<ViewDataDictionary>
+@{
+    var questionsTotal = Model.Sum(c => (int)c["questionsCount"]);
+    var selfAssessedTotal = Model.Sum(c => (int)c["selfAssessedCount"]);
+    var verifiedTotal = Model.Sum(c => (int)c["verifiedCount"]);
+}
+<h3>Overall Progress</h3>
+<p class="nhsuk-body-l">
+    <span class="score">Self assessed: @selfAssessedTotal / @questionsTotal</span>
+    <span class="score nhsuk-u-padding-6">Confirmed: @verifiedTotal / @questionsTotal</span>
+</p>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1185

### Description
Added Progress bar on supervisor review self assessment screen by adding code to ReviewSelfAssessment.cshtml and creating a partial view _ReviewSelfAssessmentOverallProgress.cshtml

### Screenshots
After code changes, the UI shows the progress bar-
![image](https://user-images.githubusercontent.com/126668828/232991612-a559d6f8-c4e8-450d-886e-a731763c281e.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
