### PR TITLE
TD-2878 Fixed incorrect message showing on confirmation screen when updating centre and primary email

### DIFF
--- a/DigitalLearningSolutions.Web/Views/VerifyYourEmail/_EmailChanged.cshtml
+++ b/DigitalLearningSolutions.Web/Views/VerifyYourEmail/_EmailChanged.cshtml
@@ -32,14 +32,14 @@
   </p>
 }
 
-@if (Model.CentreSpecificEmails.Count() > 1)
+@if (Model.CentreSpecificEmails.Count() > 0)
 {
   foreach (var ((_, centreName, centreEmail), index) in Model.CentreSpecificEmails
     .Select((emailAndCentreNames, index) => (emailAndCentreNames, index)))
   {
     var isTheFirstEmailListed = primaryEmailIsVerified && index == 0;
     <p>
-      You've @(isTheFirstEmailListed ? "" : "also") updated your email address
+            You've @(isTheFirstEmailListed ? "" : "also") updated your centre email address
       for your account at <strong>@centreName</strong>: <strong>@centreEmail</strong>.
       @VerifyYourEmailTextHelper.UnverifiedCentreEmailConsequences
     </p>


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-2878

### Description
Points addressed in this Commit :

1. Fixed incorrect message showing on confirmation screen when updating centre and primary email by modifying the view.

### Screenshots
[Edit-details---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/784bac1f-0995-4470-9cee-3464831c4dcc)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/813448a4-d151-48b1-8f4f-5e617b6f9f14)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
