### PR TITLE
TD-752 Confirmation Status Tag style adjustment on mobile view

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/learningPortal/selfAssessment.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningPortal/selfAssessment.scss
@@ -1,6 +1,7 @@
 ﻿@use "inputrange" as *;
 @use "nhsuk-frontend/packages/core/all" as *;
 @use "courses" as *;
+@use "../shared/breakpoints" as *;
 @use "../shared/searchableElements/searchableElements" as *;
 
 .competency-group-header {
@@ -202,6 +203,12 @@ details.nhsuk-details {
 
 .tag.tag-video {
   background-color: $nhsuk-link-visited-color;
+}
+
+@media only screen and (max-width: $mq-tablet) {
+  .competency-status-tag {
+    overflow: inherit;
+  }
 }
 
 .course-card {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionStatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionStatusTag.cshtml
@@ -2,29 +2,29 @@
 @model AssessmentQuestion
 <span class="status-tag competency-status-tag">
 
-  @if (Model.SelfAssessmentResultSupervisorVerificationId != null)
-  {
-    if (Model.Verified != null)
+    @if (Model.SelfAssessmentResultSupervisorVerificationId != null)
     {
-      if ((bool)Model.SignedOff)
-      {
-        <span class="nhsuk-tag nhsuk-tag--green status-tag">
-          Confirmed
-        </span>
-      }
-      else
-      {
-        <span class="nhsuk-tag nhsuk-tag--red status-tag">
-          Rejected
-        </span>
-      }
-    }
-    else
-    {
-      <span class="nhsuk-tag nhsuk-tag--yellow status-tag">
-        Awaiting confirmation
-      </span>
-    }
+        if (Model.Verified != null)
+        {
+            if ((bool)Model.SignedOff)
+            {
+                <span class="nhsuk-tag nhsuk-tag--green status-tag">
+                    Confirmed
+                </span>
+            }
+            else
+            {
+                <span class="nhsuk-tag nhsuk-tag--red status-tag">
+                    Rejected
+                </span>
+            }
+        }
+        else
+        {
+            <span class="nhsuk-tag nhsuk-tag--yellow status-tag">
+                Awaiting confirmation
+            </span>
+        }
 
-  }
+    }
 </span>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionStatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_AssessmentQuestionStatusTag.cshtml
@@ -1,6 +1,6 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
 @model AssessmentQuestion
-<span class="status-tag">
+<span class="status-tag competency-status-tag">
 
   @if (Model.SelfAssessmentResultSupervisorVerificationId != null)
   {


### PR DESCRIPTION
### JIRA link
[TD-752](https://hee-tis.atlassian.net/browse/TD-752)

### Description
updated the CSS style of the confirmation status tag on self assessment page when viewed on a mobile device

### Screenshots
![mobileUI-2](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/114475132/5e9eb035-dd70-491f-835a-67c4488f4df2)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-752]: https://hee-tis.atlassian.net/browse/TD-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ