### PR TITLE
TD-2369 Fixed 410 error on Remove from course for completed one and changed button text in Remove from activity page

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -265,7 +265,7 @@
         )
         {
             var progress = progressService.GetDetailedCourseProgress(progressId);
-            if (!courseService.DelegateHasCurrentProgress(progressId) || progress == null)
+            if (progress == null)
             {
                 return StatusCode((int)HttpStatusCode.Gone);
             }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/ConfirmRemoveFromCourse.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/ConfirmRemoveFromCourse.cshtml
@@ -48,7 +48,7 @@
                                 label="I am sure that I wish to remove the progress record for this learner on this activity."
                                 hint-text="This action will remove the activity from the delegate’s Learning Portal Activities list and archive their progress." />
 
-      <button class="nhsuk-button delete-button" role="button" type="submit">Remove enrolment</button>
+      <button class="nhsuk-button delete-button" role="button" type="submit">Remove from activity</button>
     </form>
     @if (Model.AccessedVia.Equals(DelegateAccessRoute.CourseDelegates))
     {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2369

### Description
Points addressed in this Commit :
1) Fixed 410 error on Remove from course for completed one and changed button text in Remove from activity page by modifying the controller and view.

### Screenshots
[Course-delegates---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/d28656c5-64ff-4c03-befa-ee842ed5a11b)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
