### PR TITLE
TD-1499 Displayed validation message when admin set a password for un…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -35,8 +35,10 @@
                 cd.HasBeenPromptedForPrn,
                 cd.ProfessionalRegistrationNumber,
                 cd.HasDismissedLhLoginWarning,
-                cd.ResetPasswordID
+                cd.ResetPasswordID,
+                da.RegistrationConfirmationHash
             FROM Candidates AS cd
+            INNER JOIN DelegateAccounts AS da ON da.UserID = cd.UserID
             INNER JOIN Centres AS ct ON ct.CentreID = cd.CentreID
             INNER JOIN JobGroups AS jg ON jg.JobGroupID = cd.JobGroupID";
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/SetDelegatePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/SetDelegatePasswordController.cs
@@ -43,6 +43,7 @@
             var model = new SetDelegatePasswordViewModel(
                 DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(delegateUser.FirstName, delegateUser.LastName),
                 delegateId,
+                delegateUser.RegistrationConfirmationHash,
                 isFromViewDelegatePage,
                 returnPageQuery
             );
@@ -56,7 +57,7 @@
             int delegateId,
             bool isFromViewDelegatePage
         )
-        {
+        {            
             if (!ModelState.IsValid)
             {
                 model.IsFromViewDelegatePage = isFromViewDelegatePage;

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -33,5 +33,6 @@
         public const string PasswordSimilarUsername = "Enter a password which is less similar to your user name";
         public const string PrimaryEmailInUseDuringDelegateRegistration =
             "A user with this email address is already registered";
+        public const string UnclaimedDelegateAccountResetPassword = "The user will not be able to log into their account until they have claimed it by following the link in their welcome email.";
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -33,6 +33,5 @@
         public const string PasswordSimilarUsername = "Enter a password which is less similar to your user name";
         public const string PrimaryEmailInUseDuringDelegateRegistration =
             "A user with this email address is already registered";
-        public const string UnclaimedDelegateAccountResetPassword = "The user will not be able to log into their account until they have claimed it by following the link in their welcome email.";
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
@@ -14,12 +14,14 @@
         public SetDelegatePasswordViewModel(
             string name,
             int delegateId,
+            string registrationConfirmationHash,
             bool isFromViewDelegatePage = false,
             ReturnPageQuery? returnPageQuery = null
         )
         {
             Name = name;
             DelegateId = delegateId;
+            RegistrationConfirmationHash = registrationConfirmationHash;
             IsFromViewDelegatePage = isFromViewDelegatePage;
             ReturnPageQuery = returnPageQuery;
         }
@@ -29,6 +31,8 @@
         public int DelegateId { get; set; }
 
         public bool IsFromViewDelegatePage { get; set; }
+
+        public string? RegistrationConfirmationHash { get; set; }
 
         [Required(ErrorMessage = CommonValidationErrorMessages.PasswordRequired)]
         [MinLength(8, ErrorMessage = CommonValidationErrorMessages.PasswordMinLength)]
@@ -46,7 +50,12 @@
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             List<ValidationResult> errors = new List<ValidationResult>();
-            if(Password != null && Password != string.Empty)
+
+            if (!string.IsNullOrEmpty(RegistrationConfirmationHash))
+            {
+                errors.Add(new ValidationResult(CommonValidationErrorMessages.UnclaimedDelegateAccountResetPassword));
+            }
+            else if (Password != null && Password != string.Empty)
             {
                 var passwordLower = Password.ToLower();
                 var firstnameLower = Name.ToLower().Split(' ').First();

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
@@ -14,7 +14,7 @@
         public SetDelegatePasswordViewModel(
             string name,
             int delegateId,
-            string registrationConfirmationHash,
+            string? registrationConfirmationHash,
             bool isFromViewDelegatePage = false,
             ReturnPageQuery? returnPageQuery = null
         )

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/SetDelegatePassword/SetDelegatePasswordViewModel.cs
@@ -51,11 +51,7 @@
         {
             List<ValidationResult> errors = new List<ValidationResult>();
 
-            if (!string.IsNullOrEmpty(RegistrationConfirmationHash))
-            {
-                errors.Add(new ValidationResult(CommonValidationErrorMessages.UnclaimedDelegateAccountResetPassword));
-            }
-            else if (Password != null && Password != string.Empty)
+            if (Password != null && Password != string.Empty)
             {
                 var passwordLower = Password.ToLower();
                 var firstnameLower = Name.ToLower().Split(' ').First();

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/SetDelegatePassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/SetDelegatePassword/Index.cshtml
@@ -20,6 +20,7 @@
     <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="Index">
       <input type="hidden" asp-for="Name" />
       <input type="hidden" asp-for="DelegateId" />
+      <input type="hidden" asp-for="RegistrationConfirmationHash" />
       <input type="hidden" asp-for="IsFromViewDelegatePage" />
       <input type="hidden" asp-for="ReturnPageQuery" />
       <vc:text-input asp-for="@nameof(Model.Password)"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/SetDelegatePassword/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/SetDelegatePassword/Index.cshtml
@@ -2,49 +2,60 @@
 @model SetDelegatePasswordViewModel
 
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Set delegate user password" : "Set delegate user password";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Set delegate user password" : "Set delegate user password";
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    @if (errorHasOccurred)
-    {
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Password) })" />
-    }
+    <div class="nhsuk-grid-column-full">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Password) })" />
+        }
 
-    <h1 class="nhsuk-heading-xl">Set delegate user password</h1>
+        <h1 class="nhsuk-heading-xl">Set delegate user password</h1>
+        @if (Model.RegistrationConfirmationHash != null)
+        {
+            <div class="nhsuk-warning-callout">
+                <h3 class="nhsuk-warning-callout__label">
+                    <span role="text">
+                        Unclaimed account
+                    </span>
+                </h3>
+                <p>The user will not be able to log into their account until they have claimed it by following the link in their welcome email.</p>
+            </div>
+        }
 
-    <vc:field-name-value-display display-name="User" field-value="@Model.Name" />
+        <vc:field-name-value-display display-name="User" field-value="@Model.Name" />
 
-    <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="Index">
-      <input type="hidden" asp-for="Name" />
-      <input type="hidden" asp-for="DelegateId" />
-      <input type="hidden" asp-for="RegistrationConfirmationHash" />
-      <input type="hidden" asp-for="IsFromViewDelegatePage" />
-      <input type="hidden" asp-for="ReturnPageQuery" />
-      <vc:text-input asp-for="@nameof(Model.Password)"
-                     label="Password"
-                     populate-with-current-value="false"
-                     type="text"
-                     spell-check="false"
-                     autocomplete="off"
-                     hint-text="Password should have a minimum of 8 characters with at least 1 uppercase and 1 lowercase letter, 1 number and 1 symbol."
-                     css-class="nhsuk-u-width-one-half"
-                     required="true" />
+        <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="Index">
+            <input type="hidden" asp-for="Name" />
+            <input type="hidden" asp-for="DelegateId" />
+            <input type="hidden" asp-for="RegistrationConfirmationHash" />
+            <input type="hidden" asp-for="IsFromViewDelegatePage" />
+            <input type="hidden" asp-for="ReturnPageQuery" />
+            <vc:text-input asp-for="@nameof(Model.Password)"
+                           label="Password"
+                           populate-with-current-value="false"
+                           type="text"
+                           spell-check="false"
+                           autocomplete="off"
+                           hint-text="Password should have a minimum of 8 characters with at least 1 uppercase and 1 lowercase letter, 1 number and 1 symbol."
+                           css-class="nhsuk-u-width-one-half"
+                           required="true" />
 
-      <button class="nhsuk-button" type="submit">Save</button>
-    </form>
+            <button class="nhsuk-button" type="submit">Save</button>
+        </form>
 
-    @if (Model.IsFromViewDelegatePage)
-    {
-      var routeData = new Dictionary<string, string> { { "delegateId", Model.DelegateId.ToString() } };
-      <vc:cancel-link asp-controller="ViewDelegate" asp-action="Index" asp-all-route-data="@routeData" />
-    }
-    else
-    {
-      <vc:cancel-link-with-return-page-query asp-controller="AllDelegates" asp-action="Index" return-page-query="@Model.ReturnPageQuery!.Value" />
-    }
+        @if (Model.IsFromViewDelegatePage)
+        {
+            var routeData = new Dictionary<string, string> { { "delegateId", Model.DelegateId.ToString() } };
+            <vc:cancel-link asp-controller="ViewDelegate" asp-action="Index" asp-all-route-data="@routeData" />
+        }
+        else
+        {
+            <vc:cancel-link-with-return-page-query asp-controller="AllDelegates" asp-action="Index" return-page-query="@Model.ReturnPageQuery!.Value" />
+        }
 
-  </div>
+    </div>
 </div>


### PR DESCRIPTION
…claimed delegate account.

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1499

### Description
Points addressed in this Commit :
1) Displayed validation message when admin set a password for unclaimed delegate account.

### Screenshots
![Error-Set-delegate-user-password-Digital-Learning-Solutions](https://user-images.githubusercontent.com/111436026/236471701-493cc9f5-1450-44f8-a7d7-ad21599bb7f5.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
