### PR TITLE
TD-1379 Add supervisor mobile render width

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/shared/searchableElements/searchableElements.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/searchableElements/searchableElements.scss
@@ -4,3 +4,4 @@
 @use "pagination";
 @use "tags";
 @use "itemsPerPage";
+@use "utils";

--- a/DigitalLearningSolutions.Web/Styles/shared/searchableElements/utils.scss
+++ b/DigitalLearningSolutions.Web/Styles/shared/searchableElements/utils.scss
@@ -1,0 +1,5 @@
+.util-wrap-text {
+  display: block;
+  word-break: break-all;
+  word-wrap: break-word;
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
@@ -84,10 +84,10 @@
                             {
                               <div class="nhsuk-radios__item">
                                 <input class="nhsuk-radios__input" id="supervisor-@supervisor.AdminID" name="SupervisorAdminID" type="radio" checked="@(supervisor.AdminID == Model.SupervisorAdminID)" value="@supervisor.AdminID" aria-describedby="supervisor-@supervisor.AdminID-item-hint">
-                                <label class="nhsuk-label nhsuk-radios__label" for="supervisor-@supervisor.AdminID" style="display:block; word-break:break-all; word-wrap:break-word">
-                                  @supervisor.Forename @supervisor.Surname (@supervisor.CentreName)
+                                <label class="nhsuk-label nhsuk-radios__label util-wrap-text" for="supervisor-@supervisor.AdminID">
+                                    @supervisor.Forename @supervisor.Surname (@supervisor.CentreName)
                                 </label>
-                                <div class="nhsuk-hint nhsuk-radios__hint" id="supervisor-@supervisor.AdminID-item-hint" style="display:block; word-break:break-all; word-wrap:break-word">
+                                <div class="nhsuk-hint nhsuk-radios__hint util-wrap-text" id="supervisor-@supervisor.AdminID-item-hint">
                                   @supervisor.Email
                                 </div>
                               </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddSupervisor.cshtml
@@ -79,30 +79,27 @@
                         <input type="hidden" aria-hidden="true" id="select-sort-direction" value="Ascending" />
 
                         <form id="frmSubmit" method="post" >
-                            <div id="searchable-elements" class="nhsuk-radios">
-                                @foreach (var supervisor in Model.Supervisors)
-                                {
-                                   <div Class="searchable-element nhsuk-u-padding-top-3">
-                                    <div class="nhsuk-radios__item">
-                                        <input class="nhsuk-radios__input" id="supervisor-@supervisor.AdminID" name="SupervisorAdminID" type="radio" checked="@(supervisor.AdminID == Model.SupervisorAdminID)" value="@supervisor.AdminID" aria-describedby="supervisor-@supervisor.AdminID-item-hint">
-                                        <label class="nhsuk-label nhsuk-radios__label" for="supervisor-@supervisor.AdminID">
-                                            @supervisor.Forename @supervisor.Surname (@supervisor.CentreName)
-                                        </label>
-                                        <div class="nhsuk-hint nhsuk-radios__hint" id="supervisor-@supervisor.AdminID-item-hint">
-                                            @supervisor.Email
-                                        </div>
-                                    </div>
-                                  </div>
-                                }
-                            </div> 
-                            @if (Model.Supervisors.Count() > 0 || Model.MatchingSearchResults>0)
+                          <div class="searchable-element nhsuk-u-padding-top-3">
+                            @foreach (var supervisor in Model.Supervisors)
                             {
-                                <button id="btnAddSupervisor" class="nhsuk-button nhsuk-u-margin-top-3" type="submit">
-                                    Next
-                                </button>
+                              <div class="nhsuk-radios__item">
+                                <input class="nhsuk-radios__input" id="supervisor-@supervisor.AdminID" name="SupervisorAdminID" type="radio" checked="@(supervisor.AdminID == Model.SupervisorAdminID)" value="@supervisor.AdminID" aria-describedby="supervisor-@supervisor.AdminID-item-hint">
+                                <label class="nhsuk-label nhsuk-radios__label" for="supervisor-@supervisor.AdminID" style="display:block; word-break:break-all; word-wrap:break-word">
+                                  @supervisor.Forename @supervisor.Surname (@supervisor.CentreName)
+                                </label>
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="supervisor-@supervisor.AdminID-item-hint" style="display:block; word-break:break-all; word-wrap:break-word">
+                                  @supervisor.Email
+                                </div>
+                              </div>
                             }
+                          </div>
+                          @if (Model.Supervisors.Count() > 0 || Model.MatchingSearchResults>0)
+                          {
+                            <button id="btnAddSupervisor" class="nhsuk-button nhsuk-u-margin-top-3" type="submit">
+                              Next
+                            </button>
+                          }
                         </form>
-
                     </fieldset>
                 </nhs-form-group>
             </form>


### PR DESCRIPTION
### JIRA link
[TD-1379](https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165?modal=detail&selectedIssue=TD-1379)

### Description
Added styling to allow supervisor text to wrap to new line (was expanding render width to wider that screen on mobile devices where one or more supervisors had email address or name longer than 29 characters).

### Screenshots
Screenshots below.
-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![td1379android](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/b363cd2e-9a68-4f44-b680-52193f161a30)
![td1379iphone14](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/1d9a4244-472d-42ce-8379-b9325738723b)


[TD-1379]: https://hee-tis.atlassian.net/browse/TD-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ