### PR TITLE
TD-989 Fix header text issue on failed validation.

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -432,6 +432,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
 
             if (!ModelState.IsValid)
             {
+                ViewBag.CentreName = centresDataService.GetCentreName(model.CentreId);
                 return View("CentreRoleLimits", model);
             }
 


### PR DESCRIPTION
### JIRA link
[TD-989](https://hee-tis.atlassian.net/browse/TD-989)

### Description
Fixed issue where centre name was not displayed in the header after a validation failure.

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-989]: https://hee-tis.atlassian.net/browse/TD-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![td-989](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/49746eec-9742-4530-b7b2-c85fa424b27f)
