### PR TITLE
TD-2912 login validation needs to highlight both fields

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -74,6 +74,7 @@
                 case LoginAttemptResult.InvalidCredentials:
                 case LoginAttemptResult.UnclaimedDelegateAccount:
                     ModelState.AddModelError("Password", "The credentials you have entered are incorrect");
+                    ModelState.AddModelError("Username", "The credentials you have entered are incorrect");
                     return View("Index", model);
                 case LoginAttemptResult.AccountsHaveMismatchedPasswords:
                     return View("MismatchingPasswords");


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2912

### Description
I added the username to the validation

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/07b90128-82ce-48ca-8454-3ae31559bc0b)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
