### PR TITLE
TD-2503 Fixed issue of inactive user not displaying on list and also fixed the color issue of active and inactive tag

### DIFF
--- a/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
+++ b/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
@@ -70,7 +70,7 @@
         public bool IsCentreManager => AdminAccount.IsCentreManager;
         public bool IsSuperAdmin => AdminAccount.IsSuperAdmin;
         public bool IsReportsViewer => AdminAccount.IsReportsViewer;
-
+        public bool IsActive => AdminAccount.Active;
 
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Administrator/AdministratorControllerTests.cs
@@ -71,10 +71,9 @@
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => userDataService.GetActiveAdminsByCentreId(A<int>._)).MustHaveHappened();
+                A.CallTo(() => userDataService.GetAdminsByCentreId(A<int>._)).MustHaveHappened();
                 A.CallTo(() => courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(A<int>._))
                     .MustHaveHappened();
-                A.CallTo(() => userDataService.GetActiveAdminsByCentreId(A<int>._)).MustHaveHappened();
                 A.CallTo(
                     () => searchSortFilterPaginateService.SearchFilterSortAndPaginate(
                         A<IEnumerable<AdminEntity>>._,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -75,7 +75,7 @@
             );
 
             var centreId = User.GetCentreIdKnownNotNull();
-            var adminsAtCentre = userDataService.GetActiveAdminsByCentreId(centreId);
+            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId);
             var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
             var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
 

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/AdminFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/AdminFilterOptions.cs
@@ -95,14 +95,14 @@
 
         public static readonly FilterOptionModel Active = new FilterOptionModel(
             "Active",
-            FilteringHelper.BuildFilterValueString(Group, nameof(AdminEntity.IsUserActive), "true"),
-            FilterStatus.Default
+            FilteringHelper.BuildFilterValueString(Group, nameof(AdminEntity.IsActive), "true"),
+            FilterStatus.Success
         );
 
         public static readonly FilterOptionModel Inactive = new FilterOptionModel(
             "Inactive",
-            FilteringHelper.BuildFilterValueString(Group, nameof(AdminEntity.IsUserActive), "false"),
-            FilterStatus.Default
+            FilteringHelper.BuildFilterValueString(Group, nameof(AdminEntity.IsActive), "false"),
+            FilterStatus.Warning
         );
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2503

### Description
Points addressed in this Commit :
1) Fixed issue of inactive user not displaying on list and also fixed the color issue of active and inactive tag by modifying the helper,controller and model.

### Screenshots
![Centre-administrators-Digital-Learning-Solutions-Active](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/3fbf4b60-d699-4b1a-ab81-d80c40206e2d)
![Centre-administrators-Digital-Learning-Solutions-Inactive](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/49036a0c-1f32-4364-8e12-009708a7cc7a)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/5cf9ad5e-0e55-4291-bd91-098aae621958)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
