### PR TITLE
TD-2000: Remove button will be displayed if Centre email is available.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_SearchableDelegatesCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_SearchableDelegatesCard.cshtml
@@ -129,7 +129,10 @@
                         </span>
                     </dd>
                     <dd class="nhsuk-summary-list__actions">
-                        <a asp-controller="" asp-action="" asp-route-UserId="" class="nhsuk-u-margin-left-2">Remove</a>
+                      @if(Model.CentreEmail!=null)
+                        {
+                            <a asp-controller="" asp-action="" asp-route-UserId="" class="nhsuk-u-margin-left-2">Remove</a>
+                        }
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_SearchableDelegatesCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_SearchableDelegatesCard.cshtml
@@ -121,7 +121,7 @@
                         Centre Email
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                        <span class="nhsuk-u-margin-right-4">
+                        <span class="nhsuk-u-margin-right-1">
                             @Model.CentreEmail
                         </span>
                         <span class="nhsuk-u-margin-right-4">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2000

### Description
Remove button will be displayed if Centre email is available.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/c6df0ca9-4ac1-4480-a7f4-011b20e2239a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/8a6fab27-0a28-44d0-85b5-1db6253ed0fd)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
