### PR TITLE
TD-1400 Adds logic for displaying the locked tag to the admin account partial view

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
@@ -85,9 +85,12 @@
                         <span class="nhsuk-u-margin-right-4">
                             <partial name="_StatusTag" model="@Model.IsUserActive ? (int)UserCard.Active : (int)UserCard.Inactive" />
                         </span>
-                        <span>
-                            <partial name="_StatusTag" model="(int)UserCard.Locked" />
-                        </span>
+                        @if (Model.IsLocked)
+                        {
+                            <span>
+                                <partial name="_StatusTag" model="(int)UserCard.Locked" />
+                            </span>
+                        }
                     </dd>
                     <dd class="nhsuk-summary-list__actions">
                         @if (Model.IsLocked)


### PR DESCRIPTION
### JIRA link
[TD-1400](https://hee-tis.atlassian.net/browse/TD-1400)

### Description
Adds missing logic for displaying the locked tag to the admin account partial view.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1400]: https://hee-tis.atlassian.net/browse/TD-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ