### PR TITLE
TD-1766 Corrected the store procedure to remove the hyphen if no add on is present in course name

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202306082300_AlterGetActivitiesForDelegateEnrolmentSP.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202306082300_AlterGetActivitiesForDelegateEnrolmentSP.cs
@@ -1,0 +1,17 @@
+﻿using FluentMigrator;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    [Migration(202306082300)]
+    public class AlterGetActivitiesForDelegateEnrolmentSP : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_1766_GetActivitiesForDelegateEnrolmentTweak);
+        }
+        public override void Down()
+        {
+            Execute.Sql(Properties.Resources.TD_1766_GetActivitiesForDelegateEnrolmentTweak_down);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -861,6 +861,46 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 01/06/2023 15:32:33 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 24/01/2023
+        ///-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+        ///-- ========= [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_1766_GetActivitiesForDelegateEnrolmentTweak {
+            get {
+                return ResourceManager.GetString("TD_1766_GetActivitiesForDelegateEnrolmentTweak", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 01/06/2023 15:32:33 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 24/01/2023
+        ///-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+        ///-- ========= [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_1766_GetActivitiesForDelegateEnrolmentTweak_down {
+            get {
+                return ResourceManager.GetString("TD_1766_GetActivitiesForDelegateEnrolmentTweak_down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /****** Object:  View [dbo].[AdminUsers]    Script Date: 2/6/2023 22:11:41 ******/
         ///SET ANSI_NULLS ON
         ///GO

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -262,4 +262,10 @@
   <data name="td_1610_update_getactivitiesfordelegateenrolment_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\td-1610-update_getactivitiesfordelegateenrolment_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
+    <data name="TD_1766_GetActivitiesForDelegateEnrolmentTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+        <value>..\Scripts\TD-1766-GetActivitiesForDelegateEnrolmentTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    </data>
+    <data name="TD_1766_GetActivitiesForDelegateEnrolmentTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
+        <value>..\Scripts\TD-1766-GetActivitiesForDelegateEnrolmentTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetActivitiesForDelegateEnrolmentTweak.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetActivitiesForDelegateEnrolmentTweak.sql
@@ -1,0 +1,60 @@
+/****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 01/06/2023 15:32:33 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 24/01/2023
+-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+-- =============================================
+ALTER   PROCEDURE [dbo].[GetActivitiesForDelegateEnrolment]
+	-- Add the parameters for the stored procedure here
+	@CentreID as Int = 0,
+	@DelegateID as int,
+	@CategoryId as Int = 0
+AS
+	BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+			SELECT * FROM
+			-- Insert statements for procedure here
+			(SELECT cu.CustomisationID, cu.Active, cu.CurrentVersion, cu.CentreID, cu.ApplicationID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, cu.CustomisationText, 0 AS IncludesSignposting, 0 AS IsSelfAssessment, cu.SelfRegister AS SelfRegister,
+					   cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(cu.CustomisationID, 0) AS HasDiagnostic, 
+					   dbo.CheckCustomisationSectionHasLearning(cu.CustomisationID, 0) AS HasLearning, (SELECT BrandName FROM Brands WHERE BrandID = a.BrandID) AS Brand, (SELECT CategoryName FROM CourseCategories WHERE CourseCategoryID = a.CourseCategoryID) AS Category, (SELECT CourseTopic FROM CourseTopics WHERE CourseTopicID = a.CourseTopicID) AS Topic, dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) AS DelegateStatus
+			FROM  Customisations AS cu INNER JOIN
+					   Applications AS a 
+					   ON cu.ApplicationID = a.ApplicationID 
+					   WHERE ((cu.CentreID = @CentreID) OR (cu.AllCentres = 1 AND (EXISTS(SELECT CentreApplicationID FROM CentreApplications WHERE ApplicationID = a.ApplicationID AND CentreID = @CentreID AND Active = 1)))) AND 
+					   (cu.Active = 1) AND 
+					   (a.ASPMenu = 1) AND 
+					   (a.ArchivedDate IS NULL) AND 
+					   (dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) IN (0,1,4)) AND 
+					   (cu.CustomisationName <> 'ESR') AND
+					   (a.CourseCategoryID = @CategoryId OR @CategoryId =0)
+					   UNION ALL
+					   SELECT SA.ID AS CustomisationID, 1 AS Active, 1 AS CurrentVersion, CSA.CentreID as CentreID, 0 AS ApplicationID, SA.Name AS CourseName, SA.Description AS CustomisationText, SA.IncludesSignposting, 1 AS IsSelfAssessment, CSA.AllowEnrolment AS SelfRegister, 0 AS IsAssessed, 0 AS HasDiagnostic, 0 AS HasLearning,
+										 (SELECT BrandName
+										 FROM    Brands
+										 WHERE (BrandID = SA.BrandID)) AS Brand,
+										 (SELECT CategoryName
+										 FROM    CourseCategories
+										 WHERE (CourseCategoryID = SA.CategoryID)) AS Category,
+										 '' AS Topic, 0 AS DelegateStatus
+						FROM   SelfAssessments AS SA 
+		INNER JOIN CentreSelfAssessments AS CSA ON SA.Id = CSA.SelfAssessmentID AND CSA.CentreId = @centreId AND CSA.AllowEnrolment = 1
+						WHERE (SA.ID NOT IN
+										 (SELECT SelfAssessmentID
+										 FROM    CandidateAssessments AS CA
+										 INNER JOIN Users AS U ON CA.DelegateUserID = U.ID
+										 INNER JOIN DelegateAccounts AS DA ON U.ID = DA.UserID
+										 WHERE (DA.ID = @DelegateID) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL))) AND
+					   (SA.CategoryID = @CategoryId OR @CategoryId =0)
+										 )
+										 AS Q1
+						ORDER BY Q1.CourseName
+		END
+GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetActivitiesForDelegateEnrolmentTweak_down.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetActivitiesForDelegateEnrolmentTweak_down.sql
@@ -1,0 +1,60 @@
+/****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 01/06/2023 15:32:33 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 24/01/2023
+-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+-- =============================================
+ALTER   PROCEDURE [dbo].[GetActivitiesForDelegateEnrolment]
+	-- Add the parameters for the stored procedure here
+	@CentreID as Int = 0,
+	@DelegateID as int,
+	@CategoryId as Int = 0
+AS
+	BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+			SELECT * FROM
+			-- Insert statements for procedure here
+			(SELECT cu.CustomisationID, cu.Active, cu.CurrentVersion, cu.CentreID, cu.ApplicationID, a.ApplicationName + ' - ' + cu.CustomisationName AS CourseName, cu.CustomisationText, 0 AS IncludesSignposting, 0 AS IsSelfAssessment, cu.SelfRegister AS SelfRegister,
+					   cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(cu.CustomisationID, 0) AS HasDiagnostic, 
+					   dbo.CheckCustomisationSectionHasLearning(cu.CustomisationID, 0) AS HasLearning, (SELECT BrandName FROM Brands WHERE BrandID = a.BrandID) AS Brand, (SELECT CategoryName FROM CourseCategories WHERE CourseCategoryID = a.CourseCategoryID) AS Category, (SELECT CourseTopic FROM CourseTopics WHERE CourseTopicID = a.CourseTopicID) AS Topic, dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) AS DelegateStatus
+			FROM  Customisations AS cu INNER JOIN
+					   Applications AS a 
+					   ON cu.ApplicationID = a.ApplicationID 
+					   WHERE ((cu.CentreID = @CentreID) OR (cu.AllCentres = 1 AND (EXISTS(SELECT CentreApplicationID FROM CentreApplications WHERE ApplicationID = a.ApplicationID AND CentreID = @CentreID AND Active = 1)))) AND 
+					   (cu.Active = 1) AND 
+					   (a.ASPMenu = 1) AND 
+					   (a.ArchivedDate IS NULL) AND 
+					   (dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) IN (0,1,4)) AND 
+					   (cu.CustomisationName <> 'ESR') AND
+					   (a.CourseCategoryID = @CategoryId OR @CategoryId =0)
+					   UNION ALL
+					   SELECT SA.ID AS CustomisationID, 1 AS Active, 1 AS CurrentVersion, CSA.CentreID as CentreID, 0 AS ApplicationID, SA.Name AS CourseName, SA.Description AS CustomisationText, SA.IncludesSignposting, 1 AS IsSelfAssessment, CSA.AllowEnrolment AS SelfRegister, 0 AS IsAssessed, 0 AS HasDiagnostic, 0 AS HasLearning,
+										 (SELECT BrandName
+										 FROM    Brands
+										 WHERE (BrandID = SA.BrandID)) AS Brand,
+										 (SELECT CategoryName
+										 FROM    CourseCategories
+										 WHERE (CourseCategoryID = SA.CategoryID)) AS Category,
+										 '' AS Topic, 0 AS DelegateStatus
+						FROM   SelfAssessments AS SA 
+		INNER JOIN CentreSelfAssessments AS CSA ON SA.Id = CSA.SelfAssessmentID AND CSA.CentreId = @centreId AND CSA.AllowEnrolment = 1
+						WHERE (SA.ID NOT IN
+										 (SELECT SelfAssessmentID
+										 FROM    CandidateAssessments AS CA
+										 INNER JOIN Users AS U ON CA.DelegateUserID = U.ID
+										 INNER JOIN DelegateAccounts AS DA ON U.ID = DA.UserID
+										 WHERE (DA.ID = @DelegateID) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL))) AND
+					   (SA.CategoryID = @CategoryId OR @CategoryId =0)
+										 )
+										 AS Q1
+						ORDER BY Q1.CourseName
+		END
+GO


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1766

### Description
Added a migration to alter the stored procedure - to check if add-on name is not present, then removed the hyphen.

### Screenshots
Course Setup page-
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/50d836ac-820e-473c-809c-cb9613c29c96)

Enrol delegate to a course- 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/c337cc4c-7373-4ece-a61a-b72a39543872)

Available activities-
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/a5332ff3-6a4e-41a7-b32b-020e34f4ded7)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
