### PR TITLE
TD-2872 console errors on independent self assessments and frequency word missing

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Reports/EditFilters.cshtml
@@ -55,7 +55,7 @@
                            end-date-checkbox-hint-text="Check this box to specify an end date. If left unchecked will display data until today." />
 
       <vc:select-list asp-for="@nameof(Model.ReportInterval)"
-                      label="Report by"
+                      label="Report by frequency"
                       value="@reportIntervalValue.ToString()"
                       hint-text=""
                       required="true"


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2872

### Description
Points addressed in this Commit :

1. Added 'frequency' word on 'Course reports' screen of Tracking system by modifying the views.

### Screenshots

![Edit-report-filters-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/63269dd8-654b-45f9-934f-211b37e0c47a)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
