### PR TITLE
TD-207:supervisor-review-profile-assessment-allow-searching-and-filtering-of-competencies

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -33,7 +33,6 @@
         SelfAssessmentResultSummary GetSelfAssessmentResultSummary(int candidateAssessmentId, int supervisorDelegateId);
         IEnumerable<CandidateAssessmentSupervisorVerificationSummary> GetCandidateAssessmentSupervisorVerificationSummaries(int candidateAssessmentId);
         IEnumerable<SupervisorForEnrolDelegate> GetSupervisorForEnrolDelegate(int CustomisationID, int CentreID);
-        bool IsLoggedInSupervisorIsVerifier(int supervisorDelegateId, int candidateAssessmentId, int adminId);
         //UPDATE DATA
         bool ConfirmSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId);
         bool RemoveSupervisorDelegateById(int supervisorDelegateId, int delegateUserId, int adminId);
@@ -1080,18 +1079,6 @@ WHERE (cas.CandidateAssessmentID = @candidateAssessmentId) AND (cas.SupervisorDe
             ).FirstOrDefault();
 
             return supervisorDelegate!;
-        }
-
-        public bool IsLoggedInSupervisorIsVerifier(int supervisorDelegateId, int candidateAssessmentId, int adminId)
-        {
-            return connection.Query<bool>(
-                     @"select CAST(CASE WHEN COALESCE(sd.SupervisorAdminID, 0) = @adminId THEN 1 ELSE 0 END AS Bit) AS UserIsVerifier
-	                        from CandidateAssessmentSupervisors cas 
-	                        left outer join SupervisorDelegates sd on cas.SupervisorDelegateId=sd.id
-	                        left outer join SelfAssessmentResultSupervisorVerifications sarv on sarv.CandidateAssessmentSupervisorID=cas.ID 
-	                        left outer join AdminUsers au on au.AdminID=sd.SupervisorAdminID
-	                        where sd.id=@supervisorDelegateId and cas.CandidateAssessmentID=@candidateAssessmentId", new { adminId, supervisorDelegateId, candidateAssessmentId }
-                ).FirstOrDefault();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
+++ b/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
@@ -2,6 +2,8 @@
 {
     public enum SelfAssessmentCompetencyFilter
     {
+        AwaitingConfirmation = -10,
+        PendingConfirmation = -9,
         RequiresSelfAssessment = -8,
         SelfAssessed = -7,
         ConfirmationRequested = -6,
@@ -9,8 +11,6 @@
         ConfirmationRejected = -4,
         MeetingRequirements = -3,
         PartiallyMeetingRequirements = -2,
-        NotMeetingRequirements = -1,
-        AwaitingConfirmation = -9,
-        PendingConfirmation = -10
+        NotMeetingRequirements = -1        
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
+++ b/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
@@ -9,6 +9,8 @@
         ConfirmationRejected = -4,
         MeetingRequirements = -3,
         PartiallyMeetingRequirements = -2,
-        NotMeetingRequirements = -1
+        NotMeetingRequirements = -1,
+        AwaitingConfirmation = -9,
+        PendingConfirmation = -10
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -321,9 +321,9 @@
             var competencyIds = reviewedCompetencies.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
             var competencies = SupervisorCompetencyFilterHelper.FilterCompetencies(reviewedCompetencies, competencyFlags, searchModel);
-            var isSupervisor = User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) ?? false;
+            var isSupervisor = supervisorService.IsLoggedInSupervisorIsVerifier(supervisorDelegateId, candidateAssessmentId, adminId);
             var searchViewModel = searchModel == null ?
-                new SearchSupervisorCompetencyViewModel(supervisorDelegateId, searchModel?.SearchText, delegateSelfAssessment.ID, "", delegateSelfAssessment.IsSupervisorResultsReviewed, false, null, isSupervisor, null)
+                new SearchSupervisorCompetencyViewModel(supervisorDelegateId, searchModel?.SearchText, delegateSelfAssessment.ID, delegateSelfAssessment.IsSupervisorResultsReviewed, false, null, isSupervisor, null)
                 : searchModel.Initialise(searchModel.AppliedFilters, competencyFlags.ToList(), delegateSelfAssessment.IsSupervisorResultsReviewed, false, isSupervisor);
 
             var model = new ReviewSelfAssessmentViewModel()

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -321,10 +321,9 @@
             var competencyIds = reviewedCompetencies.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
             var competencies = SupervisorCompetencyFilterHelper.FilterCompetencies(reviewedCompetencies, competencyFlags, searchModel);
-            var isSupervisor = supervisorService.IsLoggedInSupervisorIsVerifier(supervisorDelegateId, candidateAssessmentId, adminId);
             var searchViewModel = searchModel == null ?
-                new SearchSupervisorCompetencyViewModel(supervisorDelegateId, searchModel?.SearchText, delegateSelfAssessment.ID, delegateSelfAssessment.IsSupervisorResultsReviewed, false, null, isSupervisor, null)
-                : searchModel.Initialise(searchModel.AppliedFilters, competencyFlags.ToList(), delegateSelfAssessment.IsSupervisorResultsReviewed, false, isSupervisor);
+                new SearchSupervisorCompetencyViewModel(supervisorDelegateId, searchModel?.SearchText, delegateSelfAssessment.ID, delegateSelfAssessment.IsSupervisorResultsReviewed, false, null, null)
+                : searchModel.Initialise(searchModel.AppliedFilters, competencyFlags.ToList(), delegateSelfAssessment.IsSupervisorResultsReviewed, false);
 
             var model = new ReviewSelfAssessmentViewModel()
             {

--- a/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
@@ -36,9 +36,9 @@ namespace DigitalLearningSolutions.Web.Extensions
                 case SelfAssessmentCompetencyFilter.NotMeetingRequirements:
                     return "Not meeting requirements";
                 case SelfAssessmentCompetencyFilter.PendingConfirmation:
-                    return "Pending Confirmation";
+                    return "Pending confirmation";
                 case SelfAssessmentCompetencyFilter.AwaitingConfirmation:
-                    return "Awaiting Confirmation";
+                    return "Confirmation requested";
                 default:
                     return status.ToString();
             }

--- a/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
@@ -35,6 +35,10 @@ namespace DigitalLearningSolutions.Web.Extensions
                     return "Partially meeting requirements";
                 case SelfAssessmentCompetencyFilter.NotMeetingRequirements:
                     return "Not meeting requirements";
+                case SelfAssessmentCompetencyFilter.PendingConfirmation:
+                    return "Pending Confirmation";
+                case SelfAssessmentCompetencyFilter.AwaitingConfirmation:
+                    return "Awaiting Confirmation";
                 default:
                     return status.ToString();
             }

--- a/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
@@ -44,9 +44,9 @@ namespace DigitalLearningSolutions.Web.Helpers
                                        let responseStatusFilterMatchesAnyQuestion =
                                           (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.PendingConfirmation) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
-                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.AwaitingConfirmation) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.PendingConfirmation) && c.AssessmentQuestions.Any(q => q.ResultId != null &&  q.Verified == null && q.Requested != null&&q.UserIsVerifier==false))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.AwaitingConfirmation) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null && q.UserIsVerifier == true))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
                                        where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
                                            && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)

--- a/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
@@ -1,0 +1,127 @@
+﻿using DigitalLearningSolutions.Data.Enums;
+using DigitalLearningSolutions.Data.Models.SelfAssessments;
+using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DigitalLearningSolutions.Web.Helpers
+{
+    public class SupervisorCompetencyFilterHelper
+    {
+        public static IEnumerable<Competency> FilterCompetencies(IEnumerable<Competency> competencies, IEnumerable<Data.Models.Frameworks.CompetencyFlag> competencyFlags, SearchSupervisorCompetencyViewModel search)
+        {
+            var filteredCompetencies = competencies;
+            if (search != null)
+            {
+                var searchText = search.SearchText?.Trim() ?? string.Empty;
+                var filters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)) ?? Enumerable.Empty<int>();
+                search.CompetencyFlags = competencyFlags.ToList();
+                ApplyResponseStatusFilters(ref filteredCompetencies, filters, searchText);
+                UpdateRequirementsFilterDropdownOptionsVisibility(search, filteredCompetencies);
+                ApplyRequirementsFilters(ref filteredCompetencies, filters);
+
+                foreach (var competency in filteredCompetencies)
+                    competency.CompetencyFlags = search.CompetencyFlags.Where(f => f.CompetencyId == competency.Id);
+
+                ApplyCompetencyGroupFilters(ref filteredCompetencies, search);
+            }
+            return filteredCompetencies;
+        }
+
+        private static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
+        {
+            var filteredCompetencies = competencies;
+            var appliedResponseStatusFilters = filters.Where(f => IsResponseStatusFilter(f));
+            if (appliedResponseStatusFilters.Any() || searchText.Length > 0)
+            {
+                var wordsInSearchText = searchText.Split().Where(w => w != string.Empty);
+                filters = appliedResponseStatusFilters;
+                filteredCompetencies = from c in competencies
+                                       let searchTextMatchesGroup = wordsInSearchText.Any(w => c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                                       let searchTextMatchesCompetencyDescription = wordsInSearchText.Any(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                                       let searchTextMatchesCompetencyName = wordsInSearchText.Any(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                                       let responseStatusFilterMatchesAnyQuestion =
+                                          (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
+                                       where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
+                                           && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)
+                                       select c;
+            }
+            competencies = filteredCompetencies;
+        }
+
+        private static void ApplyRequirementsFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters)
+        {
+            var filteredCompetencies = competencies;
+            var appliedRequirementsFilters = filters.Where(f => IsRequirementsFilter(f));
+            if (appliedRequirementsFilters.Any())
+            {
+                filters = appliedRequirementsFilters;
+                filteredCompetencies = from c in competencies
+                                       let requirementsFilterMatchesAnyQuestion =
+                                              (filters.Contains((int)SelfAssessmentCompetencyFilter.MeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 3))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 2))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.NotMeetingRequirements) && c.AssessmentQuestions.Any(q => q.ResultRAG == 1))
+                                       where requirementsFilterMatchesAnyQuestion
+                                       select c;
+            }
+            competencies = filteredCompetencies;
+        }
+
+        private static void ApplyCompetencyGroupFilters(ref IEnumerable<Competency> competencies, SearchSupervisorCompetencyViewModel search)
+        {
+            var filteredCompetencies = competencies;
+            var appliedCompetencyGroupFilters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)).Where(f => IsCompetencyFlagFilter(f)) ?? Enumerable.Empty<int>();
+            if (appliedCompetencyGroupFilters.Any())
+            {
+                filteredCompetencies = competencies.Where(c => c.CompetencyFlags.Any(f => appliedCompetencyGroupFilters.Contains(f.FlagId)));
+            }
+            competencies = filteredCompetencies;
+        }
+
+        private static void UpdateRequirementsFilterDropdownOptionsVisibility(SearchSupervisorCompetencyViewModel search, IEnumerable<Competency> competencies)
+        {
+            var filteredQuestions = competencies.SelectMany(c => c.AssessmentQuestions);
+            if (search != null)
+            {
+                search.AnyQuestionMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 3);
+                search.AnyQuestionPartiallyMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 2);
+                search.AnyQuestionNotMeetingRequirements = filteredQuestions.Any(q => q.ResultRAG == 1);
+            }
+        }
+
+        public static bool IsRequirementsFilter(int filter)
+        {
+            var requirementFilters = new int[]
+            {
+                (int)SelfAssessmentCompetencyFilter.MeetingRequirements,
+                (int)SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements,
+                (int)SelfAssessmentCompetencyFilter.NotMeetingRequirements
+
+            };
+            return requirementFilters.Contains(filter);
+        }
+
+        public static bool IsResponseStatusFilter(int filter)
+        {
+            var responseStatusFilters = new int[]
+            {
+                (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment,
+                (int)SelfAssessmentCompetencyFilter.SelfAssessed,
+                (int)SelfAssessmentCompetencyFilter.Verified,
+                (int)SelfAssessmentCompetencyFilter.ConfirmationRequested,
+                (int)SelfAssessmentCompetencyFilter.ConfirmationRejected
+            };
+            return responseStatusFilters.Contains(filter);
+        }
+
+        public static bool IsCompetencyFlagFilter(int filter)
+        {
+            return filter > 0;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
@@ -44,8 +44,9 @@ namespace DigitalLearningSolutions.Web.Helpers
                                        let responseStatusFilterMatchesAnyQuestion =
                                           (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.PendingConfirmation) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
+                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.AwaitingConfirmation) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
                                        where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
                                            && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)
@@ -113,7 +114,8 @@ namespace DigitalLearningSolutions.Web.Helpers
                 (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment,
                 (int)SelfAssessmentCompetencyFilter.SelfAssessed,
                 (int)SelfAssessmentCompetencyFilter.Verified,
-                (int)SelfAssessmentCompetencyFilter.ConfirmationRequested,
+                (int)SelfAssessmentCompetencyFilter.PendingConfirmation,
+                (int)SelfAssessmentCompetencyFilter.AwaitingConfirmation,
                 (int)SelfAssessmentCompetencyFilter.ConfirmationRejected
             };
             return responseStatusFilters.Contains(filter);

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
@@ -14,7 +14,7 @@
         public IEnumerable<IGrouping<string, Competency>> CompetencyGroups { get; set; }
         public IEnumerable<SupervisorSignOff>? SupervisorSignOffs { get; set; }
         public bool IsSupervisorResultsReviewed { get; set; }
-
+        public SearchSupervisorCompetencyViewModel SearchViewModel { get; set; }
         public string VocabPlural(string vocabulary)
         {
             return FrameworkVocabularyHelper.VocabularyPlural(vocabulary);

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SearchSupervisorCompetencyViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SearchSupervisorCompetencyViewModel.cs
@@ -1,0 +1,105 @@
+﻿using DigitalLearningSolutions.Data.Enums;
+using DigitalLearningSolutions.Data.Models.Frameworks;
+using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+using DigitalLearningSolutions.Web.Extensions;
+using DigitalLearningSolutions.Web.Helpers;
+using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
+{
+    public class SearchSupervisorCompetencyViewModel
+    {
+        public int SupervisorDelegateId { get; set; }
+        public int CandidateAssessmentId { get; set; }
+        public int SelfAssessmentId { get; set; }
+        public int? CompetencyGroupId { get; set; }
+        public bool IsSupervisorResultsReviewed { get; set; }
+        public bool IncludeRequirementsFilters { get; set; }
+        public string Vocabulary { get; set; }
+        public string SearchText { get; set; }
+        public int SelectedFilter { get; set; }
+        public int Page { get; set; }
+        public List<FilterModel> Filters { get; set; }
+        public List<AppliedFilterViewModel> AppliedFilters { get; set; }
+        public List<CompetencyFlag> CompetencyFlags { get; set; }
+        public bool AnyQuestionMeetingRequirements { get; set; }
+        public bool AnyQuestionPartiallyMeetingRequirements { get; set; }
+        public bool AnyQuestionNotMeetingRequirements { get; set; }
+        public string FilterBy { get; set; }
+        [Obsolete]
+        public CurrentFiltersViewModel CurrentFilters
+        {
+            get
+            {
+                var route = new Dictionary<string, string>()
+                {
+                    { "CandidateAssessmentId", CandidateAssessmentId.ToString() },
+                    { "Vocabulary", Vocabulary },
+                    { "SearchText", SearchText }
+                };
+                return new CurrentFiltersViewModel(AppliedFilters, SearchText, route);
+            }
+        }
+        public SearchSupervisorCompetencyViewModel Initialise(List<AppliedFilterViewModel> appliedFilters, List<CompetencyFlag> competencyFlags, bool isSupervisorResultsReviewed, bool includeRequirementsFilters, bool isSupervisor)
+        {
+            var allFilters = Enum.GetValues(typeof(SelfAssessmentCompetencyFilter)).Cast<SelfAssessmentCompetencyFilter>();
+            var filterOptions = (from f in allFilters
+                                 let includeRejectedWhenSupervisorReviewed = f != SelfAssessmentCompetencyFilter.ConfirmationRejected || isSupervisorResultsReviewed
+                                 where CompetencyFilterHelper.IsResponseStatusFilter((int)f) && includeRejectedWhenSupervisorReviewed
+                                 select f).ToList();
+            if (includeRequirementsFilters)
+            {
+                if (AnyQuestionMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.MeetingRequirements);
+                if (AnyQuestionNotMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.NotMeetingRequirements);
+                if (AnyQuestionPartiallyMeetingRequirements) filterOptions.Add(SelfAssessmentCompetencyFilter.PartiallyMeetingRequirements);
+            }
+
+            var dropdownFilterOptions = filterOptions.Select(
+                f => new FilterOptionModel(isSupervisor ? f.GetDescription(isSupervisorResultsReviewed) == "Confirmation requested" ? "Awaiting confirmation" : f.GetDescription(isSupervisorResultsReviewed) : "Pending confirmation",
+                ((int)f).ToString(),
+                FilterStatus.Default)).ToList();
+
+            if (competencyFlags?.Count() > 0)
+            {
+                var competencyFlagOptions = competencyFlags.DistinctBy(f => f.FlagId, null)
+                    .Select(c =>
+                        new FilterOptionModel(
+                                $"{c.FlagGroup}: {c.FlagName}",
+                                c.FlagId.ToString(),
+                                FilterStatus.Default));
+                dropdownFilterOptions.AddRange(competencyFlagOptions);
+            }
+
+            Filters = new List<FilterModel>()
+            {
+                new FilterModel(
+                    filterProperty: FilterBy,
+                    filterName: FilterBy,
+                    filterOptions: dropdownFilterOptions)
+            };
+            IsSupervisorResultsReviewed = isSupervisorResultsReviewed;
+            AppliedFilters = appliedFilters ?? new List<AppliedFilterViewModel>();
+            return this;
+        }
+
+        public SearchSupervisorCompetencyViewModel(int supervisorDelegateId, string searchText, int candidateAssessmentId, string vocabulary, bool isSupervisorResultsReviewed, bool includeRequirementsFilters, List<AppliedFilterViewModel> appliedFilters, bool isSupervisor, List<CompetencyFlag> competencyFlags = null)
+        {
+            FilterBy = nameof(SelectedFilter);
+            SearchText = searchText ?? string.Empty;
+            CandidateAssessmentId = candidateAssessmentId;
+            Vocabulary = vocabulary;
+            IncludeRequirementsFilters = includeRequirementsFilters;
+            SupervisorDelegateId = supervisorDelegateId;
+            Initialise(appliedFilters, competencyFlags, isSupervisorResultsReviewed, includeRequirementsFilters, isSupervisor);
+        }
+
+        public SearchSupervisorCompetencyViewModel()
+        {
+            Filters = new List<FilterModel>();
+            AppliedFilters = new List<AppliedFilterViewModel>();
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SearchSupervisorCompetencyViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SearchSupervisorCompetencyViewModel.cs
@@ -18,7 +18,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
         public int? CompetencyGroupId { get; set; }
         public bool IsSupervisorResultsReviewed { get; set; }
         public bool IncludeRequirementsFilters { get; set; }
-        public string Vocabulary { get; set; }
         public string SearchText { get; set; }
         public int SelectedFilter { get; set; }
         public int Page { get; set; }
@@ -37,7 +36,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
                 var route = new Dictionary<string, string>()
                 {
                     { "CandidateAssessmentId", CandidateAssessmentId.ToString() },
-                    { "Vocabulary", Vocabulary },
                     { "SearchText", SearchText }
                 };
                 return new CurrentFiltersViewModel(AppliedFilters, SearchText, route);
@@ -58,7 +56,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
             }
 
             var dropdownFilterOptions = filterOptions.Select(
-                f => new FilterOptionModel(isSupervisor ? f.GetDescription(isSupervisorResultsReviewed) == "Confirmation requested" ? "Awaiting confirmation" : f.GetDescription(isSupervisorResultsReviewed) : "Pending confirmation",
+                f => new FilterOptionModel(isSupervisor ? f.GetDescription(isSupervisorResultsReviewed) == "Confirmation requested" ? "Pending confirmation" : f.GetDescription(isSupervisorResultsReviewed) : "Awaiting confirmation",
                 ((int)f).ToString(),
                 FilterStatus.Default)).ToList();
 
@@ -85,12 +83,11 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
             return this;
         }
 
-        public SearchSupervisorCompetencyViewModel(int supervisorDelegateId, string searchText, int candidateAssessmentId, string vocabulary, bool isSupervisorResultsReviewed, bool includeRequirementsFilters, List<AppliedFilterViewModel> appliedFilters, bool isSupervisor, List<CompetencyFlag> competencyFlags = null)
+        public SearchSupervisorCompetencyViewModel(int supervisorDelegateId, string searchText, int candidateAssessmentId,  bool isSupervisorResultsReviewed, bool includeRequirementsFilters, List<AppliedFilterViewModel> appliedFilters, bool isSupervisor, List<CompetencyFlag> competencyFlags = null)
         {
             FilterBy = nameof(SelectedFilter);
             SearchText = searchText ?? string.Empty;
             CandidateAssessmentId = candidateAssessmentId;
-            Vocabulary = vocabulary;
             IncludeRequirementsFilters = includeRequirementsFilters;
             SupervisorDelegateId = supervisorDelegateId;
             Initialise(appliedFilters, competencyFlags, isSupervisorResultsReviewed, includeRequirementsFilters, isSupervisor);

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SearchSupervisorCompetencyViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SearchSupervisorCompetencyViewModel.cs
@@ -41,12 +41,12 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
                 return new CurrentFiltersViewModel(AppliedFilters, SearchText, route);
             }
         }
-        public SearchSupervisorCompetencyViewModel Initialise(List<AppliedFilterViewModel> appliedFilters, List<CompetencyFlag> competencyFlags, bool isSupervisorResultsReviewed, bool includeRequirementsFilters, bool isSupervisor)
+        public SearchSupervisorCompetencyViewModel Initialise(List<AppliedFilterViewModel> appliedFilters, List<CompetencyFlag> competencyFlags, bool isSupervisorResultsReviewed, bool includeRequirementsFilters)
         {
             var allFilters = Enum.GetValues(typeof(SelfAssessmentCompetencyFilter)).Cast<SelfAssessmentCompetencyFilter>();
             var filterOptions = (from f in allFilters
                                  let includeRejectedWhenSupervisorReviewed = f != SelfAssessmentCompetencyFilter.ConfirmationRejected || isSupervisorResultsReviewed
-                                 where CompetencyFilterHelper.IsResponseStatusFilter((int)f) && includeRejectedWhenSupervisorReviewed
+                                 where SupervisorCompetencyFilterHelper.IsResponseStatusFilter((int)f) && includeRejectedWhenSupervisorReviewed
                                  select f).ToList();
             if (includeRequirementsFilters)
             {
@@ -56,7 +56,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
             }
 
             var dropdownFilterOptions = filterOptions.Select(
-                f => new FilterOptionModel(isSupervisor ? f.GetDescription(isSupervisorResultsReviewed) == "Confirmation requested" ? "Pending confirmation" : f.GetDescription(isSupervisorResultsReviewed) : "Awaiting confirmation",
+                f => new FilterOptionModel(f.GetDescription(isSupervisorResultsReviewed),
                 ((int)f).ToString(),
                 FilterStatus.Default)).ToList();
 
@@ -83,14 +83,14 @@ namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
             return this;
         }
 
-        public SearchSupervisorCompetencyViewModel(int supervisorDelegateId, string searchText, int candidateAssessmentId,  bool isSupervisorResultsReviewed, bool includeRequirementsFilters, List<AppliedFilterViewModel> appliedFilters, bool isSupervisor, List<CompetencyFlag> competencyFlags = null)
+        public SearchSupervisorCompetencyViewModel(int supervisorDelegateId, string searchText, int candidateAssessmentId,  bool isSupervisorResultsReviewed, bool includeRequirementsFilters, List<AppliedFilterViewModel> appliedFilters, List<CompetencyFlag> competencyFlags = null)
         {
             FilterBy = nameof(SelectedFilter);
             SearchText = searchText ?? string.Empty;
             CandidateAssessmentId = candidateAssessmentId;
             IncludeRequirementsFilters = includeRequirementsFilters;
             SupervisorDelegateId = supervisorDelegateId;
-            Initialise(appliedFilters, competencyFlags, isSupervisorResultsReviewed, includeRequirementsFilters, isSupervisor);
+            Initialise(appliedFilters, competencyFlags, isSupervisorResultsReviewed, includeRequirementsFilters);
         }
 
         public SearchSupervisorCompetencyViewModel()

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -78,7 +78,9 @@
     }
   </div>
 </div>
-
+<partial name="../../Supervisor/Shared/_SearchSupervisorCompetency"
+         model="@Model.SearchViewModel"
+         view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
 @if (Model.CompetencyGroups.Any())
 {
   foreach (var competencyGroup in Model.CompetencyGroups)

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SearchSupervisorCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SearchSupervisorCompetency.cshtml
@@ -1,0 +1,65 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+@using DigitalLearningSolutions.Data.Enums;
+@model SearchSupervisorCompetencyViewModel
+@{
+    var parent = (ReviewSelfAssessmentViewModel)ViewData["parent"];
+}
+<form method="post" asp-controller="SelfAssessment">
+    <div class="search-container">
+        <div class="search-box-container" id="search">
+            <label class="nhsuk-u-visually-hidden" for="search-field">Search</label>
+            <input class="search-box nhsuk-input" id="search-field" name="searchText"
+                   style="border-bottom-right-radius: initial; border-top-right-radius: initial;"
+                   type="search" placeholder="Search" autocomplete="off" value="@Model.SearchText">
+            <button class="nhsuk-button search-submit" type="submit" asp-action="SearchInSupervisorSelfAssessment">
+                <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20" aria-hidden="true" focusable="false">
+                    <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+                </svg>
+                <span class="nhsuk-u-visually-hidden">Search</span>
+            </button>
+        </div>
+    </div>
+    <div class="filter-value-container">
+        @Html.DropDownListFor(
+        m => m.SelectedFilter,
+        Model.Filters.First().FilterOptions
+        .Where(f => parent.DelegateSelfAssessment.IsSupervisorResultsReviewed
+        || f.FilterValue == ((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment).ToString()
+        || f.FilterValue == ((int)SelfAssessmentCompetencyFilter.SelfAssessed).ToString())
+        .Select(f => new SelectListItem(
+        text: f.DisplayText,
+        value: f.FilterValue,
+        selected: f.FilterValue == SelfAssessmentCompetencyFilter.RequiresSelfAssessment.ToString())
+        ),
+        new
+        {
+        @class = "nhsuk-select filter-dropdown",
+        aria_label = "ResponseStatus filter"
+        }
+        )
+        <button asp-action="AddSupervisorSelfAssessmentOverviewFilter" type="submit" class="nhsuk-button filter-submit" style="width:20%;">
+            Add filter
+        </button>
+    </div>
+    @Html.HiddenFor(m => m.SelfAssessmentId)
+    @Html.HiddenFor(m => m.CandidateAssessmentId)
+    @Html.HiddenFor(m => m.SupervisorDelegateId)
+    @Html.HiddenFor(m => m.IsSupervisorResultsReviewed)
+    @Html.HiddenFor(m => m.IncludeRequirementsFilters)
+    @Html.HiddenFor(m => m.Vocabulary)
+    @Html.HiddenFor(m => m.AnyQuestionPartiallyMeetingRequirements)
+    @Html.Hidden(nameof(Model.SearchText), Model.SearchText)
+    @for (int i = 0; i < Model.AppliedFilters.Count; i++)
+    {
+        @Html.HiddenFor(m => m.AppliedFilters[i].DisplayText)
+        @Html.HiddenFor(m => m.AppliedFilters[i].FilterValue)
+        @Html.HiddenFor(m => m.AppliedFilters[i].TagClass)
+    }
+</form>
+
+@if (Model.AppliedFilters.Count() > 0)
+{
+    <div class="nhsuk-u-margin-bottom-5">
+        <partial name="../Shared/Components/CurrentFilters/Default" model="Model.CurrentFilters" />
+    </div>
+}

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SearchSupervisorCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SearchSupervisorCompetency.cshtml
@@ -46,7 +46,6 @@
     @Html.HiddenFor(m => m.SupervisorDelegateId)
     @Html.HiddenFor(m => m.IsSupervisorResultsReviewed)
     @Html.HiddenFor(m => m.IncludeRequirementsFilters)
-    @Html.HiddenFor(m => m.Vocabulary)
     @Html.HiddenFor(m => m.AnyQuestionPartiallyMeetingRequirements)
     @Html.Hidden(nameof(Model.SearchText), Model.SearchText)
     @for (int i = 0; i < Model.AppliedFilters.Count; i++)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-207

### Description

1. Search filter has been implemented in Supervisor view. 
2.'Confirmation requested’ filter option has been  replaced with ‘Awaiting confirmation’ and ‘Pending confirmation’ filter options in dropdown.

Please note: SelfAssessment page will not get affected by filter option change.
### Screenshots

**Supervisor page before implementation:**
![image](https://user-images.githubusercontent.com/120369940/236148360-debe0784-9dd2-485f-bb21-6e612f7012cc.png)

**Supervisor page after implementation:**

![image](https://user-images.githubusercontent.com/120369940/236147686-e5aa1741-1994-411d-9dd1-2e6054164dfc.png)
![image](https://user-images.githubusercontent.com/120369940/236147784-f613fc55-d05f-4233-9a08-51237885c2db.png)

**SelfAssessment page:**

![image](https://user-images.githubusercontent.com/120369940/236147360-96dc3545-b8a4-430c-b25e-8a2bbaea188c.png)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
