### PR TITLE
TD-1434 Fixed Issue in Mobile view when navigating back from review s…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -311,7 +311,7 @@
         [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessment/{candidateAssessmentId}/Review/{selfAssessmentResultId}")]
         public IActionResult ReviewDelegateSelfAssessment(int supervisorDelegateId, int candidateAssessmentId, int? selfAssessmentResultId = null, SearchSupervisorCompetencyViewModel searchModel = null)
         {
-            var adminId = GetAdminId();
+            var adminId = GetAdminId();            
             var superviseDelegate =
                 supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
             var reviewedCompetencies = PopulateCompetencyLevelDescriptors(
@@ -349,6 +349,7 @@
             }
 
             ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
+            ViewBag.navigatedFrom = selfAssessmentResultId == null;
             return View("ReviewSelfAssessment", model);
         }
         [HttpPost]

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -311,7 +311,7 @@
         [Route("/Supervisor/Staff/{supervisorDelegateId}/ProfileAssessment/{candidateAssessmentId}/Review/{selfAssessmentResultId}")]
         public IActionResult ReviewDelegateSelfAssessment(int supervisorDelegateId, int candidateAssessmentId, int? selfAssessmentResultId = null, SearchSupervisorCompetencyViewModel searchModel = null)
         {
-            var adminId = GetAdminId();            
+            var adminId = GetAdminId();      
             var superviseDelegate =
                 supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
             var reviewedCompetencies = PopulateCompetencyLevelDescriptors(

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -1,9 +1,9 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model ReviewSelfAssessmentViewModel;
 @{
-  ViewData["Title"] = "Review Profile Assessment";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    ViewData["Title"] = "Review Profile Assessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
     var competencySummaries = from g in Model.CompetencyGroups
                               let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
                               let selfAssessedCount = questions.Count(q => q.Result.HasValue)
@@ -19,167 +19,177 @@
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            @if (ViewBag.navigatedFrom)
+            {
+                <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+           asp-action="Index">
+                    Back to Supervisor Dashboard
+                </a>
+            }
+            else
+            {
+                <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
            asp-action="DelegateProfileAssessments"
            asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
-        </li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="DelegateProfileAssessments"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-        Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </a>
-    </p>
-  </nav>
+                    Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+                </a>
+            }
+        </p>
+    </nav>
 }
-  <details class="nhsuk-details nhsuk-expander">
+<details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </h1>
+        <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+        </h1>
     </summary>
     <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
     </div>
-  </details>
-  <div class="nhsuk-grid-row">
+</details>
+<div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h2>@Model.DelegateSelfAssessment.RoleName</h2>
-            <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-">
-                <partial name="_ReviewSelfAssessmentOverallProgress"
+        <h2>@Model.DelegateSelfAssessment.RoleName</h2>
+        <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-">
+            <partial name="_ReviewSelfAssessmentOverallProgress"
                      model="@competencySummaries"
                      view-data="@(new ViewDataDictionary(ViewData))" />
-            </div>
+        </div>
     </div>
     <div class="nhsuk-grid-column-one-third">
-      @if (Model.DelegateSelfAssessment.SignOffRequested > 0)
-    {
-      <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
-    }
-    @if (Model.DelegateSelfAssessment.ResultsVerificationRequests > 1)
-    {
-      <a role="button" asp-action="VerifyMultipleResults" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Confirm multiple results</a>
-    }
-  </div>
+        @if (Model.DelegateSelfAssessment.SignOffRequested > 0)
+        {
+            <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
+        }
+        @if (Model.DelegateSelfAssessment.ResultsVerificationRequests > 1)
+        {
+            <a role="button" asp-action="VerifyMultipleResults" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Confirm multiple results</a>
+        }
+    </div>
 </div>
 <partial name="../../Supervisor/Shared/_SearchSupervisorCompetency"
          model="@Model.SearchViewModel"
          view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
 @if (Model.CompetencyGroups.Any())
 {
-  foreach (var competencyGroup in Model.CompetencyGroups)
-  {
-    var groupDetails = competencyGroup.First();
-    <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
-      <caption class="nhsuk-table__caption">
-        <h3>@competencyGroup.Key</h3>
-        @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
-        {
-          <p class="nhsuk-body-l">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
-        }
-      </caption>
-      <thead role="rowgroup" class="nhsuk-table__head">
-        <tr role="row">
-          <th role="columnheader" class="" scope="col">
-            @groupDetails.Vocabulary
-          </th>
-          <th role="columnheader" class="" scope="col">
-            @(string.IsNullOrWhiteSpace(Model.DelegateSelfAssessment.QuestionLabel) ? "Question" :
-        Model.DelegateSelfAssessment.QuestionLabel)
-          </th>
-          <th role="columnheader" class="" scope="col">
-            Self-assessment
-          </th>
-          @if (Model.IsSupervisorResultsReviewed)
-          {
-            <th role="columnheader" class="" scope="col">
-              Confirmation status
-            </th>
-          }
-          <th role="columnheader" class="" scope="col">
-            Actions
-          </th>
-        </tr>
-      </thead>
-      <tbody class="nhsuk-table__body">
-        @foreach (var competency in competencyGroup)
-        {
-          <tr role="row" class="nhsuk-table__row first-row">
-            <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
-              <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
-              <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />
-              @if (competency.Description != null && !competency.AlwaysShowDescription)
-              {
-                <details class="nhsuk-details">
-                  <summary class="nhsuk-details__summary">
-                    <h2 class="nhsuk-u-font-size-24 nhsuk-u-margin-bottom-0">
-                      <span class="nhsuk-details__summary-text">
-                        @competency.Name
-                      </span>
-                    </h2>
-                  </summary>
-                  <div class="nhsuk-details__text">
-                    @(Html.Raw(@competency.Description))
-                  </div>
-                </details>
-              }
-              else
-              {
-                <h2 class="nhsuk-u-margin-bottom-0 nhsuk-u-font-size-24">
-                  @competency.Name
-                </h2>
-                @if (competency.Description != null)
+    foreach (var competencyGroup in Model.CompetencyGroups)
+    {
+        var groupDetails = competencyGroup.First();
+        <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
+            <caption class="nhsuk-table__caption">
+                <h3>@competencyGroup.Key</h3>
+                @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
                 {
-                  <p class="nhsuk-body-l">
-                    @(Html.Raw(competency.Description))
-                  </p>
+                    <p class="nhsuk-body-l">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
                 }
-              }
-            </td>
-            <partial name="Shared/_AssessmentQuestionReviewCells"
-               model="competency.AssessmentQuestions.First()"
-               view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
-          </tr>
-          @foreach (var question in competency.AssessmentQuestions.Skip(1))
-          {
-            <tr role="row" class="nhsuk-table__row">
-              <partial name="Shared/_AssessmentQuestionReviewCells"
-               model="question"
-               view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
-            </tr>
-          }
-        }
-      </tbody>
-    </table>
+            </caption>
+            <thead role="rowgroup" class="nhsuk-table__head">
+                <tr role="row">
+                    <th role="columnheader" class="" scope="col">
+                        @groupDetails.Vocabulary
+                    </th>
+                    <th role="columnheader" class="" scope="col">
+                        @(string.IsNullOrWhiteSpace(Model.DelegateSelfAssessment.QuestionLabel) ? "Question" :
+                            Model.DelegateSelfAssessment.QuestionLabel)
+                    </th>
+                    <th role="columnheader" class="" scope="col">
+                        Self-assessment
+                    </th>
+                    @if (Model.IsSupervisorResultsReviewed)
+                    {
+                        <th role="columnheader" class="" scope="col">
+                            Confirmation status
+                        </th>
+                    }
+                    <th role="columnheader" class="" scope="col">
+                        Actions
+                    </th>
+                </tr>
+            </thead>
+            <tbody class="nhsuk-table__body">
+                @foreach (var competency in competencyGroup)
+                {
+                    <tr role="row" class="nhsuk-table__row first-row">
+                        <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
+                            <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
+                            <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />
+                            @if (competency.Description != null && !competency.AlwaysShowDescription)
+                            {
+                                <details class="nhsuk-details">
+                                    <summary class="nhsuk-details__summary">
+                                        <h2 class="nhsuk-u-font-size-24 nhsuk-u-margin-bottom-0">
+                                            <span class="nhsuk-details__summary-text">
+                                                @competency.Name
+                                            </span>
+                                        </h2>
+                                    </summary>
+                                    <div class="nhsuk-details__text">
+                                        @(Html.Raw(@competency.Description))
+                                    </div>
+                                </details>
+                            }
+                            else
+                            {
+                                <h2 class="nhsuk-u-margin-bottom-0 nhsuk-u-font-size-24">
+                                    @competency.Name
+                                </h2>
+                                @if (competency.Description != null)
+                                {
+                                    <p class="nhsuk-body-l">
+                                        @(Html.Raw(competency.Description))
+                                    </p>
+                                }
+                            }
+                        </td>
+                        <partial name="Shared/_AssessmentQuestionReviewCells"
+                     model="competency.AssessmentQuestions.First()"
+                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
+                    </tr>
+                    @foreach (var question in competency.AssessmentQuestions.Skip(1))
+                    {
+                        <tr role="row" class="nhsuk-table__row">
+                            <partial name="Shared/_AssessmentQuestionReviewCells"
+                     model="question"
+                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
 
-  }
+    }
 }
 @if (Model.SupervisorSignOffs.Any())
 {
-  <div class="nhsuk-u-margin-top-4">
-    <h3>Self Assessment Sign-off Status</h3>
-    <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
-  </div>
+    <div class="nhsuk-u-margin-top-4">
+        <h3>Self Assessment Sign-off Status</h3>
+        <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
+    </div>
 }
 @if (Model.CompetencyGroups.Any())
 {
-  <div class="nhsuk-u-margin-top-4">
-    <vc:top-link top-element-id="maincontent" link-text="Top of page" />
-  </div>
+    <div class="nhsuk-u-margin-top-4">
+        <vc:top-link top-element-id="maincontent" link-text="Top of page" />
+    </div>
 }


### PR DESCRIPTION
…elf assessments

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1434

### Description
Points addressed in this Commit :
1) Fixed Issue in Mobile view when navigating back from review self assessments.

### Screenshots
![Review-Profile-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/3db446d9-31e2-4866-ae56-038b23bb2d0b)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/81e12c4a-1dac-466c-87af-e823ac8bfc7c)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
