### PR TITLE
TD-2177- two delegate records at the same centre registered - delete unclaimed accounts issue fixed

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -671,6 +671,24 @@
 	           BEGIN TRY
 	                BEGIN TRANSACTION
 
+                        DELETE FROM aspProgress WHERE ProgressID IN (SELECT ProgressID FROM Progress WHERE CandidateID in (SELECT ID FROM DelegateAccounts where UserID = @userId))
+
+                        DELETE FROM Progress WHERE CandidateID IN (SELECT ID FROM DelegateAccounts where UserID = @userId)
+
+                        DELETE FROM ReportSelfAssessmentActivityLog where UserID = @userId
+
+                        DELETE FROM SelfAssessmentResultSupervisorVerifications WHERE CandidateAssessmentSupervisorID IN ( SELECT ID
+                        FROM CandidateAssessmentSupervisors where CandidateAssessmentID IN (select ID from CandidateAssessments where DelegateUserID = @userId))
+
+                        DELETE FROM CandidateAssessmentSupervisorVerifications WHERE CandidateAssessmentSupervisorID IN ( SELECT ID
+                        FROM CandidateAssessmentSupervisors where CandidateAssessmentID IN (select ID from CandidateAssessments where DelegateUserID = @userId))
+
+                        DELETE FROM CandidateAssessmentSupervisors where CandidateAssessmentID IN (select ID from CandidateAssessments where DelegateUserID = @userId)
+
+                        DELETE FROM CandidateAssessmentOptionalCompetencies WHERE CandidateAssessmentID IN (select ID from CandidateAssessments where DelegateUserID = @userId)
+
+                        DELETE from CandidateAssessments where DelegateUserID = @userId
+
                         DELETE FROM SupervisorDelegates WHERE DelegateUserID = @userId
 
 				        DELETE FROM UserCentreDetails WHERE UserID = @userId


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-2177

**Description**
added additional ref tables in the delete operation.

**Screenshots**
N/A
-----
**Developer checks**
I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
