### PR TITLE
TD-1451-When self assessment result is cleared (is null) it should not be included in the counts for the group or overall count

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -16,7 +16,7 @@
     .Max();
   var competencySummaries = from g in Model.CompetencyGroups
                             let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
-                            let selfAssessedCount = questions.Count(q => q.Result == 1)
+                            let selfAssessedCount = questions.Count(q => q.Result.HasValue)
                             let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
                             select new ViewDataDictionary(ViewData)
 {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -16,7 +16,7 @@
     .Max();
   var competencySummaries = from g in Model.CompetencyGroups
                             let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
-                            let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
+                            let selfAssessedCount = questions.Count(q => q.Result == 1)
                             let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
                             select new ViewDataDictionary(ViewData)
 {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1451

### Description
Changed the Linq query to get the correct status of self-assessments

### Screenshots
![image](https://user-images.githubusercontent.com/126668828/236158540-54bbe997-4e17-4479-8bb0-8018d347e7d7.png)
![image](https://user-images.githubusercontent.com/126668828/236159893-f1bac72c-8f78-423c-8ba9-aaef28ad2e47.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
