### PR TITLE
TD-989 Super Admin Centre Role Limits Validation Fix

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -110,9 +110,9 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             var expectedVm = new CentreRoleLimitsViewModel
             {
                 CentreId = 374,
-                RoleLimitCmsAdministrators = null,
+                RoleLimitCmsAdministrators = 0,
                 IsRoleLimitSetCmsAdministrators = false,    // automatically set off
-                RoleLimitCmsManagers = null,
+                RoleLimitCmsManagers = 0,
                 IsRoleLimitSetCmsManagers = false,          // automatically set off
                 IsRoleLimitSetContentCreatorLicences = true,
                 RoleLimitContentCreatorLicences = 10,

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -289,6 +289,8 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
             return RedirectToAction("ManageCentre", "Centres", new { centreId = editCentreManagerDetailsViewModel.CentreId });
         }
 
+        [HttpGet]
+        [NoCaching]
         [Route("SuperAdmin/Centres/{centreId=0:int}/CentreRoleLimits")]
         public IActionResult CentreRoleLimits(int centreId = 0)
         {
@@ -303,7 +305,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCmsAdministrators != null && roleLimits.RoleLimitCmsAdministrators != -1))
             {
-                centreRoleLimitsViewModel.RoleLimitCmsAdministrators = null;
                 centreRoleLimitsViewModel.IsRoleLimitSetCmsAdministrators = false;
             }
             else
@@ -314,7 +315,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCmsManagers != null && roleLimits.RoleLimitCmsManagers != -1))
             {
-                centreRoleLimitsViewModel.RoleLimitCmsManagers = null;
                 centreRoleLimitsViewModel.IsRoleLimitSetCmsManagers = false;
             }
             else
@@ -325,7 +325,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCcLicences != null && roleLimits.RoleLimitCcLicences != -1))
             {
-                centreRoleLimitsViewModel.RoleLimitContentCreatorLicences = null;
                 centreRoleLimitsViewModel.IsRoleLimitSetContentCreatorLicences = false;
             }
             else
@@ -336,7 +335,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCustomCourses != null && roleLimits.RoleLimitCustomCourses != -1))
             {
-                centreRoleLimitsViewModel.RoleLimitCustomCourses = null;
                 centreRoleLimitsViewModel.IsRoleLimitSetCustomCourses = false;
             }
             else
@@ -347,7 +345,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitTrainers != null && roleLimits.RoleLimitTrainers != -1))
             {
-                centreRoleLimitsViewModel.RoleLimitTrainers = null;
                 centreRoleLimitsViewModel.IsRoleLimitSetTrainers = false;
             }
             else
@@ -363,6 +360,11 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         [Route("SuperAdmin/Centres/{centreId=0:int}/CentreRoleLimits")]
         public IActionResult EditCentreRoleLimits(CentreRoleLimitsViewModel model)
         {
+            if (!ModelState.IsValid)
+            {
+                return View("CentreRoleLimits", model);
+            }
+
             if (!(model.IsRoleLimitSetCmsAdministrators))
             {
                 model.RoleLimitCmsAdministrators = -1;
@@ -383,11 +385,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
             if (!(model.IsRoleLimitSetTrainers))
             {
                 model.RoleLimitTrainers = -1;
-            }
-
-            if (!ModelState.IsValid)
-            {
-                return View("CentreRoleLimits", model);
             }
 
             centresDataService.UpdateCentreRoleLimits(

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreRoleLimitsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreRoleLimitsViewModel.cs
@@ -13,22 +13,22 @@
 
         [Required(ErrorMessage = "Please enter a number for the CMS Administrators role limit.")]
         [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitCmsAdministrators { get; set; }
+        public int RoleLimitCmsAdministrators { get; set; }
 
         [Required(ErrorMessage = "Please enter a number for the CMS Managers role limit.")]
         [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitCmsManagers { get; set; }
+        public int RoleLimitCmsManagers { get; set; }
 
         [Required(ErrorMessage = "Please enter a number for the Content Creator Licences role limit.")]
         [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitContentCreatorLicences { get; set; }
+        public int RoleLimitContentCreatorLicences { get; set; }
 
         [Required(ErrorMessage = "Please enter a number for the Custom Courses role limit.")]
         [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitCustomCourses { get; set; }
+        public int RoleLimitCustomCourses { get; set; }
 
         [Required(ErrorMessage = "Please enter a number for the Trainers role limit.")]
         [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitTrainers { get; set; }
+        public int RoleLimitTrainers { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-989](https://hee-tis.atlassian.net/browse/TD-989)

### Description
Fixed issue where Save button needed to be clicked twice under certain validation states.

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![TD-989](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/3fa11cf6-2d4c-421d-a781-30e996c538b2)


[TD-989]: https://hee-tis.atlassian.net/browse/TD-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-989]: https://hee-tis.atlassian.net/browse/TD-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ