### PR TITLE
TD-1594 Made user card expanded when clicked on view link and admin c…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
@@ -413,5 +413,10 @@
                 return RedirectToAction("EditCentre", "AdminAccounts", new { AdminId = adminId });
             }
         }
+
+        public IActionResult RedirectToUser(int UserId) {
+            TempData["UserId"] = UserId;
+            return RedirectToAction("Index", "Users",new { UserId = UserId });
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Users/UsersController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Users/UsersController.cs
@@ -344,5 +344,11 @@
             TempData["UserId"] = userId;
             return RedirectToAction("Index", "Users", new { UserId = userId });
         }
+
+        public IActionResult RedirectToAdmin(int AdminId)
+        {
+            TempData["AdminId"] = AdminId;
+            return RedirectToAction("Index", "AdminAccounts", new { AdminId = AdminId });
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
@@ -97,7 +97,7 @@
                         {
                             <a asp-controller="Users" asp-action="UnlockAccount" asp-route-UserId="@Model.UserAccountID" asp-route-RequestUrl="@Context.Request.GetDisplayUrl()">Unlock</a>
                         }
-                        <a asp-controller="Users" asp-action="Index" asp-route-UserId="@Model.UserAccountID" class="nhsuk-u-margin-left-2">View</a>
+                        <a asp-controller="AdminAccounts" asp-action="RedirectToUser" asp-route-UserId="@Model.UserAccountID" class="nhsuk-u-margin-left-2">View</a>
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Users/UserCentreAccounts.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Users/UserCentreAccounts.cshtml
@@ -58,7 +58,7 @@
                  {
                     if (centreRow.CentreId==admin.CentreId)
                     {
-                         <a class="" asp-controller="AdminAccounts" asp-action="Index" asp-route-AdminId="@admin.Id">Admin</a>
+                         <a asp-action="RedirectToAdmin" asp-route-AdminId="@admin.Id">Admin</a>
                     }
                  }
               }


### PR DESCRIPTION
…ard expanded when clicked on admin link

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1594

### Description
Points addressed in this Commit :
1) Made user card expanded when clicked on view link in Super Admin section.
2) Made admin card expanded when clicked on admin link in user account roles section.

### Screenshots
[Administrators---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/49498c50-a321-4781-9b5d-85980eb54bbc)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
