### PR TITLE
TD-1944 Fixed issue of 410 error when promoting to admin after deacti…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
@@ -51,7 +51,7 @@
                     emailVerificationDataService
                 )
                 .WithDefaultContext()
-                .WithMockUser(true);
+                .WithMockUser(true).WithMockTempData();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -68,6 +68,11 @@
                 return NotFound();
             }
 
+            if (TempData["IsDelegatePromoted"] != null)
+            {
+                TempData.Remove("IsDelegatePromoted");
+            }
+
             var delegateUserCard = new DelegateUserCard(delegateEntity);
             var categoryIdFilter = User.GetAdminCategoryId();
 


### PR DESCRIPTION
…vating the admin account by destroying the temp data in view delegate

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1944

### Description
Points addressed in this Commit :
1) Fixed issue of 410 error when promoting to admin after deactivating the admin account by destroying the temp data in view delegate by modifying the controller.

### Screenshots
[Centre-administrators---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/fb8ba7c4-ac19-40da-9d61-f31e8516eea2)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
