### PR TITLE
TD-2365 Fixed out the wrong console error showing when deleted unclai…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -21,7 +21,7 @@
 
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
-    [ServiceFilter(typeof(VerifyAdminUserCanAccessDelegateUser))]
+    [ServiceFilter(typeof(VerifyAdminAndDelegateUserCentre))]
     [SetDlsSubApplication(nameof(DlsSubApplication.TrackingSystem))]
     [SetSelectedTab(nameof(NavMenuTab.Delegates))]
     [Route("TrackingSystem/Delegates/{delegateId:int}/View")]

--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminAndDelegateUserCentre.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminAndDelegateUserCentre.cs
@@ -1,0 +1,41 @@
+﻿namespace DigitalLearningSolutions.Web.ServiceFilter
+{
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+
+    public class VerifyAdminAndDelegateUserCentre : IActionFilter
+    {
+        private readonly IUserDataService userDataService;
+
+        public VerifyAdminAndDelegateUserCentre(IUserDataService userDataService)
+        {
+            this.userDataService = userDataService;
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context) { }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!(context.Controller is Controller controller))
+            {
+                return;
+            }
+
+            var centreId = controller.User.GetCentreIdKnownNotNull();
+            var delegateUserId = int.Parse(context.RouteData.Values["delegateId"].ToString()!);
+            var delegateAccount = userDataService.GetDelegateUserById(delegateUserId);
+
+            if (delegateAccount == null)
+            {
+                context.Result = new RedirectToActionResult("StatusCode", "LearningSolutions", new { code = 410 });
+
+            }
+            else if (delegateAccount != null && delegateAccount.CentreId != centreId)
+            {
+                context.Result = new RedirectToActionResult("AccessDenied", "LearningSolutions", new { });
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -364,6 +364,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<VerifyDelegateAccessedViaValidRoute>();
             services.AddScoped<VerifyDelegateUserCanAccessSelfAssessment>();
             services.AddScoped<VerifyUserHasVerifiedPrimaryEmail>();
+            services.AddScoped<VerifyAdminAndDelegateUserCentre>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)
@@ -417,7 +418,7 @@ namespace DigitalLearningSolutions.Web
                 }
             );
 
-            app.UseExceptionHandler("/LearningSolutions/Error");
+            //app.UseExceptionHandler("/LearningSolutions/Error");
             app.UseStatusCodePagesWithReExecute("/LearningSolutions/StatusCode/{0}");
             app.UseStaticFiles();
             app.UseSerilogRequestLogging();

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -418,7 +418,7 @@ namespace DigitalLearningSolutions.Web
                 }
             );
 
-            //app.UseExceptionHandler("/LearningSolutions/Error");
+            app.UseExceptionHandler("/LearningSolutions/Error");
             app.UseStatusCodePagesWithReExecute("/LearningSolutions/StatusCode/{0}");
             app.UseStaticFiles();
             app.UseSerilogRequestLogging();


### PR DESCRIPTION
…med account on Tracking system and clicking browser back button

### JIRA link
https://hee-tis.atlassian.net/browse/TD-2365

### Description
Points addressed in this Commit :
1) Fixed out the wrong console error showing when deleted unclaimed account on Tracking system and clicking browser back button by modifying the controller and service filter.

### Screenshots
[View-delegate---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/3db58d1c-de7c-4188-8279-5de1b346de21)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
