### PR TITLE
TD-1766 Corrected the stored procedure GetCurrentCoursesForCandidate_V2

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202306260800_AlterGetCurrentCoursesForCandidateSP.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202306260800_AlterGetCurrentCoursesForCandidateSP.cs
@@ -1,0 +1,17 @@
+﻿using FluentMigrator;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    [Migration(202306270900)]
+    public class AlterGetCurrentCoursesForCandidateSP : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_1766_GetCurrentCoursesForCandidateTweak);
+        }
+        public override void Down()
+        {
+            Execute.Sql(Properties.Resources.TD_1766_GetCurrentCoursesForCandidateTweak_down);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -901,6 +901,52 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 26/06/2023 08:04:53 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 16/12/2016
+        ///-- Description:	Returns a list of active progress records for the candidate.
+        ///-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+        ///-- =============================================
+        ///ALTER PROCEDU [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_1766_GetCurrentCoursesForCandidateTweak {
+            get {
+                return ResourceManager.GetString("TD_1766_GetCurrentCoursesForCandidateTweak", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/06/2023 14:49:50 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 16/12/2016
+        ///-- Description:	Returns a list of active progress records for the candidate.
+        ///-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+        ///-- =============================================
+        ///ALTER PROCEDURE [ [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_1766_GetCurrentCoursesForCandidateTweak_down {
+            get {
+                return ResourceManager.GetString("TD_1766_GetCurrentCoursesForCandidateTweak_down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GroupCustomisation_Add_V2]    Script Date: 16/06/2023 09:17:01 ******/
         ///SET ANSI_NULLS ON
         ///GO

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -274,4 +274,10 @@
   <data name="TD_1913_AlterGroupCustomisation_Add_V2_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-1913-AlterGroupCustomisation_Add_V2_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
+  <data name="TD_1766_GetCurrentCoursesForCandidateTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-1766-GetCurrentCoursesForCandidateTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_1766_GetCurrentCoursesForCandidateTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-1766-GetCurrentCoursesForCandidateTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetCurrentCoursesForCandidateTweak.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetCurrentCoursesForCandidateTweak.sql
@@ -1,0 +1,47 @@
+/****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 26/06/2023 08:04:53 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 16/12/2016
+-- Description:	Returns a list of active progress records for the candidate.
+-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+-- =============================================
+ALTER PROCEDURE [dbo].[GetCurrentCoursesForCandidate_V2]
+	-- Add the parameters for the stored procedure here
+	@CandidateID int
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+
+    -- Insert statements for procedure here
+	SELECT p.ProgressID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, p.CustomisationID, p.SubmittedTime AS LastAccessed, 
+               p.FirstSubmittedTime AS StartedDate, p.DiagnosticScore, p.PLLocked, cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(p.CustomisationID, 0) 
+               AS HasDiagnostic, dbo.CheckCustomisationSectionHasLearning(p.CustomisationID, 0) AS HasLearning,
+                   COALESCE
+                             ((SELECT        COUNT(Passes) AS Passes
+                                 FROM            (SELECT        COUNT(AssessAttemptID) AS Passes
+                                                           FROM            AssessAttempts AS aa
+                                                           WHERE        (CandidateID = p.CandidateID) AND (CustomisationID = p.CustomisationID) AND (Status = 1)
+                                                           GROUP BY SectionNumber) AS derivedtbl_2), 0) AS Passes,
+                   (SELECT COUNT(SectionID) AS Sections
+                    FROM   Sections AS s
+                    WHERE (ApplicationID = cu.ApplicationID)) AS Sections, p.CompleteByDate, CAST(CASE WHEN p.CompleteByDate IS NULL THEN 0 WHEN p.CompleteByDate < getDate() 
+                         THEN 2 WHEN p.CompleteByDate < DATEADD(M, + 1, getDate()) THEN 1 ELSE 0 END AS INT) AS OverDue, p.EnrollmentMethodID, dbo.GetCohortGroupCustomisationID(p.ProgressID) AS GroupCustomisationID, p.SupervisorAdminID
+
+FROM  Progress AS p INNER JOIN
+               Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+               Applications AS a ON cu.ApplicationID = a.ApplicationID
+WHERE (p.Completed IS NULL) AND (p.RemovedDate IS NULL) AND (p.CandidateID = @CandidateID)AND (cu.CustomisationName <> 'ESR') AND (a.ArchivedDate IS NULL) AND (cu.Active = 1) AND (p.SubmittedTime > DATEADD(M, -6, getDate()) OR NOT p.CompleteByDate IS NULL)
+ORDER BY p.SubmittedTime Desc
+END
+
+GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetCurrentCoursesForCandidateTweak_down.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-1766-GetCurrentCoursesForCandidateTweak_down.sql
@@ -1,0 +1,45 @@
+/****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/06/2023 14:49:50 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 16/12/2016
+-- Description:	Returns a list of active progress records for the candidate.
+-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+-- =============================================
+ALTER PROCEDURE [dbo].[GetCurrentCoursesForCandidate_V2]
+	-- Add the parameters for the stored procedure here
+	@CandidateID int
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+
+    -- Insert statements for procedure here
+	SELECT p.ProgressID, a.ApplicationName + ' - ' + cu.CustomisationName AS CourseName, p.CustomisationID, p.SubmittedTime AS LastAccessed, 
+               p.FirstSubmittedTime AS StartedDate, p.DiagnosticScore, p.PLLocked, cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(p.CustomisationID, 0) 
+               AS HasDiagnostic, dbo.CheckCustomisationSectionHasLearning(p.CustomisationID, 0) AS HasLearning,
+                   COALESCE
+                             ((SELECT        COUNT(Passes) AS Passes
+                                 FROM            (SELECT        COUNT(AssessAttemptID) AS Passes
+                                                           FROM            AssessAttempts AS aa
+                                                           WHERE        (CandidateID = p.CandidateID) AND (CustomisationID = p.CustomisationID) AND (Status = 1)
+                                                           GROUP BY SectionNumber) AS derivedtbl_2), 0) AS Passes,
+                   (SELECT COUNT(SectionID) AS Sections
+                    FROM   Sections AS s
+                    WHERE (ApplicationID = cu.ApplicationID)) AS Sections, p.CompleteByDate, CAST(CASE WHEN p.CompleteByDate IS NULL THEN 0 WHEN p.CompleteByDate < getDate() 
+                         THEN 2 WHEN p.CompleteByDate < DATEADD(M, + 1, getDate()) THEN 1 ELSE 0 END AS INT) AS OverDue, p.EnrollmentMethodID, dbo.GetCohortGroupCustomisationID(p.ProgressID) AS GroupCustomisationID, p.SupervisorAdminID
+
+FROM  Progress AS p INNER JOIN
+               Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+               Applications AS a ON cu.ApplicationID = a.ApplicationID
+WHERE (p.Completed IS NULL) AND (p.RemovedDate IS NULL) AND (p.CandidateID = @CandidateID)AND (cu.CustomisationName <> 'ESR') AND (a.ArchivedDate IS NULL) AND (cu.Active = 1) AND (p.SubmittedTime > DATEADD(M, -6, getDate()) OR NOT p.CompleteByDate IS NULL)
+ORDER BY p.SubmittedTime Desc
+END
+
+GO


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1766

### Description
Corrected the stored procedure GetCurrentCoursesForCandidate_V2 by putting a condition to check if a customisation name is present or not and based on the result, appending it to the course name.

### Screenshots
Before code changes - 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/f8782e20-2b54-49db-9a73-118576a42cd0)

After code changes
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/55f29a48-0425-4a2e-aaee-4a53a6e69303)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
