### PR TITLE
TD-1873 correcting Mobile view issues with the back link 'Back to fra…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Branding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Branding.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
   }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Collaborators.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Collaborators.cshtml
@@ -24,7 +24,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My frameworks</a></p>
     </div>
   </nav>
   }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Collaborators.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Collaborators.cshtml
@@ -24,7 +24,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
   }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Description.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Description.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
   }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Framework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Framework.cshtml
@@ -16,7 +16,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Framework @ViewContext.RouteData.Values["tabname"]</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to Frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Name.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Name.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
   }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/RemoveDefaultQuestion.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/RemoveDefaultQuestion.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="FrameworkDefaultQuestions" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-actionname="@(ViewContext.RouteData.Values["actionname"])">Default Questions</a></li>
         <li class="nhsuk-breadcrumb__item">Remove Default Question</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to Frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Similar.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Similar.cshtml
@@ -17,7 +17,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
@@ -18,7 +18,7 @@
         <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
         <li class="nhsuk-breadcrumb__item">Create framework</li>
       </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to frameworks</a></p>
+      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFrameworks" asp-route-tabname="Mine">Back to My Frameworks</a></p>
     </div>
   </nav>
   }


### PR DESCRIPTION
…meworks' on Frameworks section

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1873

### Description
 correcting Mobile view issues with the back link 'Back to frameworks' on Frameworks section
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/7df9a921-05a7-40f1-98a1-fd3fb1dce65c)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
