### PR TITLE
TD-1991-Super Admin: Admin user accounts should be deactivated for all centres

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SessionDataService.cs
@@ -16,6 +16,7 @@
         int StartAdminSession(int adminId);
 
         bool HasAdminGotSessions(int adminId);
+        bool HasAdminGotReferences(int adminId);
 
         bool HasDelegateGotSessions(int delegateId);
 
@@ -78,6 +79,17 @@
         {
             return connection.ExecuteScalar<bool>(
                 "SELECT 1 WHERE EXISTS (SELECT AdminSessionId FROM AdminSessions WHERE AdminID = @adminId)",
+                new { adminId }
+            );
+        }
+        public bool HasAdminGotReferences(int adminId)
+        {
+            return connection.ExecuteScalar<bool>(
+                @"SELECT TOP 1 AdminSessions.AdminID FROM AdminSessions WHERE AdminSessions.AdminID = @adminId
+                  UNION ALL
+                  SELECT TOP 1 FrameworkCollaborators.AdminID FROM FrameworkCollaborators WHERE FrameworkCollaborators.AdminID = @adminId
+                  UNION ALL
+                  SELECT TOP 1 SupervisorDelegates.SupervisorAdminID FROM SupervisorDelegates WHERE SupervisorDelegates.SupervisorAdminID = @adminId",
                 new { adminId }
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
@@ -426,7 +426,6 @@
 
         [Route("SuperAdmin/AdminAccounts/{adminId:int}/DeactivateAdmin")]
         [HttpGet]
-        [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
         public IActionResult DeactivateOrDeleteAdmin(int adminId, ReturnPageQuery returnPageQuery)
         {
             var admin = userDataService.GetAdminById(adminId);
@@ -442,7 +441,6 @@
 
         [Route("SuperAdmin/AdminAccounts/{adminId:int}/DeactivateAdmin")]
         [HttpPost]
-        [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
         public IActionResult DeactivateOrDeleteAdmin(int adminId, DeactivateAdminViewModel model)
         {
             var admin = userDataService.GetAdminById(adminId);
@@ -457,7 +455,7 @@
                 return View(model);
             }
 
-            userService.DeactivateOrDeleteAdmin(adminId);
+            userService.DeactivateOrDeleteAdminForSuperAdmin(adminId);
 
             return View("DeactivateOrDeleteAdminConfirmation");
         }

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -74,6 +74,8 @@ namespace DigitalLearningSolutions.Web.Services
 
         void DeactivateOrDeleteAdmin(int adminId);
 
+        void DeactivateOrDeleteAdminForSuperAdmin(int adminId);        
+
         UserEntity? GetUserById(int userId);
 
         string? GetEmailVerificationHashesFromEmailVerificationHashID(int ID);
@@ -252,6 +254,29 @@ namespace DigitalLearningSolutions.Web.Services
         public void DeactivateOrDeleteAdmin(int adminId)
         {
             if (sessionDataService.HasAdminGotSessions(adminId))
+            {
+                userDataService.DeactivateAdmin(adminId);
+            }
+            else
+            {
+                try
+                {
+                    userDataService.DeleteAdminAccount(adminId);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        $"Error attempting to delete admin {adminId} with no sessions, deactivating them instead."
+                    );
+                    userDataService.DeactivateAdmin(adminId);
+                }
+            }
+        }
+
+        public void DeactivateOrDeleteAdminForSuperAdmin(int adminId)
+        {
+            if (sessionDataService.HasAdminGotReferences(adminId))
             {
                 userDataService.DeactivateAdmin(adminId);
             }


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-1991

**Description**
Created a separate method to check admin references.

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/25b4a6d7-0bc1-4ef1-a60f-90ebb5149ff6)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/e8ee23d4-d77b-4935-98b9-32938c9faaf7)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2c697548-0bc2-45b1-a443-6b06b8af172a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f7ce9b22-e554-4235-b8cb-64be46a56027)


-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
