### PR TITLE
TD-1760: Issue in "Add myself to try self-assessment" functionality is resolved

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -91,6 +91,7 @@
                 centreRegistrationPrompts
             );
             model.IsActiveSupervisorDelegateExist = IsSupervisorDelegateExistAndActive(adminId, supervisorEmail, centreId) > 0;
+            model.SelfSuperviseDelegateDetailViewModels= supervisorDelegateDetailViewModels.Where(x => x.SupervisorDelegateDetail.DelegateUserID == loggedInUserId).FirstOrDefault();
             ModelState.ClearErrorsForAllFieldsExcept("DelegateEmailAddress");
             return View("MyStaffList", model);
         }

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/MyStaffListViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/MyStaffListViewModel.cs
@@ -24,7 +24,6 @@
             AdminUser = adminUser;
             CentreRegistrationPrompts = centreRegistrationPrompts;
             SuperviseDelegateDetailViewModels = result.ItemsToDisplay.Where(x=>x.SupervisorDelegateDetail.DelegateUserID != x.LoggedInUserId);
-            SelfSuperviseDelegateDetailViewModels = result.ItemsToDisplay.Where(x => x.SupervisorDelegateDetail.DelegateUserID == x.LoggedInUserId).FirstOrDefault();
         }
 
         public MyStaffListViewModel() : this(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1760

### Description
When  "Add myself to try self-assessment" is clicked,  user is not getting listed in the page.  We are losing the self assessment delegate value after the pagination filter is applied when its position is after 10 . 

### Screenshots
Before code change:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/c6cd0459-cf2d-4480-a60a-85338dc02682)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/ff0c14a1-7f98-49e3-a9a7-f6be76afd54b)

**After code change:**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/4c1e119e-3869-4a02-8e50-a34f1466c362)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/6c84251c-195e-4ccc-92bc-f7bd5c18643e)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
