### PR TITLE
TD-1766 Added the condition to check the customisation name everywhere in the application

### DIFF
--- a/DigitalLearningSolutions.Data/Models/CourseCompletion/CourseCompletion.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseCompletion/CourseCompletion.cs
@@ -38,7 +38,7 @@
         )
         {
             Id = id;
-            CourseTitle = $"{applicationName} - {customisationName}";
+            CourseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             Completed = completed;
             Evaluated = evaluated;
             MaxPostLearningAssessmentAttempts = maxPostLearningAssessmentAttempts;

--- a/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
+++ b/DigitalLearningSolutions.Data/Models/CourseContent/CourseContent.cs
@@ -44,7 +44,7 @@
         )
         {
             Id = id;
-            Title = $"{applicationName} - {customisationName}";
+            Title = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             Description = applicationInfo;
             AverageDuration = averageDuration;
             CentreName = centreName;

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticAssessment.cs
@@ -55,7 +55,7 @@
             bool passwordSubmitted
         )
         {
-            CourseTitle = $"{applicationName} - {customisationName}";
+            CourseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             CourseDescription = applicationInfo;
             SectionName = sectionName;
             DiagnosticAttempts = diagAttempts;

--- a/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticContent.cs
+++ b/DigitalLearningSolutions.Data/Models/DiagnosticAssessment/DiagnosticContent.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.DiagnosticAssessment
 {
+    using System;
     using System.Collections.Generic;
 
     public class DiagnosticContent
@@ -22,7 +23,7 @@
             int currentVersion
         )
         {
-            CourseTitle = $"{applicationName} - {customisationName}";
+            CourseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             SectionName = sectionName;
             DiagnosticAssessmentPath = diagAssessPath;
             CanSelectTutorials = diagObjSelect;

--- a/DigitalLearningSolutions.Data/Models/PostLearningAssessment/PostLearningAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/PostLearningAssessment/PostLearningAssessment.cs
@@ -47,7 +47,7 @@
             bool passwordSubmitted
         )
         {
-            CourseTitle = $"{applicationName} - {customisationName}";
+            CourseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             CourseDescription = applicationInfo;
             SectionName = sectionName;
             PostLearningScore = bestScore;

--- a/DigitalLearningSolutions.Data/Models/PostLearningAssessment/PostLearningContent.cs
+++ b/DigitalLearningSolutions.Data/Models/PostLearningAssessment/PostLearningContent.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.PostLearningAssessment
 {
+    using System;
     using System.Collections.Generic;
 
     public class PostLearningContent
@@ -20,7 +21,7 @@
             int currentVersion
         )
         {
-            CourseTitle = $"{applicationName} - {customisationName}";
+            CourseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             SectionName = sectionName;
             PostLearningAssessmentPath = plAssessPath;
             PassThreshold = plaPassThreshold;

--- a/DigitalLearningSolutions.Data/Models/TutorialContent/TutorialVideo.cs
+++ b/DigitalLearningSolutions.Data/Models/TutorialContent/TutorialVideo.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.TutorialContent
 {
     using DigitalLearningSolutions.Data.Exceptions;
+    using System;
 
     public class TutorialVideo
     {
@@ -19,7 +20,7 @@
         {
             TutorialName = tutorialName;
             SectionName = sectionName;
-            CourseTitle = $"{applicationName} - {customisationName}";
+            CourseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
 
             VideoPath = videoPath ?? throw new VideoNotFoundException();
         }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
@@ -6,6 +6,7 @@
     using FluentAssertions;
     using Microsoft.Extensions.Configuration;
     using NUnit.Framework;
+    using System;
 
     public class ContentViewerViewModelTests
     {
@@ -213,7 +214,7 @@
             );
 
             // Then
-            var courseTitle = $"{applicationName} - {customisationName}";
+            var courseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             contentViewerViewModel.CourseTitle.Should().BeEquivalentTo(courseTitle);
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/CourseCompletionViewModelTests.cs
@@ -51,7 +51,7 @@
             var courseCompletionViewModel = new CourseCompletionViewModel(config, expectedCourseCompletion, ProgressId);
 
             // Then
-            var courseTitle = $"{applicationName} - {customisationName}";
+            var courseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             courseCompletionViewModel.CourseTitle.Should().BeEquivalentTo(courseTitle);
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticAssessmentViewModelTests.cs
@@ -29,7 +29,7 @@
                 new DiagnosticAssessmentViewModel(diagnosticAssessment, CustomisationId, SectionId);
 
             // Then
-            diagnosticAssessmentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+            diagnosticAssessmentViewModel.CourseTitle.Should().Be(!String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticContentViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.ViewModels.LearningMenu
 {
+    using System;
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.LearningMenu;
@@ -53,7 +54,7 @@
             );
 
             // Then
-            diagnosticContentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+            diagnosticContentViewModel.CourseTitle.Should().Be(!String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/IntitialMenuViewModelTests.cs
@@ -24,7 +24,7 @@
             var initialMenuViewModel = new InitialMenuViewModel(expectedCourseContent);
 
             // Then
-            initialMenuViewModel.Title.Should().Be($"{applicationName} - {customisationName}");
+            initialMenuViewModel.Title.Should().Be(!String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningAssessmentViewModelTests.cs
@@ -27,7 +27,7 @@
                 new PostLearningAssessmentViewModel(postLearningAssessment, CustomisationId, SectionId);
 
             // Then
-            postLearningAssessmentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+            postLearningAssessmentViewModel.CourseTitle.Should().Be(!String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningContentViewModelTests.cs
@@ -6,6 +6,7 @@
     using FluentAssertions;
     using Microsoft.Extensions.Configuration;
     using NUnit.Framework;
+    using System;
 
     public class PostLearningContentViewModelTests
     {
@@ -50,7 +51,7 @@
             );
 
             // Then
-            postLearningContentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+            postLearningContentViewModel.CourseTitle.Should().Be(!String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/SectionContentViewModelTests.cs
@@ -38,7 +38,7 @@
             var sectionContentViewModel = new SectionContentViewModel(config, sectionContent, CustomisationId, SectionId);
 
             // Then
-            sectionContentViewModel.CourseTitle.Should().Be($"{applicationName} - {customisationName}");
+            sectionContentViewModel.CourseTitle.Should().Be(!String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialVideoViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialVideoViewModelTests.cs
@@ -7,6 +7,7 @@
     using FluentAssertions;
     using Microsoft.Extensions.Configuration;
     using NUnit.Framework;
+    using System;
 
     class TutorialVideoViewModelTests
     {
@@ -145,7 +146,7 @@
             );
 
             // Then
-            var courseTitle = $"{applicationName} - {customisationName}";
+            var courseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
             tutorialVideoViewModel.CourseTitle.Should().BeEquivalentTo(courseTitle);
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/TutorialViewModelTests.cs
@@ -72,7 +72,7 @@
             // Given
             const string applicationName = "Application";
             const string customisationName = "Customisation";
-            var courseTitle = $"{applicationName} - {customisationName}";
+            var courseTitle = !String.IsNullOrEmpty(customisationName) ? $"{applicationName} - {customisationName}" : applicationName;
 
             var expectedTutorialInformation = TutorialContentHelper.CreateDefaultTutorialInformation(
                 applicationName: applicationName,


### PR DESCRIPTION
### JIRA link
[_DLSV2-XXXX_](https://hee-tis.atlassian.net/browse/TD-1766)

### Description
Added the condition to check the customisation name everywhere in the application

### Screenshots


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
