### PR TITLE
TD-1220 Reintroduces the insert self assessment result logic

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -401,11 +401,13 @@
                         ORDER BY DateTime DESC
 
                         IF (@existentResultId IS NOT NULL AND @existentResult = @result)
+                            BEGIN
                             UPDATE SelfAssessmentResults
                             SET [DateTime] = GETUTCDATE(),
                                 [SupportingComments] = @supportingComments
                             WHERE ID = @existentResultId
-                        ELSE
+                            END
+                        ELSE IF (@existentResultId IS NOT NULL AND @existentResult <> @result)
                             BEGIN
                             UPDATE SelfAssessmentResults
                             SET [Result] = @result, [DateTime]  = GETUTCDATE()
@@ -413,8 +415,20 @@
 
                             DELETE SARS FROM   SelfAssessmentResultSupervisorVerifications  sars
                             WHERE  SARS.SelfAssessmentResultId=@existentResultId
-                        END
-END",
+                            END
+                        ELSE
+                            BEGIN
+                            INSERT INTO SelfAssessmentResults
+                                ([SelfAssessmentID]
+                                ,[CompetencyID]
+                                ,[AssessmentQuestionID]
+                                ,[Result]
+                                ,[DateTime]
+                                ,[SupportingComments]
+                                ,[DelegateUserID])
+                            VALUES(@selfAssessmentId, @competencyId, @assessmentQuestionId, @result, GETUTCDATE(), @supportingComments,@delegateUserId)
+                            END
+                        END",
                 new { competencyId, selfAssessmentId, delegateUserId, assessmentQuestionId, result, supportingComments }
             );
 


### PR DESCRIPTION
### JIRA link
[TD-1220](https://hee-tis.atlassian.net/browse/TD-1220)

### Description
Reintroduces the insert self assessment result logic when result doesn't already exist

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1220]: https://hee-tis.atlassian.net/browse/TD-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ