### PR TITLE
TD-2116 Changes build action for nursing proficiency reports page

### DIFF
--- a/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
+++ b/DigitalLearningSolutions.Web/DigitalLearningSolutions.Web.csproj
@@ -16,7 +16,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Remove="Views\SuperAdmin\PlatformReports\NursingProficiencies.cshtml" />
         <Content Remove="wwwroot\README.txt" />
     </ItemGroup>
 
@@ -83,7 +82,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="Views\SuperAdmin\PlatformReports\NursingProficiencies.cshtml" />
         <None Include="wwwroot\favicon.ico" />
         <None Include="wwwroot\images\itSkillsPathwayLogo.png" />
         <None Include="wwwroot\images\nhsDigitalLogo.png" />


### PR DESCRIPTION
### JIRA link
TD-2116

### Description
For some reason the Build Action for the nursing proficiency reports view was set to 'None'. This fix set's the Build Action to 'Content' to fix problems with the view being unavailable when deployed.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/d53e99dd-c40c-4838-82f5-b8a14cce96c5)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
