### PR TITLE
TD-1877 Allowed supervisor to export a summary of a learner's progres…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -554,7 +554,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  (SELECT COUNT(*) AS Expr1
                     FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
                     WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (Superceded = 0)) AS ResultsVerificationRequests,
-                    ca.NonReportable
+                    ca.NonReportable,ca.DelegateUserID
                     FROM   CandidateAssessmentSupervisors AS cas INNER JOIN
                          CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
                            SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID INNER JOIN

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -347,6 +347,8 @@
                 CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup),
                 IsSupervisorResultsReviewed = delegateSelfAssessment.IsSupervisorResultsReviewed,
                 SearchViewModel = searchModel,
+                CandidateAssessmentId = candidateAssessmentId,
+                ExportToExcelHide = delegateSelfAssessment.SupervisorRoleTitle.Contains("Assessor")
             };
 
             var flags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(reviewedCompetencies.Select(c => c.Id).ToArray());
@@ -1299,9 +1301,19 @@
                 {
                     return 0;
                 }
-
             }
             return existingId;
+        }
+
+        public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string delegateName, string selfAssessmentName,int delegateUserID)
+        {
+            var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, delegateUserID, true);
+            var fileName = $"{selfAssessmentName.Substring(0,29)}-{delegateName}-{clockUtility.UtcNow:yyyy-MM-dd}.xlsx";
+            return File(
+                content,
+                FileHelper.GetContentTypeFromFileName(fileName),
+                fileName
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/SupervisorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/SupervisorController.cs
@@ -2,6 +2,8 @@
 {
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Services;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Services;
     using GDS.MultiPageFormData;
@@ -26,6 +28,8 @@
         private readonly IUserService userService;
         private readonly IEmailGenerationService emailGenerationService;
         private readonly IEmailService emailService;
+        private readonly ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService;
+        private readonly IClockUtility clockUtility;
 
         public SupervisorController(
            ISupervisorService supervisorService,
@@ -43,9 +47,11 @@
            IRegistrationService registrationService,
            ICentresDataService centresDataService,
            IUserService userService,
-            IEmailGenerationService emailGenerationService,
-            IEmailService emailService
-            )
+           IEmailGenerationService emailGenerationService,
+           IEmailService emailService,
+           ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService,
+           IClockUtility clockUtility
+           )
         {
             this.supervisorService = supervisorService;
             this.frameworkNotificationService = frameworkNotificationService;
@@ -60,6 +66,8 @@
             this.userService = userService;
             this.emailGenerationService = emailGenerationService;
             this.emailService = emailService;
+            this.candidateAssessmentDownloadFileService = candidateAssessmentDownloadFileService;
+            this.clockUtility = clockUtility;
         }
 
         private int GetCentreId()

--- a/DigitalLearningSolutions.Web/Styles/frameworks/frameworksShared.scss
+++ b/DigitalLearningSolutions.Web/Styles/frameworks/frameworksShared.scss
@@ -248,3 +248,6 @@ h1.truncate-overflow::after {
     inline-size: 305px;
   }
 }
+.float-right{
+    float:right;
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
@@ -19,5 +19,7 @@
         {
             return FrameworkVocabularyHelper.VocabularyPlural(vocabulary);
         }
+        public int CandidateAssessmentId { get; set; }
+        public bool ExportToExcelHide { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -82,6 +82,18 @@
         </div>
     </div>
     <div class="nhsuk-grid-column-one-third">
+        @if (!Model.ExportToExcelHide)
+        {
+            <a class="nhsuk-button nhsuk-button--secondary float-right"
+             asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
+             asp-route-selfAssessmentName="@Model.DelegateSelfAssessment.RoleName"
+             asp-route-delegateUserID="@Model.DelegateSelfAssessment.DelegateUserID"
+             asp-route-delegateName="@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName"
+             asp-action="ExportCandidateAssessment"
+             role="button">
+                Export to Excel
+            </a>
+        }
         @if (Model.DelegateSelfAssessment.SignOffRequested > 0)
         {
             <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>


### PR DESCRIPTION
…s to Excel when supervisor has a role that allows them to sign off the self assessment

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1877

### Description
Points addressed in this Commit :
1) Allowed supervisor to export a summary of a learner's progress to Excel when supervisor has a role that allows them to sign off the self assessment by modifying the controllers,service,styles and viewmodels.

### Screenshots
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/f5751404-c79e-4fcb-86c5-d8f63e7924d1)
![Review-Profile-Assessment-Digital-Learning-Solutions-Desktop-View](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/527b10fe-3f4d-4b74-9f26-7f6d37d3a1ce)
![Review-Profile-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/ce1a2770-8995-407e-b7e3-01a3dba2d994)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
