### PR TITLE
TD-1408-Showing console '500' error when enrolling on Self assessments for few DLS account users

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -458,9 +458,29 @@ namespace DigitalLearningSolutions.Data.DataServices
                 @"SELECT COALESCE
                  ((SELECT ID
                   FROM    CandidateAssessments
-                  WHERE (SelfAssessmentID = @selfAssessmentId) AND (DelegateUserID = @delegateUserId) AND (RemovedDate IS NULL) AND (CompletedDate IS NULL)), 0) AS ID",
+                  WHERE (SelfAssessmentID = @selfAssessmentId) AND (DelegateUserID = @delegateUserId) AND (CompletedDate IS NULL)), 0) AS ID",
                 new { selfAssessmentId, delegateUserId }
             );
+
+            if (enrolmentExists > 0)
+            {
+                var result = connection.QueryFirstOrDefault<DateTime?>(
+                @"SELECT RemovedDate
+                  FROM    CandidateAssessments
+                  WHERE ID = @enrolmentExists",
+                new { enrolmentExists }
+                );
+                DateTime? removedDate = result ?? null;
+                if (removedDate != null)
+                {
+                    connection.Execute(
+                        @"UPDATE CandidateAssessments
+                        SET RemovedDate = NULL
+                        WHERE ID = @enrolmentExists",
+                        new { enrolmentExists }
+                );
+                }
+            }
 
             if (enrolmentExists == 0)
             {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1408

### Description
The issue was intermittent with some users when they tried enrolling on a self-assessment. This issue was spotted when the assessment was dropped or removed by the supervisor and hence the column 'RemovedDate' was set to a date instead of having null value. Made code logic changes to update this column.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
