### PR TITLE
TD-1116 Feedback bar feature flag

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -10,6 +10,7 @@
     using GDS.MultiPageFormData;
     using GDS.MultiPageFormData.Enums;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.FeatureManagement.Mvc;
 
     public class UserFeedbackController : Controller
     {
@@ -105,6 +106,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/StartUserFeedbackSession")]
         [ResponseCache(CacheProfileName = "Never")]
         [TypeFilter(
@@ -136,6 +138,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackTaskAchieved")]
         public IActionResult UserFeedbackTaskAchieved(UserFeedbackViewModel userFeedbackViewModel)
         {
@@ -145,6 +148,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackTaskAchievedSet")]
         [ResponseCache(CacheProfileName = "Never")]
         [TypeFilter(
@@ -170,6 +174,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackTaskAttempted")]
         public IActionResult UserFeedbackTaskAttempted(UserFeedbackViewModel userFeedbackViewModel)
         {
@@ -179,6 +184,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackTaskAttemptedSet")]
         [ResponseCache(CacheProfileName = "Never")]
         [TypeFilter(
@@ -205,6 +211,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackTaskDifficulty")]
         public IActionResult UserFeedbackTaskDifficulty(UserFeedbackViewModel userFeedbackViewModel)
         {
@@ -214,6 +221,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackTaskDifficultySet")]
         [ResponseCache(CacheProfileName = "Never")]
         [TypeFilter(
@@ -267,6 +275,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackComplete")]
         public IActionResult UserFeedbackComplete(UserFeedbackViewModel userFeedbackViewModel)
         {
@@ -276,6 +285,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/GuestFeedbackStart")]
         public IActionResult GuestFeedbackStart(UserFeedbackViewModel userFeedbackViewModel)
         {
@@ -285,6 +295,7 @@
         }
 
         [HttpGet]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/GuestFeedbackComplete")]
         public IActionResult GuestFeedbackComplete()
         {
@@ -296,6 +307,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/GuestFeedbackComplete")]
         [ResponseCache(CacheProfileName = "Never")]
         public IActionResult GuestFeedbackComplete(UserFeedbackViewModel userFeedbackViewModel)
@@ -319,6 +331,7 @@
         }
 
         [HttpPost]
+        [FeatureGate(FeatureFlags.UserFeedbackBar)]
         [Route("/UserFeedbackReturnToUrl")]
         public IActionResult UserFeedbackReturnToUrl(string sourceUrl)
         {

--- a/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
@@ -11,5 +11,6 @@
         public const string UseSignposting = "UseSignposting";
         public const string PricingPageEnabled = "PricingPage";
         public const string RefactoredFindYourCentrePage = "RefactoredFindYourCentrePage";
+        public const string UserFeedbackBar = "UserFeedbackBar";
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -83,8 +83,10 @@
 
         </header>
 
-        <partial name="_UserFeedbackBarPartial"/>
-
+        <feature name="@(FeatureFlags.UserFeedbackBar)">
+          <partial name="_UserFeedbackBarPartial"/>
+        </feature>
+        
         <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
             <div class="nhsuk-width-container">
                 <ol class="nhsuk-breadcrumb__list">

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -166,8 +166,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div class="visual-separator @visualSeparatorNoNavBar"></div>
 
         </header>
-        
-        <partial name="_UserFeedbackBarPartial"/>
+
+        <feature name="@(FeatureFlags.UserFeedbackBar)">
+          <partial name="_UserFeedbackBarPartial"/>
+        </feature>
 
         @RenderSection("NavBreadcrumbs", false)
 

--- a/DigitalLearningSolutions.Web/appSettings.UAT.json
+++ b/DigitalLearningSolutions.Web/appSettings.UAT.json
@@ -18,7 +18,8 @@
     "CandidateAssessmentExcelExport": true,
     "UseSignposting": true,
     "PricingPage": false,
-    "RefactoredFindYourCentrePage": true
+    "RefactoredFindYourCentrePage": true,
+    "UserFeedbackBar": true
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -17,7 +17,8 @@
     "UseSignposting": true,
     "CandidateAssessmentExcelExport": true,
     "PricingPage": true,
-    "RefactoredFindYourCentrePage": true
+    "RefactoredFindYourCentrePage": true,
+    "UserFeedbackBar": true
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.Production.json
+++ b/DigitalLearningSolutions.Web/appsettings.Production.json
@@ -18,7 +18,8 @@
     "CandidateAssessmentExcelExport": true,
     "UseSignposting": false,
     "PricingPage": false,
-    "RefactoredFindYourCentrePage": true
+    "RefactoredFindYourCentrePage": true,
+    "UserFeedbackBar": true
   },
   "LearningHubOpenAPIBaseUrl": "https://learninghubnhsuk-openapi-prod.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.SIT.json
+++ b/DigitalLearningSolutions.Web/appsettings.SIT.json
@@ -15,7 +15,8 @@
     "WorkforceManagerInterface": true,
     "RefactoredSuperAdminInterface": true,
     "UseSignposting": true,
-    "PricingPage": true
+    "PricingPage": true,
+    "UserFeedbackBar": true
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-dev.azurewebsites.net",
   "LearningHubSSO": {

--- a/DigitalLearningSolutions.Web/appsettings.Test.json
+++ b/DigitalLearningSolutions.Web/appsettings.Test.json
@@ -17,7 +17,8 @@
     "RefactoredSuperAdminInterface": true,
     "UseSignposting": true,
     "PricingPage": true,
-    "RefactoredFindYourCentrePage": true
+    "RefactoredFindYourCentrePage": true,
+    "UserFeedbackBar": true
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.UarTest.json
+++ b/DigitalLearningSolutions.Web/appsettings.UarTest.json
@@ -18,7 +18,8 @@
     "CandidateAssessmentExcelExport": true,
     "UseSignposting": true,
     "PricingPage": false,
-    "RefactoredFindYourCentrePage": true
+    "RefactoredFindYourCentrePage": true,
+    "UserFeedbackBar": true
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }


### PR DESCRIPTION
### JIRA link
[TD-1116](https://hee-tis.atlassian.net/browse/TD-1116)

### Description
Added feature flag to control availability of User Feedback mechanism via config files.
Set to true/enabled by default in all environment config files.

### Screenshots
Screenshots for enabled/disabled for both headers (main header and SelfAssessments variant header).

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![td-1116 feature flag true main header](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/00900017-718b-49d2-ad01-acdad2184790)

![td-1116 feature flag false main header](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/0473eeb8-3de2-4def-8d38-68023e16faac)

![td-1116 feature flag true self assessments header](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/825941c7-97b1-47cc-8492-bd5135dd759c)

![td-1116 feature flag false self assessments header](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/2350063f-6add-466d-9bd9-2715361c5bf3)




[TD-1116]: https://hee-tis.atlassian.net/browse/TD-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ