### PR TITLE
TD-2459 Show sign off button when reconfirmed the results of self assessments

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -177,7 +177,7 @@
                     </p>
                 </div>
             }
-          @if (!Model.SupervisorSignOffs.Any()) {
+          @if (!Model.SupervisorSignOffs.Any() || latestResult > latestSignoff) {
             <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
        asp-action="RequestSignOff"
        asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2459

### Description
Points addressed in this Commit :
1) Show sign off button when reconfirmed the results of self assessments by modifying the views.

### Screenshots
![Self-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/3755046a-85c2-40b1-815f-fea2f9cc51af)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/f9e310c3-a339-4235-9add-3fb75b576322)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
