### PR TITLE
TD-2369 Displayed "Remove from course" button when course progress is complete and update the confirmation text

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/ConfirmRemoveFromCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/ConfirmRemoveFromCourse.cshtml
@@ -4,7 +4,7 @@
 
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Remove enrolment" : "Remove enrolment";
+    ViewData["Title"] = errorHasOccurred ? "Error: Remove from activity" : "Remove from activity";
 
   var cancelLinkRouteData = new Dictionary<string, string>();
 
@@ -24,7 +24,7 @@
     {
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Confirm) })" />
     }
-    <h1 class="nhsuk-heading-xl">Remove enrolment</h1>
+    <h1 class="nhsuk-heading-xl">Remove from activity</h1>
   </div>
 </div>
 
@@ -45,8 +45,8 @@
       <input type="hidden" asp-for="@Model.ReturnPageQuery" />
 
       <vc:single-checkbox asp-for="@nameof(Model.Confirm)"
-                          label="I am sure that I wish to remove this enrolment"
-                          hint-text="This action will remove the activity from the delegate’s Current Activities list and archive their progress." />
+                                label="I am sure that I wish to remove the progress record for this learner on this activity."
+                                hint-text="This action will remove the activity from the delegate’s Learning Portal Activities list and archive their progress." />
 
       <button class="nhsuk-button delete-button" role="button" type="submit">Remove enrolment</button>
     </form>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCourseProgressButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCourseProgressButtons.cshtml
@@ -10,7 +10,7 @@
   View progress
 </a>
 
-@if (string.IsNullOrEmpty(Model.Completed) && Model.RemovedDate == null)
+@if (Model.RemovedDate == null)
 {
   <a class="nhsuk-button delete-button"
    role="button"


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2369

### Description
Points addressed in this Commit :
1) Displayed "Remove from course" button when course progress is complete and update the confirmation text by modifying the views.

Note : Error showing in wave plugin is due to "single-checkbox" input component it is not due to my changes. I tried fixing it but the problem is in the view component which will be a separate ticket for investigation.

### Screenshots
![Remove-from-activity-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/6fa8c9c8-de41-4bfe-87ec-7ea649c1b3b0)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/4a3e7446-1476-4314-8914-bfb5148d5928)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
