### PR TITLE
TD-2054 Adds created and updated date fields to the config table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202306271045_AddAddedUpdatedDateFieldsToConfig.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202306271045_AddAddedUpdatedDateFieldsToConfig.cs
@@ -1,0 +1,22 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202306271045)]
+    public class AddAddedUpdatedDateFieldsToConfig : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("Config").AddColumn("CreatedDate").AsDateTime().NotNullable().WithDefaultValue(SystemMethods.CurrentDateTime)
+                .AddColumn("UpdatedDate").AsDateTime().NotNullable().WithDefaultValue(SystemMethods.CurrentDateTime);
+            Execute.Sql(
+                @$"UPDATE Config SET CreatedDate = DATEADD(YEAR,-1,GetDate()); UPDATE Config SET UpdatedDate = DATEADD(YEAR,-1,GetDate());"
+            );
+        }
+        public override void Down()
+        {
+            Delete.Column("CreatedDate").FromTable("Config");
+            Delete.Column("UpdatedDate").FromTable("Config");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Tests/DataServices/ConfigDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ConfigDataServiceTests.cs
@@ -4,6 +4,7 @@
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FluentAssertions;
     using NUnit.Framework;
+    using System;
 
     public class ConfigDataServiceTests
     {
@@ -24,6 +25,16 @@
 
             // Then
             result.Should().Be("https://www.dls.nhs.uk/tracking/");
+        }
+
+        [Test]
+        public void Get_config_last_updated_returns_a_valid_date()
+        {
+            // When
+            var result = configDataService.GetConfigLastUpdated(ConfigDataService.TrackingSystemBaseUrl);
+
+            // Then
+            result.Should().BeBefore(DateTime.Now);
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/ConfigDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ConfigDataService.cs
@@ -54,6 +54,14 @@
             ).FirstOrDefault();
         }
 
+        public DateTime GetConfigLastUpdated(string key)
+        {
+            return connection.Query<DateTime>(
+                @"SELECT UpdatedDate FROM Config WHERE ConfigName = @key",
+                new { key }
+            ).FirstOrDefault();
+        }
+
         public string GetConfigValueMissingExceptionMessage(string missingConfigValue)
         {
             return $"Encountered an error while trying to send an email: The value of {missingConfigValue} is null";


### PR DESCRIPTION
### JIRA link
[TD-2054](https://hee-tis.atlassian.net/browse/TD-2054)

### Description
Migration to add created and updated date fields to the Config table and populate them with a starter date of today minus 12 months. This will allow us to show the last reviewed date in places where we are reading config values in (such as privacy notice, accessibility statement, terms of conditions etc).

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2054]: https://hee-tis.atlassian.net/browse/TD-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ