### PR TITLE
TD-989 Super admin role limits validation fix

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -110,9 +110,9 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             var expectedVm = new CentreRoleLimitsViewModel
             {
                 CentreId = 374,
-                RoleLimitCmsAdministrators = null,
+                RoleLimitCmsAdministrators = 0,
                 IsRoleLimitSetCmsAdministrators = false,    // automatically set off
-                RoleLimitCmsManagers = null,
+                RoleLimitCmsManagers = 0,
                 IsRoleLimitSetCmsManagers = false,          // automatically set off
                 IsRoleLimitSetContentCreatorLicences = true,
                 RoleLimitContentCreatorLicences = 10,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -110,9 +110,9 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             var expectedVm = new CentreRoleLimitsViewModel
             {
                 CentreId = 374,
-                RoleLimitCmsAdministrators = 0,
+                RoleLimitCmsAdministrators = null,
                 IsRoleLimitSetCmsAdministrators = false,    // automatically set off
-                RoleLimitCmsManagers = 0,
+                RoleLimitCmsManagers = null,
                 IsRoleLimitSetCmsManagers = false,          // automatically set off
                 IsRoleLimitSetContentCreatorLicences = true,
                 RoleLimitContentCreatorLicences = 10,

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -360,55 +360,48 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         [Route("SuperAdmin/Centres/{centreId=0:int}/CentreRoleLimits")]
         public IActionResult EditCentreRoleLimits(CentreRoleLimitsViewModel model)
         {
-            if (model.IsRoleLimitSetCmsAdministrators && model.RoleLimitCmsAdministrators == null)
+            if (model.IsRoleLimitSetCmsAdministrators)
             {
                 ModelState["RoleLimitCmsAdministrators.RoleLimitCmsAdministrators"]?.Errors.Clear();
-            }
-            if (!model.IsRoleLimitSetCmsAdministrators)
-            {
+            }else{
                 model.RoleLimitCmsAdministrators = -1;
             }
-            model.RoleLimitCmsAdministrators ??= -1;
 
-            if (model.IsRoleLimitSetCmsManagers && model.RoleLimitCmsManagers == null)
+            if (model.IsRoleLimitSetCmsManagers)
             {
                 ModelState["RoleLimitCmsManagers.RoleLimitCmsManagers"]?.Errors.Clear();
             }
-            if (!model.IsRoleLimitSetCmsManagers)
+            else
             {
                 model.RoleLimitCmsManagers = -1;
             }
-            model.RoleLimitCmsManagers ??= -1;
 
-            if (model.IsRoleLimitSetContentCreatorLicences && model.RoleLimitContentCreatorLicences == null)
+            if (model.IsRoleLimitSetContentCreatorLicences)
             {
                 ModelState["RoleLimitContentCreatorLicences.RoleLimitContentCreatorLicences"]?.Errors.Clear();
             }
-            if (!model.IsRoleLimitSetContentCreatorLicences)
+            else
             {
                 model.RoleLimitContentCreatorLicences = -1;
             }
-            model.RoleLimitContentCreatorLicences ??= -1;
 
-            if (model.IsRoleLimitSetCustomCourses && model.RoleLimitCustomCourses == null)
+            if (model.IsRoleLimitSetCustomCourses)
             {
                 ModelState["RoleLimitCustomCourses.RoleLimitCustomCourses"]?.Errors.Clear();
             }
-            if (!model.IsRoleLimitSetCustomCourses)
+            else
             {
                 model.RoleLimitCustomCourses = -1;
             }
-            model.RoleLimitCustomCourses ??= -1;
 
-            if (model.IsRoleLimitSetTrainers && model.RoleLimitTrainers == null)
+            if (model.IsRoleLimitSetTrainers)
             {
                 ModelState["RoleLimitTrainers.RoleLimitTrainers"]?.Errors.Clear();
             }
-            if (!model.IsRoleLimitSetTrainers)
+            else
             {
                 model.RoleLimitTrainers = -1;
             }
-            model.RoleLimitTrainers ??= -1;
 
             if (!ModelState.IsValid)
             {

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -360,47 +360,34 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         [Route("SuperAdmin/Centres/{centreId=0:int}/CentreRoleLimits")]
         public IActionResult EditCentreRoleLimits(CentreRoleLimitsViewModel model)
         {
-            if (model.IsRoleLimitSetCmsAdministrators)
+            if (!model.IsRoleLimitSetCmsAdministrators)
             {
-                ModelState["RoleLimitCmsAdministrators.RoleLimitCmsAdministrators"]?.Errors.Clear();
-            }else{
                 model.RoleLimitCmsAdministrators = -1;
+                ModelState.Remove("RoleLimitCmsAdministrators");
             }
 
-            if (model.IsRoleLimitSetCmsManagers)
-            {
-                ModelState["RoleLimitCmsManagers.RoleLimitCmsManagers"]?.Errors.Clear();
-            }
-            else
+            if (!model.IsRoleLimitSetCmsManagers)
             {
                 model.RoleLimitCmsManagers = -1;
+                ModelState.Remove("RoleLimitCmsManagers");
             }
 
-            if (model.IsRoleLimitSetContentCreatorLicences)
-            {
-                ModelState["RoleLimitContentCreatorLicences.RoleLimitContentCreatorLicences"]?.Errors.Clear();
-            }
-            else
+            if (!model.IsRoleLimitSetContentCreatorLicences)
             {
                 model.RoleLimitContentCreatorLicences = -1;
+                ModelState.Remove("RoleLimitContentCreatorLicences");
             }
 
-            if (model.IsRoleLimitSetCustomCourses)
-            {
-                ModelState["RoleLimitCustomCourses.RoleLimitCustomCourses"]?.Errors.Clear();
-            }
-            else
+            if (!model.IsRoleLimitSetCustomCourses)
             {
                 model.RoleLimitCustomCourses = -1;
+                ModelState.Remove("RoleLimitCustomCourses");
             }
 
-            if (model.IsRoleLimitSetTrainers)
-            {
-                ModelState["RoleLimitTrainers.RoleLimitTrainers"]?.Errors.Clear();
-            }
-            else
+            if (!model.IsRoleLimitSetTrainers)
             {
                 model.RoleLimitTrainers = -1;
+                ModelState.Remove("RoleLimitTrainers");
             }
 
             if (!ModelState.IsValid)

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreRoleLimitsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreRoleLimitsViewModel.cs
@@ -11,19 +11,24 @@
         public bool IsRoleLimitSetCustomCourses { get; set; }
         public bool IsRoleLimitSetTrainers { get; set; }
 
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitCmsAdministrators { get; set; }
+        [Required(ErrorMessage = "The role limit is required.")]
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
+        public int RoleLimitCmsAdministrators { get; set; }
 
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitCmsManagers { get; set; }
+        [Required(ErrorMessage = "The role limit is required.")]
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
+        public int RoleLimitCmsManagers { get; set; }
 
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitContentCreatorLicences { get; set; }
+        [Required(ErrorMessage = "The role limit is required.")]
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
+        public int RoleLimitContentCreatorLicences { get; set; }
 
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitCustomCourses { get; set; }
+        [Required(ErrorMessage = "The role limit is required.")]
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
+        public int RoleLimitCustomCourses { get; set; }
 
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a non-negative whole number.")]
-        public int? RoleLimitTrainers { get; set; }
+        [Required(ErrorMessage = "The role limit is required.")]
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
+        public int RoleLimitTrainers { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreRoleLimitsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreRoleLimitsViewModel.cs
@@ -12,23 +12,23 @@
         public bool IsRoleLimitSetTrainers { get; set; }
 
         [Required(ErrorMessage = "The role limit is required.")]
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
-        public int RoleLimitCmsAdministrators { get; set; }
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be zero or a positive number.")]
+        public int? RoleLimitCmsAdministrators { get; set; }
 
         [Required(ErrorMessage = "The role limit is required.")]
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
-        public int RoleLimitCmsManagers { get; set; }
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be zero or a positive number.")]
+        public int? RoleLimitCmsManagers { get; set; }
 
         [Required(ErrorMessage = "The role limit is required.")]
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
-        public int RoleLimitContentCreatorLicences { get; set; }
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be zero or a positive number.")]
+        public int? RoleLimitContentCreatorLicences { get; set; }
 
         [Required(ErrorMessage = "The role limit is required.")]
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
-        public int RoleLimitCustomCourses { get; set; }
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be zero or a positive number.")]
+        public int? RoleLimitCustomCourses { get; set; }
 
         [Required(ErrorMessage = "The role limit is required.")]
-        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be a number.")]
-        public int RoleLimitTrainers { get; set; }
+        [Range(-1, int.MaxValue, ErrorMessage = "The role limit must be zero or a positive number.")]
+        public int? RoleLimitTrainers { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-989](https://hee-tis.atlassian.net/browse/TD-989)

### Description
Fixed Super Admin centre role limit validation to allow and handle null user inputs.

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-989]: https://hee-tis.atlassian.net/browse/TD-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![TD-989](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/b8fe6b0e-65d7-4a2a-9508-abb112c5cdc9)

