### PR TITLE
TD-2027 Supervisor sign-off fix for spurious Withdraw sign-off link.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -54,8 +54,10 @@
                         }
                     }
 
-                    <a asp-action="WithdrawSupervisorSignOffRequest" asp-route-selfAssessmentId=@ViewContext.RouteData.Values["selfAssessmentId"]
-                       asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="Proficiencies" asp-route-source="SupervisorSignOffSummary">Withdraw</a>
+                    @if (Context.Request.Path.Value!.Contains("SelfAssessment")) {
+                        <a asp-action="WithdrawSupervisorSignOffRequest" asp-route-selfAssessmentId=@ViewContext.RouteData.Values["selfAssessmentId"]
+                           asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="Proficiencies" asp-route-source="SupervisorSignOffSummary">Withdraw</a>
+                    }
                 }
             </dd>
         </div>


### PR DESCRIPTION
### JIRA link
[TD-2027](https://hee-tis.atlassian.net/browse/TD-2027)

### Description
Added conditional render logic so Withdraw sign-off link is not inadvertently displayed on Staff ProfileAssessment page due to use of shared _SupervisorSignOffSummary component.

### Screenshots
Screenshot below

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2027]: https://hee-tis.atlassian.net/browse/TD-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![TD-2027a](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/03e22cbd-8776-4dbb-ab73-9b954b70a8de)
![TD-2027b](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/e42fb2f0-32c6-428e-a1ad-8a02fb46267f)
