### PR TITLE
TD-1944 Fixed false console error showing when clicking browser back …

### DIFF
--- a/DigitalLearningSolutions.Data/Enums/ViewDelegateNavigationType.cs
+++ b/DigitalLearningSolutions.Data/Enums/ViewDelegateNavigationType.cs
@@ -1,0 +1,7 @@
+﻿namespace DigitalLearningSolutions.Data.Enums
+{
+    public enum ViewDelegateNavigationType
+    {
+        PromoteToAdmin
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/ViewDelegateControllerTests.cs
@@ -67,7 +67,7 @@
             A.CallTo(() => userService.GetDelegateById(delegateId)).Returns(delegateEntity);
 
             // When
-            var result = viewDelegateController.Index(delegateId);
+            var result = viewDelegateController.Index(delegateId, null);
 
             // Then
             result.As<ViewResult>().Model.As<ViewDelegateViewModel>().DelegateInfo.Email.Should()
@@ -83,7 +83,7 @@
             A.CallTo(() => userService.GetDelegateById(delegateId)).Returns(delegateEntity);
 
             // When
-            var result = viewDelegateController.Index(delegateId);
+            var result = viewDelegateController.Index(delegateId, null);
 
             // Then
             result.As<ViewResult>().Model.As<ViewDelegateViewModel>().DelegateInfo.Email.Should()
@@ -98,7 +98,7 @@
             A.CallTo(() => userService.GetDelegateById(delegateId)).Returns(null);
 
             // When
-            var result = viewDelegateController.Index(delegateId);
+            var result = viewDelegateController.Index(delegateId, null);
 
             // Then
             result.Should().BeNotFoundResult();

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -173,7 +173,7 @@
                 return new StatusCodeResult(500);
             }
             TempData["IsDelegatePromoted"] = true;
-            return RedirectToAction("Index", "ViewDelegate", new { delegateId = delegateId, callType = 1 });
+            return RedirectToAction("Index", "ViewDelegate", new { delegateId = delegateId, callType = ViewDelegateNavigationType.PromoteToAdmin });
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/PromoteToAdminController.cs
@@ -173,7 +173,7 @@
                 return new StatusCodeResult(500);
             }
             TempData["IsDelegatePromoted"] = true;
-            return RedirectToAction("Index", "ViewDelegate", new { delegateId });
+            return RedirectToAction("Index", "ViewDelegate", new { delegateId = delegateId, callType = 1 });
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -57,7 +57,7 @@
             this.emailVerificationDataService = emailVerificationDataService;
         }
 
-        public IActionResult Index(int delegateId, int? callType)
+        public IActionResult Index(int delegateId, string? callType)
         {
             var centreId = User.GetCentreIdKnownNotNull();
 
@@ -68,7 +68,7 @@
                 return NotFound();
             }
 
-            if (callType == null && TempData["IsDelegatePromoted"] != null)
+            if (string.IsNullOrEmpty(callType) && TempData["IsDelegatePromoted"] != null)
             {
                 TempData.Remove("IsDelegatePromoted");
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -57,7 +57,7 @@
             this.emailVerificationDataService = emailVerificationDataService;
         }
 
-        public IActionResult Index(int delegateId)
+        public IActionResult Index(int delegateId, int? callType)
         {
             var centreId = User.GetCentreIdKnownNotNull();
 
@@ -68,7 +68,7 @@
                 return NotFound();
             }
 
-            if (TempData["IsDelegatePromoted"] != null)
+            if (callType == null && TempData["IsDelegatePromoted"] != null)
             {
                 TempData.Remove("IsDelegatePromoted");
             }


### PR DESCRIPTION
…button after promoting the delegate to admin

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1944

### Description
Points addressed in this Commit :
1) Fixed false console error showing when clicking browser back button after promoting the delegate to admin by modifying the controller and tests.

### Screenshots
[Centre-administrators---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/15bcc8f2-169e-4072-bf7a-01889f1bb3ec)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
