### PR TITLE
TD-1211 Fixed firefox issue - XML Parsing Error: no root element found, Added…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningSolutions/CookieConsentController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningSolutions/CookieConsentController.cs
@@ -88,7 +88,7 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningSolutions
             return RedirectToAction(actionName, controllerName);
         }
 
-        public void ConfirmCookieConsent(string consent, bool setTempDataConsentViaBannerPost = false)
+        public IActionResult ConfirmCookieConsent(string consent, bool setTempDataConsentViaBannerPost = false)
         {
             if (Response != null)
             {
@@ -106,6 +106,7 @@ namespace DigitalLearningSolutions.Web.Controllers.LearningSolutions
 
                 if (setTempDataConsentViaBannerPost) TempData["consentViaBannerPost"] = consent; // Need this tempdata to display the confirmation banner
             }
+            return Json("OK");
         }
 
         private void RemoveGaAndHjCookies()


### PR DESCRIPTION
implemented a return in ConfirmCookieConsent

### JIRA link
(https://hee-tis.atlassian.net/browse/TD-1211)

### Description
Getting "XML Parsing Error: no root element found" error message on console of the Firefox. No such error message is shown on Chrome.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
