### PR TITLE
TD-581 Fixed navigation error when clicked browser back button after …

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/PromoteToAdminControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/PromoteToAdminControllerTests.cs
@@ -52,6 +52,7 @@
                     emailService
                 )
                 .WithDefaultContext();
+            controller = controller.WithMockTempData();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -64,6 +64,11 @@
             var userId = userDataService.GetUserIdFromDelegateId(delegateId);
             var userEntity = userService.GetUserById(userId);
 
+            if(TempData["IsDelegatePromoted"] != null)
+            {
+                TempData.Remove("IsDelegatePromoted");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
+            }
             if (userEntity!.CentreAccountSetsByCentreId[centreId].CanLogIntoAdminAccount)
             {
                 return NotFound();
@@ -167,7 +172,7 @@
 
                 return new StatusCodeResult(500);
             }
-
+            TempData["IsDelegatePromoted"] = true;
             return RedirectToAction("Index", "ViewDelegate", new { delegateId });
         }
     }


### PR DESCRIPTION
…promoting the delegate

### JIRA link
https://hee-tis.atlassian.net/browse/TD-581

### Description
Points addressed in this Commit :
1) Redirected to 410 error page when clicked browser back button after promoting the delegate to admin

### Screenshots
[Delegates---Digital-Learning-Solutions .webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/610bed41-246e-46e4-abf1-ed16d8c652bb)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
