### PR TITLE
TD-1608 Issue with flags when added the competencies

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -7,6 +7,7 @@ using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Linq;
 using System.Net;
 using System.Web;
@@ -194,7 +195,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                         Description = frameworkCompetency.Description
                     },
                     MatchingSearchResults = matchingSearchResults.Count,
-                    SameCompetency = similarItems
+                    SameCompetency = similarItems,
+                    selectedFlagIds = selectedFlagIds.Any() ? selectedFlagIds.Select(a => a.ToString()).Aggregate((b, c) => b + "," + c) : string.Empty,
                 };
                 return View("Developer/SimilarCompetency", model);
             }
@@ -202,7 +204,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         }
 
         [HttpPost]
-        public IActionResult AddDuplicateCompetency(int frameworkId, string competencyName, string competencyDescription, int frameworkCompetencyId, int frameworkGroupId)
+        public IActionResult AddDuplicateCompetency(int frameworkId, string competencyName, string competencyDescription, int frameworkCompetencyId, int frameworkGroupId, string selectedFlagIds)
         {
             FrameworkCompetency competency = new FrameworkCompetency()
             {
@@ -210,7 +212,8 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 Description = competencyDescription,
             };
             var adminId = GetAdminId();
-            return SaveCompetency(adminId, frameworkId, competency, frameworkCompetencyId, frameworkGroupId, null);
+            var flags = (!string.IsNullOrWhiteSpace(selectedFlagIds) && selectedFlagIds.Split(',').Any()) ? selectedFlagIds.Split(',').Select(n => Convert.ToInt32(n)).ToArray() : null;
+            return SaveCompetency(adminId, frameworkId, competency, frameworkCompetencyId, frameworkGroupId, flags);
         }
 
         private IActionResult SaveCompetency(int adminId, int frameworkId, FrameworkCompetency frameworkCompetency, int frameworkCompetencyId, int? frameworkCompetencyGroupId, int[]? selectedFlagIds)

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/SimilarCompetencyViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/SimilarCompetencyViewModel.cs
@@ -12,6 +12,8 @@
         public int FrameworkCompetencyId { get; set; }
         public string FrameworkConfig { get; set; }
         public IEnumerable<FrameworkCompetency> SameCompetency { get; set; }
+        public string selectedFlagIds { get; set; }
+
         public string VocabSingular()
         {
             return FrameworkVocabularyHelper.VocabularySingular(FrameworkConfig);

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SimilarCompetency.cshtml
@@ -65,7 +65,7 @@
 </table>
 <form asp-action="AddDuplicateCompetency" asp-route-frameworkId="@Model.FrameworkId"
       asp-route-competencyName="@Model.Competency.Name" asp-route-competencyDescription="@Model.Competency.Description"
-      asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkGroupId="@Model.FrameworkGroupId">
+      asp-route-frameworkCompetencyId="@Model.FrameworkCompetencyId" asp-route-frameworkGroupId="@Model.FrameworkGroupId" asp-route-selectedFlagIds="@Model.selectedFlagIds">
     <button class="nhsuk-button" type="submit">
         Confirm save
     </button>


### PR DESCRIPTION

### JIRA link
[TD-1608](https://hee-tis.atlassian.net/browse/TD-1608)

### Description
competency flags get lost when adding a new competency with a name similar to an existing name.

### Screenshots
check ticket link for a video

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1608]: https://hee-tis.atlassian.net/browse/TD-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ