### PR TITLE
TD-1444-Add 'Supervisor' and 'Confirmation date requested' row to proficiency self assessment result view for 'confirmation requested' proficiencies

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -143,7 +143,7 @@
       <partial name="Shared/_AssessmentQuestionStatusTag" model="Model.Competency.AssessmentQuestions.First()" />
     </dd>
   </div>
-  @if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Verified == null && !(bool)Model.Competency.AssessmentQuestions.First().UserIsVerifier)
+  @if (Model.Competency.AssessmentQuestions.First().SelfAssessmentResultSupervisorVerificationId != null && Model.Competency.AssessmentQuestions.First().Verified == null)
   {
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1444

**Description**
Removed 'UserIsVerifier' condition to show 'Supervisor' and 'Confirmation requested' row in the view.

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c44fd342-9253-4f3b-a14c-2347a0060a92)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
