### PR TITLE
TD-952:1. The heading showing on the screen made consistent with other screens 

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/Courses.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/Courses.cshtml
@@ -1,5 +1,8 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CentreCourses
 @model List<CentreCoursesViewModel>
+@{
+    ViewData["Title"] = "Courses";
+}
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
         <div class="nhsuk-width-container">
@@ -14,7 +17,7 @@
     </nav>
 }
 <link rel="stylesheet" href="@Url.Content("~/css/superAdmin/centres.css")" asp-append-version="true">
-<h1 class="nhsuk-heading-xl nhsuk-u-font-weight-normal nhsuk-fieldset__heading nhsuk-label--l">Courses - @ViewBag.CentreName</h1>
+<h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">Courses - @ViewBag.CentreName</h1>
 @foreach (var course in Model)
 {
     <partial name="_CourseCard" model="course" />


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-952

### Description
1. The heading showing on the screen made consistent with other screens 
2. Included missing  "Courses" word on tab in "View courses" page

### Screenshots
**_Before code change:_**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/ccc2aa51-cce9-4a40-85b2-a9f7670a6e46)

**_After code change:_**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/ab49dac1-7358-4c67-b29d-48bb0430828e)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
