### PR TITLE
TD-2094 Fixed duplicate entry issue when we remove the self assessment and re enrol it from the Tracking system

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -436,11 +436,20 @@ namespace DigitalLearningSolutions.Data.DataServices
 
             if (candidateAssessmentId > 0 && supervisorDelegateId > 0 && selfAssessmentSupervisorRoleId > 0)
             {
-                int numberOfAffectedRows = connection.Execute(
-                    @"INSERT INTO CandidateAssessmentSupervisors (CandidateAssessmentID, SupervisorDelegateId, SelfAssessmentSupervisorRoleID)
-                        VALUES (@candidateAssessmentId, @supervisorDelegateId, @selfAssessmentSupervisorRoleId)",
-                    new { candidateAssessmentId, supervisorDelegateId, selfAssessmentSupervisorRoleId }
+                int candidateAssessmentSupervisorsId = (int)connection.ExecuteScalar(
+                    @"SELECT COALESCE
+                             ((SELECT TOP 1 ID FROM CandidateAssessmentSupervisors WHERE CandidateAssessmentID = @candidateAssessmentID AND SupervisorDelegateId = @supervisorDelegateId), 0) AS ID",
+                    new { candidateAssessmentId, supervisorDelegateId }
                 );
+
+                if (candidateAssessmentSupervisorsId == 0)
+                {
+                    int numberOfAffectedRows = connection.Execute(
+                        @"INSERT INTO CandidateAssessmentSupervisors (CandidateAssessmentID, SupervisorDelegateId, SelfAssessmentSupervisorRoleID)
+                        VALUES (@candidateAssessmentId, @supervisorDelegateId, @selfAssessmentSupervisorRoleId)",
+                        new { candidateAssessmentId, supervisorDelegateId, selfAssessmentSupervisorRoleId }
+                    );
+                }
             }
 
             if (candidateAssessmentId > 1)
@@ -450,11 +459,12 @@ namespace DigitalLearningSolutions.Data.DataServices
                 UPDATE CandidateAssessments SET RemovedDate = NULL
                   WHERE ID = @candidateAssessmentId
 
-                UPDATE CandidateAssessmentSupervisors SET Removed = NULL
+                UPDATE CandidateAssessmentSupervisors SET Removed = NULL,
+                  SelfAssessmentSupervisorRoleID = @selfAssessmentSupervisorRoleID
                   WHERE CandidateAssessmentID = @candidateAssessmentId
 
                 COMMIT TRANSACTION"
-                , new { candidateAssessmentId });
+                , new { candidateAssessmentId, selfAssessmentSupervisorRoleId });
             }
 
             if (candidateAssessmentId < 1)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2094

### Description
Points addressed in this Commit :
1) Fixed duplicate entry issue when we remove the self assessment and re enrol it from the Tracking system by modifying the dataservice.

### Screenshots
This is backend change so no screenshot available.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
