### PR TITLE
TD-1631-Frameworks: Console '500' error on the 'Duplicate competency name' screen

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -204,7 +204,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         }
 
         [HttpPost]
-        public IActionResult AddDuplicateCompetency(int frameworkId, string competencyName, string competencyDescription, int frameworkCompetencyId, int frameworkGroupId, string selectedFlagIds)
+        public IActionResult AddDuplicateCompetency(int frameworkId, string competencyName, string competencyDescription, int frameworkCompetencyId, int? frameworkGroupId, string selectedFlagIds)
         {
             FrameworkCompetency competency = new FrameworkCompetency()
             {


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1631

**Description**
Converted 'frameworkGroupId' parameter as nullable parameter.

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/ca6b719b-0567-473f-8c36-c86aaa4af93c)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/fe70d601-d3e7-43d6-b503-cf3dd149eed3)


-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
