### PR TITLE
Reverted back changes of TD-1920

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -1,15 +1,14 @@
 ﻿namespace DigitalLearningSolutions.Data.DataServices
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.RoleProfiles;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Data.Models.Supervisor;
-    using DigitalLearningSolutions.Data.Models.User;
     using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Linq;
 
     public interface ISupervisorService
     {
@@ -51,7 +50,7 @@
         bool InsertSelfAssessmentResultSupervisorVerification(int candidateAssessmentSupervisorId, int resultId);
         //DELETE DATA
         bool RemoveCandidateAssessmentSupervisor(int selfAssessmentId, int supervisorDelegateId);
-        int IsSupervisorDelegateExistAndReturnId(int? supervisorAdminId,string delegateEmail,int centreId);
+        int IsSupervisorDelegateExistAndReturnId(int? supervisorAdminId, string delegateEmail, int centreId);
         SupervisorDelegate GetSupervisorDelegateById(int supervisorDelegateId);
     }
     public class SupervisorService : ISupervisorService
@@ -241,18 +240,15 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                     SELECT COALESCE
                     ((SELECT Top 1 ID
                         FROM  SupervisorDelegates sd
-                              LEFT OUTER JOIN AdminUsers as au ON sd.SupervisorAdminID = au.AdminID
-                        WHERE ((sd.SupervisorAdminID = @supervisorAdminID) OR (sd.SupervisorAdminID > 0 AND SupervisorEmail = @supervisorEmail))
-		                      AND((sd.DelegateUserID = @delegateUserId) OR (sd.DelegateUserID > 0 AND DelegateEmail = @delegateEmail))
-                              AND (au.CentreId = @centreId)  ORDER BY sd.DelegateUserID Desc
+                        WHERE ((sd.SupervisorAdminID = @supervisorAdminID) OR (sd.SupervisorAdminID > 0 AND SupervisorEmail = @supervisorEmail AND @supervisorAdminID = NULL))
+		                      AND((sd.DelegateUserID = @delegateUserId) OR (sd.DelegateUserID > 0 AND DelegateEmail = @delegateEmail AND @delegateUserId = NULL)) ORDER BY sd.DelegateUserID 
                         ), 0) AS ID",
                 new
                 {
                     supervisorEmail,
                     delegateEmail,
                     supervisorAdminId = supervisorAdminId ?? 0,
-                    delegateUserId = delegateUserId ?? 0,
-                    centreId
+                    delegateUserId = delegateUserId ?? 0
                 }
             );
 
@@ -288,13 +284,11 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 existingId = (int)connection.ExecuteScalar(
                     @"
                     SELECT COALESCE
-                    ((SELECT Top 1 ID
+                    ((SELECT ID
                         FROM    SupervisorDelegates sd
-                            LEFT OUTER JOIN AdminUsers as au ON sd.SupervisorAdminID = au.AdminID
                         WHERE(SupervisorEmail = @supervisorEmail) AND(DelegateEmail = @delegateEmail)
                             AND(sd.SupervisorAdminID = @supervisorAdminID OR @supervisorAdminID = 0)
                             AND(sd.DelegateUserID = @delegateUserId OR @delegateUserID = 0)
-                            AND (au.CentreId = @centreId)
                             AND (sd.Removed IS NULL)
                         ), 0) AS ID",
                     new
@@ -302,8 +296,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                         supervisorEmail,
                         delegateEmail,
                         supervisorAdminId = supervisorAdminId ?? 0,
-                        delegateUserId = delegateUserId ?? 0,
-                        centreId
+                        delegateUserId = delegateUserId ?? 0
                     }
                 ); return existingId;
             }
@@ -708,7 +701,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                ).FirstOrDefault();
         }
 
-        public int EnrolDelegateOnAssessment(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int? selfAssessmentSupervisorRoleId, int adminId, int centreId,bool isLoggedInUser)
+        public int EnrolDelegateOnAssessment(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int? selfAssessmentSupervisorRoleId, int adminId, int centreId, bool isLoggedInUser)
         {
             if (delegateUserId == 0 | supervisorDelegateId == 0 | selfAssessmentId == 0)
             {
@@ -1076,82 +1069,32 @@ WHERE (cas.CandidateAssessmentID = @candidateAssessmentId) AND (cas.SupervisorDe
 
         public int IsSupervisorDelegateExistAndReturnId(int? supervisorAdminId, string delegateEmail, int centreId)
         {
-            int? delegateUserId = null;
-
-            var user = connection.Query<UserAccount>(
-                @$"SELECT u.ID, u.PrimaryEmail, u.FirstName, u.LastName,  u.Active
+            int? delegateUserId = (int?)connection.ExecuteScalar(
+                 @"SELECT da.UserID AS DelegateUserID 
                             FROM Users u
-                            LEFT JOIN UserCentreDetails ucd
+                            INNER JOIN DelegateAccounts da
+                            ON da.UserID = u.ID
+	                        LEFT JOIN UserCentreDetails ucd
 	                        ON ucd.UserID = u.ID
-                            WHERE (u.PrimaryEmail = @delegateEmail OR ucd.Email = @delegateEmail)
-                            AND u.Active = 1", new { delegateEmail }).FirstOrDefault();
-            if (user != null)
-            {
-                delegateUserId = (int?)connection.ExecuteScalar(
-                     @"SELECT Top 1 da.UserID AS DelegateUserID 
-                            FROM DelegateAccounts da
-                            LEFT JOIN UserCentreDetails ucd
-	                        ON ucd.UserID = da.UserID
-                            WHERE (da.UserID = @Id OR ucd.Email = @delegateEmail) AND da.CentreID = @centreId",
-                     new { user?.Id, delegateEmail, centreId });
+                            AND ucd.CentreID = da.CentreID
+                            WHERE (ucd.Email = @delegateEmail OR u.PrimaryEmail = @delegateEmail)
+                            AND u.Active = 1 
+                            AND da.CentreID = @centreId", new { delegateEmail, centreId });
 
-                if (delegateUserId == null)
-                {
-                    var candidateNumber = commonService.GenerateCandidateNumber(user.FirstName, user.LastName);
-
-                    delegateUserId = connection.QuerySingle<int>(
-                        @"INSERT INTO DelegateAccounts
-                        (
-                            UserID,
-                            CentreID,
-                            DateRegistered,
-                            CandidateNumber,
-                            Approved,
-                            Active,
-                            ExternalReg,
-                            SelfReg,
-                            CentreSpecificDetailsLastChecked
-                        )
-                        OUTPUT Inserted.UserID
-                        VALUES
-                        (
-                            @Id,
-                            @centreId,
-                            GETDATE(),
-                            @candidateNumber,
-                            1,
-                            1,
-                            0,
-                            0,
-                            GETDATE()
-                        )", new { user.Id, centreId, candidateNumber }
-
-                    );
-
-
-                }
-            }
-
-            int? existingId = (int)connection.ExecuteScalar(
-                    @"
-                    SELECT COALESCE
-                    ((SELECT Top 1 ID
+            int? existingId = (int?)connection.ExecuteScalar(
+                @"
+                    SELECT ID
                         FROM    SupervisorDelegates sd
-                            LEFT OUTER JOIN AdminUsers as au ON sd.SupervisorAdminID = au.AdminID
-                        WHERE (DelegateEmail = @delegateEmail)
-                            AND(sd.SupervisorAdminID = @supervisorAdminID OR @supervisorAdminID = 0)
-                            AND (au.CentreId = @centreId)
-                            AND (sd.Removed IS null)
-                        ), 0) AS ID",
-                    new
-                    {
-                        delegateEmail,
-                        supervisorAdminId = supervisorAdminId ?? 0,
-                        centreId
-                    }
-                );
+                        WHERE (sd.SupervisorAdminID = @supervisorAdminID OR @supervisorAdminID = 0) AND (sd.DelegateUserID = @delegateUserId OR @delegateUserID = 0)
+                        ",
+                new
+                {
+                    supervisorAdminId = supervisorAdminId ?? 0,
+                    delegateUserId = delegateUserId ?? 0,
+                }
+            );
 
-            return existingId ??  0;
+            return existingId ?? 0;
         }
 
         public SupervisorDelegate GetSupervisorDelegateById(int supervisorDelegateId)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2192

### Description
Reverted back the breaking changes of 1920. This was causing Td-1917 to fail after "Ready for release"

### Screenshots
These are backend changes so no screenshots available

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
