### PR TITLE
TD-1442:Proficiency self assessment result: Replace the word 'Comment…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -124,7 +124,11 @@
   {
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">
-        Comments
+          @(((Model.Competency.AssessmentQuestions.First().SignedOff == true && Model.Competency.AssessmentQuestions.First().Verified.HasValue)
+                || (Model.Competency.AssessmentQuestions.First().ResultId != null && Model.Competency.AssessmentQuestions.First().Verified == null && Model.Competency.AssessmentQuestions.First().Requested != null && Model.Competency.AssessmentQuestions.First().UserIsVerifier == false)
+                || (Model.Competency.AssessmentQuestions.First().Verified == null && Model.Competency.AssessmentQuestions.First().Requested != null)
+                    && (!String.IsNullOrEmpty(Model.DelegateSelfAssessment.ReviewerCommentsLabel)))
+                    ? Model.DelegateSelfAssessment.ReviewerCommentsLabel : "Comments")
       </dt>
       <dd class="nhsuk-summary-list__value">
         @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1442

### Description
 Change “Comments“  to “Action plan“ for 3 statuses 'confirmed', 'confirmation requested' and 'pending confirmation' in Supervisor view.


### Screenshots
**Before code change:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/4cd2f4ed-8fc3-48bc-89ab-7b0ebe7760c3)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/a77044ff-e06b-4954-9285-8d5bb7e14f87)

**After code change:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/b8c6bf57-0510-4002-bd98-3cb0cfb1e77f)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/fee4f036-5d25-4cdb-bfd7-5182d4f15987)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/6474ef78-90ed-4865-9d28-0f1f6f8245d0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
