### PR TITLE
TD-1435 Fixed Super Admin Change Centre failure when user is already …

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.Centres;
+    using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Models.User;
 
     public partial class UserDataService
@@ -471,6 +472,16 @@
                             CentreId = @centreId
                         WHERE ID = @adminId",
             new { adminId, centreId });
+        }
+
+        public bool IsUserAlreadyAdminAtCentre(int adminId, int centreId)
+        {
+            return connection.QueryFirst<int>(
+                @$"SELECT COUNT(*)
+                     FROM AdminAccounts
+                     WHERE CentreId = @centreId AND ID = @adminId",
+                new { adminId, centreId }
+            ) > 0;
         }
     }
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.Centres;
-    using DigitalLearningSolutions.Data.Models.Email;
     using DigitalLearningSolutions.Data.Models.User;
 
     public partial class UserDataService

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -249,6 +249,7 @@
 
         int GetUserIdFromAdminId(int adminId);
         void UpdateAdminCentre(int adminId, int centreId);
+        bool IsUserAlreadyAdminAtCentre(int adminId, int centreId);
     }
 
     public partial class UserDataService : IUserDataService

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
@@ -390,6 +390,11 @@
                 model.Page = Convert.ToInt16(TempData["Page"]);
             }
             TempData["AdminId"] = adminId;
+            if (TempData["CentreId"] != null)
+            {
+                ModelState.AddModelError("CentreId", "User is already admin for the centre.");
+                TempData.Remove("CentreId");
+            }
             return View(model);
         }
         [HttpPost]
@@ -397,8 +402,16 @@
         public IActionResult EditCentre(int adminId, int centreId)
         {
             TempData["AdminId"] = adminId;
-            userDataService.UpdateAdminCentre(adminId, centreId);
-            return RedirectToAction("Index", "AdminAccounts", new { AdminId = adminId });
+            if (userDataService.IsUserAlreadyAdminAtCentre(adminId, centreId))
+            {
+                userDataService.UpdateAdminCentre(adminId, centreId);
+                return RedirectToAction("Index", "AdminAccounts", new { AdminId = adminId });
+            }
+            else
+            {
+                TempData["CentreId"] = centreId;
+                return RedirectToAction("EditCentre", "AdminAccounts", new { AdminId = adminId });
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/EditCentre.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/EditCentre.cshtml
@@ -1,9 +1,13 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Administrators
 @model EditCentreViewModel
 @{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = "Change Administrator Centre";
 }
-
+@if (errorHasOccurred)
+{
+    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.CentreId) })" />
+}
 <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
@@ -34,7 +38,7 @@
                         select-list-options="@ViewBag.Centres" />
 
 
-        <button class="nhsuk-button nhsuk-u-margin-top-2" type="submit" value="save">Submit</button>
+        <button class="nhsuk-button nhsuk-u-margin-top-2" type="submit" value="save">Save</button>
     </form>
 </div>
 <div class="nhsuk-back-link">


### PR DESCRIPTION
…Admin for that Centre

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1435

### Description
Points addressed in this Commit :
1) Fixed Super Admin Change Centre failure when user is already Admin for that Centre.
2) Changed the button text from Submit to Save.

### Screenshots
![Change-Administrator-Centre-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/213b0ec7-ddcf-4f1f-bc89-ca3c601a79bc)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/8bc20245-a650-41a1-9fbb-accb25559134)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
