### PR TITLE
TD-207:Self assessment count mismatch resolved

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -6,7 +6,7 @@
   ViewData["HeaderPathName"] = "Supervisor";
     var competencySummaries = from g in Model.CompetencyGroups
                               let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
-                              let selfAssessedCount = questions.Count(q => q.ResultId.HasValue)
+                              let selfAssessedCount = questions.Count(q => q.Result.HasValue)
                               let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
                               select new ViewDataDictionary(ViewData)
 {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-207

### Description
count mismatch in supervisor page & self assessment page fixed.

### Screenshots

**Before code fix:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/e914e236-d659-44c8-a8f5-5063baee7cc9)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/7ec424f2-f347-4c69-86ef-6528836b37e5)


**After code fix:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/e3567f07-f6fd-4424-9322-a5ea2769ca0f)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/5f67a181-79ab-4b62-b763-9e973b200e67)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
