### PR TITLE
TD-2506: Fix use of async void in ValidateAllowedDlsSubApplication.cs

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/ValidateAllowedDlsSubApplication.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/ValidateAllowedDlsSubApplication.cs
@@ -32,7 +32,7 @@
 
         public void OnActionExecuted(ActionExecutedContext context) { }
 
-        public async void OnActionExecuting(ActionExecutingContext context)
+        public  void OnActionExecuting(ActionExecutingContext context)
         {
             var user = context.HttpContext.User;
             if (!user.Identity.IsAuthenticated)
@@ -48,7 +48,7 @@
                 return;
             }
 
-            if (application == null || await ApplicationIsInaccessibleByPage(application!))
+            if (application == null || Task.Run(() => ApplicationIsInaccessibleByPage(application!)).Result)
             {
                 SetNotFoundResult(context);
                 return;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2506

### Description
Fixed the use of async void which caused memory leakage

### Screenshots

Checked the existing login functionality after code change which was using the async void method.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/91dca0c4-a580-487b-b045-e606098c328a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/a7195ccc-35c6-4439-bb6a-4d20109e592a)

**_We are getting the hit in below code after the fix._**

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/2b99b4d4-d8d8-4d6c-a08a-2db9bcbfb887)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/c06b5b75-5aca-48ce-9fd9-0b143640cf38)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
