### PR TITLE
TD-2492 restrict the number of rows that can be uploaded for bulk update in excel 

### DIFF
--- a/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
@@ -37,6 +37,7 @@
         private const string LearningHubReportAPIClientId = "LearningHubReportAPIConfig:ClientId";
         private const string LearningHubReportAPIClientIdentityKey = "LearningHubReportAPIConfig:ClientIdentityKey";
         private const string ExportQueryRowLimitKey = "FeatureManagement:ExportQueryRowLimit";
+        private const string MaxBulkUploadRowsLimitKey = "FeatureManagement:MaxBulkUploadRows";
         public static string GetAppRootPath(this IConfiguration config)
         {
             return config[AppRootPathName];
@@ -152,6 +153,9 @@
         {
             return int.Parse(config[ExportQueryRowLimitKey]);
         }
-
+        public static int GetMaxBulkUploadRowsLimit(this IConfiguration config)
+        {
+            return int.Parse(config[MaxBulkUploadRowsLimitKey]);
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -12,7 +12,8 @@
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.FeatureManagement.Mvc;
-
+    using Microsoft.Extensions.Configuration;
+    using ConfigurationExtensions = DigitalLearningSolutions.Data.Extensions.ConfigurationExtensions;
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
     [SetDlsSubApplication(nameof(DlsSubApplication.TrackingSystem))]
@@ -23,23 +24,30 @@
         private readonly IDelegateDownloadFileService delegateDownloadFileService;
         private readonly IDelegateUploadFileService delegateUploadFileService;
         private readonly IClockUtility clockUtility;
-
+        private readonly IConfiguration configuration;
         public BulkUploadController(
             IDelegateDownloadFileService delegateDownloadFileService,
             IDelegateUploadFileService delegateUploadFileService,
-            IClockUtility clockUtility
+            IClockUtility clockUtility, IConfiguration configuration
         )
         {
             this.delegateDownloadFileService = delegateDownloadFileService;
             this.delegateUploadFileService = delegateUploadFileService;
             this.clockUtility = clockUtility;
+            this.configuration = configuration;
         }
 
         public IActionResult Index()
         {
+            int MaxBulkUploadRows = GetMaxBulkUploadRowsLimit();
+            TempData["MaxBulkUploadRows"] = MaxBulkUploadRows;
             return View();
         }
+        private int GetMaxBulkUploadRowsLimit()
+        {
+            return ConfigurationExtensions.GetMaxBulkUploadRowsLimit(configuration);
 
+        }
         [Route("DownloadDelegates")]
         public IActionResult DownloadDelegates()
         {
@@ -61,6 +69,7 @@
         {
             TempData.Clear();
             var model = new UploadDelegatesViewModel(clockUtility.UtcToday);
+            model.MaxBulkUploadRows = GetMaxBulkUploadRowsLimit();
             return View("StartUpload", model);
         }
 
@@ -68,6 +77,12 @@
         [HttpPost]
         public IActionResult StartUpload(UploadDelegatesViewModel model)
         {
+            int MaxBulkUploadRows = GetMaxBulkUploadRowsLimit();
+            int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);
+            if (ExcelRowsCount > MaxBulkUploadRows)
+            {
+                ModelState.AddModelError("MaxBulkUploadRows", string.Format(CommonValidationErrorMessages.MaxBulkUploadRowsLimit, MaxBulkUploadRows));
+            }
             if (!ModelState.IsValid)
             {
                 return View("StartUpload", model);

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -34,5 +34,6 @@
         public const string PrimaryEmailInUseDuringDelegateRegistration =
             "A user with this email address is already registered";
         public const string CentreNameAlreadyExist = "The centre name you have entered already exists, please enter a different centre name";
+        public const string MaxBulkUploadRowsLimit = "File must contain no more than {0} rows";
     }
 }

--- a/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
@@ -20,6 +20,7 @@ namespace DigitalLearningSolutions.Web.Services
 {
     public interface IDelegateUploadFileService
     {
+        public int GetBulkUploadExcelRowCount(IFormFile delegatesFile);
         public BulkUploadResult ProcessDelegatesFile(IFormFile file, int centreId, DateTime welcomeEmailDate);
     }
 
@@ -309,6 +310,10 @@ namespace DigitalLearningSolutions.Web.Services
             }.OrderBy(x => x);
             var actualHeaders = table.Fields.Select(x => x.Name).OrderBy(x => x);
             return actualHeaders.SequenceEqual(expectedHeaders);
+        }
+        public int GetBulkUploadExcelRowCount(IFormFile delegatesFile)
+        {
+            return OpenDelegatesTable(delegatesFile).AsNativeDataTable().Rows.Count;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/UploadDelegatesViewModel.cs
@@ -21,7 +21,7 @@
         [AllowedExtensions(new[] { ".xlsx" }, "Delegates update file must be in xlsx format")]
         [MaxFileSize(5 * 1024 * 1024, "Maximum allowed file size is 5MB")]
         public IFormFile? DelegatesFile { get; set; }
-
+        public int MaxBulkUploadRows { get; set; }
         public DateTime GetWelcomeEmailDate()
         {
             return new DateTime(Year!.Value, Month!.Value, Day!.Value);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/Index.cshtml
@@ -28,7 +28,7 @@
       <p class="nhsuk-body-m">
         Once you have downloaded, amended and saved the Excel delegates sheet above, start the upload to process your changes.
       </p>
-
+      <p class="nhsuk-body-m">If your spreadsheet is large, you must split it so that each uploaded sheet contains no more than @TempData["MaxBulkUploadRows"] rows.</p>
       <a class="nhsuk-button nhsuk-u-margin-bottom-7" role="button" asp-controller="BulkUpload" asp-action="StartUpload">
         Start upload
       </a>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/StartUpload.cshtml
@@ -29,7 +29,7 @@
                      css-class="@(errorHasOccurred ? " nhsuk-u-padding-left-5 nhsuk-u-margin-bottom-3" : "")"
                      hint-text-lines="@hintTextLines" />
 
-      <vc:file-input asp-for="@nameof(Model.DelegatesFile)" label="File with updated information" hint-text="" css-class="nhsuk-u-width-one-half" />
+            <vc:file-input asp-for="@nameof(Model.DelegatesFile)" label="File with updated information (max @(Model.MaxBulkUploadRows) rows)" hint-text="" css-class="nhsuk-u-width-one-half" />
 
       <button class="nhsuk-button" type="submit">Upload and process</button>
     </form>

--- a/DigitalLearningSolutions.Web/appSettings.UAT.json
+++ b/DigitalLearningSolutions.Web/appSettings.UAT.json
@@ -20,7 +20,8 @@
     "PricingPage": false,
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
-    "ExportQueryRowLimit": 250
+    "ExportQueryRowLimit": 250,
+    "MaxBulkUploadRows": 200
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -20,7 +20,8 @@
     "PricingPage": true,
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
-    "ExportQueryRowLimit": 250
+    "ExportQueryRowLimit": 250,
+    "MaxBulkUploadRows": 200
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.Production.json
+++ b/DigitalLearningSolutions.Web/appsettings.Production.json
@@ -20,7 +20,8 @@
     "PricingPage": false,
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
-    "ExportQueryRowLimit": 250
+    "ExportQueryRowLimit": 250,
+    "MaxBulkUploadRows": 200
   },
   "LearningHubOpenAPIBaseUrl": "https://learninghubnhsuk-openapi-prod.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.SIT.json
+++ b/DigitalLearningSolutions.Web/appsettings.SIT.json
@@ -17,7 +17,8 @@
     "UseSignposting": true,
     "PricingPage": true,
     "UserFeedbackBar": true,
-    "ExportQueryRowLimit": 250
+    "ExportQueryRowLimit": 250,
+    "MaxBulkUploadRows": 200
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-dev.azurewebsites.net",
   "LearningHubSSO": {

--- a/DigitalLearningSolutions.Web/appsettings.Test.json
+++ b/DigitalLearningSolutions.Web/appsettings.Test.json
@@ -19,7 +19,8 @@
     "PricingPage": true,
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
-    "ExportQueryRowLimit": 250
+    "ExportQueryRowLimit": 250,
+    "MaxBulkUploadRows": 200
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.UarTest.json
+++ b/DigitalLearningSolutions.Web/appsettings.UarTest.json
@@ -20,7 +20,8 @@
     "PricingPage": false,
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
-    "ExportQueryRowLimit": 250
+    "ExportQueryRowLimit": 250,
+    "MaxBulkUploadRows": 200
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2492

### Description
1. Added an appsettings entry to store a MaxBulkUploadRows, setting it to 200 to begin with.
2. Changed the text “File with updated information“ on the TrackingSystem/Delegates/BulkUpload/StartUpload page to read “File with updated information (max 200 rows)”
3. Validation message will be shown "File must contain no more than 200 rows"

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/2a16d401-3e7d-49b1-b3be-87180336777d)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/9be010cf-c55f-4d68-b94f-a84a033014ec)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/a0533b3a-a907-400e-9e53-3a773b2e1b54)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
