### PR TITLE
TD-161-Provide searchable list of supervisors when adding a supervisor from the self assessment manage supervisors view

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -678,7 +678,7 @@
                new SearchOptions(searchString),
                new SortOptions(sortBy, sortDirection),
                null,
-               null//new PaginationOptions(page)
+               null
            );
 
             var result = searchSortFilterPaginateService.SearchFilterSortAndPaginate(
@@ -699,6 +699,7 @@
             return View("SelfAssessments/AddSupervisor", model);
         }
 
+        [NoCaching]
         [Route("/LearningPortal/SelfAssessment/{selfAssessmentId:int}/GetAllSupervisors")]
         public IActionResult GetAllSupervisors(int selfAssessmentId)
         {

--- a/DigitalLearningSolutions.Web/Scripts/learningPortal/supervisorList.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningPortal/supervisorList.ts
@@ -1,5 +1,7 @@
 import { SearchSortFilterAndPaginate } from '../searchSortFilterAndPaginate/searchSortFilterAndPaginate';
+import { setItemsPerPage } from '../searchSortFilterAndPaginate/paginate';
 
+setItemsPerPage(9999);
 const selfAssessment = <HTMLInputElement>document.getElementById('SelfAssessmentID');
 const selfAssessmentId = selfAssessment.value;
 // eslint-disable-next-line no-new
@@ -14,7 +16,7 @@ if (sInput != null) {
 function handler(event:any) {
   const sp = <HTMLSelectElement>document.getElementById('result-count-and-page-number');
   const btnSubmit = <HTMLSelectElement>document.getElementById('btnAddSupervisor');
-  if (sp.innerText.includes('0 matching')) {
+  if (sp.innerText.startsWith('0 matching')) {
     btnSubmit.style.visibility = 'hidden';
   } else {
     btnSubmit.style.visibility = 'visible';

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
@@ -1,10 +1,10 @@
 import { ISearchableElement } from './searchSortFilterAndPaginate';
 
 export const ITEMS_PER_PAGE_DEFAULT = 10;
-let itemsPerPage: number = ITEMS_PER_PAGE_DEFAULT;
+let itemsPerPage_Default: number = ITEMS_PER_PAGE_DEFAULT;
 
 export function setItemsPerPage(numberOfItemsPerPage: number) {
-  itemsPerPage = numberOfItemsPerPage;
+  itemsPerPage_Default = numberOfItemsPerPage;
 }
 
 export function setUpPagination(
@@ -90,7 +90,7 @@ export function getItemsPerPageValue(): number {
   const itemsPerPageSelect = getItemsPerPageSelect();
   return itemsPerPageSelect !== null
     ? parseInt((itemsPerPageSelect as HTMLSelectElement).value, 10)
-    : itemsPerPage;
+    : itemsPerPage_Default;
 }
 
 function getPreviousButtons() {

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
@@ -1,6 +1,6 @@
 import { ISearchableElement } from './searchSortFilterAndPaginate';
 
-export var ITEMS_PER_PAGE_DEFAULT = 10;
+export let ITEMS_PER_PAGE_DEFAULT = 10;
 
 export function setItemsPerPage(itemsPerPage: number) {
   ITEMS_PER_PAGE_DEFAULT = itemsPerPage;

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
@@ -1,10 +1,10 @@
 import { ISearchableElement } from './searchSortFilterAndPaginate';
 
 export const ITEMS_PER_PAGE_DEFAULT = 10;
-let itemsPerPage_Default: number = ITEMS_PER_PAGE_DEFAULT;
+let itemsPerPageDefault: number = ITEMS_PER_PAGE_DEFAULT;
 
 export function setItemsPerPage(numberOfItemsPerPage: number) {
-  itemsPerPage_Default = numberOfItemsPerPage;
+  itemsPerPageDefault = numberOfItemsPerPage;
 }
 
 export function setUpPagination(
@@ -90,7 +90,7 @@ export function getItemsPerPageValue(): number {
   const itemsPerPageSelect = getItemsPerPageSelect();
   return itemsPerPageSelect !== null
     ? parseInt((itemsPerPageSelect as HTMLSelectElement).value, 10)
-    : itemsPerPage_Default;
+    : itemsPerPageDefault;
 }
 
 function getPreviousButtons() {

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
@@ -1,6 +1,10 @@
 import { ISearchableElement } from './searchSortFilterAndPaginate';
 
-export const ITEMS_PER_PAGE_DEFAULT = 10;
+export var ITEMS_PER_PAGE_DEFAULT = 10;
+
+export function setItemsPerPage(itemsPerPage: number) {
+  ITEMS_PER_PAGE_DEFAULT = itemsPerPage;
+}
 
 export function setUpPagination(
   onNextPressed: VoidFunction,

--- a/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
+++ b/DigitalLearningSolutions.Web/Scripts/searchSortFilterAndPaginate/paginate.ts
@@ -1,9 +1,10 @@
 import { ISearchableElement } from './searchSortFilterAndPaginate';
 
-export let ITEMS_PER_PAGE_DEFAULT = 10;
+export const ITEMS_PER_PAGE_DEFAULT = 10;
+let itemsPerPage: number = ITEMS_PER_PAGE_DEFAULT;
 
-export function setItemsPerPage(itemsPerPage: number) {
-  ITEMS_PER_PAGE_DEFAULT = itemsPerPage;
+export function setItemsPerPage(numberOfItemsPerPage: number) {
+  itemsPerPage = numberOfItemsPerPage;
 }
 
 export function setUpPagination(
@@ -89,7 +90,7 @@ export function getItemsPerPageValue(): number {
   const itemsPerPageSelect = getItemsPerPageSelect();
   return itemsPerPageSelect !== null
     ? parseInt((itemsPerPageSelect as HTMLSelectElement).value, 10)
-    : ITEMS_PER_PAGE_DEFAULT;
+    : itemsPerPage;
 }
 
 function getPreviousButtons() {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
@@ -35,7 +35,7 @@
     </p>
 }
 <h1>New activity supervisor</h1>
-<div id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")"  style="display: inline;">
+<div id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
             <form method="get" role="search" asp-route-page="@Model.Page">
@@ -44,7 +44,9 @@
                     <vc:error-summary order-of-property-names="@(new[] {nameof(Model.SupervisorAdminID) })" />
                 }
                 <div class="nhsuk-grid-row">
-                    <partial name="SearchablePage/_Search" model="Model" />
+                    <div class="nhsuk-grid-column-full">
+                      <partial name="SearchablePage/_Search" model="Model" />
+                    </div>
                 </div>
                 <nhs-form-group nhs-validation-for="SupervisorAdminID">
                     <fieldset class="nhsuk-fieldset">
@@ -116,7 +118,6 @@
             </div>
         </div>
     </div>
-    @*@await RenderSectionAsync("scripts", false)*@
 </div>
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-161

**Description**
The search bar has aligned. To display all supervisors, the number… of supervisors per page is set to 9999

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/efedfcfe-1a0a-4275-a7c9-b951c66957fb)


-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors 
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
