### PR TITLE
TD-2157: Issue with Unapproved status resolved. Verified tag will be displayed if email is present.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -592,6 +592,7 @@
                 ce.Active AS CentreActive,
                 da.DateRegistered,
                 da.CandidateNumber,
+                da.Approved,
                 da.SelfReg,
                 da.UserID,
                 u.ID,
@@ -625,7 +626,7 @@
 	                                    OR (@accountStatus = 'Claimed' AND  da.RegistrationConfirmationHash is  null) OR (@accountStatus = 'Unclaimed' AND da.RegistrationConfirmationHash is not null))
                                     AND ((@lhlinkStatus = 'Any') OR (@lhlinkStatus = 'Linked' AND u.LearningHubAuthID IS NOT NULL) OR (@lhlinkStatus = 'Not linked' AND u.LearningHubAuthID IS NULL))";
 
-            string sql = @$"{BaseSelectQuery}{condition} ORDER BY LTRIM(u.LastName), LTRIM(u.FirstName)
+            string sql = @$"{BaseDelegateEntitySelectQuery}{condition} ORDER BY LTRIM(u.LastName), LTRIM(u.FirstName)
                             OFFSET @offset ROWS
                             FETCH NEXT @rows ROWS ONLY";
             IEnumerable<DelegateEntity> delegateEntity =

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -626,7 +626,7 @@
 	                                    OR (@accountStatus = 'Claimed' AND  da.RegistrationConfirmationHash is  null) OR (@accountStatus = 'Unclaimed' AND da.RegistrationConfirmationHash is not null))
                                     AND ((@lhlinkStatus = 'Any') OR (@lhlinkStatus = 'Linked' AND u.LearningHubAuthID IS NOT NULL) OR (@lhlinkStatus = 'Not linked' AND u.LearningHubAuthID IS NULL))";
 
-            string sql = @$"{BaseDelegateEntitySelectQuery}{condition} ORDER BY LTRIM(u.LastName), LTRIM(u.FirstName)
+            string sql = @$"{BaseSelectQuery}{condition} ORDER BY LTRIM(u.LastName), LTRIM(u.FirstName)
                             OFFSET @offset ROWS
                             FETCH NEXT @rows ROWS ONLY";
             IEnumerable<DelegateEntity> delegateEntity =

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_SearchableDelegatesCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_SearchableDelegatesCard.cshtml
@@ -122,10 +122,13 @@
                     </dt>
                     <dd class="nhsuk-summary-list__value">
                         <span class="nhsuk-u-margin-right-1">
-                            @Model.CentreEmail
+                            @(Model.CentreEmail != null ? Model.CentreEmail : "-")
                         </span>
                         <span class="nhsuk-u-margin-right-4">
+                        @if(Model.CentreEmail!=null)
+                        {
                             <partial name="_DelegateStatusTag" model="@Model.IsCentreEmailVerified ? (int)DelegateAccountCard.Verified : (int)DelegateAccountCard.Unverified" />
+                        }
                         </span>
                     </dd>
                     <dd class="nhsuk-summary-list__actions">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2157

### Description
1. Issue with Unapproved status resolved
2. Verified tag will be displayed if email is present.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/0228d724-e5f3-460b-9857-5168bfaedb03)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/16812341-1d20-46b1-b696-0e5fd0f33111)


Email status when value present
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/e0478737-4b34-48f7-974b-85af96aa55e5)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/3572e4f9-bfda-4bf6-984b-6e2a71a6c344)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
