### PR TITLE
TD-1116 user feedback browser nav back issue

### DIFF
--- a/DigitalLearningSolutions.Data/Models/UserFeedback/UserFeedbackTempData.cs
+++ b/DigitalLearningSolutions.Data/Models/UserFeedback/UserFeedbackTempData.cs
@@ -21,13 +21,8 @@
         public string? SourceUrl { get; set; }
         public string? SourcePageTitle { get; set; }
         public bool? TaskAchieved { get; set; }
-
-        [Required(ErrorMessage = "[UserFeedbackTempData] Please enter the task you were attempting to perform.")]
-        public string TaskAttempted { get; set; }
-
-        [Required(ErrorMessage = "[UserFeedbackTempData] Please enter your feedback text.")]
-        public string FeedbackText { get; set; }
-
+        public string? TaskAttempted { get; set; }
+        public string? FeedbackText { get; set; }
         public int? TaskRating { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
@@ -222,13 +222,13 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
             userFeedbackViewModel.FeedbackText = FeedbackText;
 
             // When
-            var result = _userFeedbackController.GuestFeedbackComplete(userFeedbackViewModel) as ViewResult;
+            var result = _userFeedbackController.GuestFeedbackComplete(userFeedbackViewModel) as RedirectToActionResult;
 
             // Then
             A.CallTo(() => _userFeedbackDataService.SaveUserFeedback(null, A<string>._, A<string>._, null, A<string>._, A<string>._, null))
                 .MustHaveHappenedOnceExactly();
             result.Should().NotBeNull();
-            result?.ViewName.Should().Be("GuestFeedbackComplete");
+            result?.ActionName.Should().Be("GuestFeedbackComplete");
         }
 
         [Test]
@@ -238,13 +238,13 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
             var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
-            var result = _userFeedbackController.GuestFeedbackComplete(userFeedbackViewModel) as ViewResult;
+            var result = _userFeedbackController.GuestFeedbackComplete(userFeedbackViewModel) as RedirectToActionResult;
 
             // Then
             A.CallTo(() => _userFeedbackDataService.SaveUserFeedback(null, A<string>._, A<string>._, null, A<string>._, A<string>._, null))
                 .MustNotHaveHappened();
             result.Should().NotBeNull();
-            result?.ViewName.Should().Be("GuestFeedbackComplete");
+            result?.ActionName.Should().Be("GuestFeedbackComplete");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackStart.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackStart.cshtml
@@ -42,7 +42,7 @@
 
         <vc:text-input asp-for="TaskAttempted"
                      label="What task did you come to do today?"
-                     populate-with-current-value="false"
+                     populate-with-current-value="true"
                      type="text"
                      spell-check="false"
                      hint-text=""
@@ -52,7 +52,7 @@
 
         <vc:text-area asp-for="FeedbackText"
                     label="Please describe in detail your experience and what you came here to achieve."
-                    populate-with-current-value="false"
+                    populate-with-current-value="true"
                     rows="5"
                     type="text"
                     spell-check="false"

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAttempted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAttempted.cshtml
@@ -41,7 +41,7 @@
 
       <vc:text-input asp-for="TaskAttempted"
                      label="What task did you come to do today?"
-                     populate-with-current-value="false"
+                     populate-with-current-value="true"
                      type="text"
                      spell-check="false"
                      hint-text=""
@@ -51,7 +51,7 @@
 
       <vc:text-area asp-for="FeedbackText"
                     label="Please describe in detail your experience and what you came here to achieve."
-                    populate-with-current-value="false"
+                    populate-with-current-value="true"
                     rows="5"
                     type="text"
                     spell-check="false"


### PR DESCRIPTION
### JIRA link
[TD-1116](https://hee-tis.atlassian.net/browse/TD-1116)

### Description
Updated caching and multipageformdata handling to allow for user browser back button.
The code now retains user values when the back button is clicked.
Once the feedback is submitted, the page no longer available message is shown as standard.

### Screenshots
Screenshots below.
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![Screenshot 2023-07-03 181252](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/b247d612-8997-421d-b4bc-524dce7545ce)


[TD-1116]: https://hee-tis.atlassian.net/browse/TD-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ