### PR TITLE
TD-1496 - Issues when adding the supervisors for the self assessments

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -88,8 +88,6 @@
         // SelfAssessmentSupervisorDataService
         SelfAssessmentSupervisor? GetSupervisorForSelfAssessmentId(int selfAssessmentId, int delegateUserId);
 
-        IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int delegateUserId);
-
         IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(int selfAssessmentId, int delegateUserId);
 
         IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -67,19 +67,6 @@
             ).FirstOrDefault();
         }
 
-        public IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(
-            int selfAssessmentId,
-            int delegateUserId
-        )
-        {
-            return connection.Query<SelfAssessmentSupervisor>(
-                @$"{BaseGetSelfAssessmentSupervisorQuery}
-                    WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (sd.DelegateUserID = @delegateUserId)
-                        AND (ca.SelfAssessmentID = @selfAssessmentId)",
-                new { selfAssessmentId, delegateUserId }
-            );
-        }
-
         public IEnumerable<SelfAssessmentSupervisor> GetAllSupervisorsForSelfAssessmentId(
             int selfAssessmentId,
             int delegateUserId

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -409,6 +409,18 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 );
                 return false;
             }
+
+            var numberOfAffectedRowsCAS = connection.Execute(
+         @"UPDATE CandidateAssessmentSupervisors SET Removed = getUTCDate()
+            WHERE SupervisorDelegateId = @supervisorDelegateId AND Removed IS NULL",
+        new { supervisorDelegateId });
+            if (numberOfAffectedRowsCAS < 1)
+            {
+                logger.LogWarning(
+                    $"Not removing CandidateAssessmentSupervisors as db update failed. supervisorDelegateId: {supervisorDelegateId}"
+                );
+                return false;
+            }
             return true;
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -64,7 +64,7 @@
 
             selfAssessmentService.IncrementLaunchCount(selfAssessmentId, delegateUserId);
             selfAssessmentService.UpdateLastAccessed(selfAssessmentId, delegateUserId);
-            var supervisors = selfAssessmentService.GetSupervisorsForSelfAssessmentId(
+            var supervisors = selfAssessmentService.GetAllSupervisorsForSelfAssessmentId(
                 selfAssessmentId,
                 delegateUserId
             ).ToList();

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -70,7 +70,6 @@
         void UpdateCandidateAssessmentOptionalCompetencies(int selfAssessmentStructureId, int delegateUserId);
 
         // Supervisor
-        IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(int selfAssessmentId, int delegateUserId);
 
         IEnumerable<SupervisorSignOff> GetSupervisorSignOffsForCandidateAssessment(
             int selfAssessmentId,
@@ -192,14 +191,6 @@
         public IEnumerable<Competency> GetResultSupervisorVerifications(int selfAssessmentId, int delegateId)
         {
             return selfAssessmentDataService.GetResultSupervisorVerifications(selfAssessmentId, delegateId);
-        }
-
-        public IEnumerable<SelfAssessmentSupervisor> GetSupervisorsForSelfAssessmentId(
-            int selfAssessmentId,
-            int delegateUserId
-        )
-        {
-            return selfAssessmentDataService.GetSupervisorsForSelfAssessmentId(selfAssessmentId, delegateUserId);
         }
 
         public IEnumerable<SupervisorSignOff> GetSupervisorSignOffsForCandidateAssessment(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1496

### Description
Issues addressed in this commit - 
1.Updating the CandidateAssessmentSupervisors table setting removed = null when removing a delegate from the supervisor interface solves the issues.
2. Removed the similar method GetSupervisorsForSelfAssessmentId which solves the count mismatch issue on supervisor list

### Screenshots
Using ‘madhavi.martha@hee.nhs.uk’
Issue 1(a) – For the dev testing centre, supervisor added with assessor role and we can see in activity supervisor list
Before -
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/135112f0-7ec0-4d3d-abb9-d3563b9c8083)
After - 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/e0c443a8-1046-4819-8799-5af23448c8e2)

Issue 1(b) – Added as supervisor in dev testing centre with role as educator/manager
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/6df010cf-98d5-435b-82a4-3583066b110e)
After adding the above, here is the New activity supervisor screen which shows that the account we are testing for is not shown anymore.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/fd50d993-c3a5-45a5-93cc-7770c81caaf2)

Issue 2 – Using my own account (Rohit Shrivastava) and Used HEE demo centre :
Before-
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/90e4f0ad-de8f-45e6-b434-1579164bd4ec)
After Adding –
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/e2cac0d7-3f13-4488-a485-ed091f66d4b6)

Issue 3 – Count seems to be the in sync (using ‘madhavi.martha@hee.nhs.uk’)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/fb05b554-e04a-4f90-b2a0-4fdd2284b4a5)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/3c73d342-f9a7-4638-ae92-dbd0561863c8)

Issue 4 : Duplicates are not showing anymore on ‘View assessments’
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/89f29e24-cc74-4073-bd65-e954e5b604d1)

Issue 5 : Able to add following accounts which were not adding in the video posted – 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/889bc834-8aa5-47ae-806f-00fd240321f7)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
