### PR TITLE
TD-1761 Added “NonReportable” bit field in CandidateAssessments table…

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202306091036_AddNonReportableBitFieldToCandidateAssessments.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202306091036_AddNonReportableBitFieldToCandidateAssessments.cs
@@ -1,0 +1,25 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202306091036)]
+    public class AddNonReportableBitFieldToCandidateAssessments : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("CandidateAssessments").AddColumn("NonReportable").AsBoolean().WithDefaultValue(false);
+            Execute.Sql(
+                @$"UPDATE CandidateAssessments
+                    SET NonReportable=1
+                    FROM CandidateAssessments AS CA
+                    INNER JOIN CandidateAssessmentSupervisors AS CAS ON CA.ID = cas.CandidateAssessmentID AND CAS.Removed IS NULL
+                    INNER JOIN SupervisorDelegates AS SD ON SD.ID = CAS.SupervisorDelegateId
+                    INNER JOIN AdminAccounts AS AA ON AA.ID = SD.SupervisorAdminID AND AA.UserID = SD.DelegateUserID"
+                );
+        }
+        public override void Down()
+        {
+            Delete.Column("NonReportable").FromTable("CandidateAssessments");
+        }
+    }
+}


### PR DESCRIPTION
… and Update existing CandidateAssessments

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1761

### Description
Points addressed in this Commit :
1) Added “NonReportable” bit field in CandidateAssessments table and created a migration to update this new field in the existing CandidateAssessments table as per the conditions given in the jira.

### Screenshots
This is backend change so no screenshot available.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
