### PR TITLE
TD-2507 Tidies the framework vocabulary drop down options

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
@@ -61,8 +61,7 @@ else
     <select class="nhsuk-select" asp-for="FrameworkConfig" name="FrameworkConfig">
       <option value="Capability" selected="selected">Capabilities</option>
       <option value="Competency">Competencies</option>
-      <option value="Proficiency">Proficiency</option>
-      <option value="Requirement">Requirements</option>
+      <option value="Proficiency">Proficiencies</option>
     </select>
     <span nhs-validation-for="FrameworkConfig"></span>
   </nhs-form-group>


### PR DESCRIPTION
### JIRA link
[TD-2507](https://hee-tis.atlassian.net/browse/TD-2507)

### Description
Tidies the framework vocabulary list, pluralising "Proficiency" and removing "Requirements" from the drop-down.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/b3766f74-928e-4c0e-8a00-4ec6558f3d90)

### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2507]: https://hee-tis.atlassian.net/browse/TD-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ