### PR TITLE
Develop/feature/td 1469 add filters for claimed and unclaimed delegates

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -39,8 +39,7 @@
                         WHERE aa.UserID = da.UserID
                             AND aa.CentreID = da.CentreID
                             AND aa.Active = 1
-                ) AS AdminID,
-                da.RegistrationConfirmationHash
+                ) AS AdminID
             FROM DelegateAccounts AS da
             INNER JOIN Centres AS c ON c.CentreID = da.CentreID
             INNER JOIN Users AS u ON u.ID = da.UserID

--- a/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
@@ -37,7 +37,6 @@
             SelfReg = delegateEntity.DelegateAccount.SelfReg;
             ExternalReg = delegateEntity.DelegateAccount.ExternalReg;
             AdminId = delegateEntity.AdminId;
-            RegistrationConfirmationHash = delegateEntity.DelegateAccount.RegistrationConfirmationHash;
         }
 
         public bool SelfReg { get; set; }
@@ -45,6 +44,7 @@
         public int? AdminId { get; set; }
         public bool IsPasswordSet => !string.IsNullOrWhiteSpace(Password);
         public bool IsAdmin => AdminId.HasValue;
+        public bool IsYetToBeClaimed => RegistrationConfirmationHash != null;
 
         public RegistrationType RegistrationType => (SelfReg, ExternalReg) switch
         {

--- a/DigitalLearningSolutions.Web.Tests/Helpers/FilterableTagHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/FilterableTagHelperTests.cs
@@ -51,7 +51,8 @@
                 new SearchableTagViewModel(DelegateActiveStatusFilterOptions.IsActive),
                 new SearchableTagViewModel(DelegateAdminStatusFilterOptions.IsAdmin),
                 new SearchableTagViewModel(DelegatePasswordStatusFilterOptions.PasswordSet),
-                new SearchableTagViewModel(DelegateRegistrationTypeFilterOptions.SelfRegistered)
+                new SearchableTagViewModel(DelegateRegistrationTypeFilterOptions.SelfRegistered),
+                new SearchableTagViewModel(AccountStatusFilterOptions.ClaimedVerifiedAccount)
             };
 
             // When
@@ -74,7 +75,8 @@
                 new SearchableTagViewModel(DelegateActiveStatusFilterOptions.IsNotActive),
                 new SearchableTagViewModel(DelegateAdminStatusFilterOptions.IsNotAdmin, true),
                 new SearchableTagViewModel(DelegatePasswordStatusFilterOptions.PasswordNotSet),
-                new SearchableTagViewModel(DelegateRegistrationTypeFilterOptions.RegisteredByCentre)
+                new SearchableTagViewModel(DelegateRegistrationTypeFilterOptions.RegisteredByCentre),
+                new SearchableTagViewModel(AccountStatusFilterOptions.ClaimedVerifiedAccount)
             };
 
             // When
@@ -98,7 +100,8 @@
                 new SearchableTagViewModel(DelegateActiveStatusFilterOptions.IsNotActive),
                 new SearchableTagViewModel(DelegateAdminStatusFilterOptions.IsNotAdmin, true),
                 new SearchableTagViewModel(DelegatePasswordStatusFilterOptions.PasswordNotSet),
-                new SearchableTagViewModel(DelegateRegistrationTypeFilterOptions.SelfRegisteredExternal)
+                new SearchableTagViewModel(DelegateRegistrationTypeFilterOptions.SelfRegisteredExternal),
+                new SearchableTagViewModel(AccountStatusFilterOptions.ClaimedVerifiedAccount)
             };
 
             // When

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -115,7 +115,7 @@
             var centreId = User.GetCentreIdKnownNotNull();
             var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
             var customPrompts = promptsService.GetCentreRegistrationPrompts(centreId);
-            var delegateUsers = userDataService.GetDelegateUserCardsByCentreId(centreId);
+            var delegateUsers = userDataService.GetDelegateUserCardsByCentreId(centreId).Where(c => !Guid.TryParse(c.EmailAddress, out _));
 
             var model = new AllDelegateItemsViewModel(delegateUsers, jobGroups, customPrompts);
 

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateFilterOptions.cs
@@ -41,6 +41,23 @@
         );
     }
 
+    public static class AccountStatusFilterOptions
+    {
+        private const string Group = "IsYetToBeClaimed";
+
+        public static readonly FilterOptionModel ClaimedVerifiedAccount = new FilterOptionModel(
+            "Claimed/verified",
+            FilteringHelper.BuildFilterValueString(Group, Group, "false"),
+            FilterStatus.Default
+        );
+
+        public static readonly FilterOptionModel UnclaimedUnverifiedAccount = new FilterOptionModel(
+            "Unclaimed/unverified",
+            FilteringHelper.BuildFilterValueString(Group, Group, "true"),
+            FilterStatus.Default
+        );
+    }
+
     public static class DelegateActiveStatusFilterOptions
     {
         private const string Group = "ActiveStatus";

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -213,6 +213,9 @@
                 new SearchableTagViewModel(
                     DelegateRegistrationTypeFilterOptions.FromRegistrationType(delegateUser.RegistrationType)
                 ),
+                delegateUser.IsYetToBeClaimed
+                    ? new SearchableTagViewModel(AccountStatusFilterOptions.UnclaimedUnverifiedAccount)
+                    : new SearchableTagViewModel(AccountStatusFilterOptions.ClaimedVerifiedAccount)
             };
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
@@ -35,6 +35,12 @@
             DelegateRegistrationTypeFilterOptions.RegisteredByCentre,
         };
 
+        public static readonly IEnumerable<FilterOptionModel> AccountStatusOptions = new[]
+        {
+            AccountStatusFilterOptions.ClaimedVerifiedAccount,
+            AccountStatusFilterOptions.UnclaimedUnverifiedAccount
+        };
+
         public static List<FilterModel> GetAllDelegatesFilterViewModels(
             IEnumerable<(int id, string name)> jobGroups,
             IEnumerable<CentreRegistrationPrompt> promptsWithOptions
@@ -51,6 +57,7 @@
                     DelegatesViewModelFilters.GetJobGroupOptions(jobGroups)
                 ),
                 new FilterModel("RegistrationType", "Registration Type", RegistrationTypeOptions),
+                new FilterModel("AccountStatus", "Account Status", AccountStatusOptions),
             };
             filters.AddRange(
                 promptsWithOptions.Select(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1469

### Description
Points addressed in this Commit :
1) Added filter option for claimed and unclaimed delegates.
2) Fixed mismatch of data in delegate list in javascript paging searching filter and serverside paging searching filter.

### Screenshots
![Delegates-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/2d4fe14b-3f3b-4170-bd0b-5475b00f84a6)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
