### PR TITLE
TD-1606:Issue with 'Back to framework structure' link in Mobile view on Frameworks section

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId" asp-fragment="fc-@Model.FrameworkCompetency.Id" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Framework Structure</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.VocabSingular()</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId" asp-fragment="fc-@Model.FrameworkCompetency.Id" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Back to framework structure</a></p>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkCompetencyGroupId="@Model.FrameworkCompetencyGroupId" asp-fragment="fc-@Model.FrameworkCompetency.Id" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Back to framework structure</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-fragment="fcgroup-@Model.CompetencyGroupBase.ID" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Framework Structure</a></li>
         <li class="nhsuk-breadcrumb__item">@Model.VocabSingular() Group</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-fragment="fcgroup-@Model.CompetencyGroupBase.ID" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Back to framework structure</a></p>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-fragment="fcgroup-@Model.CompetencyGroupBase.ID" asp-route-frameworkId="@Model.DetailFramework.ID" asp-route-tabname="Structure">Back to framework structure</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroupRemoveConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroupRemoveConfirm.cshtml
@@ -20,7 +20,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-fragment="fcgroup-@Model.CompetencyGroupId" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Framework Structure</a></li>
         <li class="nhsuk-breadcrumb__item">Confirm Remove Group</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-fragment="fcgroup-@Model.CompetencyGroupId" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Back to framework structure</a></p>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-fragment="fcgroup-@Model.CompetencyGroupId" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Back to framework structure</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/ImportCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/ImportCompetencies.cshtml
@@ -20,7 +20,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Framework Structure</a></li>
         <li class="nhsuk-breadcrumb__item">Excel import</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">>Back to framework structure</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Back to framework structure</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/ImportCompleted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/ImportCompleted.cshtml
@@ -22,7 +22,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Framework Structure</a></li>
         <li class="nhsuk-breadcrumb__item">Excel import</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">>Back to framework structure</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Back to framework structure</a></p>
     </div>
   </nav>
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1606

### Description
Issue with 'Back to framework structure' link in Mobile view on Frameworks section when editing, add proficiency, adding grouped/ungrouped proficiencies

### Screenshots
Before code change('Back to framework structure' link not working in mobile view) :
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/f7a3aa3e-fc1d-42db-8bd6-5956e1e1676e)

After code change:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/a2b778a0-86d1-44f8-95c4-37d50d5d3e41)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/f3e58f19-b509-41b2-8c77-9951dc4cae8a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/88ff19bf-fa0b-4a37-8dea-29abbdcc78f9)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
