### PR TITLE
TD-937 TD-2522 validation to prevent report filter returning too many…

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/ReportsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/ReportsControllerTests.cs
@@ -70,7 +70,7 @@
             var result = reportsController.EditFilters(model);
 
             // Then
-            A.CallTo(() => httpResponse.Cookies.Append("ReportsFilterCookie", A<string>._, A<CookieOptions>._))
+            A.CallTo(() => httpResponse.Cookies.Append("CourseUsageReportFilterCookie", A<string>._, A<CookieOptions>._))
                 .MustHaveHappened();
             result.Should().BeRedirectToActionResult().WithActionName("Index");
         }

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Centre/Reports/EditFilterViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Centre/Reports/EditFilterViewModelTests.cs
@@ -56,6 +56,7 @@
                 StartMonth = 1,
                 StartYear = 2021,
                 EndDate = false,
+                ReportInterval = Data.Enums.ReportInterval.Months,
             };
 
             // When
@@ -75,6 +76,7 @@
                 StartMonth = 1,
                 StartYear = 2021,
                 EndDate = true,
+                ReportInterval = Data.Enums.ReportInterval.Months,
             };
             const string expectedErrorMessage = "Enter an End Date";
 
@@ -146,6 +148,7 @@
                 EndMonth = endMonth,
                 EndYear = endYear,
                 EndDate = false,
+                ReportInterval = Data.Enums.ReportInterval.Months,
             };
 
             // When

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/IndependentSelfAssessmentReport.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/IndependentSelfAssessmentReport.cs
@@ -10,8 +10,13 @@
         [Route("SelfAssessments/Independent")]
         public IActionResult IndependentSelfAssessmentsReport()
         {
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminDSATReportsFilterCookie", null);
-            Response.Cookies.SetReportsFilterCookie("SuperAdminDSATReportsFilterCookie", filterData, clockUtility.UtcNow);
+            //Removing an old cookie if it exists because it may contain problematic options (filters that return too many rows):
+            if (HttpContext.Request.Cookies.ContainsKey("SuperAdminDSATReportsFilterCookie"))
+            {
+                HttpContext.Response.Cookies.Delete("SuperAdminDSATReportsFilterCookie");
+            }
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminIndependentSAReportsFilterCookie", null);
+            Response.Cookies.SetReportsFilterCookie("SuperAdminIndependentSAReportsFilterCookie", filterData, clockUtility.UtcNow);
             var activity = platformReportsService.GetSelfAssessmentActivity(filterData, false);
             var (regionName, centreTypeName, centreName, jobGroupName, brandName, categoryName, selfAssessmentName) = reportFilterService.GetSelfAssessmentFilterNames(filterData);
             var selfAssessmentReportFilterModel = new SelfAssessmentReportFilterModel(
@@ -43,7 +48,7 @@
         [Route("SelfAssessments/Independent/EditFilters")]
         public IActionResult IndependentSelfAssessmentsEditFilters()
         {
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminDSATReportsFilterCookie", null);
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminIndependentSAReportsFilterCookie", null);
             var filterOptions = GetDropdownValues(false);
             var dataStartDate = platformReportsService.GetSelfAssessmentActivityStartDate(false);
             var model = new SelfAssessmentsEditFiltersViewModel(
@@ -84,7 +89,7 @@
                 model.FilterType,
                 model.ReportInterval
             );
-            Response.Cookies.SetReportsFilterCookie("SuperAdminDSATReportsFilterCookie", filterData, clockUtility.UtcNow);
+            Response.Cookies.SetReportsFilterCookie("SuperAdminIndependentSAReportsFilterCookie", filterData, clockUtility.UtcNow);
 
             return RedirectToAction("IndependentSelfAssessmentsReport");
         }

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/PlatformReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/PlatformReportsController.cs
@@ -54,7 +54,7 @@
         [Route("SelfAssessments/{selfAssessmentType}/Data")]
         public IEnumerable<SelfAssessmentActivityDataRowModel> GetGraphData(string selfAssessmentType)
         {
-            var cookieName = selfAssessmentType == "Independent" ? "SuperAdminDSATReportsFilterCookie" : "SuperAdminReportsFilterCookie";
+            var cookieName = selfAssessmentType == "Independent" ? "SuperAdminIndependentSAReportsFilterCookie" : "SuperAdminSupervisedSAReportsFilterCookie";
             var filterData = Request.Cookies.RetrieveFilterDataFromCookie(cookieName, null);
             var activity = platformReportsService.GetSelfAssessmentActivity(filterData!, selfAssessmentType == "Independent" ? false : true);
             return activity.Select(

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/SupervisedSelfAssessmentReport.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/SupervisedSelfAssessmentReport.cs
@@ -4,6 +4,7 @@
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common;
     using DigitalLearningSolutions.Web.ViewModels.SuperAdmin.PlatformReports;
+    using DocumentFormat.OpenXml.InkML;
     using Microsoft.AspNetCore.Mvc;
 
     public partial class PlatformReportsController
@@ -11,8 +12,13 @@
         [Route("SelfAssessments/Supervised")]
         public IActionResult SupervisedSelfAssessmentsReport()
         {
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminReportsFilterCookie", null);
-            Response.Cookies.SetReportsFilterCookie("SuperAdminReportsFilterCookie", filterData, clockUtility.UtcNow);
+            //Removing an old cookie if it exists because it may contain problematic options (filters that return too many rows):
+            if (HttpContext.Request.Cookies.ContainsKey("SuperAdminReportsFilterCookie"))
+            {
+                HttpContext.Response.Cookies.Delete("SuperAdminReportsFilterCookie");
+            }
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminSupervisedSAReportsFilterCookie", null);
+            Response.Cookies.SetReportsFilterCookie("SuperAdminSupervisedSAReportsFilterCookie", filterData, clockUtility.UtcNow);
             var activity = platformReportsService.GetSelfAssessmentActivity(filterData, true);
             var (regionName, centreTypeName, centreName, jobGroupName, brandName, categoryName, selfAssessmentName) = reportFilterService.GetSelfAssessmentFilterNames(filterData);
             var selfAssessmentReportFilterModel = new SelfAssessmentReportFilterModel(
@@ -46,7 +52,7 @@
         [Route("SelfAssessments/Supervised/EditFilters")]
         public IActionResult SupervisedSelfAssessmentsEditFilters()
         {
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminReportsFilterCookie", null);
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("SuperAdminSupervisedSAReportsFilterCookie", null);
             var filterOptions = GetDropdownValues(true);
             var dataStartDate = platformReportsService.GetSelfAssessmentActivityStartDate(true);
             var model = new SelfAssessmentsEditFiltersViewModel(
@@ -88,7 +94,7 @@
                 model.FilterType,
                 model.ReportInterval
             );
-            Response.Cookies.SetReportsFilterCookie("SuperAdminReportsFilterCookie", filterData, clockUtility.UtcNow);
+            Response.Cookies.SetReportsFilterCookie("SuperAdminSupervisedSAReportsFilterCookie", filterData, clockUtility.UtcNow);
             return RedirectToAction("SupervisedSelfAssessmentsReport");
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Reports/ReportsController.cs
@@ -46,10 +46,14 @@
         {
             var centreId = User.GetCentreIdKnownNotNull();
             var categoryIdFilter = User.GetAdminCategoryId();
+            //Removing an old cookie if it exists because it may contain problematic options (filters that return too many rows):
+            if (HttpContext.Request.Cookies.ContainsKey("ReportsFilterCookie"))
+            {
+                HttpContext.Response.Cookies.Delete("ReportsFilterCookie");
+            }
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("CourseUsageReportFilterCookie", categoryIdFilter);
 
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("ReportsFilterCookie", categoryIdFilter);
-
-            Response.Cookies.SetReportsFilterCookie("ReportsFilterCookie", filterData, clockUtility.UtcNow);
+            Response.Cookies.SetReportsFilterCookie("CourseUsageReportFilterCookie", filterData, clockUtility.UtcNow);
 
             var activity = activityService.GetFilteredActivity(centreId, filterData);
 
@@ -84,7 +88,7 @@
             var centreId = User.GetCentreIdKnownNotNull();
             var categoryIdFilter = User.GetAdminCategoryId();
 
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("ReportsFilterCookie", categoryIdFilter);
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("CourseUsageReportFilterCookie", categoryIdFilter);
 
             var activity = activityService.GetFilteredActivity(centreId, filterData!);
             return activity.Select(
@@ -98,7 +102,7 @@
         {
             var centreId = User.GetCentreIdKnownNotNull();
             var categoryIdFilter = User.GetAdminCategoryId();
-            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("ReportsFilterCookie", categoryIdFilter);
+            var filterData = Request.Cookies.RetrieveFilterDataFromCookie("CourseUsageReportFilterCookie", categoryIdFilter);
 
             var filterOptions = GetDropdownValues(centreId, categoryIdFilter);
 
@@ -144,7 +148,7 @@
                 model.ReportInterval
             );
 
-            Response.Cookies.SetReportsFilterCookie("ReportsFilterCookie", filterData, clockUtility.UtcNow);
+            Response.Cookies.SetReportsFilterCookie("CourseUsageReportFilterCookie", filterData, clockUtility.UtcNow);
 
             return RedirectToAction("Index");
         }

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -34,5 +34,6 @@
         public const string PrimaryEmailInUseDuringDelegateRegistration =
             "A user with this email address is already registered";
         public const string CentreNameAlreadyExist = "The centre name you have entered already exists, please enter a different centre name";
+        public const string ReportFilterReturnsTooManyRows = "The report frequency is too high for the date range. Choose a lower report frequency (or shorten the date range)";
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/ReportValidationHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ReportValidationHelper.cs
@@ -1,0 +1,35 @@
+﻿using DigitalLearningSolutions.Data.Enums;
+using System;
+
+namespace DigitalLearningSolutions.Web.Helpers
+{
+    public static class ReportValidationHelper
+    {
+        public static bool IsPeriodCompatibleWithDateRange(ReportInterval reportInterval, DateTime startDate, DateTime? endDate)
+        {
+            if (endDate == null)
+            {
+                endDate = DateTime.Now;
+            }
+
+            int rowLimit = 250;
+            int differenceInDays = (int)(endDate.Value - startDate).TotalDays;
+
+            switch (reportInterval)
+            {
+                case ReportInterval.Days:
+                    return (differenceInDays) <= rowLimit;
+                case ReportInterval.Weeks:
+                    return (differenceInDays / 7) <= rowLimit;
+                case ReportInterval.Months:
+                    return (differenceInDays / 30) <= rowLimit;
+                case ReportInterval.Quarters:
+                    return (differenceInDays / 90) <= rowLimit;
+                case ReportInterval.Years:
+                    return (differenceInDays / 365) <= rowLimit;
+                default:
+                    throw new ArgumentException("Invalid report interval");
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/CourseUsageEditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/CourseUsageEditFiltersViewModel.cs
@@ -221,19 +221,22 @@
         }
         private void ValidatePeriodIsCompatibleWithDateRange(List<ValidationResult> periodValidationResults)
         {
-            var startDate = GetValidatedStartDate();
-            var endDate = GetValidatedEndDate();
-            if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+            if (!periodValidationResults.Any())
             {
-                periodValidationResults.Add(
-                    new ValidationResult(
-                        CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
-                        new[]
-                        {
+                var startDate = GetValidatedStartDate();
+                var endDate = GetValidatedEndDate();
+                if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+                {
+                    periodValidationResults.Add(
+                        new ValidationResult(
+                            CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
+                            new[]
+                            {
                             nameof(ReportInterval),
-                        }
-                    )
-                    );
+                            }
+                        )
+                        );
+                }
             }
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/CourseUsageEditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/CourseUsageEditFiltersViewModel.cs
@@ -92,6 +92,8 @@
                 ValidateEndDate(validationResults);
             }
 
+            ValidatePeriodIsCompatibleWithDateRange(validationResults);
+
             return validationResults;
         }
 
@@ -150,11 +152,11 @@
         {
             var startDate = GetValidatedStartDate();
 
-            if (startDate < DataStart)
+            if (startDate.AddDays(1) < DataStart)
             {
                 startDateValidationResults.Add(
                     new ValidationResult(
-                        "Enter a start date after the start of data for this centre",
+                        "Enter a start date after the start of data in the platform",
                         new[]
                         {
                             nameof(StartDay),
@@ -215,6 +217,23 @@
                         }
                     )
                 );
+            }
+        }
+        private void ValidatePeriodIsCompatibleWithDateRange(List<ValidationResult> periodValidationResults)
+        {
+            var startDate = GetValidatedStartDate();
+            var endDate = GetValidatedEndDate();
+            if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+            {
+                periodValidationResults.Add(
+                    new ValidationResult(
+                        CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
+                        new[]
+                        {
+                            nameof(ReportInterval),
+                        }
+                    )
+                    );
             }
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/SelfAssessmentsEditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/SelfAssessmentsEditFiltersViewModel.cs
@@ -92,6 +92,8 @@
                 ValidateEndDate(validationResults);
             }
 
+            ValidatePeriodIsCompatibleWithDateRange(validationResults);
+
             return validationResults;
         }
 
@@ -148,11 +150,11 @@
         {
             var startDate = GetValidatedStartDate();
 
-            if (startDate < DataStart)
+            if (startDate.AddDays(1) < DataStart)
             {
                 startDateValidationResults.Add(
                     new ValidationResult(
-                        "Enter a start date after the start of data for this centre",
+                        "Enter a start date after the start of data in the platform",
                         new[]
                         {
                             nameof(StartDay),
@@ -214,6 +216,25 @@
                     )
                 );
             }
+        }
+        private void ValidatePeriodIsCompatibleWithDateRange(List<ValidationResult> periodValidationResults)
+        {
+            var startDate = GetValidatedStartDate();
+            var endDate = GetValidatedEndDate();
+
+            if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+            {
+                periodValidationResults.Add(
+                    new ValidationResult(
+                        CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
+                        new[]
+                        {
+                            nameof(ReportInterval),
+                        }
+                    )
+                    );
+            }
+
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/SelfAssessmentsEditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/PlatformReports/SelfAssessmentsEditFiltersViewModel.cs
@@ -219,22 +219,24 @@
         }
         private void ValidatePeriodIsCompatibleWithDateRange(List<ValidationResult> periodValidationResults)
         {
-            var startDate = GetValidatedStartDate();
-            var endDate = GetValidatedEndDate();
-
-            if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+            if (!periodValidationResults.Any())
             {
-                periodValidationResults.Add(
-                    new ValidationResult(
-                        CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
-                        new[]
-                        {
-                            nameof(ReportInterval),
-                        }
-                    )
-                    );
-            }
+                var startDate = GetValidatedStartDate();
+                var endDate = GetValidatedEndDate();
 
+                if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+                {
+                    periodValidationResults.Add(
+                        new ValidationResult(
+                            CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
+                            new[]
+                            {
+                            nameof(ReportInterval),
+                            }
+                        )
+                        );
+                }
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
@@ -174,7 +174,7 @@
                 .ToValidationResultList(nameof(EndDay), nameof(EndMonth), nameof(EndYear));
 
             ValidateEndDateIsAfterStartDate(endDateValidationResults);
-
+            ValidatePeriodIsCompatibleWithDateRange(endDateValidationResults);
             validationResults.AddRange(endDateValidationResults);
         }
 
@@ -203,22 +203,26 @@
                     )
                 );
             }
+
         }
         private void ValidatePeriodIsCompatibleWithDateRange(List<ValidationResult> periodValidationResults)
         {
-            var startDate = GetValidatedStartDate();
-            var endDate = GetValidatedEndDate();
-            if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+            if (!periodValidationResults.Any())
             {
-                periodValidationResults.Add(
-                    new ValidationResult(
-                        CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
-                        new[]
-                        {
+                var startDate = GetValidatedStartDate();
+                var endDate = GetValidatedEndDate();
+                if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+                {
+                    periodValidationResults.Add(
+                        new ValidationResult(
+                            CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
+                            new[]
+                            {
                             nameof(ReportInterval),
-                        }
-                    )
-                    );
+                            }
+                        )
+                        );
+                }
             }
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/EditFiltersViewModel.cs
@@ -81,6 +81,8 @@
                 ValidateEndDate(validationResults);
             }
 
+            ValidatePeriodIsCompatibleWithDateRange(validationResults);
+
             return validationResults;
         }
 
@@ -135,7 +137,7 @@
         {
             var startDate = GetValidatedStartDate();
 
-            if (startDate < DataStart)
+            if (startDate.AddDays(1) < DataStart)
             {
                 startDateValidationResults.Add(
                     new ValidationResult(
@@ -200,6 +202,23 @@
                         }
                     )
                 );
+            }
+        }
+        private void ValidatePeriodIsCompatibleWithDateRange(List<ValidationResult> periodValidationResults)
+        {
+            var startDate = GetValidatedStartDate();
+            var endDate = GetValidatedEndDate();
+            if (!ReportValidationHelper.IsPeriodCompatibleWithDateRange(ReportInterval, startDate, endDate))
+            {
+                periodValidationResults.Add(
+                    new ValidationResult(
+                        CommonValidationErrorMessages.ReportFilterReturnsTooManyRows,
+                        new[]
+                        {
+                            nameof(ReportInterval),
+                        }
+                    )
+                    );
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/SelfAssessmentsEditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/SelfAssessmentsEditFilters.cshtml
@@ -31,7 +31,7 @@
         }
 
         <h1 class="nhsuk-heading-xl">Edit report filters</h1>
-        <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action=@(Model.Supervised ? "SupervisedSelfAssessmentsEditFilters" : "IndependentSelfAssessmentsEditFilters" )>
+        <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action=@(Model.Supervised ? "SupervisedSelfAssessmentsEditFilters" : "IndependentSelfAssessmentsEditFilters")>
             <input type="hidden" name="dataStart" value="@Model.DataStart" />
 
             <vc:select-list asp-for="@nameof(Model.RegionId)"
@@ -102,7 +102,6 @@
                                  end-date-checkbox-label="End date"
                                  hint-text="Reporting data starts on @Model.DataStart?.ToString(DateHelper.StandardDateFormat). Please select any date range between that date and now."
                                  end-date-checkbox-hint-text="Check this box to specify an end date. If left unchecked will display data until today." />
-
             <vc:select-list asp-for="@nameof(Model.ReportInterval)"
                             label="Report by frequency"
                             value="@reportIntervalValue.ToString()"
@@ -111,9 +110,8 @@
                             css-class="nhsuk-u-width-one-half"
                             default-option=""
                             select-list-options="@Model.ReportIntervalOptions" />
-
             <button class="nhsuk-button" type="submit" value="save">Apply filters</button>
-            <vc:cancel-link asp-controller="PlatformReports" asp-action=@(Model.Supervised ? "SupervisedSelfAssessmentsReport" : "IndependentSelfAssessmentsReport" ) />
+            <vc:cancel-link asp-controller="PlatformReports" asp-action=@(Model.Supervised ? "SupervisedSelfAssessmentsReport" : "IndependentSelfAssessmentsReport") />
         </form>
     </div>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-937 TD-2522](https://hee-tis.atlassian.net/browse/TD-2522)

### Description
Implements view model validation to prevent report filters from being applied that return more than 250 data rows.

### Screenshots
Desktop:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/d6db84cf-6481-4daf-ab9e-573fa2d140ac)
Mobile:
![localhost_44363_SuperAdmin_Reports_CourseUsage_EditFilters](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/b72b1f78-f495-46b5-8fa4-94f8284e39f4)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
