### PR TITLE
TD-1443:Proficiency self assessment result: when viewing a 'pending c…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -153,7 +153,7 @@
     {
       <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
-          Verification Requested
+          Confirmation date requested
         </dt>
         <dd class="nhsuk-summary-list__value">
           @{

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -153,7 +153,7 @@
     {
       <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
-          Confirmation date requested
+          Confirmation requested date
         </dt>
         <dd class="nhsuk-summary-list__value">
           @{


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1443

### Description
Proficiency self assessment result:  'Verification requested' text has been changed to 'Confirmation date requested' (with a little 'r' as well) in Supervisor view.

### Screenshots
**Before code change:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/6ae5a239-bba9-4041-8b74-eeeace85b470)

**After code change:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/ed6fcc10-b112-453b-92c6-fba48a9a5006)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
