### PR TITLE
TD-1555 Reverts to legacy tracker endpoint and improves param mapping

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
+++ b/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
@@ -9,7 +9,7 @@
         public int? ProgressId { get; set; }
         public string? DiagnosticOutcome { get; set; }
         public int? TutorialStatus { get; set; }
-        public int? TutorialTime { get; set; }
+        public double? TutorialTime { get; set; }
         public int? CandidateId { get; set; }
         public int? Version { get; set; }
         public int? TutorialId { get; set; }

--- a/DigitalLearningSolutions.Web.Tests/Helpers/SystemEndpointHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/SystemEndpointHelperTests.cs
@@ -34,7 +34,7 @@
         public void GetTrackingUrl_returns_expected()
         {
             // Given
-            const string expected = "https://www.dls.nhs.uk/v2/tracking/tracker";
+            const string expected = "https://www.dls.nhs.uk/tracking/tracker";
 
             // Then
             SystemEndpointHelper.GetTrackingUrl(config).Should().Be(expected);

--- a/DigitalLearningSolutions.Web.Tests/Services/TrackerServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/TrackerServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Services
 {
+    using System;
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.Tracker;
@@ -28,7 +29,7 @@
             ProgressId = 101,
             Version = 1,
             TutorialId = 123,
-            TutorialTime = 2,
+            TutorialTime = 2.123,
             TutorialStatus = 3,
             CandidateId = 456,
             CustomisationId = 1,
@@ -211,7 +212,7 @@
                         query.Version!.Value,
                         DefaultProgressText,
                         query.TutorialId!.Value,
-                        query.TutorialTime!.Value,
+                        Convert.ToInt32(query.TutorialTime!.Value),
                         query.TutorialStatus!.Value,
                         query.CandidateId!.Value,
                         query.CustomisationId!.Value
@@ -254,7 +255,7 @@
                         query.Version!.Value,
                         DefaultProgressText,
                         query.TutorialId!.Value,
-                        query.TutorialTime!.Value,
+                        Convert.ToInt32(query.TutorialTime!.Value),
                         query.TutorialStatus!.Value,
                         query.CandidateId!.Value,
                         query.CustomisationId!.Value,

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
@@ -252,7 +252,7 @@
             const int customisationId = 24861;
             var expectedHtmlUrl = "https://www.dls.nhs.uk/CMS/CMSContent/Course508/Section1904/Tutorials/Intro to Social Media/itspplayer.html"
                                 + "?CentreID=101&CustomisationID=24861&TutorialID=4&CandidateID=254480&Version=2&ProgressID=276837&type=learn"
-                                + $"&TrackURL={AppRootPathUrl}/tracking/tracker";
+                                + $"&TrackURL={BaseUrl}/tracking/tracker";
 
             // Given
             var expectedTutorialContent = TutorialContentHelper.CreateDefaultTutorialContent(

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticContentViewModelTests.cs
@@ -162,7 +162,7 @@
             diagnosticContentViewModel.ContentSource.Should().Be(
                 "https://www.dls.nhs.uk/CMS/CMSContent/Course119/Diagnostic/07DiagnosticTesting/itspplayer.html" +
                 "?CentreID=6&CustomisationID=5&CandidateID=8&SectionID=7&Version=55&ProgressID=9" +
-                $"&type=diag&TrackURL={AppRootPathUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
+                $"&type=diag&TrackURL={BaseUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
             );
         }
 
@@ -198,7 +198,7 @@
             diagnosticContentViewModel.ContentSource.Should().Be(
                 "https://www.dls.nhs.uk/CMS/CMSContent/Course119/Diagnostic/07DiagnosticTesting/itspplayer.html" +
                 "?CentreID=6&CustomisationID=5&CandidateID=8&SectionID=7&Version=55&ProgressID=9" +
-                $"&type=diag&TrackURL={AppRootPathUrl}/tracking/tracker&objlist=[1,2,3,4]&plathresh=77"
+                $"&type=diag&TrackURL={BaseUrl}/tracking/tracker&objlist=[1,2,3,4]&plathresh=77"
             );
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningContentViewModelTests.cs
@@ -150,7 +150,7 @@
             postLearningContentViewModel.ContentSource.Should().Be(
                 "https://www.dls.nhs.uk/CMS/CMSContent/Course120/PLAssess/03-PLA-Working-with-files/itspplayer.html" +
                 "?CentreID=6&CustomisationID=5&CandidateID=8&SectionID=7&Version=55&ProgressID=9" +
-                $"&type=pl&TrackURL={AppRootPathUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
+                $"&type=pl&TrackURL={BaseUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
             );
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/TrackerController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/TrackerController.cs
@@ -20,7 +20,6 @@
         {
             this.trackerService = trackerService;
         }
-        [HttpPost(), HttpGet()]
         public string Index([FromQuery] TrackerEndpointQueryParams queryParams)
         {
             var sessionVariables = GetSessionVariablesDictionary();

--- a/DigitalLearningSolutions.Web/Helpers/SystemEndpointHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SystemEndpointHelper.cs
@@ -12,7 +12,7 @@
 
         public static string GetTrackingUrl(IConfiguration config)
         {
-            return $"{config.GetAppRootPath()}/tracking/tracker";
+            return $"{config.GetCurrentSystemBaseUrl()}/tracking/tracker";
         }
 
         public static string GetScormPlayerUrl(IConfiguration config)

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -79,7 +79,7 @@
                             query.Version,
                             sessionVariables[TrackerEndpointSessionVariable.LmGvSectionRow],
                             query.TutorialId,
-                            query.TutorialTime,
+                            Convert.ToInt32(query.TutorialTime),
                             query.TutorialStatus,
                             query.CandidateId,
                             query.CustomisationId
@@ -93,7 +93,7 @@
                             query.Version,
                             sessionVariables[TrackerEndpointSessionVariable.LmGvSectionRow],
                             query.TutorialId,
-                            query.TutorialTime,
+                            Convert.ToInt32(query.TutorialTime),
                             query.TutorialStatus,
                             query.CandidateId,
                             query.CustomisationId,


### PR DESCRIPTION
### JIRA link
[TD-1555](https://hee-tis.atlassian.net/browse/TD-1555)

### Description
Reverts to legacy tracker endpoint because the new endpoint doesn't support posting data. Also improves param mapping for time which is passed in as a double but stored as an integer for when we do move to new endpoint.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1555]: https://hee-tis.atlassian.net/browse/TD-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ