### PR TITLE
TD-2117 Adds and populates self assessment activity log table for report data

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202307031453_AddReportSelfAssessmentActivityLogTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202307031453_AddReportSelfAssessmentActivityLogTable.cs
@@ -1,0 +1,79 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202307031453)]
+    public class AddReportSelfAssessmentActivityLogTable : Migration
+    {
+        public override void Up()
+        {
+            Create.Table("ReportSelfAssessmentActivityLog")
+                .WithColumn("ID").AsInt32().NotNullable().PrimaryKey().Identity()
+                .WithColumn("DelegateID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_DelegateID_DelegateAccounts_ID", "DelegateAccounts", "ID").WithDefaultValue(0)
+                .WithColumn("UserID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_UserID_Users_ID", "Users", "ID").WithDefaultValue(0)
+                .WithColumn("CentreID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_CentreID_Centres_CentreID", "Centres", "CentreID").WithDefaultValue(0)
+                .WithColumn("RegionID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_RegionID_Regions_RegionID", "Regions", "RegionID").WithDefaultValue(0)
+                .WithColumn("JobGroupID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_JobGroupID_JobGroups_JobGroupID", "JobGroups", "JobGroupID").WithDefaultValue(0)
+                .WithColumn("CategoryID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_CategoryID_CourseCategories_CourseCategoryID", "CourseCategories", "CourseCategoryID").WithDefaultValue(0)
+                .WithColumn("National").AsBoolean().NotNullable().WithDefaultValue(0)
+                .WithColumn("SelfAssessmentID").AsInt32().Nullable()
+                .ForeignKey("FK_ReportSelfAssessmentActivityLog_SelfAssessmentID_SelfAssessments_ID", "SelfAssessments", "ID").WithDefaultValue(0)
+                .WithColumn("ActivityDate").AsDateTime().NotNullable()
+                .WithColumn("Enrolled").AsBoolean().NotNullable().WithDefaultValue(0)
+                .WithColumn("Submitted").AsBoolean().NotNullable().WithDefaultValue(0)
+                .WithColumn("SignedOff").AsBoolean().NotNullable().WithDefaultValue(0)
+                ;
+            //Insert enrolments into the new table:
+            Execute.Sql(
+                @$"INSERT INTO ReportSelfAssessmentActivityLog (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
+                    SELECT da.ID, ca.DelegateUserID, ca.CentreID, ce.RegionID, u.JobGroupID, sa.CategoryID, sa.[National], ca.SelfAssessmentID, ca.StartedDate, 1, 0, 0
+                    FROM   CandidateAssessments AS ca INNER JOIN
+                                 Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                 SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
+                                 Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID;"
+            );
+            //Insert submitted self assessments into the new table:
+            Execute.Sql(
+                @$"INSERT INTO ReportSelfAssessmentActivityLog
+                                 (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
+                   SELECT da.ID, ca.DelegateUserID, ca.CentreID, ce.RegionID, u.JobGroupID, sa.CategoryID, sa.[National], ca.SelfAssessmentID, ca.SubmittedDate, 0, 1, 0
+                   FROM   CandidateAssessments AS ca INNER JOIN
+                                 Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                 SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
+                                 Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
+                    WHERE ca.SubmittedDate IS NOT NULL;"
+            );
+            //Insert signed off self assessments into the new table:
+            Execute.Sql(
+               @$"INSERT INTO ReportSelfAssessmentActivityLog
+                                 (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
+                   SELECT da.ID, ca.DelegateUserID, ca.CentreID, ce.RegionID, u.JobGroupID, sa.CategoryID, sa.[National], ca.SelfAssessmentID, casv.Verified, 0, 0, 1
+                    FROM   CandidateAssessments AS ca INNER JOIN
+                                 Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                 SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
+                                 Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID INNER JOIN
+                                 CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID INNER JOIN
+                                 CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
+                   WHERE (NOT (casv.Verified IS NULL)) AND (casv.SignedOff = 1);"
+           );
+            Execute.Sql(Properties.Resources.TD_2117_CreatePopulateReportSelfAssessmentActivityLog_SP);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql(
+               @$"DROP PROCEDURE [dbo].[PopulateReportSelfAssessmentActivityLog]"
+           );
+            Delete.Table("ReportSelfAssessmentActivityLog");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202307031453_AddReportSelfAssessmentActivityLogTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202307031453_AddReportSelfAssessmentActivityLogTable.cs
@@ -37,7 +37,8 @@
                                  Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
                                  SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
                                  Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
-                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID;"
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
+                    WHERE (ca.NonReportable = 0);"
             );
             //Insert submitted self assessments into the new table:
             Execute.Sql(
@@ -49,7 +50,7 @@
                                  SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
                                  Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
                                  DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
-                    WHERE ca.SubmittedDate IS NOT NULL;"
+                    WHERE (ca.NonReportable = 0) AND (ca.SubmittedDate IS NOT NULL);"
             );
             //Insert signed off self assessments into the new table:
             Execute.Sql(
@@ -63,7 +64,7 @@
                                  DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID INNER JOIN
                                  CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID INNER JOIN
                                  CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
-                   WHERE (NOT (casv.Verified IS NULL)) AND (casv.SignedOff = 1);"
+                   WHERE (ca.NonReportable = 0) AND (NOT (casv.Verified IS NULL)) AND (casv.SignedOff = 1);"
            );
             Execute.Sql(Properties.Resources.TD_2117_CreatePopulateReportSelfAssessmentActivityLog_SP);
         }

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -943,6 +943,32 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SET ANSI_NULLS ON
+        ///GO
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 03/07/2023
+        ///-- Description:	Populate the ReportSelfAssessmentActivityLog table with recent activity
+        ///-- =============================================
+        ///CREATE OR ALTER PROCEDURE PopulateReportSelfAssessmentActivityLog
+        ///
+        ///AS
+        ///BEGIN
+        ///	-- SET NOCOUNT ON added to prevent extra result sets from
+        ///	-- interfering with SELECT statements.
+        ///	SET NOCOUNT ON;
+        ///
+        ///   DECLARE @ [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_2117_CreatePopulateReportSelfAssessmentActivityLog_SP {
+            get {
+                return ResourceManager.GetString("TD_2117_CreatePopulateReportSelfAssessmentActivityLog_SP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /****** Object:  View [dbo].[AdminUsers]    Script Date: 2/6/2023 22:11:41 ******/
         ///SET ANSI_NULLS ON
         ///GO

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -274,4 +274,7 @@
   <data name="TD_1913_AlterGroupCustomisation_Add_V2_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-1913-AlterGroupCustomisation_Add_V2_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
+  <data name="TD_2117_CreatePopulateReportSelfAssessmentActivityLog_SP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql
@@ -26,7 +26,7 @@ SELECT @StartDate = MAX(ActivityDate) FROM ReportSelfAssessmentActivityLog;
                                  SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
                                  Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
                                  DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
-								 WHERE (ca.StartedDate > @StartDate);
+								 WHERE (ca.NonReportable = 0) AND (ca.StartedDate > @StartDate);
             --Insert submitted self assessments into the new table:
 INSERT INTO ReportSelfAssessmentActivityLog
                                  (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
@@ -36,7 +36,7 @@ INSERT INTO ReportSelfAssessmentActivityLog
                                  SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
                                  Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
                                  DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
-                    WHERE (NOT (ca.SubmittedDate IS NULL)) AND (ca.SubmittedDate > @StartDate);
+                    WHERE (ca.NonReportable = 0) AND (NOT (ca.SubmittedDate IS NULL)) AND (ca.SubmittedDate > @StartDate);
             --Insert signed off self assessments into the new table:
 INSERT INTO ReportSelfAssessmentActivityLog
                                  (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
@@ -48,6 +48,6 @@ INSERT INTO ReportSelfAssessmentActivityLog
                                  DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID INNER JOIN
                                  CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID INNER JOIN
                                  CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
-                   WHERE (NOT (casv.Verified IS NULL)) AND (casv.SignedOff = 1) AND (casv.Verified > @StartDate);
+                   WHERE (ca.NonReportable = 0) AND (NOT (casv.Verified IS NULL)) AND (casv.SignedOff = 1) AND (casv.Verified > @StartDate);
 END
 GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql
@@ -1,0 +1,53 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 03/07/2023
+-- Description:	Populate the ReportSelfAssessmentActivityLog table with recent activity
+-- =============================================
+CREATE OR ALTER PROCEDURE PopulateReportSelfAssessmentActivityLog
+
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+
+   DECLARE @StartDate datetime
+SELECT @StartDate = MAX(ActivityDate) FROM ReportSelfAssessmentActivityLog;
+--Insert enrolments into the new table:
+                INSERT INTO ReportSelfAssessmentActivityLog
+                (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
+                    SELECT da.ID, ca.DelegateUserID, ca.CentreID, ce.RegionID, u.JobGroupID, sa.CategoryID, sa.[National], ca.SelfAssessmentID, ca.StartedDate, 1, 0, 0
+                    FROM   CandidateAssessments AS ca INNER JOIN
+                                 Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                 SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
+                                 Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
+								 WHERE (ca.StartedDate > @StartDate);
+            --Insert submitted self assessments into the new table:
+INSERT INTO ReportSelfAssessmentActivityLog
+                                 (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
+                   SELECT da.ID, ca.DelegateUserID, ca.CentreID, ce.RegionID, u.JobGroupID, sa.CategoryID, sa.[National], ca.SelfAssessmentID, ca.SubmittedDate, 0, 1, 0
+                   FROM   CandidateAssessments AS ca INNER JOIN
+                                 Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                 SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
+                                 Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID
+                    WHERE (NOT (ca.SubmittedDate IS NULL)) AND (ca.SubmittedDate > @StartDate);
+            --Insert signed off self assessments into the new table:
+INSERT INTO ReportSelfAssessmentActivityLog
+                                 (DelegateID, UserID, CentreID, RegionID, JobGroupID, CategoryID, [National], SelfAssessmentID, ActivityDate, Enrolled, Submitted, SignedOff)
+                   SELECT da.ID, ca.DelegateUserID, ca.CentreID, ce.RegionID, u.JobGroupID, sa.CategoryID, sa.[National], ca.SelfAssessmentID, casv.Verified, 0, 0, 1
+                    FROM   CandidateAssessments AS ca INNER JOIN
+                                 Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                 SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
+                                 Centres AS ce ON ca.CentreID = ce.CentreID INNER JOIN
+                                 DelegateAccounts AS da ON ca.DelegateUserID = da.UserID AND ca.CentreID = da.CentreID INNER JOIN
+                                 CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID INNER JOIN
+                                 CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
+                   WHERE (NOT (casv.Verified IS NULL)) AND (casv.SignedOff = 1) AND (casv.Verified > @StartDate);
+END
+GO


### PR DESCRIPTION
### JIRA link
[TD-2117](https://hee-tis.atlassian.net/browse/TD-2117)

### Description
Migration to add a new ReportSelfAssessmentActivityLog table and populate it. Also includes a migration to add a stored procedure to append data to the table when executed by SQL agent job. SQL agent job will need adding to the production and test databases once published.

### Screenshots
Table created and populated:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/2319f201-063b-4b32-9585-4786747b9fd0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2117]: https://hee-tis.atlassian.net/browse/TD-2117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ