### PR TITLE
TD-1462 Issue in 'Mobile view' when navigating back from the screens …

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationPickResults.cshtml
@@ -1,146 +1,146 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @model VerificationPickResultsViewModel
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  Layout = "SelfAssessments/_Layout";
-  ViewData["Title"] = "Self Assessment";
-  ViewData["SelfAssessmentTitle"] = @Model.SelfAssessmentName;
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    Layout = "SelfAssessments/_Layout";
+    ViewData["Title"] = "Self Assessment";
+    ViewData["SelfAssessmentTitle"] = @Model.SelfAssessmentName;
 }
 
 @section breadcrumbs {
-  <li class="nhsuk-breadcrumb__item">
-    <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@(Model.SelfAssessmentName) introduction</a>
-  </li>
-  <li class="nhsuk-breadcrumb__item">
-    <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@(Model.VocabPlural()) home</a>
-  </li>
-  <li class="nhsuk-breadcrumb__item">
-    <a class="nhsuk-breadcrumb__link" asp-action="ReviewConfirmationRequests" asp-route-selfAssessmentId="@Model.SelfAssessmentId">Confirmation requests</a>
-  </li>
-  <li class="nhsuk-breadcrumb__item">New</li>
+    <li class="nhsuk-breadcrumb__item">
+        <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@(Model.SelfAssessmentName) introduction</a>
+    </li>
+    <li class="nhsuk-breadcrumb__item">
+        <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">@(Model.VocabPlural()) home</a>
+    </li>
+    <li class="nhsuk-breadcrumb__item">
+        <a class="nhsuk-breadcrumb__link" asp-action="ReviewConfirmationRequests" asp-route-selfAssessmentId="@Model.SelfAssessmentId">Confirmation requests</a>
+    </li>
+    <li class="nhsuk-breadcrumb__item">New</li>
 }
 
-  @section mobilebacklink
-  {
-  <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink"
-     asp-action="ReviewConfirmationRequests"
-     asp-route-selfAssessmentId="@Model.SelfAssessmentId">
-      Back to Confirmation requests
-    </a>
-  </p>
+@section mobilebacklink
+    {
+    <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink"
+       asp-action="VerificationPickSupervisor"
+       asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+            Back to Choose a supervisor
+        </a>
+    </p>
 }
 
-  <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
-  <h1>Request @Model.Vocabulary.ToLower() confirmation</h1>
-  @if (errorHasOccurred)
+<link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
+<h1>Request @Model.Vocabulary.ToLower() confirmation</h1>
+@if (errorHasOccurred)
 {
-  <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ResultIds) })" />
+    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ResultIds) })" />
 }
 @if (Model.CompetencyGroups.Any())
 {
-  <h2>Choose the @Model.Vocabulary.ToLower() self assessment results that you wish to confirm.</h2>
-  <form method="post">
-    <nhs-form-group nhs-validation-for="ResultIds">
-      @foreach (var competencyGroup in Model.CompetencyGroups)
-      {
-        <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
-          <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-            <span class="nhsuk-fieldset__heading">
-              @competencyGroup.Key
-            </span>
-          </legend>
-        </fieldset>
-        @if (competencyGroup.Count() > 1)
-        {
-          <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
-            <div class="nhsuk-grid-column-full">
-              <a class="nhsuk-button select-all-button select-all status-tag" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural().ToLower()</a>
-              <a class="nhsuk-button select-all-button deselect-all status-tag" role="button" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural().ToLower()</a>
-            </div>
-          </div>
-        }
-        <table role="table" class="nhsuk-table-responsive">
-          <thead role="rowgroup" class="nhsuk-table__head">
-            <tr role="row">
-              <th role="columnheader" class="" scope="col">
-                @competencyGroup.First().Vocabulary
-              </th>
-              <th role="columnheader" class="" scope="col">
-                Question
-              </th>
-              <th role="columnheader" class="" scope="col">
-                Response
-              </th>
-            </tr>
-          </thead>
-          <tbody class="nhsuk-table__body">
-            @foreach (var competency in competencyGroup)
+    <h2>Choose the @Model.Vocabulary.ToLower() self assessment results that you wish to confirm.</h2>
+    <form method="post">
+        <nhs-form-group nhs-validation-for="ResultIds">
+            @foreach (var competencyGroup in Model.CompetencyGroups)
             {
-              @foreach (var question in competency.AssessmentQuestions)
-              {
-                <tr role="row" class="nhsuk-table__row">
-                  <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                    <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
-                    <div class="nhsuk-checkboxes__item">
-                      <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.ResultId" name="ResultIds" checked="@(Model.ResultIds != null ? Model.ResultIds.Contains((int)question.ResultId) : false)" type="checkbox" value="@question.ResultId">
-                      <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.ResultId">
-                        @competency.Name
-                      </label>
+                <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
+                    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                        <span class="nhsuk-fieldset__heading">
+                            @competencyGroup.Key
+                        </span>
+                    </legend>
+                </fieldset>
+                @if (competencyGroup.Count() > 1)
+                {
+                    <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
+                        <div class="nhsuk-grid-column-full">
+                            <a class="nhsuk-button select-all-button select-all status-tag" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural().ToLower()</a>
+                            <a class="nhsuk-button select-all-button deselect-all status-tag" role="button" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural().ToLower()</a>
+                        </div>
                     </div>
-                  </td>
-                  <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                    <span class="nhsuk-table-responsive__heading">Question </span>
-                    @question.Question
-                    @if (!question.Required)
-                    {
-                      <span>(Optional)</span>
-                    }
-                  </td>
-                  <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                    <span class="nhsuk-table-responsive__heading">Response </span>
-                    <partial name="../../Supervisor/Shared/_AssessmentQuestionResponse" model="question" />
-                  </td>
+                }
+                <table role="table" class="nhsuk-table-responsive">
+                    <thead role="rowgroup" class="nhsuk-table__head">
+                        <tr role="row">
+                            <th role="columnheader" class="" scope="col">
+                                @competencyGroup.First().Vocabulary
+                            </th>
+                            <th role="columnheader" class="" scope="col">
+                                Question
+                            </th>
+                            <th role="columnheader" class="" scope="col">
+                                Response
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="nhsuk-table__body">
+                        @foreach (var competency in competencyGroup)
+                        {
+                            @foreach (var question in competency.AssessmentQuestions)
+                            {
+                                <tr role="row" class="nhsuk-table__row">
+                                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                        <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
+                                        <div class="nhsuk-checkboxes__item">
+                                            <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.ResultId" name="ResultIds" checked="@(Model.ResultIds != null ? Model.ResultIds.Contains((int)question.ResultId) : false)" type="checkbox" value="@question.ResultId">
+                                            <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.ResultId">
+                                                @competency.Name
+                                            </label>
+                                        </div>
+                                    </td>
+                                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                        <span class="nhsuk-table-responsive__heading">Question </span>
+                                        @question.Question
+                                        @if (!question.Required)
+                                        {
+                                            <span>(Optional)</span>
+                                        }
+                                    </td>
+                                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                        <span class="nhsuk-table-responsive__heading">Response </span>
+                                        <partial name="../../Supervisor/Shared/_AssessmentQuestionResponse" model="question" />
+                                    </td>
 
-                </tr>
-              }
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
             }
-          </tbody>
-        </table>
-      }
-    </nhs-form-group>
-    <input type="hidden" asp-for="SelfAssessmentName" />
-    <input type="hidden" asp-for="Vocabulary" />
-    <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
-      <div class="nhsuk-grid-column-full">
-        <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
-          Back
+        </nhs-form-group>
+        <input type="hidden" asp-for="SelfAssessmentName" />
+        <input type="hidden" asp-for="Vocabulary" />
+        <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+            <div class="nhsuk-grid-column-full">
+                <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+                    Back
+                </a>
+                <button class="nhsuk-button" type="submit">Next</button>
+            </div>
+        </div>
+    </form>
+    <div class="nhsuk-back-link">
+        <a class="nhsuk-back-link__link"
+       asp-action="SelfAssessmentOverview"
+       asp-route-selfAssessmentId="@Model.SelfAssessmentId" asp-route-vocabulary="@Model.VocabPlural()">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
         </a>
-        <button class="nhsuk-button" type="submit">Next</button>
-      </div>
     </div>
-  </form>
-  <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link"
-     asp-action="SelfAssessmentOverview"
-     asp-route-selfAssessmentId="@Model.SelfAssessmentId" asp-route-vocabulary="@Model.VocabPlural()">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-      </svg>
-      Cancel
-    </a>
-  </div>
 }
 else
 {
-  <p>
-    There are no self assessment results ready for confirmation.
-  </p>
-  <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
-    Cancel
-  </a>
+    <p>
+        There are no self assessment results ready for confirmation.
+    </p>
+    <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessmentId">
+        Cancel
+    </a>
 }
 
 @section scripts {
-  <script src="@Url.Content("~/js/learningPortal/verificationPickResults.js")" asp-append-version="true"></script>
+    <script src="@Url.Content("~/js/learningPortal/verificationPickResults.js")" asp-append-version="true"></script>
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
@@ -1,67 +1,67 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @model VerificationSummaryViewModel
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  Layout = "SelfAssessments/_Layout";
-  ViewData["Title"] = "Self Assessment";
-  ViewData["SelfAssessmentTitle"] = @Model.SelfAssessment.Name;
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    Layout = "SelfAssessments/_Layout";
+    ViewData["Title"] = "Self Assessment";
+    ViewData["SelfAssessmentTitle"] = @Model.SelfAssessment.Name;
 }
 @section breadcrumbs {
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a></li>
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.VocabPlural()) home</a></li>
-  <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="ReviewConfirmationRequests" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Confirmation requests</a></li>
-  <li class="nhsuk-breadcrumb__item">New</li>
+    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a></li>
+    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.VocabPlural()) home</a></li>
+    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" asp-action="ReviewConfirmationRequests" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Confirmation requests</a></li>
+    <li class="nhsuk-breadcrumb__item">New</li>
 }
-  @section mobilebacklink
-  {
-  <p class="nhsuk-breadcrumb__back">
-    <a class="nhsuk-breadcrumb__backlink"
-     asp-action="ReviewConfirmationRequests"
-     asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-      Back to Confirmation requests
-    </a>
-  </p>
-}
-  <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
-  <h1>Request @Model.SelfAssessment.Vocabulary.ToLower() confirmation</h1>
-  <h2>Summary</h2>
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        @Model.SelfAssessment.VerificationRoleName
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.Supervisor
-      </dd>
-      <dd class="nhsuk-summary-list__actions">
-        <a asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-          Change
+@section mobilebacklink
+    {
+    <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink"
+           asp-action="VerificationPickResults"
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+            Back to Proficiency planning
         </a>
-      </dd>
+    </p>
+}
+<link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
+<h1>Request @Model.SelfAssessment.Vocabulary.ToLower() confirmation</h1>
+<h2>Summary</h2>
+<dl class="nhsuk-summary-list">
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            @Model.SelfAssessment.VerificationRoleName
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.Supervisor
+        </dd>
+        <dd class="nhsuk-summary-list__actions">
+            <a asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+                Change
+            </a>
+        </dd>
     </div>
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Results to confirm
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.ResultCount
-      </dd>
-      <dd class="nhsuk-summary-list__actions">
+        <dt class="nhsuk-summary-list__key">
+            Results to confirm
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.ResultCount
+        </dd>
+        <dd class="nhsuk-summary-list__actions">
 
-        <a asp-action="VerificationPickResults" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-          Change
-        </a>
-      </dd>
+            <a asp-action="VerificationPickResults" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+                Change
+            </a>
+        </dd>
     </div>
-  </dl>
-  <form method="post" asp-action="SubmitVerification">
+</dl>
+<form method="post" asp-action="SubmitVerification">
     <button class="nhsuk-button" type="submit">Submit</button>
-  </form>
-  <div class="nhsuk-back-link">
+</form>
+<div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="SelfAssessmentOverview" asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-      </svg>
-      Cancel
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
     </a>
-  </div>
+</div>


### PR DESCRIPTION
Issue in 'Mobile view' when navigating back from the screens when requesting proficiency confirmation from Learning Portal

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1462

### Description
Points Addressed:
1. The back links renamed as per screen navigation and now navigate to the previous screens

### Screenshots
The video is attached in the jira

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
