### PR TITLE
TD-2036 Migration to switch off system versioning on all tables

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202306261100_SwitchOffAllSystemVersioning.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202306261100_SwitchOffAllSystemVersioning.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202306261100)]
+    public class SwitchOffAllSystemVersioning : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_2036_SwitchSystemVersioningOffAllTables_UP);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql(Properties.Resources.TD_2036_SwitchSystemVersioningOffAllTables_DOWN);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -943,17 +943,16 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to -- Remove versioning from FrameworkCompetencies table
+        ///   Looks up a localized string similar to -- Switch on versioning from FrameworkCompetencies table
         ///ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetenciesHistory));
         ///GO
         ///
-        ///-- Remove versioning from FrameworkCompetencyGroups table
+        ///-- Switch on versioning from FrameworkCompetencyGroups table
         ///ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetencyGroupsHistory));
         ///GO
         ///
-        ///-- Remove versioning from Frameworks table
-        ///ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHistory));
-        ///GO [rest of string was truncated]&quot;;.
+        ///-- Switch on versioning from Frameworks table
+        ///ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHisto [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_2036_SwitchSystemVersioningOffAllTables_DOWN {
             get {

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -943,6 +943,50 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to -- Remove versioning from FrameworkCompetencies table
+        ///ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetenciesHistory));
+        ///GO
+        ///
+        ///-- Remove versioning from FrameworkCompetencyGroups table
+        ///ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetencyGroupsHistory));
+        ///GO
+        ///
+        ///-- Remove versioning from Frameworks table
+        ///ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHistory));
+        ///GO [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_2036_SwitchSystemVersioningOffAllTables_DOWN {
+            get {
+                return ResourceManager.GetString("TD_2036_SwitchSystemVersioningOffAllTables_DOWN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to -- Remove versioning from FrameworkCompetencies table
+        ///ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = OFF);
+        ///GO
+        ///
+        ///-- Remove versioning from FrameworkCompetencyGroups table
+        ///ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = OFF);
+        ///GO
+        ///
+        ///-- Remove versioning from Frameworks table
+        ///ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = OFF);
+        ///GO
+        ///
+        ///-- Remove versioning from Competencies table
+        ///ALTER TABLE Competencies SET (SYSTEM_VERSIONING = OFF);
+        ///GO
+        ///
+        ///-- Remove versioning from Competency [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_2036_SwitchSystemVersioningOffAllTables_UP {
+            get {
+                return ResourceManager.GetString("TD_2036_SwitchSystemVersioningOffAllTables_UP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /****** Object:  View [dbo].[AdminUsers]    Script Date: 2/6/2023 22:11:41 ******/
         ///SET ANSI_NULLS ON
         ///GO

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -274,4 +274,10 @@
   <data name="TD_1913_AlterGroupCustomisation_Add_V2_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-1913-AlterGroupCustomisation_Add_V2_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
+  <data name="TD_2036_SwitchSystemVersioningOffAllTables_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_2036_SwitchSystemVersioningOffAllTables_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-2036-SwitchSystemVersioningOffAllTables-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql
@@ -1,35 +1,36 @@
--- Remove versioning from FrameworkCompetencies table
+-- Switch on versioning from FrameworkCompetencies table
 ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetenciesHistory));
 GO
 
--- Remove versioning from FrameworkCompetencyGroups table
+-- Switch on versioning from FrameworkCompetencyGroups table
 ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetencyGroupsHistory));
 GO
 
--- Remove versioning from Frameworks table
+-- Switch on versioning from Frameworks table
 ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHistory));
 GO
 
--- Remove versioning from Competencies table
+-- Switch on versioning from Competencies table
 ALTER TABLE Competencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].CompetenciesHistory));
 GO
 
--- Remove versioning from CompetencyGroups table
+-- Switch on versioning from CompetencyGroups table
 ALTER TABLE CompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].CompetencyGroupsHistory));
 GO
 
--- Remove versioning from AssessmentQuestions table
+-- Switch on versioning from AssessmentQuestions table
 ALTER TABLE AssessmentQuestions SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].AssessmentQuestionsHistory));
 GO
-
--- Remove versioning from AssessmentQuestionLevels table
+EXEC sp_RENAME 'AssessmentQuestionLevelsHistory.LevelValueID' , 'LevelValue', 'COLUMN'
+GO
+-- Switch on versioning from AssessmentQuestionLevels table
 ALTER TABLE AssessmentQuestionLevels SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].AssessmentQuestionLevelsHistory));
 GO
 
--- Remove versioning from SelfAssessmentResults table
+-- Switch on versioning from SelfAssessmentResults table
 ALTER TABLE SelfAssessmentResults SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].SelfAssessmentResultsHistory));
 GO
 
--- Remove versioning from SelfAssessmentResultSupervisorVerifications table
+-- Switch on versioning from SelfAssessmentResultSupervisorVerifications table
 ALTER TABLE SelfAssessmentResultSupervisorVerifications SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].SelfAssessmentResultSupervisorVerificationsHistory));
 GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql
@@ -1,0 +1,35 @@
+-- Remove versioning from FrameworkCompetencies table
+ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetenciesHistory));
+GO
+
+-- Remove versioning from FrameworkCompetencyGroups table
+ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetencyGroupsHistory));
+GO
+
+-- Remove versioning from Frameworks table
+ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHistory));
+GO
+
+-- Remove versioning from Competencies table
+ALTER TABLE Competencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].CompetenciesHistory));
+GO
+
+-- Remove versioning from CompetencyGroups table
+ALTER TABLE CompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].CompetencyGroupsHistory));
+GO
+
+-- Remove versioning from AssessmentQuestions table
+ALTER TABLE AssessmentQuestions SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].AssessmentQuestionsHistory));
+GO
+
+-- Remove versioning from AssessmentQuestionLevels table
+ALTER TABLE AssessmentQuestionLevels SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].AssessmentQuestionLevelsHistory));
+GO
+
+-- Remove versioning from SelfAssessmentResults table
+ALTER TABLE SelfAssessmentResults SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].SelfAssessmentResultsHistory));
+GO
+
+-- Remove versioning from SelfAssessmentResultSupervisorVerifications table
+ALTER TABLE SelfAssessmentResultSupervisorVerifications SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].SelfAssessmentResultSupervisorVerificationsHistory));
+GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchSystemVersioningOffAllTables-UP.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchSystemVersioningOffAllTables-UP.sql
@@ -1,0 +1,35 @@
+-- Remove versioning from FrameworkCompetencies table
+ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from FrameworkCompetencyGroups table
+ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from Frameworks table
+ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from Competencies table
+ALTER TABLE Competencies SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from CompetencyGroups table
+ALTER TABLE CompetencyGroups SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from AssessmentQuestions table
+ALTER TABLE AssessmentQuestions SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from AssessmentQuestionLevels table
+ALTER TABLE AssessmentQuestionLevels SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from SelfAssessmentResults table
+ALTER TABLE SelfAssessmentResults SET (SYSTEM_VERSIONING = OFF);
+GO
+
+-- Remove versioning from SelfAssessmentResultSupervisorVerifications table
+ALTER TABLE SelfAssessmentResultSupervisorVerifications SET (SYSTEM_VERSIONING = OFF);
+GO


### PR DESCRIPTION
### JIRA link
[TD-2036](https://hee-tis.atlassian.net/browse/TD-2036)

### Description
Adds reversible migration to switch system versioning off on all database tables. 

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
