### PR TITLE
TD-2855 non relevant text found in filters cshtml

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_Filters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/SearchablePage/_Filters.cshtml
@@ -11,7 +11,7 @@
         <option value="" disabled selected="selected">Select filter category</option>
         @foreach (var filter in Model.Filters)
         {
-            <option value="filter-@filter.FilterProperty">Auldrin possa</option>
+            <option value="filter-@filter.FilterProperty">@filter.FilterName</option>
         }
     </select>
     <div class="filters-container" id="filters-container">


### PR DESCRIPTION
**JIRA link**
https://hee-tis.atlassian.net/browse/TD-2855

**Description**
 Non relevant text replaced with filter object property which were causing issues JavaScript filters.

**Screenshots**
Need to test JavaScript filters option if they are displaying correctly . e.g. JavaScript filter from Tracking System > Admins

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f73804d6-dd3f-4585-877d-04e924c2097b)


-----
**Developer checks**

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
