### PR TITLE
TD-2411 Fixed wrong value showing on 'Customise Role limits' screen

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -110,9 +110,9 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             var expectedVm = new CentreRoleLimitsViewModel
             {
                 CentreId = 374,
-                RoleLimitCmsAdministrators = null,
+                RoleLimitCmsAdministrators = -1,
                 IsRoleLimitSetCmsAdministrators = false,    // automatically set off
-                RoleLimitCmsManagers = null,
+                RoleLimitCmsManagers = -1,
                 IsRoleLimitSetCmsManagers = false,          // automatically set off
                 IsRoleLimitSetContentCreatorLicences = true,
                 RoleLimitContentCreatorLicences = 10,

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -252,7 +252,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
             );
             return RedirectToAction("ManageCentre", "Centres", new { centreId = model.CentreId });
         }
-        
+
         [Route("SuperAdmin/Centres/{centreId=0:int}/DeactivateCentre")]
         public IActionResult DeactivateCentre(int centreId = 0)
         {
@@ -305,6 +305,14 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCmsAdministrators != null && roleLimits.RoleLimitCmsAdministrators != -1))
             {
+                if (roleLimits.RoleLimitCmsAdministrators != -1)
+                {
+                    centreRoleLimitsViewModel.RoleLimitCmsAdministrators = null;
+                }
+                else
+                {
+                    centreRoleLimitsViewModel.RoleLimitCmsAdministrators = -1;
+                }
                 centreRoleLimitsViewModel.IsRoleLimitSetCmsAdministrators = false;
             }
             else
@@ -315,6 +323,14 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCmsManagers != null && roleLimits.RoleLimitCmsManagers != -1))
             {
+                if (roleLimits.RoleLimitCmsManagers != -1)
+                {
+                    centreRoleLimitsViewModel.RoleLimitCmsManagers = null;
+                }
+                else
+                {
+                    centreRoleLimitsViewModel.RoleLimitCmsManagers = -1;
+                }
                 centreRoleLimitsViewModel.IsRoleLimitSetCmsManagers = false;
             }
             else
@@ -325,6 +341,14 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCcLicences != null && roleLimits.RoleLimitCcLicences != -1))
             {
+                if (roleLimits.RoleLimitCcLicences != -1)
+                {
+                    centreRoleLimitsViewModel.RoleLimitContentCreatorLicences = null;
+                }
+                else
+                {
+                    centreRoleLimitsViewModel.RoleLimitContentCreatorLicences = -1;
+                }
                 centreRoleLimitsViewModel.IsRoleLimitSetContentCreatorLicences = false;
             }
             else
@@ -335,6 +359,14 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitCustomCourses != null && roleLimits.RoleLimitCustomCourses != -1))
             {
+                if (roleLimits.RoleLimitCustomCourses != -1)
+                {
+                    centreRoleLimitsViewModel.RoleLimitCustomCourses = null;
+                }
+                else
+                {
+                    centreRoleLimitsViewModel.RoleLimitCustomCourses = -1;
+                }
                 centreRoleLimitsViewModel.IsRoleLimitSetCustomCourses = false;
             }
             else
@@ -345,6 +377,14 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!(roleLimits.RoleLimitTrainers != null && roleLimits.RoleLimitTrainers != -1))
             {
+                if (roleLimits.RoleLimitTrainers != -1)
+                {
+                    centreRoleLimitsViewModel.RoleLimitTrainers = null;
+                }
+                else
+                {
+                    centreRoleLimitsViewModel.RoleLimitTrainers = -1;
+                }
                 centreRoleLimitsViewModel.IsRoleLimitSetTrainers = false;
             }
             else
@@ -526,10 +566,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                         contractTypeViewModel.CentreId,
                         day,
                         month,
-                        year,
-                        contractTypeViewModel.ContractTypeID,
-                        contractTypeViewModel.ServerSpaceBytesInc,
-                        contractTypeViewModel.DelegateUploadSpace
+                        year
                     });
                 }
             }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2411

### Description
Points addressed in this Commit :

1. Fixed wrong value showing on 'Customise Role limits' screen by modifying the controller.

### Screenshots
[Manage-Centre---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/a9007806-14b4-4cac-84b4-f647208becb6)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
