### PR TITLE
TD-1550-Super Admin: Issue in mobile view on 'Administrators' section for the 'inactivate/reactivate' links showing for the Admin ID

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
@@ -27,27 +27,34 @@
                     <dt class="nhsuk-summary-list__key">
                         Admin ID
                     </dt>
-                    <dd class="nhsuk-summary-list__value">
-                        <span class="nhsuk-u-margin-right-4">
-                            @Model.Id
-                        </span>
-                        <span class="complete">
-                            <partial name="_StatusTag" model="@Model.IsAdminActive ? (int)UserCard.Active : (int)UserCard.Inactive" />
-                        </span>
-                    </dd>
-                    <dd class="nhsuk-summary-list__actions">
-                        @if (!Model.IsAdminActive)
-                        {
-                            <a class="nhsuk-u-float-right" asp-controller="AdminAccounts" asp-action="UpdateAdminStatus" asp-route-adminId="@Model.Id" asp-route-actionType="Reactivate">
-                                Reactivate
-                            </a>
-                        }
-                        else
-                        {
-                            <a class="nhsuk-u-float-right" asp-controller="AdminAccounts" asp-action="UpdateAdminStatus" asp-route-adminId="@Model.Id" asp-route-actionType="Inactivate">
-                                Inactivate
-                            </a>
-                        }
+                    <dd class="nhsuk-summary-list__value nhsuk-u-width-full">
+                        <div class="nhsuk-grid-row">
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-one-third">
+                                <span class="nhsuk-u-margin-right-4">
+                                    @Model.Id
+                                </span>
+                            </div>
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-one-third">
+                                <span class="complete">
+                                    <partial name="_StatusTag" model="@Model.IsAdminActive ? (int)UserCard.Active : (int)UserCard.Inactive" />
+                                </span>
+                            </div>
+
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-one-third">
+                                @if (!Model.IsAdminActive)
+                                {
+                                    <a class="nhsuk-u-float-right" asp-controller="AdminAccounts" asp-action="UpdateAdminStatus" asp-route-adminId="@Model.Id" asp-route-actionType="Reactivate">
+                                        Reactivate
+                                    </a>
+                                }
+                                else
+                                {
+                                    <a class="nhsuk-u-float-right" asp-controller="AdminAccounts" asp-action="UpdateAdminStatus" asp-route-adminId="@Model.Id" asp-route-actionType="Inactivate">
+                                        Inactivate
+                                    </a>
+                                }
+                            </div>
+                        </div>
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row">
@@ -78,36 +85,50 @@
                     <dt class="nhsuk-summary-list__key">
                         User Account
                     </dt>
-                    <dd class="nhsuk-summary-list__value">
-                        <span class="nhsuk-u-margin-right-4">
-                            ID: @Model.UserAccountID
-                        </span>
-                        <span class="nhsuk-u-margin-right-4">
-                            <partial name="_StatusTag" model="@Model.IsUserActive ? (int)UserCard.Active : (int)UserCard.Inactive" />
-                        </span>
-                        @if (Model.IsLocked)
-                        {
-                            <span>
-                                <partial name="_StatusTag" model="(int)UserCard.Locked" />
-                            </span>
-                        }
-                    </dd>
-                    <dd class="nhsuk-summary-list__actions">
-                        @if (Model.IsLocked)
-                        {
-                            <a asp-controller="Users" asp-action="UnlockAccount" asp-route-UserId="@Model.UserAccountID" asp-route-RequestUrl="@Context.Request.GetDisplayUrl()">Unlock</a>
-                        }
-                        <a asp-controller="Users" asp-action="Index" asp-route-UserId="@Model.UserAccountID" class="nhsuk-u-margin-left-2">View</a>
+                    <dd class="nhsuk-summary-list__value nhsuk-u-width-full">
+                        <div class="nhsuk-grid-row">
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-one-third">
+                                <span class="nhsuk-u-margin-right-4">
+                                    ID: @Model.UserAccountID
+                                </span>
+                            </div>
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-one-third">
+                                <span class="nhsuk-u-margin-right-1">
+                                    <partial name="_StatusTag" model="@Model.IsUserActive ? (int)UserCard.Active : (int)UserCard.Inactive" />
+                                    @if (Model.IsLocked)
+                                    {
+                                        <partial name="_StatusTag" model="(int)UserCard.Locked" />
+                                    }
+                                </span>
+                            </div>
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-one-third ">
+                                <a class="nhsuk-u-float-right nhsuk-u-margin-left-5" asp-controller="Users" asp-action="Index" asp-route-UserId="@Model.UserAccountID">View</a>
+                                @if (Model.IsLocked)
+                                {
+                                    <a class="nhsuk-u-float-right" asp-controller="Users" asp-action="UnlockAccount" asp-route-UserId="@Model.UserAccountID" asp-route-RequestUrl="@Context.Request.GetDisplayUrl()">Unlock</a>
+                                }
+                                
+                            </div>
+                        </div>
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
                     <dt class="nhsuk-summary-list__key">
                         Centre
                     </dt>
-                    <partial name="_SummaryFieldValue" model="@Model.Centre" />
-                    <dd class="nhsuk-summary-list__actions">
-                        <a asp-controller="AdminAccounts" asp-action="EditCentre" asp-route-adminId="@Model.Id" asp-route-RequestUrl="@Context.Request.GetDisplayUrl()">Change</a>
+                    <dd class="nhsuk-summary-list__value  nhsuk-u-width-full">
+                        <div class="nhsuk-grid-row">
+                            <div class="nhsuk-grid-column-two-thirds nhsuk-u-width-two-thirds">
+                                <span class="nhsuk-u-margin-right-4">
+                                    @Model.Centre
+                                </span>
+                            </div>
+                            <div class="nhsuk-grid-column-one-third nhsuk-u-width-one-third">
+                                <a class="nhsuk-u-float-right" asp-controller="AdminAccounts" asp-action="EditCentre" asp-route-adminId="@Model.Id" asp-route-RequestUrl="@Context.Request.GetDisplayUrl()">Change</a>
+                            </div>
+                        </div>
                     </dd>
+
                 </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
                     <dt class="nhsuk-summary-list__key">


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1550

**Description**
view changes done for mobile view issue.

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/4271e776-87e7-45d5-8654-80451247a02c)


-----
**Developer checks**

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
