### PR TITLE
TD-1166 quick add same supervisors are added multiple times

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -583,6 +583,16 @@
             var roles = supervisorService.GetSupervisorRolesForSelfAssessment(selfAssessmentId).ToArray();
             if (roles.Count() > 1)
             {
+                var sessionAddSupervisor = new SessionAddSupervisor()
+                {
+                    SelfAssessmentID = selfAssessmentId
+                };
+
+                multiPageFormService.SetMultiPageFormData(
+                    sessionAddSupervisor,
+                    MultiPageFormDataFeature.AddNewSupervisor,
+                    TempData
+                );
                 return RedirectToAction("SetSupervisorRole", new { selfAssessmentId, supervisorDelegateId });
             }
 
@@ -798,7 +808,7 @@
                 MultiPageFormDataFeature.AddNewSupervisor,
                 TempData
             );
-            TempData["CentreID"]=model.CentreID.ToString();
+            TempData["CentreID"] = model.CentreID.ToString();
             return RedirectToAction("AddNewSupervisor", new { model.SelfAssessmentID });
         }
 
@@ -808,6 +818,11 @@
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/Supervisors/Add/Role")]
         public IActionResult SetSupervisorRole(int selfAssessmentId, int? supervisorDelegateId)
         {
+            if (TempData[MultiPageFormDataFeature.AddNewSupervisor.TempDataKey] == null)
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = (int)HttpStatusCode.Gone });
+            }
+
             int? selfAssessmentSupervisorRoleId = null;
             string selfAssessmentName;
             var supervisorAdminId = 0;
@@ -903,6 +918,7 @@
                 model.SelfAssessmentID,
                 model.SelfAssessmentSupervisorRoleId
             );
+            TempData.Clear();
             return RedirectToAction("ManageSupervisors", new { model.SelfAssessmentID });
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -822,7 +822,6 @@
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = (int)HttpStatusCode.Gone });
             }
-
             int? selfAssessmentSupervisorRoleId = null;
             string selfAssessmentName;
             var supervisorAdminId = 0;

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -822,6 +822,7 @@
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = (int)HttpStatusCode.Gone });
             }
+
             int? selfAssessmentSupervisorRoleId = null;
             string selfAssessmentName;
             var supervisorAdminId = 0;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1166

### Description
Quick Add - Same Supervisors are added multiple times  -Implemented the functionality to display the 410 error on the browser's back button after adding the supervisor.

### Screenshots
After change: 
![image](https://user-images.githubusercontent.com/121869435/233416534-ab9791a5-e6cc-4707-ad34-4df075f0a1f4.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
