### PR TITLE
TD-2177-two delegate records at the same centre -primary email check at UserCentreDetails table added

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -459,9 +459,10 @@
         {
             return connection.QueryFirst<int>(
                 @$"SELECT COUNT(*)
-                    FROM Users
-                    WHERE PrimaryEmail = @email
-                    {(userId == null ? "" : "AND Id <> @userId")}",
+                    FROM Users AS u
+                         LEFT OUTER JOIN UserCentreDetails AS ucd ON u.ID = ucd.UserID
+                    WHERE (u.PrimaryEmail = @email OR ucd.Email = @email)  
+                    {(userId == null ? "" : "AND u.Id <> @userId")}",
                 new { email, userId }
             ) > 0;
         }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterController.cs
@@ -425,14 +425,6 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
                 CommonValidationErrorMessages.EmailInUseDuringDelegateRegistration
             );
 
-            if (!string.IsNullOrEmpty(model.PrimaryEmail) && model.Centre > 0)
-            {
-                if (userDataService.CentreSpecificEmailIsInUseAtCentre(model.PrimaryEmail, (int)model.Centre))
-                {
-                    ModelState.AddModelError("PrimaryEmail", CommonValidationErrorMessages.EmailInUseAtCentre);
-                }
-            }
-
             RegistrationEmailValidator.ValidateCentreEmailIfNecessary(
                 model.CentreSpecificEmail,
                 model.Centre,


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-2177

**Description**
primary email checked at UserCentreDetails table along with Users table.

**Screenshots**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/5e00cfae-f16c-4ce9-85c6-fa413a498499)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f95cbb2d-4694-482f-bd08-368bac01a088)


-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
