### PR TITLE
TD_2004 course are not shown in Course Setup for existing customisations

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_CourseSectionExpandable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/CourseContent/_CourseSectionExpandable.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.CourseSetup.CourseContent
 @model CourseSectionViewModel
 
-@if (Model.Tutorials.Any(t => t.DiagnosticEnabled || t.LearningEnabled))
+@if (Model.Tutorials.Any())
 {
   <div class="nhsuk-panel word-break">
     <details class="nhsuk-details nhsuk-expander">
@@ -14,8 +14,6 @@
         <dl class="nhsuk-summary-list">
           @foreach (var tutorial in Model.Tutorials)
           {
-            @if (tutorial.DiagnosticEnabled || tutorial.LearningEnabled)
-            {
               <div class="nhsuk-summary-list__row basic-summary-list__row">
                 <dt class="nhsuk-summary-list__key">
                   @tutorial.TutorialName
@@ -35,7 +33,6 @@
                   }
                 </dd>
               </div>
-            }
           }
         </dl>
         <a class="nhsuk-button"


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2004

### Description
course are not shown in Course Setup for existing customisations
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/7bfb5bdb-59c4-4021-94be-35e2d88cda98)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c31c69e3-0d57-4812-a397-2cf010045257)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
