### PR TITLE
TD-1396-Issue with back links in Mobile view when adding a supervisor for the assessments in Learning Portal

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisorSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisorSummary.cshtml
@@ -13,9 +13,9 @@
   @section mobilebacklink
   {
   <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors"
+    <a class="nhsuk-breadcrumb__backlink" asp-action="SetSupervisorRole"
      asp-route-selfAssessmentId="@Model.SelfAssessmentID">
-      Back to Manage Supervisors
+      Back
     </a>
   </p>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SetSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SetSupervisorRole.cshtml
@@ -14,9 +14,9 @@
   @section mobilebacklink
   {
   <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors"
+    <a class="nhsuk-breadcrumb__backlink" asp-action="AddNewSupervisor"
      asp-route-selfAssessmentId="@Model.SelfAssessmentID">
-      Back to Manage Supervisors
+      Back
     </a>
   </p>
 }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1396

**Description**
Links are updated accordingly.

**Screenshots**
Updated in the Jira ticket.

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
