### PR TITLE
TD-1498 Tracking system course setup filters refix

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptionsTests.cs
@@ -38,22 +38,16 @@
             new[]
             {
                 new FilterOptionModel(
-                    "Inactive",
-                    "Status" + FilteringHelper.Separator + "Active" + FilteringHelper.Separator +
-                    "false",
-                    FilterStatus.Warning
-                ),
-                new FilterOptionModel(
                     "Active",
                     "Status" + FilteringHelper.Separator + "Active" + FilteringHelper.Separator +
                     "true",
                     FilterStatus.Success
                 ),
                 new FilterOptionModel(
-                    "Archived",
-                    "Status" + FilteringHelper.Separator + "Archived" + FilteringHelper.Separator +
+                    "Inactive/archived",
+                    "Status" + FilteringHelper.Separator + "NotActive" + FilteringHelper.Separator +
                     "true",
-                    FilterStatus.Default
+                    FilterStatus.Success
                 ),
             }
         );

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -88,6 +88,8 @@
 
             var details = courseService.GetCentreCourseDetails(centreId, categoryId);
 
+            var courses = UpdateCoursesNotActiveStatus(details.Courses);
+            
             var availableFilters = CourseStatisticsViewModelFilterOptions
                 .GetFilterOptions(categoryId.HasValue ? new string[] { } : details.Categories, details.Topics).ToList();
 
@@ -103,7 +105,7 @@
             );
 
             var result = searchSortFilterPaginateService.SearchFilterSortAndPaginate(
-                details.Courses,
+                courses,
                 searchSortPaginationOptions
             );
 
@@ -634,5 +636,25 @@
                 tempData.CourseDetailsData.NotificationEmails
             );
         }
-    }
+
+        private static IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> UpdateCoursesNotActiveStatus(IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> courses)
+        {
+            var updatedCourses = courses.ToList();
+
+            foreach (var course in updatedCourses)
+            {
+                if (course.Archived || course.Active == false)
+                {
+                  course.NotActive = true;
+                }
+                else
+                {
+                  course.NotActive = false;
+                }
+            }
+
+            return updatedCourses;
+        }
+
+  }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/CourseStatisticsViewModelFilterOptions.cs
@@ -13,8 +13,7 @@
         private static readonly IEnumerable<FilterOptionModel> CourseStatusOptions = new[]
         {
             CourseStatusFilterOptions.IsActive,
-            CourseStatusFilterOptions.IsInactive,
-            CourseStatusFilterOptions.IsArchived,
+            CourseStatusFilterOptions.NotActive
         };
 
         private static readonly IEnumerable<FilterOptionModel> CourseVisibilityOptions = new[]


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1498

### Description
Updated TrackingSystem/CourseSetup view to make it consistent with DelegateCourses filters. Now has a working combined Inactive+Archived filter for both JS and non-JS modes (<250 records)

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![TD-1498](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/15f68c0a-fd52-4542-b5a1-04b6a721c796)


[TD-1498]: https://hee-tis.atlassian.net/browse/TD-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ