### PR TITLE
TD-2871 Formats numbers across report grids with comma separators

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/_CourseActivityTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/_CourseActivityTable.cshtml
@@ -33,13 +33,13 @@
                     <span class="nhsuk-table-responsive__heading">Period </span>@activityRow.Period
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Enrolments </span>@activityRow.Enrolments
+                    <span class="nhsuk-table-responsive__heading">Enrolments </span>@activityRow.Enrolments.ToString("#,##0.##")
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Completions </span>@activityRow.Completions
+                    <span class="nhsuk-table-responsive__heading">Completions </span>@activityRow.Completions.ToString("#,##0.##")
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Evaluations </span>@activityRow.Evaluations
+                    <span class="nhsuk-table-responsive__heading">Evaluations </span>@activityRow.Evaluations.ToString("#,##0.##")
                 </td>
             </tr>
         }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/_SelfAssessmentActivityTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/_SelfAssessmentActivityTable.cshtml
@@ -30,10 +30,10 @@
                     <span class="nhsuk-table-responsive__heading">Period </span>@activityRow.Period
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Enrolments </span>@activityRow.Enrolments
+                    <span class="nhsuk-table-responsive__heading">Enrolments </span>@activityRow.Enrolments.ToString("#,##0.##")
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Completions </span>@activityRow.Completions
+                    <span class="nhsuk-table-responsive__heading">Completions </span>@activityRow.Completions.ToString("#,##0.##")
                 </td>
             </tr>
         }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_ActivityTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/_ActivityTable.cshtml
@@ -33,14 +33,14 @@
                     <span class="nhsuk-table-responsive__heading">Period </span>@activityRow.Period
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Enrolments </span>@activityRow.Enrolments
+                    <span class="nhsuk-table-responsive__heading">Enrolments </span>@activityRow.Enrolments.ToString("#,##0.##")
 
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Completions </span>@activityRow.Completions
+                    <span class="nhsuk-table-responsive__heading">Completions </span>@activityRow.Completions.ToString("#,##0.##")
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading">Evaluations </span>@activityRow.Evaluations
+                    <span class="nhsuk-table-responsive__heading">Evaluations </span>@activityRow.Evaluations.ToString("#,##0.##")
                 </td>
             </tr>
         }


### PR DESCRIPTION
### JIRA link
[TD-2871](https://hee-tis.atlassian.net/browse/TD-2871)

### Description
Adds comma separators to the numbers displayed in report data lists.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/b09d95e9-dfbe-4457-8c98-2266c3416113)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/14b73a5d-621e-4934-8a88-662eb2180d0e)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2871]: https://hee-tis.atlassian.net/browse/TD-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ