### PR TITLE
TD-2281 Fixed 500 error while updating centre email of inactive learner by removing active flag criteria in getting email list

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -259,10 +259,10 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             DateTime date = new DateTime(model.ContractReviewYear.Value, model.ContractReviewMonth.Value, model.ContractReviewDay.Value, 0, 0, 0);
 
             // When
-            var result = controller.EditContractInfo(model, DateTime.UtcNow.Day, DateTime.UtcNow.Month, DateTime.UtcNow.Year);
+            var result = controller.EditContractInfo(model, DateTime.UtcNow.Day +1, DateTime.UtcNow.Month, DateTime.UtcNow.Year);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithActionName("EditContractInfo");
+            result.Should().BeRedirectToActionResult().WithActionName("ManageCentre");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -221,7 +221,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             A.CallTo(() => centresDataService.GetContractInfo(CenterId)).Returns(CentreContractAdminUsageTestHelper.GetDefaultEditContractInfo(CenterId));
 
             // When
-            var result = controller.EditContractInfo(centreId,28,8,2023);
+            var result = controller.EditContractInfo(centreId, 28, 8, 2023);
 
             // Then
             using (new AssertionScope())
@@ -251,25 +251,18 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
                 ContractTypeID = 1,
                 ServerSpaceBytesInc = 5368709120,
                 DelegateUploadSpace = 52428800,
-                ContractReviewDate = DateTime.Parse("2023-08-28 16:28:55.247"),
-                ContractReviewDay = 28,
-                ContractReviewMonth = 8,
-                ContractReviewYear = 2023
+                ContractReviewDate = DateTime.Parse(DateTime.UtcNow.ToString()),
+                ContractReviewDay = DateTime.UtcNow.Day,
+                ContractReviewMonth = DateTime.UtcNow.Month,
+                ContractReviewYear = DateTime.UtcNow.Year
             };
             DateTime date = new DateTime(model.ContractReviewYear.Value, model.ContractReviewMonth.Value, model.ContractReviewDay.Value, 0, 0, 0);
 
             // When
-            var result = controller.EditContractInfo(model,28,8,2023);
+            var result = controller.EditContractInfo(model, DateTime.UtcNow.Day, DateTime.UtcNow.Month, DateTime.UtcNow.Year);
 
             // Then
-
-            A.CallTo(() => centresDataService.UpdateContractTypeandCenter(model.CentreId,
-               model.ContractTypeID,
-               model.DelegateUploadSpace,
-               model.ServerSpaceBytesInc,
-               date
-               )).MustHaveHappened();
-            result.Should().BeRedirectToActionResult().WithActionName("ManageCentre");
+            result.Should().BeRedirectToActionResult().WithActionName("EditContractInfo");
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -256,12 +256,19 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
                 ContractReviewMonth = DateTime.UtcNow.Month,
                 ContractReviewYear = DateTime.UtcNow.Year
             };
-            DateTime date = new DateTime(model.ContractReviewYear.Value, model.ContractReviewMonth.Value, model.ContractReviewDay.Value, 0, 0, 0);
+            DateTime date = new DateTime(model.ContractReviewYear.Value, model.ContractReviewMonth.Value, model.ContractReviewDay.Value + 1, 0, 0, 0);
 
             // When
-            var result = controller.EditContractInfo(model, DateTime.UtcNow.Day +1, DateTime.UtcNow.Month, DateTime.UtcNow.Year);
+            var result = controller.EditContractInfo(model, DateTime.UtcNow.Day + 1, DateTime.UtcNow.Month, DateTime.UtcNow.Year);
 
             // Then
+            A.CallTo(() => centresDataService.UpdateContractTypeandCenter(model.CentreId,
+               model.ContractTypeID,
+               model.DelegateUploadSpace,
+               model.ServerSpaceBytesInc,
+               date
+               )).MustHaveHappened();
+
             result.Should().BeRedirectToActionResult().WithActionName("ManageCentre");
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -474,7 +474,7 @@
                 : new List<EditDelegateRegistrationPromptViewModel>();
 
             var allCentreSpecificEmails = centreId == null
-                ? userService.GetAllActiveCentreEmailsForUser(userId).Select(
+                ? userService.GetAllActiveCentreEmailsForUser(userId,true).Select(
                     row =>
                     {
                         string? email = null;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2281

### Description
Points addressed in this Commit :
1) Fixed 500 error while updating centre email of inactive learner by removing active flag criteria in getting email list by modifying the controller.

### Screenshots
[Choose-A-Centre---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/7db3841d-7bb9-4f3f-ae75-eccc60d7a7d0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
