### PR TITLE
TD-2284 Corrected spelling for unapproved account

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_DelegateStatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/_DelegateStatusTag.cshtml
@@ -26,7 +26,7 @@
     case 3:
         <text>
             <strong class="nhsuk-tag status-tag nhsuk-tag--red">
-                Unpproved
+                Unapproved
             </strong>
         </text>
         break;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2284

### Description
Corrected spelling for unapproved account as per testing notes.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/f587fd82-29f6-4b21-ba0f-e0ac5f7bd58b)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
