### PR TITLE
TD-1438 Migration to add VersionInfo primary key

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202306260804_AddVersionInfoPrimaryKey.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202306260804_AddVersionInfoPrimaryKey.cs
@@ -1,0 +1,20 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202306260804)]
+    public class AddVersionInfoPrimaryKey : Migration
+    {
+        public override void Up()
+        {
+            if (!Schema.Table("VersionInfo").Constraint("PK_VersionInfo").Exists())
+            {
+                Create.PrimaryKey("PK_VersionInfo").OnTable("VersionInfo").Column("Version");
+            }
+        }
+        public override void Down()
+        {
+            Delete.PrimaryKey("PK_VersionInfo").FromTable("VersionInfo");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-1438](https://hee-tis.atlassian.net/browse/TD-1438)

### Description
Adds a primary key to the existing, unique Version field on the VersionInfo table if it doesn't exist. This is needed for Azure SQL replication.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/e6f8cdef-dd8f-483c-a375-fe04e4a2edc0)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1438]: https://hee-tis.atlassian.net/browse/TD-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ