### PR TITLE
TD-1220 Renames CandidateID table in SelfAssessmentResultsHistory

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202304191130_Delete_SelfAssessmentResult_SupervisorVerifications.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202304191130_Delete_SelfAssessmentResult_SupervisorVerifications.cs
@@ -7,7 +7,6 @@
     {
         public override void Up()
         {
-
             Execute.Sql(
                    @$"DELETE FROM SelfAssessmentResultSupervisorVerifications
                         WHERE SelfAssessmentResultId NOT IN (SELECT MAX(ID)
@@ -21,6 +20,12 @@
                         FROM SelfAssessmentResults
                         GROUP BY CompetencyID, AssessmentQuestionID, DelegateUserID)"
               );
+            if(Schema.Table("SelfAssessmentResultsHistory").Column("CandidateID").Exists())
+            {
+                Execute.Sql("ALTER TABLE SelfAssessmentResults SET (SYSTEM_VERSIONING = OFF);");
+                Rename.Column("CandidateID").OnTable("SelfAssessmentResultsHistory").To("CandidateID_deprecated");
+                Execute.Sql("ALTER TABLE SelfAssessmentResults SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[SelfAssessmentResultsHistory]));");
+            }
             Create.UniqueConstraint(
                     "IX_SelfAssessmentResults_DelegateUserID_CompetencyID_AssessmentQuestionID"
                 )

--- a/DigitalLearningSolutions.Web/Helpers/MigrationHelperMethods.cs
+++ b/DigitalLearningSolutions.Web/Helpers/MigrationHelperMethods.cs
@@ -3,6 +3,7 @@
     using DigitalLearningSolutions.Data.Migrations;
     using FluentMigrator.Runner;
     using Microsoft.Extensions.DependencyInjection;
+    using System;
 
     public static class MigrationHelperMethods
     {
@@ -14,6 +15,7 @@
                 (
                     rb => rb
                         .AddSqlServer2016()
+                        .WithGlobalCommandTimeout(TimeSpan.FromSeconds(360))
                         .WithGlobalConnectionString(connectionString)
                         .ScanIn(typeof(AddSelfAssessmentTables).Assembly)
                         .For.Migrations()


### PR DESCRIPTION
### JIRA link
[TD-1220](https://hee-tis.atlassian.net/browse/TD-1220)

### Description
The unique index implemented as part of previous work on TD-1220 failed when published to UAR-TEST because the SelfAssessmentResultsHistory table had a column name (CandidateID) mismatch with the SelfAssessmentResults table (CandidateID_deprecated).

This change introduces a check for the incorrect column name and updates it if required.

The DELETE queries were also triggering a command timeout. We increase the global command timeout to 360 seconds in this change.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1220]: https://hee-tis.atlassian.net/browse/TD-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ