### PR TITLE
TD-1960 Trimmed whitespaces from usernames before insert or update in Users Table

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
@@ -8,7 +8,9 @@
     using Dapper;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.Centres;
     using DigitalLearningSolutions.Data.Models.Register;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Data.Utilities;
@@ -973,18 +975,18 @@
         }
 
         [Test]
-        public void RegisterUserAccount_inserts_user_account_into_database()
+        [TestCase("   TestFirstName  ", "   TestLastName   ", "r@g.com")]
+        public void RegisterUserAccount_inserts_user_account_into_database(string firstName, string lastName, string primaryEmail)
         {
             using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
+            connection.EnsureOpen();
+            using var transaction = connection.BeginTransaction();
             // Given
-            const string firstName = "   TestFirstName  ";
-            const string lastName = "   TestLastName   ";
             var delegateRegistrationModel =
                 RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel(
                    firstName: firstName,
                    lastName: lastName,
-                   primaryEmail: "r@g.com"
+                   primaryEmail: primaryEmail
                 );
 
             var currentTime = DateTime.Now;
@@ -995,7 +997,7 @@
                 delegateRegistrationModel,
                 currentTime,
                 registerJourneyContainsTermsAndConditions,
-                null
+                transaction
             );
 
             // Then

--- a/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/RegistrationDataServiceTests.cs
@@ -971,5 +971,40 @@
                 user.UserCentreDetails.EmailVerified.Should().BeNull();
             }
         }
+
+        [Test]
+        public void RegisterUserAccount_inserts_user_account_into_database()
+        {
+            using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            // Given
+            const string firstName = "   TestFirstName  ";
+            const string lastName = "   TestLastName   ";
+            var delegateRegistrationModel =
+                RegistrationModelTestHelper.GetDefaultDelegateRegistrationModel(
+                   firstName: firstName,
+                   lastName: lastName,
+                   primaryEmail: "r@g.com"
+                );
+
+            var currentTime = DateTime.Now;
+            bool registerJourneyContainsTermsAndConditions = true;
+
+            // When
+            var insertedUserId = service.RegisterUserAccount(
+                delegateRegistrationModel,
+                currentTime,
+                registerJourneyContainsTermsAndConditions,
+                null
+            );
+
+            // Then
+            var userdetails = userDataService.GetUserAccountById(insertedUserId)!;
+            using (new AssertionScope())
+            {
+                userdetails.FirstName.Should().Be("TestFirstName");
+                userdetails.LastName.Should().Be("TestLastName");
+            }
+        }
     }
 }

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
@@ -187,8 +187,8 @@
             try
             {
                 // Given
-                const string firstName = "TestFirstName";
-                const string lastName = "TestLastName";
+                const string firstName = "   TestFirstName  ";
+                const string lastName = "   TestLastName   ";
                 const string email = "update.test@email.com";
                 const string professionalRegNumber = "test-1234";
                 const int jobGroupId = 1;
@@ -207,17 +207,17 @@
                     61188,
                     true
                 );
-                var updatedUser = userDataService.GetDelegateUserById(2)!;
+                var updatedUser = userDataService.GetDelegateById(2)!;
 
                 // Then
                 using (new AssertionScope())
                 {
-                    updatedUser.FirstName.Should().BeEquivalentTo(firstName);
-                    updatedUser.LastName.Should().BeEquivalentTo(lastName);
-                    updatedUser.EmailAddress.Should().BeEquivalentTo(email);
-                    updatedUser.ProfessionalRegistrationNumber.Should().BeEquivalentTo(professionalRegNumber);
-                    updatedUser.HasBeenPromptedForPrn.Should().BeTrue();
-                    updatedUser.JobGroupId.Should().Be(jobGroupId);
+                    updatedUser.UserAccount.FirstName.Should().Be("TestFirstName");
+                    updatedUser.UserAccount.LastName.Should().Be("TestLastName");
+                    updatedUser.UserAccount.PrimaryEmail.Should().BeEquivalentTo(email);
+                    updatedUser.UserAccount.ProfessionalRegistrationNumber.Should().BeEquivalentTo(professionalRegNumber);
+                    updatedUser.UserAccount.HasBeenPromptedForPrn.Should().BeTrue();
+                    updatedUser.UserAccount.JobGroupId.Should().Be(jobGroupId);
                 }
             }
             finally
@@ -367,22 +367,22 @@
             try
             {
                 // Given
-                const string firstName = "TestFirstName";
-                const string lastName = "TestLastName";
+                const string firstName = "   TestFirstName  ";
+                const string lastName = "   TestLastName  ";
                 const string email = "update.test@email.com";
                 const int jobGroupId = 1;
 
                 // When
                 userDataService.UpdateUserDetails(firstName, lastName, email, jobGroupId, 61188);
-                var updatedUser = userDataService.GetDelegateUserById(2)!;
+                var updatedUser = userDataService.GetDelegateById(2)!;
 
                 // Then
                 using (new AssertionScope())
                 {
-                    updatedUser.FirstName.Should().BeEquivalentTo(firstName);
-                    updatedUser.LastName.Should().BeEquivalentTo(lastName);
-                    updatedUser.EmailAddress.Should().BeEquivalentTo(email);
-                    updatedUser.JobGroupId.Should().Be(jobGroupId);
+                    updatedUser.UserAccount.FirstName.Should().Be("TestFirstName");
+                    updatedUser.UserAccount.LastName.Should().Be("TestLastName");
+                    updatedUser.UserAccount.PrimaryEmail.Should().BeEquivalentTo(email);
+                    updatedUser.UserAccount.JobGroupId.Should().Be(jobGroupId);
                 }
             }
             finally

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/DelegateUserDataServiceTests.cs
@@ -181,18 +181,12 @@
         }
 
         [Test]
-        public void UpdateUser_updates_user()
+        [TestCase("   TestFirstName  ", "   TestLastName   ", "update.test@email.com", "test-1234",1)]
+        public void UpdateUser_updates_user(string firstName, string lastName, string email, string professionalRegNumber, int jobGroupId)
         {
             using var transaction = new TransactionScope();
             try
             {
-                // Given
-                const string firstName = "   TestFirstName  ";
-                const string lastName = "   TestLastName   ";
-                const string email = "update.test@email.com";
-                const string professionalRegNumber = "test-1234";
-                const int jobGroupId = 1;
-
                 // When
                 userDataService.UpdateUser(
                     firstName,
@@ -361,17 +355,12 @@
         }
 
         [Test]
-        public void UpdateUserDetails_updates_user()
+        [TestCase("   TestFirstName  ", "   TestLastName  ", "update.test@email.com",1)]
+        public void UpdateUserDetails_updates_user(string firstName, string lastName, string email, int jobGroupId)
         {
             using var transaction = new TransactionScope();
             try
             {
-                // Given
-                const string firstName = "   TestFirstName  ";
-                const string lastName = "   TestLastName  ";
-                const string email = "update.test@email.com";
-                const int jobGroupId = 1;
-
                 // When
                 userDataService.UpdateUserDetails(firstName, lastName, email, jobGroupId, 61188);
                 var updatedUser = userDataService.GetDelegateById(2)!;

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserDataServiceTests.cs
@@ -318,17 +318,12 @@
         }
 
         [Test]
-        public void UpdateUserDetailsAccount_update_username_trimmed()
+        [TestCase("   TestFirstName  ", "   TestLastName   ", "update.test@email.com",1, "PRN123",61188)]
+        public void UpdateUserDetailsAccount_update_username_trimmed(string firstName, string lastName, string email, int jobGroupId, string prnNumber, int userId)
         {
             using var transaction = new TransactionScope();
             //Given
-            const string firstName = "   TestFirstName  ";
-            const string lastName = "   TestLastName   ";
-            const string email = "update.test@email.com";
-            const int jobGroupId = 1;
-            const string prnNumber = "PRN123";
             var emailVerified = DateTime.Now;
-            const int userId = 61188;
 
             // When
             this.userDataService.UpdateUserDetailsAccount(
@@ -339,7 +334,7 @@
             prnNumber,
             emailVerified,
             userId
-        );
+            );
             var updatedUser = userDataService.GetUserAccountById(userId)!;
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/UserDataServiceTests.cs
@@ -7,6 +7,7 @@
     using DigitalLearningSolutions.Data.Mappers;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using FluentAssertions;
+    using FluentAssertions.Execution;
     using Microsoft.Data.SqlClient;
     using NUnit.Framework;
 
@@ -314,6 +315,38 @@
             active.Should().BeTrue();
 
             userDataService.DeleteUser(userId);
+        }
+
+        [Test]
+        public void UpdateUserDetailsAccount_update_username_trimmed()
+        {
+            using var transaction = new TransactionScope();
+            //Given
+            const string firstName = "   TestFirstName  ";
+            const string lastName = "   TestLastName   ";
+            const string email = "update.test@email.com";
+            const int jobGroupId = 1;
+            const string prnNumber = "PRN123";
+            var emailVerified = DateTime.Now;
+            const int userId = 61188;
+
+            // When
+            this.userDataService.UpdateUserDetailsAccount(
+            firstName,
+            lastName,
+            email,
+            jobGroupId,
+            prnNumber,
+            emailVerified,
+            userId
+        );
+            var updatedUser = userDataService.GetUserAccountById(userId)!;
+            // Then
+            using (new AssertionScope())
+            {
+                updatedUser.FirstName.Should().Be("TestFirstName");
+                updatedUser.LastName.Should().Be("TestLastName");
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -256,10 +256,12 @@
             IDbTransaction transaction
         )
         {
+            string trimmedFirstName = delegateRegistrationModel.FirstName.Trim();
+            string trimmedLastName = delegateRegistrationModel.LastName.Trim();
             var userValues = new
             {
-                delegateRegistrationModel.FirstName,
-                delegateRegistrationModel.LastName,
+                FirstName = trimmedFirstName,
+                LastName = trimmedLastName,
                 delegateRegistrationModel.PrimaryEmail,
                 delegateRegistrationModel.JobGroup,
                 delegateRegistrationModel.UserIsActive,

--- a/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/RegistrationDataService.cs
@@ -249,7 +249,7 @@
             return adminUserId;
         }
 
-        private int RegisterUserAccount(
+        public int RegisterUserAccount(
             DelegateRegistrationModel delegateRegistrationModel,
             DateTime currentTime,
             bool registerJourneyContainsTermsAndConditions,

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -266,11 +266,13 @@
             bool changeMadeBySameUser = false
         )
         {
+            string trimmedFirstName = firstName.Trim();
+            string trimmedLastName = surname.Trim();
             connection.Execute(
                 @"UPDATE Users
                         SET
-                            FirstName = @firstName,
-                            LastName = @surname,
+                            FirstName = @trimmedFirstName,
+                            LastName = @trimmedLastName,
                             PrimaryEmail = @primaryEmail,
                             ProfileImage = (CASE WHEN @changeMadeBySameUser = 1 THEN @profileImage ELSE ProfileImage END),
                             ProfessionalRegistrationNumber = @professionalRegNumber,
@@ -281,8 +283,8 @@
                         WHERE ID = @userId",
                 new
                 {
-                    firstName,
-                    surname,
+                    trimmedFirstName,
+                    trimmedLastName,
                     primaryEmail,
                     profileImage,
                     userId,
@@ -299,15 +301,17 @@
 
         public void UpdateUserDetails(string firstName, string surname, string primaryEmail, int jobGroupId, int userId)
         {
+            string trimmedFirstName = firstName.Trim();
+            string trimmedLastName = surname.Trim();
             connection.Execute(
                 @"UPDATE Users
                         SET
-                            FirstName = @firstName,
-                            LastName = @surname,
+                            FirstName = @trimmedFirstName,
+                            LastName = @trimmedLastName,
                             PrimaryEmail = @primaryEmail,
                             JobGroupId = @jobGroupId
                         WHERE ID = @userId",
-                new { firstName, surname, primaryEmail, jobGroupId, userId }
+                new { trimmedFirstName, trimmedLastName, primaryEmail, jobGroupId, userId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -560,17 +560,19 @@
 
         public void UpdateUserDetailsAccount(string firstName, string lastName, string primaryEmail, int jobGroupId, string? prnNumber, DateTime? emailVerified, int userId)
         {
+            string trimmedFirstName = firstName.Trim();
+            string trimmedLastName = lastName.Trim();
             connection.Execute(
                 @"UPDATE Users
                   SET
-                  FirstName = @firstName,
-                  LastName = @lastName,
+                  FirstName = @trimmedFirstName,
+                  LastName = @trimmedLastName,
                   PrimaryEmail = @primaryEmail,
                   JobGroupId = @jobGroupId,
                   ProfessionalRegistrationNumber = @prnNumber,
                   EmailVerified = @emailVerified
                 WHERE ID = @userId",
-                new { firstName, lastName, primaryEmail, jobGroupId, prnNumber, emailVerified, userId }
+                new { trimmedFirstName, trimmedLastName, primaryEmail, jobGroupId, prnNumber, emailVerified, userId }
             );
         }
     }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1960

### Description
Points addressed in this commit - 
1. Remove whitespace before insert during external registration
2. Remove whitespace before insert during internal registration
3. Remove whitespace before update from Tracking system --> Delegates
4. Remove whitespace before update from Super Admin --> Delegates
5. Bulk Upload users

### Screenshots
Since this is a backend database change, no screenshot is required

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
