### PR TITLE
TD-1760 Showing "Add myself to try self assessments" button in My sta…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1,22 +1,22 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.SupervisorController
 {
+    using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Helpers;
+    using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+    using DigitalLearningSolutions.Data.Models.SelfAssessments;
+    using DigitalLearningSolutions.Data.Models.SessionData.Supervisor;
     using DigitalLearningSolutions.Data.Models.Supervisor;
-    using DigitalLearningSolutions.Web.Helpers;
-    using DigitalLearningSolutions.Web.ViewModels.Supervisor;
-    using Microsoft.AspNetCore.Mvc;
-    using System.Linq;
     using DigitalLearningSolutions.Web.Extensions;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.ServiceFilter;
+    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+    using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+    using GDS.MultiPageFormData.Enums;
+    using Microsoft.AspNetCore.Mvc;
     using System;
     using System.Collections.Generic;
-    using DigitalLearningSolutions.Data.Helpers;
-    using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
-    using DigitalLearningSolutions.Data.Models.SessionData.Supervisor;
-    using DigitalLearningSolutions.Data.Models.SelfAssessments;
-    using DigitalLearningSolutions.Data.Models;
-    using DigitalLearningSolutions.Web.ServiceFilter;
-    using GDS.MultiPageFormData.Enums;
-    using DigitalLearningSolutions.Data.Enums;
-    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+    using System.Linq;
 
     public partial class SupervisorController
     {
@@ -49,6 +49,7 @@
             var adminId = GetAdminId();
             var loggedInUserId = User.GetAdminId();
             var centreId = GetCentreId();
+            var supervisorEmail = GetUserEmail();
             var loggedInAdminUser = userDataService.GetAdminUserById(loggedInUserId!.GetValueOrDefault());
             var centreRegistrationPrompts = centreRegistrationPromptsService.GetCentreRegistrationPromptsByCentreId(centreId);
             var supervisorDelegateDetails = supervisorService.GetSupervisorDelegateDetailsForAdminId(adminId);
@@ -88,8 +89,19 @@
                 result,
                 centreRegistrationPrompts
             );
+            model.IsActiveSupervisorDelegateExist = IsSupervisorDelegateExistAndActive(adminId, supervisorEmail, centreId) > 0;
             ModelState.ClearErrorsForAllFieldsExcept("DelegateEmailAddress");
             return View("MyStaffList", model);
+        }
+
+        public IActionResult AddSelfToSelfAssessment()
+        {
+            var adminId = GetAdminId();
+            var centreId = GetCentreId();
+            var supervisorEmail = GetUserEmail();
+            
+            AddSupervisorDelegateAndReturnId(adminId, supervisorEmail, supervisorEmail, centreId);
+            return RedirectToAction("MyStaffList");
         }
 
         [HttpPost]

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/MyStaffListViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/MyStaffListViewModel.cs
@@ -61,6 +61,8 @@
             }
         }
 
+        public bool IsActiveSupervisorDelegateExist { get; set; }
+
         public override bool NoDataFound => !SuperviseDelegateDetailViewModels.Any() && NoSearchOrFilter;
 
         [Required(ErrorMessage = "Enter an email")]

--- a/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
@@ -3,130 +3,136 @@
 @inject IConfiguration Configuration
 @model MyStaffListViewModel;
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: My Staff List" : "My Staff List";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: My Staff List" : "My Staff List";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">My Staff</li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="Index">Back to Supervisor Dashboard</a>
-    </p>
-  </nav>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">My Staff</li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="Index">Back to Supervisor Dashboard</a>
+        </p>
+    </nav>
 }
 
-  @if (Model.JavascriptSearchSortFilterPaginateEnabled)
+@if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  <vc:loading-spinner page-has-side-nav-menu="false" />
+    <vc:loading-spinner page-has-side-nav-menu="false" />
 }
 <div id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
-  @if (errorHasOccurred)
-  {
-    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.DelegateEmailAddress) })" />
-  }
-  <h1>My Staff</h1>
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      @if (Model.SuperviseDelegateDetailViewModels.Any() | (Model.SearchString != null))
-      {
-        <form method="get" role="search" asp-action="Index" asp-route-page="@Model.Page">
-          <div class="nhsuk-grid-row">
-            <partial name="SearchablePage/_Search" model="Model" />
-          </div>
-          <div class="nhsuk-grid-row">
+    @if (errorHasOccurred)
+    {
+        <vc:error-summary order-of-property-names="@(new[] { nameof(Model.DelegateEmailAddress) })" />
+    }
+    <h1>My Staff</h1>
+    <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full">
+            @if (Model.SuperviseDelegateDetailViewModels.Any() | (Model.SearchString != null))
+            {
+                <form method="get" role="search" asp-action="Index" asp-route-page="@Model.Page">
+                    <div class="nhsuk-grid-row">
+                        <partial name="SearchablePage/_Search" model="Model" />
+                    </div>
+                    <div class="nhsuk-grid-row">
+                        <div class="nhsuk-grid-column-full">
+                            <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+                            <partial name="SearchablePage/_TopPagination" model="Model" />
+                            <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
+
+                            <input type="hidden" aria-hidden="true" id="select-sort-by" value="SearchableName" />
+                            <input type="hidden" aria-hidden="true" id="select-sort-direction" value="Ascending" />
+                            @if (Model.SuperviseDelegateDetailViewModels.Any())
+                            {
+                                <div id="searchable-elements">
+                                    @foreach (var supervisorDelegateDetail in Model.SuperviseDelegateDetailViewModels)
+                                    {
+                                        <partial name="Shared/_StaffMemberCard" model="supervisorDelegateDetail" />
+                                    }
+                                </div>
+
+                                <partial name="SearchablePage/_BottomPagination" model="Model" />
+                            }
+                            else
+                            {
+                                <p>Please change your search criteria and try again.</p>
+                            }
+                        </div>
+                    </div>
+                </form>
+            }
+            else if (!errorHasOccurred)
+            {
+                <p>You are not supervising any staff, yet.</p>
+            }
+        </div>
+    </div>
+    @if (!Model.IsNominatedSupervisor)
+    {
+        <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-full">
-              <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-              <partial name="SearchablePage/_TopPagination" model="Model" />
-              <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
-
-              <input type="hidden" aria-hidden="true" id="select-sort-by" value="SearchableName" />
-              <input type="hidden" aria-hidden="true" id="select-sort-direction" value="Ascending" />
-              @if (Model.SuperviseDelegateDetailViewModels.Any())
-              {
-                <div id="searchable-elements">
-                  @foreach (var supervisorDelegateDetail in Model.SuperviseDelegateDetailViewModels)
-                  {
-                    <partial name="Shared/_StaffMemberCard" model="supervisorDelegateDetail" />
-                  }
-                </div>
-
-                <partial name="SearchablePage/_BottomPagination" model="Model" />
-              }
-              else
-              {
-                <p>Please change your search criteria and try again.</p>
-              }
+                <form method="post">
+                    <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
+                        <h2>Add a member of staff</h2>
+                    </label>
+                    <div class="nhsuk-form-group">
+                        <div class=" sort-select-container">
+                            <vc:text-input asp-for="DelegateEmailAddress"
+                                       label="User email address"
+                                       populate-with-current-value="false"
+                                       type="text"
+                                       spell-check="false"
+                                       hint-text="Provide the work email address of a member of staff to add to your supervision list.<br/>If the email address already exists in your staff list, it will be ignored."
+                                       autocomplete="email"
+                                       css-class="nhsuk-input"
+                                       required="true" />
+                        </div>
+                    </div>
+                    <button class="nhsuk-button" type="submit" asp-action="AddSuperviseDelegate">
+                        Submit
+                    </button>
+                    @Html.HiddenFor(m => m.SearchString)
+                    @Html.HiddenFor(m => m.SortBy)
+                    @Html.HiddenFor(m => m.SortDirection)
+                    @Html.HiddenFor(m => m.Page)
+                </form>
             </div>
-          </div>
-        </form>
-      }
-      else if (!errorHasOccurred)
-      {
-        <p>You are not supervising any staff, yet.</p>
-      }
-    </div>
-  </div>
-  @if (!Model.IsNominatedSupervisor)
-  {
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
-        <form method="post">
-          <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
-            <h2>Add a member of staff</h2>
-          </label>
-          <div class="nhsuk-form-group">
-            <div class=" sort-select-container">
-              <vc:text-input asp-for="DelegateEmailAddress"
-                           label="User email address"
-                           populate-with-current-value="false"
-                           type="text"
-                           spell-check="false"
-                           hint-text="Provide the work email address of a member of staff to add to your supervision list.<br/>If the email address already exists in your staff list, it will be ignored."
-                           autocomplete="email"
-                           css-class="nhsuk-input"
-                           required="true" />
+        </div>
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-full">
+                <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-4" role="button" asp-action="AddMultipleSuperviseDelegates">
+                    Add multiple staff members
+                </a>
+                @if (!Model.IsActiveSupervisorDelegateExist)
+                {
+                    <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-4" role="button" asp-action="AddSelfToSelfAssessment">
+                        Add myself to try self assessments
+                    </a>
+                }
             </div>
-          </div>
-          <button class="nhsuk-button" type="submit" asp-action="AddSuperviseDelegate">
-            Submit
-          </button>
-          @Html.HiddenFor(m => m.SearchString)
-          @Html.HiddenFor(m => m.SortBy)
-          @Html.HiddenFor(m => m.SortDirection)
-          @Html.HiddenFor(m => m.Page)
-        </form>
-      </div>
-    </div>
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
-        <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-4" role="button" asp-action="AddMultipleSuperviseDelegates">
-          Add multiple staff members
-        </a>
-      </div>
-    </div>
-  }
+        </div>
+    }
 </div>
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  @section scripts {
-  <script src="@Url.Content("~/js/supervisor/staffList.js")" asp-append-version="true"></script>
+    @section scripts {
+    <script src="@Url.Content("~/js/supervisor/staffList.js")" asp-append-version="true"></script>
 }
 }


### PR DESCRIPTION
…ff when supervisor delegate record doesn’t exist

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1760

### Description
Points addressed in this Commit :
1) Showing "Add myself to try self assessments" button in My staff page by modifying the view and created action in controller.

### Screenshots
![My-Staff-List-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/04dc1bb4-d235-4649-9ae7-40f3233bfa4a)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/fc7acdd8-2360-4278-b595-62487fa09946)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
