### PR TITLE
TD-1602 Fixed 410 error on click of register after complete registration

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -104,7 +104,7 @@
             );
 
             Response.UpdateFilterCookie(DelegateFilterCookieName, result.FilterString);
-
+            TempData.Remove("delegateRegistered");
             return View(model);
         }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1602

### Description
Points addressed in this Commit :
1) Fixed 410 error on click of register after complete registration

### Screenshots
[Register-delegate---Summary---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/331decaa-06ce-430f-9464-bcd57dbb8115)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
