### PR TITLE
TD-1464 Fixed issue in mobile view when clicking back link on Choose …

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SetSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SetSupervisorRole.cshtml
@@ -14,7 +14,7 @@
   @section mobilebacklink
   {
   <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink" asp-action="AddNewSupervisor"
+        <a class="nhsuk-breadcrumb__backlink" asp-action="ManageSupervisors"
      asp-route-selfAssessmentId="@Model.SelfAssessmentID" asp-route-searchString=@TempData["SearchString"]>
       Back to Choose a supervisor
     </a>


### PR DESCRIPTION
…supervisor role page.

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1464

### Description
Points addressed in this Commit :
1) Fixed issue in mobile view when clicking back link on Choose supervisor role page.

### Screenshots
[My-Current-Activities---Digital-Learning-Solutions.webm](https://user-images.githubusercontent.com/111436026/236171584-706c97c4-9f72-4391-8e1c-81bcf150a830.webm)
![WavePlugin](https://user-images.githubusercontent.com/111436026/236171597-31caf00a-fea3-47b4-a7fe-548af53fb843.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
