### PR TITLE
TD-2027 Fixes conditions for the display of withdraw and resend

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SignOffHistory.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SignOffHistory.cshtml
@@ -1,5 +1,6 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
-
+﻿@using DigitalLearningSolutions.Data.Utilities;
+@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
+@inject IClockUtility ClockUtility
 @model SignOffHistoryViewModel
 
 @if (Model.SupervisorSignOffs.Any())
@@ -50,27 +51,33 @@
                     </td>
 
                     <td role="cell" class="nhsuk-table__cell">
-                        <div class="nhsuk-grid-column-one-half nhsuk-u-padding-0">
-                            <a asp-action="ResendSupervisorSignOffRequest"
-                               asp-route-selfAssessmentId=@Model.SelfAssessment.Id
-                               asp-route-candidateAssessmentSupervisorId=@supervisorSignOff.CandidateAssessmentSupervisorID
-                               asp-route-candidateAssessmentSupervisorVerificationId=@supervisorSignOff.ID
-                               asp-route-supervisorName=@supervisorSignOff.SupervisorName
-                               asp-route-supervisorEmail=@supervisorSignOff.SupervisorEmail
-                               asp-route-vocabulary="Proficiencies">
-                                Resend
-                            </a>
-                        </div>
+                        @if (supervisorSignOff.Verified == null && supervisorSignOff.Removed == null)
+                        {
+                            @if (supervisorSignOff.EmailSent == null || supervisorSignOff.EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString())
+                            {
+                                <div class="nhsuk-grid-column-one-half nhsuk-u-padding-0">
+                                    <a asp-action="ResendSupervisorSignOffRequest"
+                                       asp-route-selfAssessmentId=@Model.SelfAssessment.Id
+                                       asp-route-candidateAssessmentSupervisorId=@supervisorSignOff.CandidateAssessmentSupervisorID
+                                       asp-route-candidateAssessmentSupervisorVerificationId=@supervisorSignOff.ID
+                                       asp-route-supervisorName=@supervisorSignOff.SupervisorName
+                                       asp-route-supervisorEmail=@supervisorSignOff.SupervisorEmail
+                                       asp-route-vocabulary="Proficiencies">
+                                        Resend
+                                    </a>
+                                </div>
+                            }
 
-                        <div class="nhsuk-grid-column-one-half nhsuk-u-padding-0">
-                            <a asp-action="WithdrawSupervisorSignOffRequest"
-                               asp-route-selfAssessmentId=@Model.SelfAssessment.Id
-                               asp-route-candidateAssessmentSupervisorVerificationId=@supervisorSignOff.ID
-                               asp-route-vocabulary="Proficiencies"
-                               asp-route-source="SignOffHistory">
-                                Withdraw
-                            </a>
-                        </div>
+                            <div class="nhsuk-grid-column-one-half nhsuk-u-padding-0">
+                                <a asp-action="WithdrawSupervisorSignOffRequest"
+                                   asp-route-selfAssessmentId=@Model.SelfAssessment.Id
+                                   asp-route-candidateAssessmentSupervisorVerificationId=@supervisorSignOff.ID
+                                   asp-route-vocabulary="Proficiencies"
+                                   asp-route-source="SignOffHistory">
+                                    Withdraw
+                                </a>
+                            </div>
+                        }
                     </td>
                 </tr>
             }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -44,17 +44,19 @@
                 }
             </dd>
             <dd class="nhsuk-summary-list__actions">
-                @if (((
-               Model.FirstOrDefault().EmailSent == null && Model.FirstOrDefault().Verified == null || (Model.FirstOrDefault().Verified == null) && Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString()) && Model.FirstOrDefault().Removed == null))
+                @if (Model.FirstOrDefault().Verified == null && Model.FirstOrDefault().Removed == null)
                 {
-                    @if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
+                    @if (Model.FirstOrDefault().EmailSent == null || Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString())
                     {
-                        <a asp-action="SendRequestSignOffReminder" asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-candidateAssessmentSupervisorId="@Model.FirstOrDefault().CandidateAssessmentSupervisorID" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">Send reminder</a>
+                        @if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
+                        {
+                            <a asp-action="SendRequestSignOffReminder" asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-candidateAssessmentSupervisorId="@Model.FirstOrDefault().CandidateAssessmentSupervisorID" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">Send reminder</a>
+                        }
                     }
-                }
 
-                <a asp-action="WithdrawSupervisorSignOffRequest" asp-route-selfAssessmentId=@ViewContext.RouteData.Values["selfAssessmentId"]
-                   asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="Proficiencies" asp-route-source="SupervisorSignOffSummary">Withdraw</a>
+                    <a asp-action="WithdrawSupervisorSignOffRequest" asp-route-selfAssessmentId=@ViewContext.RouteData.Values["selfAssessmentId"]
+                       asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="Proficiencies" asp-route-source="SupervisorSignOffSummary">Withdraw</a>
+                }
             </dd>
         </div>
         <div class="nhsuk-summary-list__row">


### PR DESCRIPTION
### JIRA link
[TD-2027](https://hee-tis.atlassian.net/browse/TD-2027)

### Description
Shows withdraw and resend links on supervisor sign off and sign off history views only when the status of the sign off request is not signed off.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2027]: https://hee-tis.atlassian.net/browse/TD-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ