### PR TITLE
TD-937 Groups data returned from DB by date to reduce number of rows retrieved

### DIFF
--- a/DigitalLearningSolutions.Data.Tests/DataServices/ActivityDataServiceTests.cs
+++ b/DigitalLearningSolutions.Data.Tests/DataServices/ActivityDataServiceTests.cs
@@ -33,8 +33,8 @@
             // when
             var result = service.GetFilteredActivity(
                     101,
-                    DateTime.Parse("2014-01-01 00:00:00.000"),
-                    DateTime.Parse("2014-01-31 23:59:59.999"),
+                    DateTime.Parse("2014-01-01"),
+                    DateTime.Parse("2014-01-31"),
                     null,
                     null,
                     null
@@ -48,22 +48,22 @@
                 result.Count().Should().Be(9);
 
                 var first = result.First();
-                first.LogDate.Should().Be(DateTime.Parse("2014-01-08 11:04:35.753"));
+                first.LogDate.Should().Be(DateTime.Parse("2014-01-08"));
                 first.LogYear.Should().Be(2014);
                 first.LogQuarter.Should().Be(1);
                 first.LogMonth.Should().Be(1);
-                first.Completed.Should().BeFalse();
-                first.Evaluated.Should().BeFalse();
-                first.Registered.Should().BeTrue();
+                first.Completed.Should().Equals(0);
+                first.Evaluated.Should().Equals(0);
+                first.Registered.Should().Equals(1);
 
                 var last = result.Last();
-                last.LogDate.Should().Be(DateTime.Parse("2014-01-31 09:43:28.840"));
+                last.LogDate.Should().Be(DateTime.Parse("2014-01-31"));
                 last.LogYear.Should().Be(2014);
                 last.LogQuarter.Should().Be(1);
                 last.LogMonth.Should().Be(1);
-                last.Completed.Should().BeFalse();
-                last.Evaluated.Should().BeFalse();
-                last.Registered.Should().BeTrue();
+                last.Completed.Should().Equals(0);
+                last.Evaluated.Should().Equals(0);
+                last.Registered.Should().Equals(1);
             }
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ActivityDataService.cs
@@ -40,13 +40,13 @@ namespace DigitalLearningSolutions.Data.DataServices
         {
             return connection.Query<ActivityLog>(
                 @"SELECT
-                        LogDate,
+                        Cast(LogDate As Date) As LogDate,
                         LogYear,
                         LogQuarter,
                         LogMonth,
-                        Registered,
-                        Completed,
-                        Evaluated
+                        SUM(CAST(Registered AS Int)) AS Registered,
+						SUM(CAST(Completed AS Int)) AS Completed,
+						SUM(CAST(Evaluated AS Int)) AS Evaluated
                     FROM tActivityLog AS al
                     WHERE (LogDate >= @startDate
                         AND (@endDate IS NULL OR LogDate <= @endDate)
@@ -59,7 +59,10 @@ namespace DigitalLearningSolutions.Data.DataServices
                             SELECT ap.ApplicationID
                             FROM Applications ap
                             WHERE ap.ApplicationID = al.ApplicationID
-                            AND ap.DefaultContentTypeID <> 4)",
+                            AND ap.DefaultContentTypeID <> 4)
+                    GROUP BY  Cast(LogDate As Date), LogYear,
+                        LogQuarter,
+                        LogMonth",
                 new
                 {
                     centreId,

--- a/DigitalLearningSolutions.Data/DataServices/PlatformReportsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PlatformReportsDataService.cs
@@ -41,7 +41,7 @@
     {
         private readonly IDbConnection connection;
         private readonly ILogger<PlatformReportsDataService> logger;
-        private readonly string selectSelfAssessmentActivity = @"SELECT al.ActivityDate, al.Enrolled, al.Submitted | al.SignedOff AS Completed
+        private readonly string selectSelfAssessmentActivity = @"SELECT Cast(al.ActivityDate As Date) As ActivityDate, SUM(CAST(al.Enrolled AS Int)) AS Enrolled, SUM(CAST((al.Submitted | al.SignedOff) AS Int)) AS Completed
                                                                     FROM   ReportSelfAssessmentActivityLog AS al WITH (NOLOCK) INNER JOIN
                                                                                      Centres AS ce WITH (NOLOCK) ON al.CentreID = ce.CentreID INNER JOIN
                                                                                      SelfAssessments AS sa WITH (NOLOCK) ON sa.ID = al.SelfAssessmentID
@@ -116,7 +116,7 @@
         {
             var whereClause = GetSelfAssessmentWhereClause(supervised);
             return connection.Query<SelfAssessmentActivity>(
-                  $@"{selectSelfAssessmentActivity} AND {whereClause}",
+                  $@"{selectSelfAssessmentActivity} AND {whereClause} GROUP BY  Cast(al.ActivityDate As Date)",
                   new
                   {
                       centreId,

--- a/DigitalLearningSolutions.Data/DataServices/PlatformReportsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/PlatformReportsDataService.cs
@@ -157,13 +157,13 @@
         {
             return connection.Query<ActivityLog>(
                 @"SELECT
-                        LogDate,
-                        LogYear,
+                        Cast(LogDate As Date) As LogDate,
+						LogYear,
                         LogQuarter,
                         LogMonth,
-                        Registered,
-                        Completed,
-                        Evaluated
+                        SUM(CAST(Registered AS Int)) AS Registered,
+						SUM(CAST(Completed AS Int)) AS Completed,
+						SUM(CAST(Evaluated AS Int)) AS Evaluated
                     FROM tActivityLog AS al WITH(NOLOCK) INNER JOIN
                          Applications AS ap WITH(NOLOCK) ON ap.ApplicationID = al.ApplicationID INNER JOIN
                          Centres AS ce  WITH(NOLOCK) ON al.CentreID = ce.CentreID
@@ -178,7 +178,10 @@
                         AND (@centreTypeID IS NULL OR ce.CentreTypeID = @centreTypeID)
                         AND (@brandId IS NULL OR al.BrandID = @brandId)
                         AND (al.Registered = 1 OR al.Completed = 1 OR al.Evaluated = 1)
-                        AND (@coreContent IS NULL OR ap.CoreContent = @coreContent)",
+                        AND (@coreContent IS NULL OR ap.CoreContent = @coreContent)
+					GROUP BY  Cast(LogDate As Date), LogYear,
+                        LogQuarter,
+                        LogMonth",
                 new
                 {
                     centreId,

--- a/DigitalLearningSolutions.Data/Models/PlatformReports/SelfAssessmentActivity.cs
+++ b/DigitalLearningSolutions.Data/Models/PlatformReports/SelfAssessmentActivity.cs
@@ -4,7 +4,7 @@
     public class SelfAssessmentActivity
     {
         public DateTime ActivityDate { get; set; }
-        public bool Enrolled { get; set; }
-        public bool Completed { get; set; }
+        public int Enrolled { get; set; }
+        public int Completed { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityLog.cs
+++ b/DigitalLearningSolutions.Data/Models/TrackingSystem/ActivityLog.cs
@@ -8,8 +8,8 @@
         public int LogYear { get; set; }
         public int LogQuarter { get; set; }
         public int LogMonth { get; set; }
-        public bool Registered { get; set; }
-        public bool Completed { get; set; }
-        public bool Evaluated { get; set; }
+        public int Registered { get; set; }
+        public int Completed { get; set; }
+        public int Evaluated { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Services/ActivityServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ActivityServiceTests.cs
@@ -82,9 +82,9 @@
             {
                 new ActivityLog
                 {
-                    Completed = true,
-                    Evaluated = false,
-                    Registered = false,
+                    Completed = 1,
+                    Evaluated = 0,
+                    Registered = 0,
                     LogDate = DateTime.Parse("2015-12-22"),
                     LogYear = 2015,
                     LogQuarter = 4,
@@ -575,9 +575,9 @@
             {
                 new ActivityLog
                 {
-                    Completed = true,
-                    Evaluated = false,
-                    Registered = false,
+                    Completed = 1,
+                    Evaluated = 0,
+                    Registered = 0,
                     LogDate = DateTime.Parse("2020-12-22"),
                     LogYear = 2020,
                     LogQuarter = 4,

--- a/DigitalLearningSolutions.Web/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Web/Services/ActivityService.cs
@@ -201,9 +201,9 @@
                         new DateTime(groupingOfLogs.Key),
                         interval
                     ),
-                    groupingOfLogs.Count(activityLog => activityLog.Registered),
-                    groupingOfLogs.Count(activityLog => activityLog.Completed),
-                    groupingOfLogs.Count(activityLog => activityLog.Evaluated)
+                    groupingOfLogs.Sum(activityLog => activityLog.Registered),
+                    groupingOfLogs.Sum(activityLog => activityLog.Completed),
+                    groupingOfLogs.Sum(activityLog => activityLog.Evaluated)
                 )
             );
         }

--- a/DigitalLearningSolutions.Web/Services/PlatformReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/PlatformReportService.cs
@@ -172,9 +172,9 @@
                         new DateTime(groupingOfLogs.Key),
                         interval
                     ),
-                    groupingOfLogs.Count(activityLog => activityLog.Registered),
-                    groupingOfLogs.Count(activityLog => activityLog.Completed),
-                    groupingOfLogs.Count(activityLog => activityLog.Evaluated)
+                    groupingOfLogs.Sum(activityLog => activityLog.Registered),
+                    groupingOfLogs.Sum(activityLog => activityLog.Completed),
+                    groupingOfLogs.Sum(activityLog => activityLog.Evaluated)
                 )
             );
         }

--- a/DigitalLearningSolutions.Web/Services/PlatformReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/PlatformReportService.cs
@@ -97,8 +97,8 @@
                         new DateTime(groupingOfLogs.Key),
                         interval
                     ),
-                    groupingOfLogs.Count(activityLog => activityLog.Enrolled),
-                    groupingOfLogs.Count(activityLog => activityLog.Completed)
+                    groupingOfLogs.Sum(activityLog => activityLog.Enrolled),
+                    groupingOfLogs.Sum(activityLog => activityLog.Completed)
                 )
             );
         }


### PR DESCRIPTION
### JIRA link
[TD-937](https://hee-tis.atlassian.net/browse/TD-937)

### Description
Adds SQL grouping to Course and Self Assessment usage data retrieved to reduce the number of rows returned by SQL. This vastly improves the performance of the report pages.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-937]: https://hee-tis.atlassian.net/browse/TD-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ