### PR TITLE
TD-1569 Relabel course delegate view and nav

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedCourseDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedCourseDetailsViewModel.cs
@@ -17,7 +17,12 @@
             IEnumerable<FilterModel> availableFilters,
             CourseDelegatesData courseDelegatesData,
             Dictionary<string, string> routeData
-        ) : base(result, true, availableFilters, routeData: routeData)
+        ) : base(
+            result,
+            true,
+            availableFilters,
+            routeData: routeData,
+            searchLabel: "Search activity")
         {
             var currentCourse =
                 courseDelegatesData.Courses.Single(c => c.CustomisationId == courseDelegatesData.CustomisationId);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/CourseDelegates/Index.cshtml
@@ -4,7 +4,7 @@
   <link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/delegates/courseDelegates.css")" asp-append-version="true">
 
   @{
-  ViewData["Title"] = "Course delegates";
+  ViewData["Title"] = "Activity delegates";
 }
 
 @section NavBreadcrumbs {
@@ -37,7 +37,7 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
           <p>
-            Choose a course to see delegates enrolled on it.
+            Choose an activity to see delegates enrolled on it.
           </p>
         </div>
       </div>
@@ -52,12 +52,12 @@
         <div class="nhsuk-grid-row">
           <form method="get" role="search">
             <div class="nhsuk-grid-column-full nhsuk-form-group">
-              <label class="nhsuk-label--s nhsuk-u-margin-bottom-1">Choose course</label>
+              <label class="nhsuk-label--s nhsuk-u-margin-bottom-1">Choose activity</label>
               <div class="course-dropdown-container">
                 <select id="selected-customisation-Id" class="nhsuk-select course-dropdown"
                       asp-for="CustomisationId"
                       asp-items="Model.Courses"
-                      aria-label="Choose course">
+                      aria-label="Choose activity">
                 </select>
                 <button class="nhsuk-button course-submit" type="submit">
                   Select
@@ -74,7 +74,7 @@
             @if (Model.CourseDetails.NoDataFound)
             {
               <p class="nhsuk-u-margin-top-4" role="alert">
-                <b>No delegates are enrolled on this course.</b>
+                <b>No delegates are enrolled on this activity.</b>
               </p>
             }
             else
@@ -101,8 +101,8 @@
       {
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-full">
-            <p class="nhsuk-body-m">There are no courses set up in your centre for the category you manage.</p>
-            <vc:action-link asp-controller="CourseSetup" asp-action="Index" link-text="Course setup"></vc:action-link>
+            <p class="nhsuk-body-m">There are no activities set up in your centre for the category you manage.</p>
+            <vc:action-link asp-controller="CourseSetup" asp-action="Index" link-text="Activity setup"></vc:action-link>
           </div>
         </div>
       }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCoursesBreadcrumbs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCoursesBreadcrumbs.cshtml
@@ -4,11 +4,11 @@
   <div class="nhsuk-width-container">
     <ol class="nhsuk-breadcrumb__list">
       <li class="nhsuk-breadcrumb__item">
-        <a class="nhsuk-breadcrumb__link" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Delegate courses</a>
+        <a class="nhsuk-breadcrumb__link" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Delegate activities</a>
       </li>
     </ol>
     <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Back to delegate courses</a>
+      <a class="nhsuk-breadcrumb__backlink" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Back to delegate activities</a>
     </p>
   </div>
 </nav>


### PR DESCRIPTION
### JIRA link
[TD-1569](https://hee-tis.atlassian.net/browse/TD-1569)

### Description
Updated Delegate Course screen to show 'activity' instead of 'course'

### Screenshots
Screenshot below.

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

![TD-1569](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/113513647/553aba6a-dcf2-4e00-8928-f1901abec18a)


[TD-1569]: https://hee-tis.atlassian.net/browse/TD-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-1569]: https://hee-tis.atlassian.net/browse/TD-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ