### PR TITLE
TD-1462 Changed back link label from "Back to Proficiency planning" t…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
@@ -18,7 +18,7 @@
         <a class="nhsuk-breadcrumb__backlink"
            asp-action="VerificationPickResults"
            asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-            Back to Proficiency planning
+            Back to Choose proficiency results
         </a>
     </p>
 }


### PR DESCRIPTION
…o "Back to Choose proficiency results" in Request proficiency confirmation

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1462

### Description
Points addressed in this Commit :
1) Changed back link label from "Back to Proficiency planning" to "Back to Choose proficiency results" in Request proficiency confirmation by modifying the view.

### Screenshots
![Self-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/5f778600-1d43-4028-83e4-e8f94ee27bc9)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/201a9ef3-ccb8-42fd-99dc-568dc89cbc24)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
