### PR TITLE
TD-2115 & TD-2116 Corrects the case for the script name

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/SelfAssessmentsReport.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/SelfAssessmentsReport.cshtml
@@ -38,4 +38,4 @@
         </div>
     </div>
 </div>
-<script src="@Url.Content("~/js/superAdmin/platformReports.js")" asp-append-version="true"></script>
+<script src="@Url.Content("~/js/superAdmin/selfAssessmentReports.js")" asp-append-version="true"></script>

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/SelfAssessmentsReport.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/SelfAssessmentsReport.cshtml
@@ -38,4 +38,4 @@
         </div>
     </div>
 </div>
-<script src="@Url.Content("~/js/superAdmin/platformreports.js")" asp-append-version="true"></script>
+<script src="@Url.Content("~/js/superAdmin/platformReports.js")" asp-append-version="true"></script>


### PR DESCRIPTION
### JIRA link
[TD-2115](https://hee-tis.atlassian.net/browse/TD-2115) and [TD-2116](https://hee-tis.atlassian.net/browse/TD-2116)

### Description
Fixes the name of the reports JavaScript file in the script tag to match the case of the actual file name.

### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2115]: https://hee-tis.atlassian.net/browse/TD-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-2116]: https://hee-tis.atlassian.net/browse/TD-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ