### PR TITLE
TD-1429  Clicking browser back button after requesting for proficienc…

### DIFF
--- a/DigitalLearningSolutions.Web/Attributes/NoCachingAttribute.cs
+++ b/DigitalLearningSolutions.Web/Attributes/NoCachingAttribute.cs
@@ -6,7 +6,10 @@
     {
         public override void OnActionExecuted(ActionExecutedContext context)
         {
-            context.HttpContext.Response.Headers.Add("Cache-Control", "no-store, max-age=0");
+            if (!context.HttpContext.Response.Headers.ContainsKey("Cache-Control"))
+            {
+                context.HttpContext.Response.Headers.Add("Cache-Control", "no-store, max-age=0");
+            }
         }
     }
 }


### PR DESCRIPTION
Clicking browser back button after requesting for proficiency confirmation can see console '500' error on the screen

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1429

### Description
When learner requests the proficiency confirmation request of any assessment from the ‘Learning Portal’ and clicking browser back button results in console ‘500’ error. This is fixed now.

### Screenshots
The video is attached in the jira

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
