### PR TITLE
TD-2865 improve error messages when bulk upload excel file doesn't contain correct worksheet

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -80,16 +80,19 @@
         public IActionResult StartUpload(UploadDelegatesViewModel model)
         {
             int MaxBulkUploadRows = GetMaxBulkUploadRowsLimit();
-            var workbook = new XLWorkbook(model.DelegatesFile.OpenReadStream());
-            if (!workbook.Worksheets.Contains(DelegateDownloadFileService.DelegatesSheetName))
+            if (model.DelegatesFile != null)
             {
-                ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidExcelValidationMessage);
-                return View("StartUpload", model);
-            }
-            int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);
-            if (ExcelRowsCount > MaxBulkUploadRows)
-            {
-                ModelState.AddModelError("MaxBulkUploadRows", string.Format(CommonValidationErrorMessages.MaxBulkUploadRowsLimit, MaxBulkUploadRows));
+                var workbook = new XLWorkbook(model.DelegatesFile.OpenReadStream());
+                if (!workbook.Worksheets.Contains(DelegateDownloadFileService.DelegatesSheetName))
+                {
+                    ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidExcelValidationMessage);
+                    return View("StartUpload", model);
+                }
+                int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);
+                if (ExcelRowsCount > MaxBulkUploadRows)
+                {
+                    ModelState.AddModelError("MaxBulkUploadRows", string.Format(CommonValidationErrorMessages.MaxBulkUploadRowsLimit, MaxBulkUploadRows));
+                }
             }
             if (!ModelState.IsValid)
             {

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -85,7 +85,7 @@
                 var workbook = new XLWorkbook(model.DelegatesFile.OpenReadStream());
                 if (!workbook.Worksheets.Contains(DelegateDownloadFileService.DelegatesSheetName))
                 {
-                    ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidExcelValidationMessage);
+                    ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidBulkUploadExcelFile);
                     return View("StartUpload", model);
                 }
                 int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -14,6 +14,8 @@
     using Microsoft.FeatureManagement.Mvc;
     using Microsoft.Extensions.Configuration;
     using ConfigurationExtensions = DigitalLearningSolutions.Data.Extensions.ConfigurationExtensions;
+    using ClosedXML.Excel;
+
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
     [SetDlsSubApplication(nameof(DlsSubApplication.TrackingSystem))]
@@ -78,6 +80,12 @@
         public IActionResult StartUpload(UploadDelegatesViewModel model)
         {
             int MaxBulkUploadRows = GetMaxBulkUploadRowsLimit();
+            var workbook = new XLWorkbook(model.DelegatesFile.OpenReadStream());
+            if (!workbook.Worksheets.Contains(DelegateDownloadFileService.DelegatesSheetName))
+            {
+                ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidExcelValidationMessage);
+                return View("StartUpload", model);
+            }
             int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);
             if (ExcelRowsCount > MaxBulkUploadRows)
             {

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -35,5 +35,6 @@
             "A user with this email address is already registered";
         public const string CentreNameAlreadyExist = "The centre name you have entered already exists, please enter a different centre name";
         public const string MaxBulkUploadRowsLimit = "File must contain no more than {0} rows";
+        public const string InvalidExcelValidationMessage = "The uploaded file must contain a \"DelegatesBulkUpload\" worksheet. Use the \"Download delegates\" button to generate a template.";
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CommonValidationErrorMessages.cs
@@ -35,6 +35,6 @@
             "A user with this email address is already registered";
         public const string CentreNameAlreadyExist = "The centre name you have entered already exists, please enter a different centre name";
         public const string MaxBulkUploadRowsLimit = "File must contain no more than {0} rows";
-        public const string InvalidExcelValidationMessage = "The uploaded file must contain a \"DelegatesBulkUpload\" worksheet. Use the \"Download delegates\" button to generate a template.";
+        public const string InvalidBulkUploadExcelFile = "The uploaded file must contain a \"DelegatesBulkUpload\" worksheet. Use the \"Download delegates\" button to generate a template.";
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2865

### Description
Added an error validation if  bulk upload excel file doesn't contain correct worksheet **_"DelegatesBulkUpload”_**

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/7ef5db7a-db79-4f4b-b798-20e4345d2995)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
