### PR TITLE
TD-952 Addressed back link in mobile view,breadcrumb and mobile view …

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/superAdmin/centres.scss
+++ b/DigitalLearningSolutions.Web/Styles/superAdmin/centres.scss
@@ -31,3 +31,18 @@ button.nhsuk-pagination__link {
 #maincontentwrapper {
   display: block;
 }
+.nhsuk-table__row {
+  td.nhsuk-table__cell {
+    &.choose-centre-td {
+      .nhsuk-table-responsive__heading {
+        min-width: 4.25em;
+      }
+
+      @include govuk-media-query($until: desktop) {
+        border-bottom: none;
+        justify-content: left;
+        text-align: left;
+      }
+    }
+  }
+}

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/Courses.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/Courses.cshtml
@@ -4,11 +4,16 @@
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
         <div class="nhsuk-width-container">
             <ol class="nhsuk-breadcrumb__list">
-                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Centres" asp-action="Index">Admin</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Centres" asp-action="Index">Centres</a></li>
             </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__backlink"
+               asp-controller="Centres" asp-action="Index">Back to Centres</a>
+            </p>
         </div>
     </nav>
 }
+<link rel="stylesheet" href="@Url.Content("~/css/superAdmin/centres.css")" asp-append-version="true">
 <h1 class="nhsuk-heading-xl nhsuk-u-font-weight-normal nhsuk-fieldset__heading nhsuk-label--l">Courses - @ViewBag.CentreName</h1>
 @foreach (var course in Model)
 {

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/_CourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/_CourseCard.cshtml
@@ -9,26 +9,36 @@
         </summary>
 
         <div class="nhsuk-details__text">
-            <dl class="nhsuk-summary-list">
-                <div class="nhsuk-summary-list__row">
-                    <dt class="nhsuk-summary-list__value">
-                        <h3>Customisation name (ID)</h3>
-                    </dt>
-                    <dd class="nhsuk-summary-list__value">
-                        <h3>Total delegates</h3>
-                    </dd>
-                </div>
-                @foreach (var customisation in Model.CentreCourseCustomisations)
-                {
-                    <div class="nhsuk-summary-list__row">
-                        <dt class="nhsuk-summary-list__key nhsuk-u-font-weight-normal">
-                            @customisation.CustomisationName (@customisation.CustomisationID)
-                        </dt>
-                        <dd class="nhsuk-summary-list__value nhsuk-u-font-weight-normal">
-                            @customisation.DelegateCount
-                        </dd>
-                    </div>
-                }
+            <table role="table" class="nhsuk-table-responsive">
+                <thead role="rowgroup" class="nhsuk-table__head">
+                    <tr role="row">
+                        <th role="columnheader" scope="col">
+                            <b>Customisation name (ID)</b>
+                        </th>
+                        <th role="columnheader" scope="col">
+                            <b>Total delegates</b>
+                        </th>
+                    </tr>
+                </thead>
+
+                <tbody class="nhsuk-table__body">
+                    @foreach (var customisation in Model.CentreCourseCustomisations)
+                    {
+                        <tr role="row" class="nhsuk-table__row">
+                            <td role="cell" class="nhsuk-table__cell choose-centre-td">
+                                <span class="nhsuk-table-responsive__heading"><b>Customisation name (ID): </b></span>
+                                <span class="word-break">@customisation.CustomisationName (@customisation.CustomisationID)</span>
+                            </td>
+                            <td role="cell" class="nhsuk-table__cell choose-centre-td">
+                                <span class="nhsuk-table-responsive__heading">
+                                    <b>Total delegates: </b>
+                                </span>
+                                <span class="word-break">@customisation.DelegateCount</span>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
         </div>
     </details>
 </div>


### PR DESCRIPTION
…issues as per comment added in ticket

### JIRA link
https://hee-tis.atlassian.net/browse/TD-952

### Description
Points addressed in this Commit :
1) Changed the layout in mobile view.
2) Changed label of link from "Admin" to "Centres" in breadcrumb.
3) Added back link in mobile view.

### Screenshots
![Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/e6929934-5648-4859-93fa-3ae955d6dca3)
![Digital-Learning-Solutions-Mobile](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/78ba3939-7f71-4a6b-8ebd-c4dd91ebcb0d)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/d0cbb93b-473d-43f8-9cee-bc84b80742f4)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
