### PR TITLE
TD-1449-Change wording of 'Proficiencies confirmation' button to 'Manage confirmation requests' in Learning Portal

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
@@ -17,7 +17,7 @@
    asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
    asp-action="ReviewConfirmationRequests"
    role="button">
-    @FrameworkVocabularyHelper.FirstLetterToUpper(Model.VocabPlural()) confirmation
+    Manage confirmation requests
   </a>
 }
 <feature name="@(FeatureFlags.CandidateAssessmentExcelExport)">


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1449

**Description**
Button text changed.

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b2032e5c-e902-40af-bc96-3d0d06f743e0)


-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
