### PR TITLE
TD-1406 Exclude records which contains guid in email column of Digita…

### DIFF
--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
@@ -2,6 +2,7 @@
 {
     using ClosedXML.Excel;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using System;
     using System.Collections.Generic;
@@ -35,7 +36,7 @@
         }
         public byte[] GetDigitalCapabilityExcelExportForCentre(int centreId)
         {
-            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatusForCentre(centreId).Where(c => !Guid.TryParse(c.Email, out _));
+            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatusForCentre(centreId);
             var outcomeSummary = dcsaReportDataService.GetOutcomeSummaryForCentre(centreId);
             var summary = delegateCompletionStatus.Select(
                 x => new
@@ -44,7 +45,7 @@
                     x.EnrolledYear,
                     x.FirstName,
                     x.LastName,
-                    x.Email,
+                    Email = (Guid.TryParse(x.Email, out _) ? string.Empty : x.Email),
                     x.CentreField1,
                     x.CentreField2,
                     x.CentreField3,
@@ -78,7 +79,7 @@
                 }
                 );
             using var workbook = new XLWorkbook();
-            AddSheetToWorkbook(workbook, "Delegate Completion Status", delegateCompletionStatus);
+            AddSheetToWorkbook(workbook, "Delegate Completion Status", summary);
             AddSheetToWorkbook(workbook, "Assessment Outcome Summary", outcomeSummary);
             using var stream = new MemoryStream();
             workbook.SaveAs(stream);

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
@@ -3,6 +3,7 @@
     using ClosedXML.Excel;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -34,7 +35,7 @@
         }
         public byte[] GetDigitalCapabilityExcelExportForCentre(int centreId)
         {
-            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatusForCentre(centreId);
+            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatusForCentre(centreId).Where(c => !Guid.TryParse(c.Email, out _));
             var outcomeSummary = dcsaReportDataService.GetOutcomeSummaryForCentre(centreId);
             var summary = delegateCompletionStatus.Select(
                 x => new


### PR DESCRIPTION
…l Capability Self assessment Report

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1406

### Description
Points addressed in this Commit :
1) Exclude records which contains guid in email column of Digital Capability Self assessment Report

### Screenshots
This is backend change so no screenshot available.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
