### PR TITLE
TD-2094: Self assessments not displaying after removing the staff and adding back issue has been resolved

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -172,7 +172,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                         FROM CandidateAssessments AS ca  LEFT JOIN
                         CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL INNER JOIN
                         SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID 
-                        WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = sd.ID OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID AND sa.[National] = 1 )
+                        WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = sd.ID OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID)
 				        AND ((sa.SupervisorSelfAssessmentReview = 1) OR (sa.SupervisorResultsReview = 1)))) AS CandidateAssessmentCount, 
 		                CAST(COALESCE (au2.IsNominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, 
 		                CAST(COALESCE (au2.IsSupervisor, 0) AS Bit) AS DelegateIsSupervisor,             
@@ -450,7 +450,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
                  RIGHT OUTER JOIN SupervisorDelegates AS sd ON sd.ID=@supervisorDelegateId
                  RIGHT OUTER JOIN AdminAccounts AS au ON au.ID = sd.SupervisorAdminID
-                 WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = @supervisorDelegateId OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID AND sa.[National] = 1 )  AND ((sa.SupervisorSelfAssessmentReview = 1) OR
+                 WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = @supervisorDelegateId OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID)  AND ((sa.SupervisorSelfAssessmentReview = 1) OR
                          (sa.SupervisorResultsReview = 1)))", new { supervisorDelegateId }
                 );
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2094

### Description
Self assessments not displaying after removing the staff and adding back issue.
Enrolled 2 self-assessment to the staff → Removed the staff and added back → Only one self-assessment is assigned with the staff

### Screenshots

**_Before code change:_**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/992dbc25-b9b2-4d88-b99a-a6ed2bda30ce)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/85c400a7-8279-4e4f-935c-f662474cfba6)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/fcc12435-fe8a-436c-b2bd-bc1a56cb6b89)

**_After code change:_**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/baa2ddc0-e3fa-4878-ab57-17f6920c2006)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/49c9f113-96f1-4bbb-a899-d2b5cda56135)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/20609a80-a51a-46e5-9482-c617c279ab4a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/07e50320-a868-49e7-b405-8e481476b880)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/104283d0-1df0-4d18-913b-75a3d0fc4fc7)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
