### PR TITLE
TD-2524 show resend link only when all assessments are in confirmed state and sign off button when all results are confirmed

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -155,7 +155,8 @@
              model="@competencySummaries"
              view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
         <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
-        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs" />
+        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
+             view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) }})" />
         @if (Model.AllQuestionsVerifiedOrNotRequired)
         {
             @if (!Model.SupervisorSignOffs.Any())

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -85,16 +85,20 @@
         @if (!Model.ExportToExcelHide)
         {
             <a class="nhsuk-button nhsuk-button--secondary float-right"
-             asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
-             asp-route-selfAssessmentName="@Model.DelegateSelfAssessment.RoleName"
-             asp-route-delegateUserID="@Model.DelegateSelfAssessment.DelegateUserID"
-             asp-route-delegateName="@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName"
-             asp-action="ExportCandidateAssessment"
-             role="button">
+           asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
+           asp-route-selfAssessmentName="@Model.DelegateSelfAssessment.RoleName"
+           asp-route-delegateUserID="@Model.DelegateSelfAssessment.DelegateUserID"
+           asp-route-delegateName="@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName"
+           asp-action="ExportCandidateAssessment"
+           role="button">
                 Export to Excel
             </a>
         }
-        @if (Model.DelegateSelfAssessment.SignOffRequested > 0)
+        @if (
+          Model.DelegateSelfAssessment.SignOffRequested > 0 &&
+          Model.DelegateSelfAssessment.ResultsVerificationRequests == 0 &&
+          competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"])
+        )
         {
             <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
         }
@@ -200,7 +204,7 @@
 {
     <div class="nhsuk-u-margin-top-4">
         <h3>Self Assessment Sign-off Status</h3>
-        <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" />
+        <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", true }})" />
     </div>
 }
 @if (Model.CompetencyGroups.Any())

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -48,7 +48,7 @@
                 {
                     @if (Model.FirstOrDefault().EmailSent == null || Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString())
                     {
-                        @if (ViewContext.RouteData.Values.ContainsKey("vocabulary"))
+                        @if (ViewContext.RouteData.Values.ContainsKey("vocabulary") && (bool)ViewData["IsAllCompetencyConfirmed"])
                         {
                             <a asp-action="SendRequestSignOffReminder" asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="@ViewContext.RouteData.Values["vocabulary"]" asp-route-candidateAssessmentSupervisorId="@Model.FirstOrDefault().CandidateAssessmentSupervisorID" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]">Resend</a>
                         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2524

### Description
Points addressed in this Commit :
1) Show sign off button only when all results are confirmed.
2) Show resend link only when all assessments are in confirmed state.

### Screenshots
![WavePlugin1](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/ab59b330-9de8-4b89-8f01-fd7e77690be8)
![WavePlugin2](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/6a909358-337c-4e0c-afc2-6bb5916cdace)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
