### PR TITLE
TD-1220 Fixes to update self assessment result logic

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -408,13 +408,11 @@
                         ELSE
                             BEGIN
                             UPDATE SelfAssessmentResults
-                            SET [Result] = @result
+                            SET [Result] = @result, [DateTime]  = GETUTCDATE()
                             WHERE ID = @existentResultId
 
-                            DELETE SARS FROM   SelfAssessmentResultSupervisorVerifications  sars INNER JOIN
-                             CandidateAssessmentSupervisors  cas ON SARS.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
-                             SupervisorDelegates  sd ON cas.SupervisorDelegateId = sd.ID
-                            WHERE  sd.SupervisorAdminID = @delegateUserId AND SARS.SelfAssessmentResultId=@existentResultId
+                            DELETE SARS FROM   SelfAssessmentResultSupervisorVerifications  sars
+                            WHERE  SARS.SelfAssessmentResultId=@existentResultId
                         END
 END",
                 new { competencyId, selfAssessmentId, delegateUserId, assessmentQuestionId, result, supportingComments }


### PR DESCRIPTION
### JIRA link
[TD-1220](https://hee-tis.atlassian.net/browse/TD-1220)

### Description
Updates the self assessment result datetime when updating a result and removes **any** associated self assessment result supervisor verification record.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1220]: https://hee-tis.atlassian.net/browse/TD-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ