### PR TITLE
TD-1485 Duplicates allowed without showing error msg on the screen 

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/FrameworkService.cs
@@ -446,7 +446,7 @@
 
         public IEnumerable<FrameworkCompetency> GetAllCompetenciesForAdminId(string name, int adminId)
         {
-            var adminFilter = adminId  > 0 ? "AND c.UpdatedByAdminID = @adminId":string.Empty;
+            var adminFilter = adminId > 0 ? "AND c.UpdatedByAdminID = @adminId" : string.Empty;
             return connection.Query<FrameworkCompetency>(
                 $@"SELECT f.FrameworkName,c.Description,c.UpdatedByAdminID,c.Name from Competencies as c
                     INNER JOIN FrameworkCompetencies AS fc ON c.ID = fc.CompetencyID

--- a/DigitalLearningSolutions.Data/DataServices/FrameworkService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/FrameworkService.cs
@@ -446,11 +446,12 @@
 
         public IEnumerable<FrameworkCompetency> GetAllCompetenciesForAdminId(string name, int adminId)
         {
+            var adminFilter = adminId  > 0 ? "AND c.UpdatedByAdminID = @adminId":string.Empty;
             return connection.Query<FrameworkCompetency>(
                 $@"SELECT f.FrameworkName,c.Description,c.UpdatedByAdminID,c.Name from Competencies as c
                     INNER JOIN FrameworkCompetencies AS fc ON c.ID = fc.CompetencyID
                     INNER JOIN Frameworks AS f ON fc.FrameworkID = f.ID
-                    WHERE fc.FrameworkID = f.ID AND c.Name = @name AND c.UpdatedByAdminID = @adminId",
+                    WHERE fc.FrameworkID = f.ID AND c.Name = @name {adminFilter}",
                 new { name, adminId }
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -170,7 +170,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 frameworkService.UpdateCompetencyFlags(frameworkId, frameworkCompetency.CompetencyID, selectedFlagIds);
                 return new RedirectResult(Url.Action("ViewFramework", new { tabname = "Structure", frameworkId, frameworkCompetencyGroupId, frameworkCompetencyId }) + "#fc-" + frameworkCompetencyId.ToString());
             }
-            var allCompetenciesWithSimilarName = frameworkService.GetAllCompetenciesForAdminId(frameworkCompetency.Name, adminId);
+            var allCompetenciesWithSimilarName = frameworkService.GetAllCompetenciesForAdminId(frameworkCompetency.Name, 0);
 
             var sortedItems = GenericSortingHelper.SortAllItems(
                allCompetenciesWithSimilarName.AsQueryable(),


### PR DESCRIPTION

### JIRA link
[TD-1485](https://hee-tis.atlassian.net/browse/TD-1485)

### Description
Duplicates allowed without showing error msg on the screen if added the competency with the name of existing one in frameworks.  This was as a result of the duplicate competency being attached to a different admindId. The query now fetches all competencies from the database irrespective of the attached adminId.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1485]: https://hee-tis.atlassian.net/browse/TD-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ