### PR TITLE
TD-1877 And TD-2459 Fixed the visibility issue of a "Request sign off" and "Sign off" button

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -163,7 +163,7 @@
             {
                 <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
             }
-            else if (latestResult > latestSignoff)
+            else if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any() && latestResult > latestSignoff)
             {
                 <div class="nhsuk-warning-callout">
                     <h3 class="nhsuk-warning-callout__label">
@@ -178,15 +178,18 @@
                     </p>
                 </div>
             }
-          @if (!Model.SupervisorSignOffs.Any() || latestResult > latestSignoff) {
-            <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-       asp-action="RequestSignOff"
-       asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
-       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-       role="button">
-                Request @Model.SelfAssessment.SignOffRoleName sign-off
-            </a>
-          }
+            @if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any()
+           && latestResult > latestSignoff
+           )
+            {
+                <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
+                   asp-action="RequestSignOff"
+                   asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
+                   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+                   role="button">
+                    Request @Model.SelfAssessment.SignOffRoleName sign-off
+                </a>
+            }
         }
         else
         {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -96,8 +96,7 @@
         }
         @if (
           Model.DelegateSelfAssessment.SignOffRequested > 0 &&
-          Model.DelegateSelfAssessment.ResultsVerificationRequests == 0 &&
-          competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"])
+          Model.DelegateSelfAssessment.ResultsVerificationRequests == 0
         )
         {
             <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2459

### Description
Points addressed in this Commit :
1) Fixed the visibility issue of a "Request sign off" and "Sign off" button by modifying the views.

### Screenshots
![Review-Profile-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/65d11c6b-5b78-427e-9efc-8d17154bdc8b)
![Self-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/2cca23ee-ad49-46df-9f07-faf653765a79)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
