### PR TITLE
TD-2865: Invalid file format validation not working issue fixed.

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -81,25 +81,22 @@
         {
             int MaxBulkUploadRows = GetMaxBulkUploadRowsLimit();
             model.MaxBulkUploadRows = MaxBulkUploadRows;
-            if (model.DelegatesFile != null)
-            {
-                var workbook = new XLWorkbook(model.DelegatesFile.OpenReadStream());
-                if (!workbook.Worksheets.Contains(DelegateDownloadFileService.DelegatesSheetName))
-                {
-                    ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidBulkUploadExcelFile);
-                    return View("StartUpload", model);
-                }
-                int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);
-                if (ExcelRowsCount > MaxBulkUploadRows)
-                {
-                    ModelState.AddModelError("MaxBulkUploadRows", string.Format(CommonValidationErrorMessages.MaxBulkUploadRowsLimit, MaxBulkUploadRows));
-                }
-            }
             if (!ModelState.IsValid)
             {
                 return View("StartUpload", model);
             }
-
+            var workbook = new XLWorkbook(model.DelegatesFile.OpenReadStream());
+            if (!workbook.Worksheets.Contains(DelegateDownloadFileService.DelegatesSheetName))
+            {
+                ModelState.AddModelError("MaxBulkUploadRows", CommonValidationErrorMessages.InvalidBulkUploadExcelFile);
+                return View("StartUpload", model);
+            }
+            int ExcelRowsCount = delegateUploadFileService.GetBulkUploadExcelRowCount(model.DelegatesFile);
+            if (ExcelRowsCount > MaxBulkUploadRows)
+            {
+                ModelState.AddModelError("MaxBulkUploadRows", string.Format(CommonValidationErrorMessages.MaxBulkUploadRowsLimit, MaxBulkUploadRows));
+                return View("StartUpload", model);
+            }
             try
             {
                 var results = delegateUploadFileService.ProcessDelegatesFile(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2865

### Description
1. Invalid upload file validation was not working- Issue fixed

### Screenshots
Below validations verified
1. Invalid file (tried .xls,pdf files)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/e668be9d-7b7a-4e10-bf9d-f2a8c440dc7e)
2. No file selected
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/13a7ecaf-ee69-49d9-8625-43fd8ee766ee)
3.  File with more than 200 rows
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/0fe55e09-08d1-4582-9946-1de198645c22)
4. File without “DelegatesBulkUpload” worksheet.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/60581966-ee00-4e62-ae82-18aa82138267)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
