### PR TITLE
TD-1758: 1. Supervise action link is already available if CandidateAssessmentSupervisors.Removed is not null. 2. Count mismatch in self assessment card & self assessment page has been fixed.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -167,9 +167,11 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 		                COALESCE (au.CentreID, da.CentreID) AS CentreID, 
 		                au.Forename + ' ' + au.Surname AS SupervisorName,                 
 		                (SELECT COUNT(ca.ID) AS Expr1
-                        FROM CandidateAssessments AS ca INNER JOIN SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID LEFT JOIN CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID
-                        WHERE (ca.DelegateUserID = sd.DelegateUserID) AND ((sa.SupervisorSelfAssessmentReview = 1) OR
-                         (sa.SupervisorResultsReview = 1)) AND (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = sd.ID  OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID AND sa.[National] = 1))) AS CandidateAssessmentCount, 
+                        FROM CandidateAssessments AS ca  LEFT JOIN
+                        CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL INNER JOIN
+                        SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID 
+                        WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = sd.ID OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID AND sa.[National] = 1 )
+				        AND ((sa.SupervisorSelfAssessmentReview = 1) OR (sa.SupervisorResultsReview = 1)))) AS CandidateAssessmentCount, 
 		                CAST(COALESCE (au2.IsNominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, 
 		                CAST(COALESCE (au2.IsSupervisor, 0) AS Bit) AS DelegateIsSupervisor,             
 		                da.ID AS Expr1


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1758

### Description
1. Supervise action link is already available if CandidateAssessmentSupervisors.Removed is not null. 
2. Count mismatch in self assessment card & self assessment page has been fixed.

### Screenshots
Before code change:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/516bb11e-fdc7-4d70-88af-4a609a4217f1)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/7a1995e5-b7ce-45ce-a668-a5d8dd8fba4f)


After code change:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/8bc25c56-e18e-4773-b4ae-2872ac097780)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/fc7f22ba-f7f4-48bb-beb2-3cac8182f579)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
