### PR TITLE
TD-1635 Show promote to admin when password is not set in manage dele…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -482,7 +482,19 @@
                 new { userId, centreId }
             ) > 0;
         }
+
+        public void LinkAdminAccountToNewUser(
+            int currentUserIdForAdminAccount,
+            int newUserIdForAdminAccount,
+            int centreId
+        )
+        {
+            connection.Execute(
+                @"UPDATE AdminAccounts
+                    SET UserID = @newUserIdForAdminAccount
+                    WHERE UserID = @currentUserIdForAdminAccount AND CentreID = @centreId",
+                new { currentUserIdForAdminAccount, newUserIdForAdminAccount, centreId }
+            );
+        }
     }
-
-
 }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -250,6 +250,12 @@
         int GetUserIdFromAdminId(int adminId);
         void UpdateAdminCentre(int adminId, int centreId);
         bool IsUserAlreadyAdminAtCentre(int? userId, int centreId);
+
+        void LinkAdminAccountToNewUser(
+            int currentUserIdForAdminAccount,
+            int newUserIdForAdminAccount,
+            int centreId
+        );
     }
 
     public partial class UserDataService : IUserDataService

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -64,8 +64,7 @@
             var userId = userDataService.GetUserIdFromDelegateId(delegateId);
             var userEntity = userService.GetUserById(userId);
 
-            if (userEntity!.CentreAccountSetsByCentreId[centreId].CanLogIntoAdminAccount
-                || string.IsNullOrWhiteSpace(userEntity.UserAccount.PasswordHash))
+            if (userEntity!.CentreAccountSetsByCentreId[centreId].CanLogIntoAdminAccount)
             {
                 return NotFound();
             }

--- a/DigitalLearningSolutions.Web/Services/ClaimAccountService.cs
+++ b/DigitalLearningSolutions.Web/Services/ClaimAccountService.cs
@@ -90,6 +90,7 @@
         public void LinkAccount(int currentUserIdForAccount, int newUserIdForAccount, int centreId)
         {
             userDataService.LinkDelegateAccountToNewUser(currentUserIdForAccount, newUserIdForAccount, centreId);
+            userDataService.LinkAdminAccountToNewUser(currentUserIdForAccount, newUserIdForAccount, centreId);
             userDataService.LinkUserCentreDetailsToNewUser(currentUserIdForAccount, newUserIdForAccount, centreId);
             userDataService.DeleteUser(currentUserIdForAccount);
         }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ViewDelegate/Index.cshtml
@@ -102,7 +102,8 @@
                asp-route-isFromViewDelegatePage="true">
                     Set password
                 </a>
-                @if (User.HasCentreManagerPermissions() && !Model.DelegateInfo.IsAdmin && Model.DelegateInfo.IsPasswordSet && !string.IsNullOrWhiteSpace(Model.DelegateInfo.Email) && !string.IsNullOrWhiteSpace(Model.DelegateInfo.Name))
+                @if (User.HasCentreManagerPermissions() && !Model.DelegateInfo.IsAdmin
+                && !string.IsNullOrWhiteSpace(Model.DelegateInfo.Email) && !string.IsNullOrWhiteSpace(Model.DelegateInfo.Name))
                 {
                     <a class="nhsuk-button nhsuk-button--secondary view-delegate-button"
                role="button"
@@ -141,6 +142,7 @@
             }
         </div>
     </div>
+  </div>
 
     <div class="nhsuk-grid-column-full">
         <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">Courses</h2>


### PR DESCRIPTION
…gate

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1635

### Description
Points addressed in this Commit :
1) Show promote to admin when password is not set in manage delegate.
2) Update the user ID of AdminAccounts associated with the user record removed during this process.

### Screenshots
![View-delegate-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/be1716f4-5b8d-4413-a9c1-3f00ddbf31f4)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
