### PR TITLE
TD-1943 adding header and aligning the header in the mobile view of c…

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/2023090611401334_updateCookiePolicyContentHtml.cs
+++ b/DigitalLearningSolutions.Data.Migrations/2023090611401334_updateCookiePolicyContentHtml.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace DigitalLearningSolutions.Data.Migrations
 {
-    [Migration(202309061452)]
+    [Migration(202309131452)]
 
     public class UpdateCookiePolicyContentHtml : Migration
     {

--- a/DigitalLearningSolutions.Data.Migrations/2023090611401334_updateCookiePolicyContentHtml.cs
+++ b/DigitalLearningSolutions.Data.Migrations/2023090611401334_updateCookiePolicyContentHtml.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace DigitalLearningSolutions.Data.Migrations
 {
-    [Migration(202309131452)]
+    [Migration(202309141452)]
 
     public class UpdateCookiePolicyContentHtml : Migration
     {

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -1033,7 +1033,8 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;div class=nhsuk-u-reading-width&gt;
+        ///   Looks up a localized string similar to 
+        ///  &lt;div class=nhsuk-u-reading-width&gt;
         ///&lt;h2&gt;What are cookies?&lt;/h2&gt;
         ///&lt;p&gt;Cookies are files saved on your phone, tablet or computer when you visit a website.&lt;/p&gt;
         ///&lt;p&gt;They store information about how you use the website, such as the pages you visit.&lt;/p&gt;
@@ -1041,7 +1042,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///&lt;h2&gt;How we use cookies&lt;/h2&gt;&lt;p&gt;We only use cookies to:&lt;/p&gt;
         ///&lt;ul&gt;
         ///&lt;li&gt;make our website work&lt;/li&gt;
-        ///&lt;li&gt;measure how you use our website, such as which links you clic [rest of string was truncated]&quot;;.
+        ///&lt;li&gt;measure how you use our website, such as which links you  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_1943_CookiePolicyContentHtml {
             get {

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -1033,8 +1033,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///  &lt;div class=nhsuk-u-reading-width&gt;
+        ///   Looks up a localized string similar to   &lt;div class=nhsuk-u-reading-width&gt;
         ///&lt;h2&gt;What are cookies?&lt;/h2&gt;
         ///&lt;p&gt;Cookies are files saved on your phone, tablet or computer when you visit a website.&lt;/p&gt;
         ///&lt;p&gt;They store information about how you use the website, such as the pages you visit.&lt;/p&gt;
@@ -1042,7 +1041,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///&lt;h2&gt;How we use cookies&lt;/h2&gt;&lt;p&gt;We only use cookies to:&lt;/p&gt;
         ///&lt;ul&gt;
         ///&lt;li&gt;make our website work&lt;/li&gt;
-        ///&lt;li&gt;measure how you use our website, such as which links you  [rest of string was truncated]&quot;;.
+        ///&lt;li&gt;measure how you use our website, such as which links you cl [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_1943_CookiePolicyContentHtml {
             get {

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -1033,7 +1033,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to   &lt;div class=nhsuk-u-reading-width&gt;
+        ///   Looks up a localized string similar to &lt;div class=nhsuk-u-reading-width&gt;
         ///&lt;h2&gt;What are cookies?&lt;/h2&gt;
         ///&lt;p&gt;Cookies are files saved on your phone, tablet or computer when you visit a website.&lt;/p&gt;
         ///&lt;p&gt;They store information about how you use the website, such as the pages you visit.&lt;/p&gt;
@@ -1041,7 +1041,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///&lt;h2&gt;How we use cookies&lt;/h2&gt;&lt;p&gt;We only use cookies to:&lt;/p&gt;
         ///&lt;ul&gt;
         ///&lt;li&gt;make our website work&lt;/li&gt;
-        ///&lt;li&gt;measure how you use our website, such as which links you cl [rest of string was truncated]&quot;;.
+        ///&lt;li&gt;measure how you use our website, such as which links you clic [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_1943_CookiePolicyContentHtml {
             get {

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -301,10 +301,10 @@
   <data name="TermsConditions" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\TermsConditions.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
-  <data name="TD_1943_CookiePolicyContentHtml" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD_1943_CookiePolicyContentHtml.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-  </data>
   <data name="TD_1943_CookiePolicyContentHtmlOldRecord" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\TD_1943_CookiePolicyContentHtmlOldRecord.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_1943_CookiePolicyContentHtml" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD_1943_CookiePolicyContentHtml.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD_1943_CookiePolicyContentHtml.txt
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD_1943_CookiePolicyContentHtml.txt
@@ -1,4 +1,5 @@
-<div class=nhsuk-u-reading-width>
+
+  <div class=nhsuk-u-reading-width>
 <h2>What are cookies?</h2>
 <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
 <p>They store information about how you use the website, such as the pages you visit.</p>
@@ -10,7 +11,7 @@
 </li>
 </ul>
 <p>We do not use any other cookies, for example, cookies that remember your settings or cookies that help with health campaigns.</p>
-<p>We sometimes use tools on other organisations'' websites to collect data or to ask for feedback. These tools set their own cookies.</p>
+<p>We sometimes use tools on other organisations' websites to collect data or to ask for feedback. These tools set their own cookies.</p>
 <h2>Cookies that make our website work</h2><p>We use cookies to keep our website secure and fast.</p></div>
 <details class="nhsuk-details">
 <summary class="nhsuk-details__summary">
@@ -37,7 +38,7 @@ ASP.NET_SessionId</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-Used to remember the users'' session on the web server.</td>
+Used to remember the users' session on the web server.</td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
  <span class="nhsuk-table-responsive__heading">Expiry</span>
 When you close the browser</td>
@@ -54,7 +55,7 @@ When you close the browser</td>
 Remembers your login user details.</td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>
-When you close the browser or after 14 days if you tick “Remember me” when logging in</td>
+When you close the browser or after 14 days if you tick “Remember me” when logging in</td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
 <td class="nhsuk-table__cell" data-label="Cookie name"role="cell"><span class="nhsuk-table-responsive__heading">Cookie name</span>.AspNetCore.Antiforgery.KCJdAkfXyjI</td>
@@ -102,8 +103,8 @@ When you close the browser (if you do not use the banner) or 1 year (if you use 
 <p><a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<p>Several of these are used to remember your filter selections when using the application. Including:
-<ul><li>AdminFilter<li>DelegateFilter<li>DelegateGroupsFilter<li>CourseFilter</ul></td>
+<div><p>Several of these are used to remember your filter selections when using the application. Including:
+<ul><li>AdminFilter<li>DelegateFilter<li>DelegateGroupsFilter<li>CourseFilter</ul></div></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>5 months </td>
 </tr>
@@ -126,7 +127,7 @@ Legacy tracking system cookies</td>
 <p><a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<p>Several of these are used to remember your grid search, filter and sort selections when using the legacy applications. Including:<ul><li>cms_courses_aspx_MainContent_<ul><li>bsgvCourses</ul><li>tracking_tickets_aspx_MainContent_<ul><li>bsgvTickets<li>bsgvCentreDelegates<li>bsgvCustomisations<li>bsgvAdminUsers<li>bsgvSuperviseDelegates</ul></ul></td>
+<div><p>Several of these are used to remember your grid search, filter and sort selections when using the legacy applications. Including:<ul><li>cms_courses_aspx_MainContent_<ul><li>bsgvCourses</ul><li>tracking_tickets_aspx_MainContent_<ul><li>bsgvTickets<li>bsgvCentreDelegates<li>bsgvCustomisations<li>bsgvAdminUsers<li>bsgvSuperviseDelegates</ul></ul></div></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell"><span class="nhsuk-table-responsive__heading">Expiry</span>12 months</td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
@@ -172,7 +173,7 @@ Google analytics cookies</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<p>These cookies are used to collect information about how visitors use our site, which we use to help improve it. The cookies collect information in an anonymous form, including the number of visitors to the site, where visitors have come to the site from and the pages they visited. These cookies may also be identified as originating from england.nhs.uk<p>These include cookies with names starting "_ga"<p><a href=http://www.google.com/intl/en-GB/policies/technologies/cookies/ >More information about Google cookies</a>.</td>
+<div><p>These cookies are used to collect information about how visitors use our site, which we use to help improve it. The cookies collect information in an anonymous form, including the number of visitors to the site, where visitors have come to the site from and the pages they visited. These cookies may also be identified as originating from england.nhs.uk<p>These include cookies with names starting "_ga"<p><a href=http://www.google.com/intl/en-GB/policies/technologies/cookies/ >More information about Google cookies</a>.</div></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell"><span class="nhsuk-table-responsive__heading">Expiry</span>13 months</td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
@@ -184,7 +185,7 @@ Hotjar cookies</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<p>Hotjar Tracking Code cookies are set on a visitor''s browser when they visit a website that loads the Hotjar Tracking Code. These cookies allow the Hotjar Tracking Code to function correctly. Apart from cookies, the Hotjar Tracking Code uses local and session storage as well.<p>These include cookies with names starting "_hj".<p><a href=https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code>More information about Hotjar cookies</a>.</td>
+<div><p>Hotjar Tracking Code cookies are set on a visitor's browser when they visit a website that loads the Hotjar Tracking Code. These cookies allow the Hotjar Tracking Code to function correctly. Apart from cookies, the Hotjar Tracking Code uses local and session storage as well.<p>These include cookies with names starting "_hj".<p><a href=https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code>More information about Hotjar cookies</a>.</div></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>1 year</td>
 </tr>

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD_1943_CookiePolicyContentHtml.txt
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD_1943_CookiePolicyContentHtml.txt
@@ -1,4 +1,3 @@
-
   <div class=nhsuk-u-reading-width>
 <h2>What are cookies?</h2>
 <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
@@ -11,7 +10,7 @@
 </li>
 </ul>
 <p>We do not use any other cookies, for example, cookies that remember your settings or cookies that help with health campaigns.</p>
-<p>We sometimes use tools on other organisations' websites to collect data or to ask for feedback. These tools set their own cookies.</p>
+<p>We sometimes use tools on other organisations'' websites to collect data or to ask for feedback. These tools set their own cookies.</p>
 <h2>Cookies that make our website work</h2><p>We use cookies to keep our website secure and fast.</p></div>
 <details class="nhsuk-details">
 <summary class="nhsuk-details__summary">
@@ -38,7 +37,7 @@ ASP.NET_SessionId</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-Used to remember the users' session on the web server.</td>
+Used to remember the users'' session on the web server.</td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
  <span class="nhsuk-table-responsive__heading">Expiry</span>
 When you close the browser</td>
@@ -185,11 +184,11 @@ Hotjar cookies</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<div><p>Hotjar Tracking Code cookies are set on a visitor's browser when they visit a website that loads the Hotjar Tracking Code. These cookies allow the Hotjar Tracking Code to function correctly. Apart from cookies, the Hotjar Tracking Code uses local and session storage as well.<p>These include cookies with names starting "_hj".<p><a href=https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code>More information about Hotjar cookies</a>.</div></td>
+<div><p>Hotjar Tracking Code cookies are set on a visitor''s browser when they visit a website that loads the Hotjar Tracking Code. These cookies allow the Hotjar Tracking Code to function correctly. Apart from cookies, the Hotjar Tracking Code uses local and session storage as well.<p>These include cookies with names starting "_hj".<p><a href=https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code>More information about Hotjar cookies</a>.</div></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>1 year</td>
 </tr>
 </table>
 </div>
 </div>
-</details>
+</details> 

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD_1943_CookiePolicyContentHtml.txt
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD_1943_CookiePolicyContentHtml.txt
@@ -1,4 +1,4 @@
-  <div class=nhsuk-u-reading-width>
+<div class=nhsuk-u-reading-width>
 <h2>What are cookies?</h2>
 <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
 <p>They store information about how you use the website, such as the pages you visit.</p>
@@ -54,7 +54,7 @@ When you close the browser</td>
 Remembers your login user details.</td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>
-When you close the browser or after 14 days if you tick “Remember me” when logging in</td>
+When you close the browser or after 14 days if you tick "Remember me" when logging in</td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
 <td class="nhsuk-table__cell" data-label="Cookie name"role="cell"><span class="nhsuk-table-responsive__heading">Cookie name</span>.AspNetCore.Antiforgery.KCJdAkfXyjI</td>
@@ -102,13 +102,14 @@ When you close the browser (if you do not use the banner) or 1 year (if you use 
 <p><a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<div><p>Several of these are used to remember your filter selections when using the application. Including:
-<ul><li>AdminFilter<li>DelegateFilter<li>DelegateGroupsFilter<li>CourseFilter</ul></div></td>
+<p>Several of these are used to remember your filter selections when using the application. Including:
+<ul><li>AdminFilter<li>DelegateFilter<li>DelegateGroupsFilter<li>CourseFilter</ul></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>5 months </td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
-<td class="nhsuk-table__cell" data-label="Cookie name"role="cell"><span class="nhsuk-table-responsive__heading">Cookie name</span>FindCentre</td>
+<td class="nhsuk-table__cell" data-label="Cookie name"role="cell">
+<span class="nhsuk-table-responsive__heading">Cookie name</span>FindCentre</td>
 <td class="nhsuk-table__cell" data-label="Domain" role="cell">
 <span class="nhsuk-table-responsive__heading">Domain</span>
 <p><a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
@@ -126,7 +127,7 @@ Legacy tracking system cookies</td>
 <p><a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<div><p>Several of these are used to remember your grid search, filter and sort selections when using the legacy applications. Including:<ul><li>cms_courses_aspx_MainContent_<ul><li>bsgvCourses</ul><li>tracking_tickets_aspx_MainContent_<ul><li>bsgvTickets<li>bsgvCentreDelegates<li>bsgvCustomisations<li>bsgvAdminUsers<li>bsgvSuperviseDelegates</ul></ul></div></td>
+<p>Several of these are used to remember your grid search, filter and sort selections when using the legacy applications. Including:<ul><li>cms_courses_aspx_MainContent_<ul><li>bsgvCourses</ul><li>tracking_tickets_aspx_MainContent_<ul><li>bsgvTickets<li>bsgvCentreDelegates<li>bsgvCustomisations<li>bsgvAdminUsers<li>bsgvSuperviseDelegates</ul></ul></td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell"><span class="nhsuk-table-responsive__heading">Expiry</span>12 months</td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
@@ -172,7 +173,7 @@ Google analytics cookies</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<div><p>These cookies are used to collect information about how visitors use our site, which we use to help improve it. The cookies collect information in an anonymous form, including the number of visitors to the site, where visitors have come to the site from and the pages they visited. These cookies may also be identified as originating from england.nhs.uk<p>These include cookies with names starting "_ga"<p><a href=http://www.google.com/intl/en-GB/policies/technologies/cookies/ >More information about Google cookies</a>.</div></td>
+<p>These cookies are used to collect information about how visitors use our site, which we use to help improve it. The cookies collect information in an anonymous form, including the number of visitors to the site, where visitors have come to the site from and the pages they visited. These cookies may also be identified as originating from england.nhs.uk<p>These include cookies with names starting "_ga"<p><a href=http://www.google.com/intl/en-GB/policies/technologies/cookies/ >More information about Google cookies</a>.</td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell"><span class="nhsuk-table-responsive__heading">Expiry</span>13 months</td>
 </tr>
 <tr class="nhsuk-table__row" role="row">
@@ -184,11 +185,11 @@ Hotjar cookies</td>
 <a href=http://www.dls.nhs.uk/ data-cke-saved-href=http://www.dls.nhs.uk/ title=http://www.dls.nhs.uk>www.dls.nhs.uk</a></td>
 <td class="nhsuk-table__cell" data-label="Purpose" role="cell">
 <span class="nhsuk-table-responsive__heading">Purpose</span>
-<div><p>Hotjar Tracking Code cookies are set on a visitor''s browser when they visit a website that loads the Hotjar Tracking Code. These cookies allow the Hotjar Tracking Code to function correctly. Apart from cookies, the Hotjar Tracking Code uses local and session storage as well.<p>These include cookies with names starting "_hj".<p><a href=https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code>More information about Hotjar cookies</a>.</div></td>
+<p>Hotjar Tracking Code cookies are set on a visitor''s browser when they visit a website that loads the Hotjar Tracking Code. These cookies allow the Hotjar Tracking Code to function correctly. Apart from cookies, the Hotjar Tracking Code uses local and session storage as well.<p>These include cookies with names starting "_hj".<p><a href=https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code>More information about Hotjar cookies</a>.</td>
 <td class="nhsuk-table__cell" data-label="Expiry" role="cell">
 <span class="nhsuk-table-responsive__heading">Expiry</span>1 year</td>
 </tr>
 </table>
 </div>
 </div>
-</details> 
+</details>

--- a/DigitalLearningSolutions.Web/Views/CookieConsent/CookiePolicy.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CookieConsent/CookiePolicy.cshtml
@@ -10,8 +10,12 @@
             word-break: break-word;
         }
 
+        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table-responsive__heading {
+            min-width: 90px
+        }
         .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
-            display: block;
+            justify-content: flex-start;
+            text-align: left;
         }
     }
 </style>


### PR DESCRIPTION
…ookie policy

### JIRA link
https://hee-tis.atlassian.net/browse/TD-1943

### Description
I needed to add inline css to align the mobile view header of the cookie policy

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/50d24868-5d87-48c2-a0fa-96a293bdfb9f)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/ca82b8dc-76e5-476c-8548-792422861889)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/2cb4c073-e5da-42aa-9ffb-205b18a0f08a)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
