### PR TITLE
TD-1911 Updates field names in query to match model

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -24,92 +24,91 @@
         public IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId)
         {
             return connection.Query<DCSAOutcomeSummary>(
-                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, 
-             CASE WHEN (caa.SubmittedDate IS NOT NULL) THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
-                 (SELECT COUNT(*) AS Expr1
-                 FROM    FilteredLearningActivity AS fla
-                 WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
-                 (SELECT COUNT(*) AS Expr1
-                 FROM    FilteredLearningActivity AS fla
-                 WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationANDParticipationConfidence,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
-                 (SELECT AVG(sar.Result) AS AvgConfidence
-                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
-FROM   Candidates AS ca INNER JOIN
-             CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN
-             Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
-             JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
-WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
-ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
+                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
+                             THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
+                                 (SELECT COUNT(*) AS Expr1
+                                 FROM    FilteredLearningActivity AS fla
+                                 WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
+                                 (SELECT COUNT(*) AS Expr1
+                                 FROM    FilteredLearningActivity AS fla
+                                 WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
+                                 (SELECT AVG(sar.Result) AS AvgConfidence
+                                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                                (SELECT AVG(sar.Result) AS AvgConfidence
+                                FROM    SelfAssessmentResults AS sar INNER JOIN
+                                             Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                             SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
+                FROM   Candidates AS ca INNER JOIN
+                             CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
+                             JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
+                WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
+                ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
                 new { centreId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -24,91 +24,92 @@
         public IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId)
         {
             return connection.Query<DCSAOutcomeSummary>(
-                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
-                             THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
-                                 (SELECT COUNT(*) AS Expr1
-                                 FROM    FilteredLearningActivity AS fla
-                                 WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
-                                 (SELECT COUNT(*) AS Expr1
-                                 FROM    FilteredLearningActivity AS fla
-                                 WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationParticipationConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationParticipationRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationResearchConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationResearchRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
-                                (SELECT AVG(sar.Result) AS AvgConfidence
-                                FROM    SelfAssessmentResults AS sar INNER JOIN
-                                             Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                             SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
-                FROM   Candidates AS ca INNER JOIN
-                             CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
-                             JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
-                WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
-                ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
+                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, 
+             CASE WHEN (caa.SubmittedDate IS NOT NULL) THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
+                 (SELECT COUNT(*) AS Expr1
+                 FROM    FilteredLearningActivity AS fla
+                 WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
+                 (SELECT COUNT(*) AS Expr1
+                 FROM    FilteredLearningActivity AS fla
+                 WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationANDParticipationConfidence,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                 (SELECT AVG(sar.Result) AS AvgConfidence
+                 FROM    SelfAssessmentResults AS sar INNER JOIN
+                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                              DelegateAccounts AS da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
+FROM   Candidates AS ca INNER JOIN
+             CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN
+             Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
+             JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
+WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
+ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
                 new { centreId }
             );
         }


### PR DESCRIPTION
### JIRA link
[TD-1911](https://hee-tis.atlassian.net/browse/TD-1911)

### Description
There was a mismatch between the name of fields returned by the query and the cs model. This change updates the field names in the query to match the model. This maps correctly now so that the data is included in the Excl export.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/2a3cdab5-9706-4d36-addf-497b1b07a4cd)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1911]: https://hee-tis.atlassian.net/browse/TD-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ