### PR TITLE
TD-2503 Displayed admin account with inactive user account ,added filter for user account status and reactivate admin account

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/UserDataServiceTests/AdminUserDataServiceTests.cs
@@ -167,10 +167,10 @@
         }
 
         [Test]
-        public void GetNumberOfActiveAdminsAtCentre_returns_expected_count()
+        public void GetNumberOfAdminsAtCentre_returns_expected_count()
         {
             // When
-            var count = userDataService.GetNumberOfActiveAdminsAtCentre(2);
+            var count = userDataService.GetNumberOfAdminsAtCentre(2);
 
             // Then
             count.Should().Be(3);

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -1,12 +1,12 @@
 ﻿namespace DigitalLearningSolutions.Data.DataServices.UserDataService
 {
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models.Centres;
+    using DigitalLearningSolutions.Data.Models.User;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using Dapper;
-    using DigitalLearningSolutions.Data.Models.Centres;
-    using DigitalLearningSolutions.Data.Models.User;
 
     public partial class UserDataService
     {
@@ -177,6 +177,21 @@
             );
         }
 
+        public IEnumerable<AdminEntity> GetAdminsByCentreId(int centreId)
+        {
+            var sql = $@"{BaseAdminEntitySelectQuery} WHERE aa.centreID = @centreId";
+
+            return connection.Query<AdminAccount, UserAccount, UserCentreDetails, AdminEntity>(
+                sql,
+                (adminAccount, userAccount, userCentreDetails) => new AdminEntity(
+                    adminAccount,
+                    userAccount,
+                    userCentreDetails
+                ),
+                new { centreId }
+            );
+        }
+
         [Obsolete("New code should use GetAdminById instead")]
         public AdminUser? GetAdminUserById(int id)
         {
@@ -210,10 +225,10 @@
             return users;
         }
 
-        public int GetNumberOfActiveAdminsAtCentre(int centreId)
+        public int GetNumberOfAdminsAtCentre(int centreId)
         {
             return (int)connection.ExecuteScalar(
-                @"SELECT COUNT(*) FROM AdminUsers WHERE Active = 1 AND CentreID = @centreId",
+                @"SELECT COUNT(*) FROM AdminUsers WHERE CentreID = @centreId",
                 new { centreId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -19,13 +19,15 @@
 
         IEnumerable<AdminEntity> GetActiveAdminsByCentreId(int centreId);
 
+        IEnumerable<AdminEntity> GetAdminsByCentreId(int centreId);
+
         AdminUser? GetAdminUserById(int id);
 
         List<AdminUser> GetAdminUsersByCentreId(int centreId);
 
         AdminUser? GetAdminUserByEmailAddress(string emailAddress);
 
-        int GetNumberOfActiveAdminsAtCentre(int centreId);
+        int GetNumberOfAdminsAtCentre(int centreId);
 
         void UpdateAdminUserPermissions(
             int adminId,

--- a/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
+++ b/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
@@ -59,6 +59,7 @@
 
         public string? CategoryName => AdminAccount.CategoryName;
         public bool IsLocked => UserAccount.FailedLoginCount >= AuthHelper.FailedLoginThreshold;
+        public bool IsUserActive => UserAccount.Active;
         public bool IsCmsAdministrator => AdminAccount.IsCmsAdministrator;
         public bool IsCmsManager => AdminAccount.IsCmsManager;
         public bool IsCentreAdmin => AdminAccount.IsCentreAdmin;

--- a/DigitalLearningSolutions.Web.Tests/Helpers/FilterableTagHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/FilterableTagHelperTests.cs
@@ -28,6 +28,7 @@
                 new SearchableTagViewModel(AdminRoleFilterOptions.CmsAdministrator),
                 new SearchableTagViewModel(AdminRoleFilterOptions.ContentCreatorLicense),
                 new SearchableTagViewModel(AdminRoleFilterOptions.SuperAdmin),
+                new SearchableTagViewModel(UserAccountStatusFilterOptions.Active),
             };
 
             // When

--- a/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
@@ -136,7 +136,7 @@
                         adminUser!.CategoryId
                     )
             ).Returns(courseCount);
-            A.CallTo(() => userDataService.GetNumberOfActiveAdminsAtCentre(CentreId)).Returns(adminCount);
+            A.CallTo(() => userDataService.GetNumberOfAdminsAtCentre(CentreId)).Returns(adminCount);
             A.CallTo(() => centresService.GetCentreRankForCentre(CentreId)).Returns(centreRank);
             A.CallTo(() => supportTicketDataService.GetNumberOfUnarchivedTicketsForAdminId(AdminId))
                 .Returns(ticketCountForAdmin);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -113,7 +113,7 @@
             var centreId = User.GetCentreIdKnownNotNull();
             var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
 
-            var adminsAtCentre = userDataService.GetActiveAdminsByCentreId(centreId);
+            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId);
             var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
             var model = new AllAdminsViewModel(
                 adminsAtCentre,
@@ -270,6 +270,17 @@
             userService.DeactivateOrDeleteAdmin(adminId);
 
             return View("DeactivateOrDeleteAdminConfirmation");
+        }
+
+        [Route("{adminId:int}/ReactivateAdmin")]
+        [HttpGet]
+        [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
+        public IActionResult ReactivateAdmin(
+            int adminId
+        )
+        {
+            userService.ReactivateAdmin(adminId);
+            return RedirectToAction("Index");
         }
 
         private bool CurrentUserCanDeactivateAdmin(AdminAccount adminToDeactivate)

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/AdminFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/AdminFilterOptions.cs
@@ -88,4 +88,21 @@
             FilterStatus.Default
         );
     }
+
+    public static class UserAccountStatusFilterOptions
+    {
+        private const string Group = "UserStatus";
+
+        public static readonly FilterOptionModel Active = new FilterOptionModel(
+            "Active",
+            FilteringHelper.BuildFilterValueString(Group, nameof(AdminEntity.IsUserActive), "true"),
+            FilterStatus.Default
+        );
+
+        public static readonly FilterOptionModel Inactive = new FilterOptionModel(
+            "Inactive",
+            FilteringHelper.BuildFilterValueString(Group, nameof(AdminEntity.IsUserActive), "false"),
+            FilterStatus.Default
+        );
+    }
 }

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -73,6 +73,15 @@
                 tags.Add(new SearchableTagViewModel(AdminRoleFilterOptions.ReportsViewer));
             }
 
+            if (admin.UserAccount.Active && admin.AdminAccount.Active)
+            {
+                tags.Add(new SearchableTagViewModel(UserAccountStatusFilterOptions.Active));
+            }
+            else
+            {
+                tags.Add(new SearchableTagViewModel(UserAccountStatusFilterOptions.Inactive));
+            }
+
             return tags;
         }
 

--- a/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
+++ b/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
@@ -47,7 +47,7 @@
                     centreId,
                     adminUser.CategoryId
                 );
-            var adminCount = userDataService.GetNumberOfActiveAdminsAtCentre(centreId);
+            var adminCount = userDataService.GetNumberOfAdminsAtCentre(centreId);
             var supportTicketCount = adminUser.IsCentreManager
                 ? ticketDataService.GetNumberOfUnarchivedTicketsForCentreId(centreId)
                 : ticketDataService.GetNumberOfUnarchivedTicketsForAdminId(adminId);

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -74,7 +74,7 @@ namespace DigitalLearningSolutions.Web.Services
 
         void DeactivateOrDeleteAdmin(int adminId);
 
-        void DeactivateOrDeleteAdminForSuperAdmin(int adminId);        
+        void DeactivateOrDeleteAdminForSuperAdmin(int adminId);
 
         UserEntity? GetUserById(int userId);
 
@@ -109,6 +109,8 @@ namespace DigitalLearningSolutions.Web.Services
         void SetEmailVerified(int userId, string email, DateTime verifiedDateTime);
 
         bool EmailIsHeldAtCentre(string? email, int centreId);
+
+        void ReactivateAdmin(int adminId);
     }
 
     public class UserService : IUserService
@@ -652,6 +654,13 @@ namespace DigitalLearningSolutions.Web.Services
             }
 
             return false;
+        }
+
+        public void ReactivateAdmin(int adminId)
+        {
+            userDataService.ReactivateAdmin(adminId);
+            int? userId = userDataService.GetUserIdByAdminId(adminId);
+            userDataService.ActivateUser(userId.GetValueOrDefault());
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/AdministratorsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/AdministratorsViewModelFilterOptions.cs
@@ -31,6 +31,12 @@
             AdminAccountStatusFilterOptions.IsNotLocked,
         };
 
+        public static readonly IEnumerable<FilterOptionModel> UserStatusOptions = new[]
+        {
+            UserAccountStatusFilterOptions.Active,
+            UserAccountStatusFilterOptions.Inactive,
+        };
+
         public static IEnumerable<FilterOptionModel> GetCategoryOptions(IEnumerable<string> categories)
         {
             return categories.Select(
@@ -59,6 +65,11 @@
                     "AccountStatus",
                     "Account Status",
                     AccountStatusOptions
+                ),
+                new FilterModel(
+                    "UserStatus",
+                    "User Status",
+                    UserStatusOptions
                 ),
             };
             return filters;

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/SearchableAdminViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/SearchableAdminViewModel.cs
@@ -21,7 +21,7 @@
             CategoryName = admin.AdminAccount.CategoryName ?? "All";
             EmailAddress = admin.EmailForCentreNotifications;
             IsLocked = admin.UserAccount.FailedLoginCount >= AuthHelper.FailedLoginThreshold;
-
+            IsActive = admin.AdminAccount.Active;
             CanShowDeactivateAdminButton =
                 UserPermissionsHelper.LoggedInAdminCanDeactivateUser(admin.AdminAccount, loggedInAdminAccount);
 
@@ -42,6 +42,8 @@
         public string? EmailAddress { get; set; }
 
         public bool IsLocked { get; set; }
+
+        public bool IsActive { get; set; }
 
         public ReturnPageQuery ReturnPageQuery { get; set; }
     }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/_SearchableAdminCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Administrator/_SearchableAdminCard.cshtml
@@ -3,84 +3,94 @@
 @model SearchableAdminViewModel
 
 <div class="searchable-element nhsuk-panel word-break" id="@Model.Id-card">
-  <details class="nhsuk-details nhsuk-expander">
-    <summary class="nhsuk-details__summary">
-      <span class="nhsuk-details__summary-text" id="@Model.Id-name">
-        <span class="searchable-element-title" name="name">
-          @Model.Name
-        </span>
-        <span class="searchable-element-email">
-          @DisplayStringHelper.GetEmailDisplayString(Model.EmailAddress)
-        </span>
-      </span>
-    </summary>
-    <div class="nhsuk-details__text">
+    <details class="nhsuk-details nhsuk-expander">
+        <summary class="nhsuk-details__summary">
+            <span class="nhsuk-details__summary-text" id="@Model.Id-name">
+                <span class="searchable-element-title" name="name">
+                    @Model.Name
+                </span>
+                <span class="searchable-element-email">
+                    @DisplayStringHelper.GetEmailDisplayString(Model.EmailAddress)
+                </span>
+            </span>
+        </summary>
+        <div class="nhsuk-details__text">
 
-      <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
+            <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
 
-      <dl class="nhsuk-summary-list details-list-with-button">
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Email
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            @Model.EmailAddress
-          </dd>
+            <dl class="nhsuk-summary-list details-list-with-button">
+                <div class="nhsuk-summary-list__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Email
+                    </dt>
+                    <dd class="nhsuk-summary-list__value">
+                        @Model.EmailAddress
+                    </dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Course category
+                    </dt>
+                    <dd class="nhsuk-summary-list__value" data-filter-value="@Model.CategoryFilter">
+                        @Model.CategoryName
+                    </dd>
+                </div>
+            </dl>
+
+            @if (Model.IsLocked)
+            {
+                <p class="nhsuk-body-m">This account is currently locked out</p>
+                var unlockAccountAspAllRouteData = new Dictionary<string, string> { { "adminId", Model.Id.ToString() } };
+                <form asp-action="UnlockAccount" asp-all-route-data="unlockAccountAspAllRouteData" class="unlock-account-form">
+                    <button class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1"
+                        role="button"
+                        type="submit">
+                        Unlock account
+                    </button>
+                </form>
+            }
+            else
+            {
+                @if (!(Model.EmailAddress == String.Empty || Guid.TryParse(Model.EmailAddress, out _)))
+                {
+                    <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1"
+                       role="button"
+                       data-return-page-enabled="true"
+                       asp-controller="Administrator"
+                       asp-action="EditAdminRoles"
+                       asp-route-adminId="@Model.Id"
+                       asp-route-returnPageQuery="@Model.ReturnPageQuery"
+                    >
+                        Manage roles
+                    </a>
+                }
+            }
+            @if (!Model.IsActive)
+            {
+                <a class="nhsuk-button nhsuk-u-margin-bottom-1"
+                   role="button"
+                   aria-label="Reactivate admin account"
+                   asp-controller="Administrator"
+                   asp-action="ReactivateAdmin"
+                   asp-route-adminId="@Model.Id"
+                >
+                    Reactivate admin account
+                </a>
+            }
+            @if (Model.IsActive && Model.CanShowDeactivateAdminButton)
+            {
+                <a class="nhsuk-button delete-button nhsuk-u-margin-bottom-1"
+                   role="button"
+                   aria-label="Deactivate admin account"
+                   data-return-page-enabled="true"
+                   asp-controller="Administrator"
+                   asp-action="DeactivateOrDeleteAdmin"
+                   asp-route-adminId="@Model.Id"
+                   asp-route-returnPageQuery="@Model.ReturnPageQuery"
+                >
+                    Deactivate admin account
+                </a>
+            }
         </div>
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Course category
-          </dt>
-          <dd class="nhsuk-summary-list__value" data-filter-value="@Model.CategoryFilter">
-            @Model.CategoryName
-          </dd>
-        </div>
-      </dl>
-
-      @if (Model.IsLocked)
-      {
-        <p class="nhsuk-body-m">This account is currently locked out</p>
-      }
-
-      @if (Model.IsLocked)
-      {
-        var unlockAccountAspAllRouteData = new Dictionary<string, string> { { "adminId", Model.Id.ToString() } };
-        <form asp-action="UnlockAccount" asp-all-route-data="unlockAccountAspAllRouteData" class="unlock-account-form">
-          <button class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1"
-                role="button"
-                type="submit">
-            Unlock account
-          </button>
-        </form>
-      }
-      else
-      {
-        @if (!(Model.EmailAddress == String.Empty || Guid.TryParse(Model.EmailAddress, out _)))
-        {
-          <a class="nhsuk-button left-button-mobile-margin-bottom nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-1"
-         role="button"
-         data-return-page-enabled="true"
-         asp-controller="Administrator"
-         asp-action="EditAdminRoles"
-         asp-route-adminId="@Model.Id"
-         asp-route-returnPageQuery="@Model.ReturnPageQuery">
-            Manage roles
-          </a>
-        }
-      }
-      @if (Model.CanShowDeactivateAdminButton)
-      {
-        <a class="nhsuk-button delete-button nhsuk-u-margin-bottom-1"
-         role="button"
-         aria-label="Deactivate admin account"
-         data-return-page-enabled="true"
-         asp-controller="Administrator"
-         asp-action="DeactivateOrDeleteAdmin"
-         asp-route-adminId="@Model.Id"
-         asp-route-returnPageQuery="@Model.ReturnPageQuery">
-          Deactivate admin account
-        </a>
-      }
-    </div>
-  </details>
+    </details>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2503

### Description
Points addressed in this Commit :
1) Displayed admin accounts with inactive user account in 'Centre administrators' section of Tracking system.
2) Added filter options for filter of Centre administrators on the basis of user account status.
3) Added feature reactivating the Centre administrator account.

### Screenshots
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/518bcf7e-8fcb-48eb-9074-4afbea958be7)
![Centre-administrators-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/d12183a4-a2e3-4c59-9fb6-531367562bc5)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
