### PR TITLE
TD-2000: Super admin -Unused data fetch from table removed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Delegates/DelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Delegates/DelegatesController.cs
@@ -56,11 +56,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
           string? SearchString = "",
           string? ExistingFilterString = "")
         {
-            var loggedInSuperAdmin = userDataService.GetDelegateById(User.GetAdminId()!.Value);
-            if (loggedInSuperAdmin.DelegateAccount.Active == false)
-            {
-                return NotFound();
-            }
 
             if (string.IsNullOrEmpty(SearchString) || string.IsNullOrEmpty(ExistingFilterString))
             {
@@ -145,8 +140,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
             }
             TempData["Page"] = result.Page;
             var model = new DelegatesViewModel(
-                result,
-                loggedInSuperAdmin!.DelegateAccount
+                result
             );
 
             ViewBag.LHLinkStatus = SelectListHelper.MapOptionsToSelectListItems(

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Delegates/DelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Delegates/DelegatesViewModel.cs
@@ -10,8 +10,7 @@
     public class DelegatesViewModel : BaseSearchablePageViewModel<DelegateEntity>
     {
         public DelegatesViewModel(
-            SearchSortFilterPaginationResult<DelegateEntity> result,
-            DelegateAccount loggedInSuperAdminAccount
+            SearchSortFilterPaginationResult<DelegateEntity> result
         ) : base(
             result,
             true,
@@ -22,7 +21,6 @@
             Delegates = result.ItemsToDisplay.Select(
                 delegates => new SearchableDelegatesViewModel(
                     delegates,
-                    loggedInSuperAdminAccount,
                     result.GetReturnPageQuery($"{delegates.DelegateAccount.Id}-card")
                 )
             );

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Delegates/SearchableDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Delegates/SearchableDelegatesViewModel.cs
@@ -12,7 +12,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Delegates
         public readonly bool CanShowInactivateDelegateButton;
         public SearchableDelegatesViewModel(
            DelegateEntity delegates,
-           DelegateAccount delegateAccount,
            ReturnPageQuery returnPageQuery
        )
         {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2000

### Description
Super admin -Unused data fetch from table removed

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/d4bbf74c-d9a9-4d17-8604-c919bee9e16a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/3e863090-a033-4f33-a4a4-ca47fea6b82f)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
