### PR TITLE
TD-988: Super admin-edit centre page- Date field null issue and  Dropdown values not retaining

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
@@ -763,8 +763,8 @@
                             c.CentreName,
                             ct.ContractTypeID,
                             ct.ContractType,
-                            ct.ServerSpaceBytesInc,
-                            ct.DelegateUploadSpace,
+                            c.ServerSpaceBytes  ServerSpaceBytesInc,
+                            c.CandidateByteLimit DelegateUploadSpace,
                              c.ContractReviewDate
 					    FROM Centres AS c
                         INNER JOIN ContractTypes AS ct ON ct.ContractTypeID = c.ContractTypeId
@@ -775,11 +775,6 @@
             {
                 logger.LogWarning($"No centre found for centre id {centreId}");
                 return null;
-            }
-            if (centre.ContractReviewDate == null)
-            {
-                centre.ContractReviewDate = DateTime.Now;
-                return centre;
             }
             return centre;
         }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -221,7 +221,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             A.CallTo(() => centresDataService.GetContractInfo(CenterId)).Returns(CentreContractAdminUsageTestHelper.GetDefaultEditContractInfo(CenterId));
 
             // When
-            var result = controller.EditContractInfo(centreId,21,8,2023);
+            var result = controller.EditContractInfo(centreId,28,8,2023);
 
             // Then
             using (new AssertionScope())
@@ -259,7 +259,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             DateTime date = new DateTime(model.ContractReviewYear.Value, model.ContractReviewMonth.Value, model.ContractReviewDay.Value, 0, 0, 0);
 
             // When
-            var result = controller.EditContractInfo(model,21,8,2023);
+            var result = controller.EditContractInfo(model,28,8,2023);
 
             // Then
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -221,7 +221,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             A.CallTo(() => centresDataService.GetContractInfo(CenterId)).Returns(CentreContractAdminUsageTestHelper.GetDefaultEditContractInfo(CenterId));
 
             // When
-            var result = controller.EditContractInfo(centreId);
+            var result = controller.EditContractInfo(centreId,21,8,2023);
 
             // Then
             using (new AssertionScope())
@@ -259,7 +259,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             DateTime date = new DateTime(model.ContractReviewYear.Value, model.ContractReviewMonth.Value, model.ContractReviewDay.Value, 0, 0, 0);
 
             // When
-            var result = controller.EditContractInfo(model);
+            var result = controller.EditContractInfo(model,21,8,2023);
 
             // Then
 

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/ContractTypeViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/ContractTypeViewModel.cs
@@ -1,7 +1,11 @@
 ﻿
 namespace DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Centres
 {
+    using DigitalLearningSolutions.Web.Helpers;
+    using Microsoft.AspNetCore.Mvc.Rendering;
     using System;
+    using System.Collections.Generic;
+
     public class ContractTypeViewModel
     {
         public ContractTypeViewModel()
@@ -36,7 +40,10 @@ namespace DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Centres
         public int? ContractReviewDay { get; set; }
         public int? ContractReviewMonth { get; set; }
         public int? ContractReviewYear { get; set; }
-
+        public OldDateValidator.ValidationResult? CompleteByValidationResult { get; set; }
+        public IEnumerable<SelectListItem> ContractTypeOptions { get; set; } = new List<SelectListItem>();
+        public IEnumerable<SelectListItem> ServerSpaceOptions { get; set; } = new List<SelectListItem>();
+        public IEnumerable<SelectListItem> PerDelegateUploadSpaceOptions { get; set; } = new List<SelectListItem>();
 
     }
 }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/EditContractInfo.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/EditContractInfo.cshtml
@@ -1,19 +1,45 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Centres
+﻿@using DigitalLearningSolutions.Data.Utilities;
+@using DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Centres
+@inject IClockUtility ClockUtility
 @model ContractTypeViewModel
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = errorHasOccurred ? "Error: Edit Contract Info" : "Edit Contract Info";
- 
+    var exampleDate = ClockUtility.UtcToday;
     var hintTextLines = new List<string> {
-    $"For example, {@Model.ContractReviewDay} {@Model.ContractReviewMonth} {@Model.ContractReviewYear}. Leave the boxes blank to clear the contract review date.",
+    $"For example, {@exampleDate.Day} {@exampleDate.Month} { @exampleDate.Year}. Leave the boxes blank to clear the contract review date.",
     " ", };
 }
-
 @if (errorHasOccurred)
 {
     <vc:error-summary order-of-property-names="@(new string[] { nameof(Model.CentreName),nameof(Model.ContractType)})" />
 }
- 
+@{
+    string contractReviewDay;
+    string ContractReviewMonth;
+    string ContractReviewYear;
+    if (Model.CompleteByValidationResult?.DateValid == false)
+    {
+        contractReviewDay = Model.CompleteByValidationResult?.Day.ToString() ?? "";
+        ContractReviewMonth = Model.CompleteByValidationResult?.Month.ToString() ?? "";
+        ContractReviewYear = Model.CompleteByValidationResult?.Year.ToString() ?? "";
+        contractReviewDay = contractReviewDay == "0" ? "" : contractReviewDay;
+        ContractReviewMonth = ContractReviewMonth == "0" ? "" : ContractReviewMonth;
+        ContractReviewYear = ContractReviewYear == "0" ? "" : ContractReviewYear;
+    }
+    else
+    {
+        contractReviewDay = Model.ContractReviewDate?.Day.ToString() ?? "";
+        ContractReviewMonth = Model.ContractReviewDate?.Month.ToString() ?? "";
+        ContractReviewYear = Model.ContractReviewDate?.Year.ToString() ?? "";
+    }
+    
+    
+    var dayErrorClass = Model.CompleteByValidationResult?.DayValid == false ? "nhsuk-input--error" : "";
+    var monthErrorClass = Model.CompleteByValidationResult?.MonthValid == false ? "nhsuk-input--error" : "";
+    var yearErrorClass = Model.CompleteByValidationResult?.YearValid == false ? "nhsuk-input--error" : "";
+    var formErrorClass = Model.CompleteByValidationResult?.DateValid == false ? "nhsuk-form-group--error" : "";
+}
 
 <div id="form-group">
     <h1 class="nhsuk-heading-xl">Edit contract info for @Model.CentreName </h1>
@@ -32,7 +58,7 @@
                                 required="true"
                                 css-class="nhsuk-u-width-one-half"
                                 default-option=""
-                                select-list-options="@ViewBag.ContractTypes" />
+                                select-list-options="@Model.ContractTypeOptions" />
 
                 <vc:select-list asp-for="@nameof(Model.ServerSpaceBytesInc)"
                                 label="Server space"
@@ -41,7 +67,7 @@
                                 required="true"
                                 css-class="nhsuk-u-width-one-half"
                                 default-option=""
-                                select-list-options="@ViewBag.Serverspace" />
+                                select-list-options="@Model.ServerSpaceOptions" />
 
                 <vc:select-list asp-for="@nameof(Model.DelegateUploadSpace)"
                                 label=" Per delegate upload space"
@@ -50,16 +76,48 @@
                                 required="true"
                                 css-class="nhsuk-u-width-one-half"
                                 default-option=""
-                                select-list-options="@ViewBag.Delegatespace" />
-                                  <vc:date-input id="complete-by-date"
-                               label="Contract review date"
-                               day-id="ContractReviewDay"
-                               month-id="ContractReviewMonth"
-                               year-id="ContractReviewYear"
-                               css-class="nhsuk-u-margin-bottom-2"
-                               hint-text-lines="@hintTextLines" />
-               
+                                select-list-options="@Model.PerDelegateUploadSpaceOptions" />
+                <fieldset class="nhsuk-fieldset" aria-labelledby="form-heading" aria-describedby="example-hint" role="group">
+                <legend class="nhsuk-fieldset__legend nhsuk-label">
+                    Contract review date
+                </legend>
+                <span class="nhsuk-hint" id="example-hint">
+                    For example, @exampleDate.Day @exampleDate.Month @exampleDate.Year. Leave the boxes blank to clear the contract review date..
+                </span>
+                    @if (Model.CompleteByValidationResult?.DateValid == false)
+                    {
+                        <span class="nhsuk-error-message" id="validation-message" role="alert">
+                            <span class="nhsuk-u-visually-hidden">Error:</span>@Model.CompleteByValidationResult?.ErrorMessage
+                        </span>
+                    }
+                <div class="nhsuk-date-input" id="date">
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label nhsuk-date-input__label" for="day">
+                Day
+              </label>
+                            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @dayErrorClass" id="day" name="day" type="number" value="@contractReviewDay">
+            </div>
+          </div>
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label nhsuk-date-input__label" for="month">
+                Month
+              </label>
+                            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 @monthErrorClass" id="month" name="month" type="number" value="@ContractReviewMonth">
+            </div>
+          </div>
+          <div class="nhsuk-date-input__item">
+            <div class="nhsuk-form-group">
+              <label class="nhsuk-label nhsuk-date-input__label" for="year">
+                Year
+              </label>
+                            <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4 @yearErrorClass" id="year" name="year" type="number" value="@ContractReviewYear">
+            </div>
+          </div>
+        </div>
 
+                </fieldset>
             </div>
         </div>
         <button class="nhsuk-button" type="submit">

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/ManageCentre.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/ManageCentre.cshtml
@@ -195,7 +195,7 @@
                         <b>Contract review date</b>
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                        @Model.ContractReviewDate
+                        @string.Format("{0:dd/MM/yyyy}",@Model.ContractReviewDate)
                     </dd>
                 </div>
             </dl>


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-988

### Description
Super admin-edit centre page issues resolved
1.  Date field null issue 
2.   Dropdown values not retaining
3. Date validation included

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/24eb4da3-a85b-4d63-8eeb-38068ce31fbb)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/b215f446-9523-42da-8958-569a46c6ad7c)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
