### PR TITLE
TD-2121 updates report query to use new activity log table

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/PlatformReportsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PlatformReportsDataService.cs
@@ -36,20 +36,18 @@
                  (SELECT COUNT(ProgressID) AS CourseCompletions
                  FROM    Progress AS P WITH (NOLOCK)
                  WHERE (Completed IS NOT NULL)) AS CourseCompletions,
+                 (SELECT COUNT(ID) AS Expr1
+                 FROM    ReportSelfAssessmentActivityLog WITH (NOLOCK)
+                 WHERE (SelfAssessmentID = 1) AND (Enrolled=1)) AS DCSAEnrolments,
+                 (SELECT COUNT(ID) AS Expr1
+                 FROM    ReportSelfAssessmentActivityLog WITH (NOLOCK)
+                 WHERE (SelfAssessmentID = 1) AND (Submitted = 1)) AS DCSACompletions,
                  (SELECT COUNT(*) AS Expr1
-                 FROM    CandidateAssessments WITH (NOLOCK)
-                 WHERE (SelfAssessmentID = 1)) AS DCSAEnrolments,
+                 FROM    ReportSelfAssessmentActivityLog WITH (NOLOCK)
+                 WHERE (SelfAssessmentID > 1) AND (Enrolled=1)) AS NursingPassportEnrolments,
                  (SELECT COUNT(*) AS Expr1
-                 FROM    CandidateAssessments AS CandidateAssessments_2 WITH (NOLOCK)
-                 WHERE (SelfAssessmentID = 1) AND (SubmittedDate IS NOT NULL)) AS DCSACompletions,
-                 (SELECT COUNT(*) AS Expr1
-                 FROM    CandidateAssessments AS CandidateAssessments_1 WITH (NOLOCK)
-                 WHERE (SelfAssessmentID > 1)) AS NursingPassportEnrolments,
-                 (SELECT COUNT(*) AS Expr1
-                 FROM    CandidateAssessments AS ca WITH (NOLOCK) INNER JOIN
-                              CandidateAssessmentSupervisors AS cas WITH (NOLOCK) ON ca.ID = cas.CandidateAssessmentID INNER JOIN
-                              CandidateAssessmentSupervisorVerifications AS casv WITH (NOLOCK) ON cas.ID = casv.CandidateAssessmentSupervisorID AND casv.SignedOff = 1
-                 WHERE (ca.SelfAssessmentID > 1)) AS NursingPassportCompletions"
+                 FROM    ReportSelfAssessmentActivityLog
+                 WHERE (SelfAssessmentID > 1) AND (SignedOff = 1)) AS NursingPassportCompletions"
             );
         }
     }


### PR DESCRIPTION
### JIRA link
[TD-2121](https://hee-tis.atlassian.net/browse/TD-2121)

### Description
Updates the queries added in TD-935 to reference the new self assessment activity log table for quicker retrieval.

### Screenshots
Old query results vs new query results:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/ebf2d287-ef7c-4b37-9265-e53813580c4a)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2121]: https://hee-tis.atlassian.net/browse/TD-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ