### PR TITLE
TD-1439 Changed the back link label and its navigation in enrol self …

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -701,6 +701,9 @@
         [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessment/Enrol/CompleteBy")]
         public IActionResult EnrolDelegateSetCompleteBy(int supervisorDelegateId, int day, int month, int year)
         {
+            TempData["completeByDate"] = day;
+            TempData["completeByMonth"] = month;
+            TempData["completeByYear"] = year;
             var sessionEnrolOnRoleProfile = multiPageFormService.GetMultiPageFormData<SessionEnrolOnRoleProfile>(MultiPageFormDataFeature.EnrolDelegateOnProfileAssessment, TempData).GetAwaiter().GetResult();
             if (day != 0 | month != 0 | year != 0)
             {
@@ -725,6 +728,7 @@
                 supervisorService.GetSupervisorRolesForSelfAssessment(sessionEnrolOnRoleProfile.SelfAssessmentID.Value);
             if (supervisorRoles.Count() > 1)
             {
+                TempData["navigatedFrom"] = "EnrolDelegateSupervisorRole";
                 return RedirectToAction(
                     "EnrolDelegateSupervisorRole",
                     "Supervisor",
@@ -773,6 +777,9 @@
                 SelfAssessmentSupervisorRoleId = sessionEnrolOnRoleProfile.SelfAssessmentSupervisorRoleId,
                 SelfAssessmentSupervisorRoles = supervisorRoles
             };
+            ViewBag.completeByDate = TempData["completeByDate"];
+            ViewBag.completeByMonth = TempData["completeByMonth"];
+            ViewBag.completeByYear = TempData["completeByYear"];
             return View("EnrolDelegateSupervisorRole", model);
         }
 
@@ -845,6 +852,10 @@
                 CompleteByDate = sessionEnrolOnRoleProfile.CompleteByDate,
                 SupervisorRoleCount = supervisorRoleCount
             };
+            ViewBag.completeByDate = TempData["completeByDate"];
+            ViewBag.completeByMonth = TempData["completeByMonth"];
+            ViewBag.completeByYear = TempData["completeByYear"];
+            ViewBag.navigatedFrom = TempData["navigatedFrom"];
             return View("EnrolDelegateSummary", model);
         }
 

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSetCompleteBy.cshtml
@@ -34,9 +34,9 @@
     </div>
     <p class="nhsuk-breadcrumb__back">
       <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="DelegateProfileAssessments"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+           asp-action="EnrolDelegateOnProfileAssessment"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                Back to Self Assessments
       </a>
     </p>
   </nav>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSummary.cshtml
@@ -1,123 +1,137 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model EnrolDelegateSummaryViewModel;
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = "Enrol on Profile Assessment";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = "Enrol on Profile Assessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-           asp-action="DelegateProfileAssessments"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          Enrol
-        </li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="DelegateProfileAssessments"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </a>
-    </p>
-  </nav>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    Enrol
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            @if (ViewBag.navigatedFrom == "EnrolDelegateSupervisorRole")
+            {
+                <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+                   asp-action="EnrolDelegateSupervisorRole"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                    Back to Enrol Delegate Supervisor Role
+                </a>
+            }
+            else
+            {
+                <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+                   asp-action="EnrolDelegateCompleteBy"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+                   asp-route-day="@ViewBag.completeByDate"
+                   asp-route-month="@ViewBag.completeByMonth"
+                   asp-route-year="@ViewBag.completeByYear">
+                    Back to Complete By Date
+                </a>
+            }
+        </p>
+    </nav>
 }
 
-  <details class="nhsuk-details nhsuk-expander">
+<details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </h1>
+        <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+        </h1>
     </summary>
     <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
     </div>
-  </details>
-  <h2>Enrolment Summary</h2>
-  <dl class="nhsuk-summary-list">
+</details>
+<h2>Enrolment Summary</h2>
+<dl class="nhsuk-summary-list">
 
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Self Assessment
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.RoleProfile.RoleProfileName
-      </dd>
+        <dt class="nhsuk-summary-list__key">
+            Self Assessment
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.RoleProfile.RoleProfileName
+        </dd>
 
-      <dd class="nhsuk-summary-list__actions">
+        <dd class="nhsuk-summary-list__actions">
 
-        <a asp-action="EnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-          Change<span class="nhsuk-u-visually-hidden"> role profile</span>
-        </a>
+            <a asp-action="EnrolDelegateOnProfileAssessment" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+                Change<span class="nhsuk-u-visually-hidden"> role profile</span>
+            </a>
 
-      </dd>
-
-    </div>
-
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Complete by date
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @(Model.CompleteByDate == null ? "Not set" : Model.CompleteByDate.Value.ToShortDateString())
-      </dd>
-
-      <dd class="nhsuk-summary-list__actions">
-
-        <a asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-          Change<span class="nhsuk-u-visually-hidden"> complete by date</span>
-        </a>
-
-      </dd>
+        </dd>
 
     </div>
 
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Supervisor role
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SupervisorRoleName
-      </dd>
+        <dt class="nhsuk-summary-list__key">
+            Complete by date
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @(Model.CompleteByDate == null ? "Not set" : Model.CompleteByDate.Value.ToShortDateString())
+        </dd>
 
-      <dd class="nhsuk-summary-list__actions">
-        @if (Model.SupervisorRoleCount > 1)
-      {
-        <a asp-action="EnrolDelegateSupervisorRole" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-          Change<span class="nhsuk-u-visually-hidden"> supervisor role</span>
-        </a>
-      }
+        <dd class="nhsuk-summary-list__actions">
+
+            <a asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+                Change<span class="nhsuk-u-visually-hidden"> complete by date</span>
+            </a>
+
+        </dd>
+
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Supervisor role
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.SupervisorRoleName
+        </dd>
+
+        <dd class="nhsuk-summary-list__actions">
+            @if (Model.SupervisorRoleCount > 1)
+            {
+                <a asp-action="EnrolDelegateSupervisorRole" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+                    Change<span class="nhsuk-u-visually-hidden"> supervisor role</span>
+                </a>
+            }
 
 
-    </dd>
+        </dd>
 
-  </div>
+    </div>
 
 </dl>
 <a class="nhsuk-button" role="button" asp-action="EnrolDelegateConfirm" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" asp-route-delegateUserId="@Model.SupervisorDelegateDetail.DelegateUserID.Value">
-  Confirm
+    Confirm
 </a>
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-controller="Supervisor"
-     asp-action="DelegateProfileAssessments"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
-  </a>
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSupervisorRole.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/EnrolDelegateSupervisorRole.cshtml
@@ -1,103 +1,107 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model EnrolDelegateSupervisorRoleViewModel;
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Enrol on Profile Assessment" : "Enrol on Profile Assessment";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Enrol on Profile Assessment" : "Enrol on Profile Assessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-           asp-action="DelegateProfileAssessments"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          Enrol
-        </li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="DelegateProfileAssessments"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </a>
-    </p>
-  </nav>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    Enrol
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+               asp-action="EnrolDelegateCompleteBy"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-day="@ViewBag.completeByDate"
+               asp-route-month="@ViewBag.completeByMonth"
+               asp-route-year="@ViewBag.completeByYear"
+            >
+                Back to Complete By Date
+            </a>
+        </p>
+    </nav>
 }
-  <details class="nhsuk-details nhsuk-expander">
+<details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </h1>
+        <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+        </h1>
     </summary>
     <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
     </div>
-  </details>
-  @if (errorHasOccurred)
+</details>
+@if (errorHasOccurred)
 {
-  <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SelfAssessmentSupervisorRoleId) })" />
+    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SelfAssessmentSupervisorRoleId) })" />
 }
 <form method="post">
-  <div class="nhsuk-form-group">
+    <div class="nhsuk-form-group">
 
-    <fieldset class="nhsuk-fieldset">
-      <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-        <h2 class="nhsuk-fieldset__heading">
-          Choose your supervisor role
-        </h2>
-      </legend>
-      <nhs-form-group nhs-validation-for="SelfAssessmentSupervisorRoleId">
-        <div class="nhsuk-radios">
-          @foreach (var role in Model.SelfAssessmentSupervisorRoles)
-          {
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input" id="role-@role.ID" name="SelfAssessmentSupervisorRoleId" asp-for="SelfAssessmentSupervisorRoleId" type="radio" value="@role.ID">
-              <label class="nhsuk-label nhsuk-radios__label" for="role-@role.ID">
-                @role.RoleName
-              </label>
-              @if (role.RoleDescription != null)
-              {
-                <div class="nhsuk-hint nhsuk-radios__hint" id="role-@role.ID-hint">
-                  @role.RoleDescription
+        <fieldset class="nhsuk-fieldset">
+            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                <h2 class="nhsuk-fieldset__heading">
+                    Choose your supervisor role
+                </h2>
+            </legend>
+            <nhs-form-group nhs-validation-for="SelfAssessmentSupervisorRoleId">
+                <div class="nhsuk-radios">
+                    @foreach (var role in Model.SelfAssessmentSupervisorRoles)
+                    {
+                        <div class="nhsuk-radios__item">
+                            <input class="nhsuk-radios__input" id="role-@role.ID" name="SelfAssessmentSupervisorRoleId" asp-for="SelfAssessmentSupervisorRoleId" type="radio" value="@role.ID">
+                            <label class="nhsuk-label nhsuk-radios__label" for="role-@role.ID">
+                                @role.RoleName
+                            </label>
+                            @if (role.RoleDescription != null)
+                            {
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="role-@role.ID-hint">
+                                    @role.RoleDescription
+                                </div>
+                            }
+
+                        </div>
+                    }
+
                 </div>
-              }
-
-            </div>
-          }
-
+            </nhs-form-group>
+        </fieldset>
+        <div class=" nhsuk-u-margin-top-5">
+            <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
+                Back
+            </a>
+            <button class="nhsuk-button" id="save-button" type="submit">Next</button>
         </div>
-      </nhs-form-group>
-    </fieldset>
-    <div class=" nhsuk-u-margin-top-5">
-      <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="EnrolDelegateCompleteBy" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID">
-        Back
-      </a>
-      <button class="nhsuk-button" id="save-button" type="submit">Next</button>
     </div>
-  </div>
 </form>
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link" asp-controller="Supervisor"
-     asp-action="DelegateProfileAssessments"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
-  </a>
+    <a class="nhsuk-back-link__link" asp-controller="Supervisor"
+       asp-action="DelegateProfileAssessments"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
 </div>


### PR DESCRIPTION
…assessment.

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1439

### Description
Points addressed in this Commit :
1) Changed the back link label of pages in enrol self assessment.
2) Changed the back link navigation to navigate to the back page in enrol self assessment.

### Screenshots
![EnrolmentSummaryWavePlugin](https://user-images.githubusercontent.com/111436026/236246283-0e9d1241-b868-4a9f-af26-2550679189cf.png)
[My-Staff-List---Digital-Learning-Solutions.webm](https://user-images.githubusercontent.com/111436026/236246294-d7307e9a-6ac9-4f13-a914-49998e832c37.webm)
![SupervisorRoleWavePlugin](https://user-images.githubusercontent.com/111436026/236246319-1a010dc7-b00f-4b47-9e1f-2e5c476b6a0d.png)
![CompleteByDateWavePlugin](https://user-images.githubusercontent.com/111436026/236246323-1e489ddd-0b16-4e1e-a67f-a3608d0661a0.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
