### PR TITLE
TD-1185-Removed the condition of 5 groups limit in the supervisor view.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -61,14 +61,11 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h2>@Model.DelegateSelfAssessment.RoleName</h2>
-        @if (Model.CompetencyGroups.Count() > 5)
-        {
             <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-">
                 <partial name="_ReviewSelfAssessmentOverallProgress"
                      model="@competencySummaries"
                      view-data="@(new ViewDataDictionary(ViewData))" />
             </div>
-        }
     </div>
     <div class="nhsuk-grid-column-one-third">
       @if (Model.DelegateSelfAssessment.SignOffRequested > 0)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1185

### Description
Removed the condition of 5 groups limit in the supervisor view. This solves the test fail for Adult Critical Care Passport.

### Screenshots
![image](https://user-images.githubusercontent.com/126668828/233930605-6d94b898-a762-4e7d-ab46-74c90446b2b7.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
