### PR TITLE
TD-2868 Error: 'Redirected to learning portal when logged in as delegate' is fixed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FindYourCentreController.cs
@@ -17,7 +17,6 @@
 
     [SetDlsSubApplication(nameof(DlsSubApplication.Main))]
     [SetSelectedTab(nameof(NavMenuTab.FindYourCentre))]
-    [RedirectDelegateOnlyToLearningPortal]
     public class FindYourCentreController : Controller
     {
         private const string FindCentreFilterCookieName = "FindCentre";


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2868

### Description
Points addressed in this Commit :
1) Error: 'Redirected to learning portal when logged in as delegate' is fixed by modifying the controller

### Screenshots
[Choose-A-Centre---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/d6bea151-5592-4077-8547-bd3322167eaa)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
