### PR TITLE
TD-1758: When user enroll himself and a supevisor add this user as staff member, all assessments will be displayed irrespective of centres.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -170,9 +170,9 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 		                au.Forename + ' ' + au.Surname AS SupervisorName,                 
 		                (SELECT COUNT(ca.ID) AS Expr1
                         FROM CandidateAssessments AS ca  LEFT JOIN
-                        CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL INNER JOIN
+                        CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL AND cas.SupervisorDelegateId = sd.ID INNER JOIN
                         SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID 
-                        WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = sd.ID OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID)
+                        WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = sd.ID OR (cas.CandidateAssessmentID IS NULL)
 				        AND ((sa.SupervisorSelfAssessmentReview = 1) OR (sa.SupervisorResultsReview = 1)))) AS CandidateAssessmentCount, 
 		                CAST(COALESCE (au2.IsNominatedSupervisor, 0) AS Bit) AS DelegateIsNominatedSupervisor, 
 		                CAST(COALESCE (au2.IsSupervisor, 0) AS Bit) AS DelegateIsSupervisor,             
@@ -442,7 +442,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (sarsv.Superceded = 0)) AS ResultsVerificationRequests
                  FROM   CandidateAssessments AS ca  LEFT JOIN
-                 CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL INNER JOIN
+                 CandidateAssessmentSupervisors AS cas ON cas.CandidateAssessmentID = ca.ID AND cas.Removed IS NULL and cas.SupervisorDelegateId=@supervisorDelegateId INNER JOIN
                  SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID LEFT OUTER JOIN
                  NRPProfessionalGroups AS pg ON sa.NRPProfessionalGroupID = pg.ID LEFT OUTER JOIN
                  NRPSubGroups AS sg ON sa.NRPSubGroupID = sg.ID LEFT OUTER JOIN
@@ -450,7 +450,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
                  RIGHT OUTER JOIN SupervisorDelegates AS sd ON sd.ID=@supervisorDelegateId
                  RIGHT OUTER JOIN AdminAccounts AS au ON au.ID = sd.SupervisorAdminID
-                 WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = @supervisorDelegateId OR (cas.CandidateAssessmentID IS NULL AND ca.CentreID = au.CentreID)  AND ((sa.SupervisorSelfAssessmentReview = 1) OR
+                 WHERE (ca.RemovedDate IS NULL) AND (ca.DelegateUserID=sd.DelegateUserID) AND (cas.SupervisorDelegateId = @supervisorDelegateId OR (cas.CandidateAssessmentID IS NULL)  AND ((sa.SupervisorSelfAssessmentReview = 1) OR
                          (sa.SupervisorResultsReview = 1)))", new { supervisorDelegateId }
                 );
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1758

### Description
When user enrol assessments by himself and a supervisor add this user as a staff member, all assessments will be displayed irrespective of centres.

### Screenshots
User enrolled with 4 assessments
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/9a68ac10-17eb-489f-b7ca-4527b5cca7d8)

assessments will be displayed with **_"Supervise"_** link
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/37971849-20a7-4fbf-8925-86f1abb17105)

When removed IV Therapy

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/ddb2c2a8-41d8-49a1-8129-b26bf9465e4e)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/50dec27b-7b80-41ba-b0a4-e2fed43c4419)

When IV Therapy added back
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/962c07af-71ab-4919-9800-b2c98fae9937)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/28c14e43-6c7c-4aca-a7b8-ab5ec5e90f5f)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
