### PR TITLE
TD-1396-Issue with back links in Mobile view when adding a supervisor for the assessments in Learning Portal

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -667,6 +667,7 @@
             if (sessionAddSupervisor?.CentreID != null)
             {
                 supervisors = supervisors.Where(s => s.CentreID == sessionAddSupervisor.CentreID).ToList();
+                TempData["CentreID"] = sessionAddSupervisor.CentreID;
             }
 
             var model = new AddSupervisorViewModel
@@ -687,13 +688,14 @@
             if (!ModelState.IsValid)
             {
                 var supervisors = selfAssessmentService.GetValidSupervisorsForActivity(
-               User.GetCentreIdKnownNotNull(),
-               sessionAddSupervisor.SelfAssessmentID,
-               User.GetUserIdKnownNotNull()
-           );
+                                    User.GetCentreIdKnownNotNull(),
+                                    sessionAddSupervisor.SelfAssessmentID,
+                                    User.GetUserIdKnownNotNull()
+                                  );
                 if (sessionAddSupervisor?.CentreID != null)
                 {
                     supervisors = supervisors.Where(s => s.CentreID == sessionAddSupervisor.CentreID);
+                    TempData["CentreID"] = sessionAddSupervisor.CentreID;
                 }
                 model.Supervisors = supervisors;
                 return View("SelfAssessments/AddSupervisor", model);
@@ -766,7 +768,8 @@
             {
                 SelfAssessmentID = sessionAddSupervisor.SelfAssessmentID,
                 SelfAssessmentName = sessionAddSupervisor.SelfAssessmentName,
-                Centres = supervisorCentres
+                Centres = supervisorCentres,
+                CentreID = sessionAddSupervisor.CentreID ?? 0
             };
 
             return View("SelfAssessments/SelectSupervisorCentre", model);
@@ -778,6 +781,7 @@
         {
             var sessionAddSupervisor = multiPageFormService.GetMultiPageFormData<SessionAddSupervisor>(MultiPageFormDataFeature.AddNewSupervisor, TempData).GetAwaiter().GetResult();
             sessionAddSupervisor.CentreID = model.CentreID;
+            TempData["CentreID"] = model.CentreID.ToString();
 
             if (!ModelState.IsValid)
             {
@@ -808,7 +812,7 @@
                 MultiPageFormDataFeature.AddNewSupervisor,
                 TempData
             );
-            TempData["CentreID"] = model.CentreID.ToString();
+
             return RedirectToAction("AddNewSupervisor", new { model.SelfAssessmentID });
         }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
@@ -22,11 +22,11 @@
     <p class="nhsuk-breadcrumb__back">
       @if(TempData["CentreID"] == null)
       {
-        <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back</a>
+        <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back to Manage Supervisors</a>
       }
       else
       {
-        <a class="nhsuk-breadcrumb__backlink" asp-action="SelectSupervisorCentre" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back</a>
+        <a class="nhsuk-breadcrumb__backlink" asp-action="SelectSupervisorCentre" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back to Choose a centre</a>
       }
     </p>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisorSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisorSummary.cshtml
@@ -15,7 +15,7 @@
   <p class="nhsuk-breadcrumb__back">
     <a class="nhsuk-breadcrumb__backlink" asp-action="SetSupervisorRole"
      asp-route-selfAssessmentId="@Model.SelfAssessmentID">
-      Back
+      Back to Choose supervisor role
     </a>
   </p>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelectSupervisorCentre.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelectSupervisorCentre.cshtml
@@ -20,7 +20,7 @@
   @section mobilebacklink
   {
   <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back</a>
+    <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessmentID">Back to Manage Supervisors </a>
   </p>
 }
   <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SetSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SetSupervisorRole.cshtml
@@ -16,7 +16,7 @@
   <p class="nhsuk-breadcrumb__back">
     <a class="nhsuk-breadcrumb__backlink" asp-action="AddNewSupervisor"
      asp-route-selfAssessmentId="@Model.SelfAssessmentID">
-      Back
+      Back to Choose a supervisor
     </a>
   </p>
 }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1396

**Description**
Links are updated, tempdata is maintained to store CentreID.

**Screenshots**
N/A

-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
