### PR TITLE
TD-1568 Show self assessments published to the Centre into the "Delegate activities" List

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -128,6 +128,9 @@ namespace DigitalLearningSolutions.Data.DataServices
         public (IEnumerable<DelegateCourseInfo>, int) GetDelegateCourseInfosPerPageForCourse(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
             int customisationId, int centreId, bool? isDelegateActive, bool? isProgressLocked, bool? removed, bool? hasCompleted, string? answer1, string? answer2, string? answer3);
 
+        public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
+
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(int centreId);
     }
 
     public class CourseDataService : ICourseDataService
@@ -1624,6 +1627,117 @@ namespace DigitalLearningSolutions.Data.DataServices
 				order by ap.ApplicationName",
                 new { centreId }
             );
+        }
+
+        public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString,int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,string isActive, string categoryName, string courseTopic, string hasAdminFields
+        )
+        {
+            string courseStatisticsSelect = @$" SELECT
+                        cu.CustomisationID,
+                        cu.CentreID,
+                        cu.Active,
+                        CASE WHEN ap.ArchivedDate IS NOT NULL THEN 0 ELSE cu.Active END AS Active,
+                        cu.AllCentres,
+                        ap.ApplicationId,
+                        ap.ApplicationName,
+                        cu.CustomisationName,
+                        {DelegateCountQuery},
+                        {CompletedCountQuery},
+                        {AllAttemptsQuery},
+                        {AttemptsPassedQuery},
+                        cu.HideInLearnerPortal,
+                        cc.CategoryName,
+                        ct.CourseTopic,
+                        cu.LearningTimeMins AS LearningMinutes,
+                        cu.IsAssessed,
+                        CASE WHEN ap.ArchivedDate IS NOT NULL THEN 1 ELSE 0 END AS Archived,
+                        ((SELECT COUNT(pr.CandidateID)
+		                    FROM dbo.Progress AS pr WITH (NOLOCK) 
+		                    INNER JOIN dbo.Candidates AS can WITH (NOLOCK) ON can.CandidateID = pr.CandidateID
+		                    WHERE pr.CustomisationID = cu.CustomisationID
+		                    AND can.CentreID = @centreId
+		                    AND RemovedDate IS NULL) - 
+		                (SELECT COUNT(pr.CandidateID)
+		                    FROM dbo.Progress AS pr WITH (NOLOCK) 
+		                    INNER JOIN dbo.Candidates AS can WITH (NOLOCK) ON can.CandidateID = pr.CandidateID
+		                    WHERE pr.CustomisationID = cu.CustomisationID AND pr.Completed IS NOT NULL
+		                    AND can.CentreID = @centreId)) AS InProgressCount ";
+            string courseStatisticsFromTable = @$" FROM dbo.Customisations AS cu WITH (NOLOCK)
+                    INNER JOIN dbo.CentreApplications AS ca WITH (NOLOCK) ON ca.ApplicationID = cu.ApplicationID
+                    INNER JOIN dbo.Applications AS ap WITH (NOLOCK) ON ap.ApplicationID = ca.ApplicationID
+                    INNER JOIN dbo.CourseCategories AS cc WITH (NOLOCK) ON cc.CourseCategoryID = ap.CourseCategoryID
+                    INNER JOIN dbo.CourseTopics AS ct WITH (NOLOCK) ON ct.CourseTopicID = ap.CourseTopicId
+
+                    LEFT JOIN CoursePrompts AS cp1 WITH (NOLOCK) 
+			            ON cu.CourseField1PromptID = cp1.CoursePromptID
+		            LEFT JOIN CoursePrompts AS cp2 WITH (NOLOCK) 
+			            ON cu.CourseField2PromptID = cp2.CoursePromptID
+		            LEFT JOIN CoursePrompts AS cp3 WITH (NOLOCK) 
+			            ON cu.CourseField3PromptID = cp3.CoursePromptID
+
+                    WHERE (ap.CourseCategoryID = @categoryId OR @categoryId IS NULL)
+                        AND (cu.CentreID = @centreId OR (cu.AllCentres = 1 AND ca.Active = @allCentreCourses))
+                        AND ca.CentreID = @centreId
+                        AND ap.DefaultContentTypeID <> 4
+                        AND ( ap.ApplicationName + IIF(cu.CustomisationName IS NULL, '', ' - ' + cu.CustomisationName) LIKE N'%' + @searchString + N'%')
+                        AND ((@isActive = 'Any') OR (@isActive = 'true' AND (cu.Active = 1 AND ap.ArchivedDate IS NULL)) OR (@isActive = 'false' AND ((cu.Active = 0 OR ap.ArchivedDate IS NOT NULL))))
+                        AND ((@categoryName = 'Any') OR (cc.CategoryName = @categoryName))
+                        AND ((@courseTopic = 'Any') OR (ct.CourseTopic = @courseTopic))
+                        AND ((@hasAdminFields = 'Any') OR (@hasAdminFields = 'true' AND (cp1.CoursePrompt IS NOT NULL OR cp2.CoursePrompt IS NOT NULL OR cp3.CoursePrompt IS NOT NULL))
+                                                       OR (@hasAdminFields = 'false' AND (cp1.CoursePrompt IS NULL AND cp2.CoursePrompt IS NULL AND cp3.CoursePrompt IS NULL)))";
+
+            if (hideInLearnerPortal != null)
+                courseStatisticsFromTable += " AND cu.HideInLearnerPortal = @hideInLearnerPortal";
+
+            var courseStatisticsQuery = courseStatisticsSelect + courseStatisticsFromTable;
+
+            IEnumerable<CourseStatistics> courseStatistics = connection.Query<CourseStatistics>(
+                courseStatisticsQuery,
+                new
+                {
+                    searchString,
+                    centreId,
+                    categoryId,
+                    allCentreCourses,
+                    hideInLearnerPortal,
+                    isActive,
+                    categoryName,
+                    courseTopic,
+                    hasAdminFields
+                },
+                commandTimeout: 3000
+            );
+
+            return courseStatistics;
+        }
+
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(int centreId)
+        {
+                string assessmentStatisticsSelectQuery = $@"SELECT
+                        sa.Name AS Name,
+                        cc.CategoryName AS Category,
+                        CASE 
+                          WHEN sa.SupervisorSelfAssessmentReview = 1 OR sa.SupervisorResultsReview = 1 THEN 1
+                          ELSE 0
+                        END AS Supervised,
+                        (SELECT COUNT(can.ID)
+                        FROM dbo.CandidateAssessments AS can WITH (NOLOCK)
+                        WHERE can.CentreID = @centreId AND can.SelfAssessmentID = csa.SelfAssessmentID) AS DelegateCount,
+                        (SELECT COUNT(can.ID)
+                        FROM dbo.CandidateAssessments AS can WITH (NOLOCK)
+                        LEFT JOIN dbo.CandidateAssessmentSupervisors AS cas ON can.ID = cas.CandidateAssessmentID
+                        LEFT JOIN dbo.CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
+                        WHERE can.CentreID = @centreId AND can.SelfAssessmentID = CSA.SelfAssessmentID 
+                        AND (can.SubmittedDate IS NOT NULL OR casv.SignedOff = 1)
+                        ) AS SubmittedSignedOffCount,
+                        CC.Active AS Active
+                        from CentreSelfAssessments AS csa 
+                        INNER join SelfAssessments AS sa ON csa.SelfAssessmentID = sa.ID
+                        INNER JOIN CourseCategories AS cc ON sa.CategoryID = cc.CourseCategoryID
+                        WHERE csa.CentreID= @centreId";
+
+                IEnumerable<DelegateAssessmentStatistics> delegateAssessmentStatistics = connection.Query<DelegateAssessmentStatistics>(assessmentStatisticsSelectQuery, new { centreId }, commandTimeout: 3000);
+                return delegateAssessmentStatistics;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateAssessmentStatistics.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateAssessmentStatistics.cs
@@ -1,0 +1,22 @@
+﻿namespace DigitalLearningSolutions.Data.Models.Courses
+{
+    public class DelegateAssessmentStatistics : CourseStatistics
+    {
+        public DelegateAssessmentStatistics()
+        {
+            this.Name = null!;
+            this.Category= null!;
+        }
+
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public bool Supervised { get; set; }
+        public int SubmittedSignedOffCount { get; set; }
+
+        public override string SearchableName
+        {
+            get => SearchableNameOverrideForFuzzySharp ?? Name;
+            set => SearchableNameOverrideForFuzzySharp = value;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateCoursesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateCoursesControllerTests.cs
@@ -50,9 +50,9 @@
         private HttpRequest httpRequest = null!;
         private HttpResponse httpResponse = null!;
         private IPaginateService paginateService = null!;
-        private IActivityService activityService = null;
-        private ICourseCategoriesDataService courseCategoriesDataService = null;
-        private ICourseTopicsDataService courseTopicsDataService = null;
+        private IActivityService activityService = null!;
+        private ICourseCategoriesDataService courseCategoriesDataService = null!;
+        private ICourseTopicsDataService courseTopicsDataService = null!;
 
         [SetUp]
         public void Setup()
@@ -97,15 +97,17 @@
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => courseService.GetCentreCourses(A<string>._, A<int>._, A<int>._, A<string>._, A<string>._, A<int>._, A<int?>._, A<bool>._, A<bool?>._,
-                    A<string>._, A<string>._, A<string>._, A<string>._)).MustHaveHappened();
+                var delegateCourses = Builder<CourseStatisticsWithAdminFieldResponseCounts>.CreateListOfSize(5).Build();
+                A.CallTo(() => courseService.GetDelegateCourses(string.Empty, 1, 1, true, true, string.Empty, string.Empty, string.Empty, string.Empty)).Returns(delegateCourses);
+
+                A.CallTo(() => courseService.GetDelegateAssessments(A<int>._)).MustHaveHappened();
                 A.CallTo(
-                    () => paginateService.Paginate(
-                        A<IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>>._,
+                    () => paginateService.Paginate(A<IEnumerable<CourseStatistics>>._,
                          A<int>._,
                         A<PaginationOptions>._, A<FilterOptions>._, A<string>._, A<string>._, A<string>._
                     )
                 ).MustHaveHappened();
+
                 A.CallTo(
                         () => httpResponse.Cookies.Append(
                             CookieName,

--- a/DigitalLearningSolutions.Web.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/CourseServiceTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Services
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models;
@@ -18,6 +15,9 @@
     using FluentAssertions.Execution;
     using Microsoft.Extensions.Configuration;
     using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public class CourseServiceTests
     {
@@ -172,8 +172,7 @@
         }
 
         [Test]
-        public void
-            VerifyAdminUserCanManageCourse_should_return_true_when_centreId_matches_and_admin_category_id_is_null()
+        public void VerifyAdminUserCanManageCourse_should_return_true_when_centreId_matches_and_admin_category_id_is_null()
         {
             // Given
             var validationDetails = new CourseValidationDetails
@@ -955,6 +954,44 @@
                 A.CallTo(
                     () => progressDataService.GetLearningLogEntries(progressId)
                 ).MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [Test]
+        public void GetDelegateCourses_GetDelegateCourseStatisticsAtCentre_ShouldBeInvokedAndReturnsCourseStatisticsWithAdminFieldResponseCounts()
+        {
+            // Given
+            var delegateCourses = Builder<CourseStatisticsWithAdminFieldResponseCounts>.CreateListOfSize(5).Build();
+            A.CallTo(() => courseDataService.GetDelegateCourseStatisticsAtCentre(string.Empty, 1, 1, true, true, string.Empty, string.Empty, string.Empty, string.Empty)).Returns(delegateCourses);
+
+            // When
+            var result = courseService.GetDelegateCourses(string.Empty, 1, 1, true, true, string.Empty, string.Empty, string.Empty, string.Empty);
+
+            // Then
+            using (new AssertionScope())
+            {
+                A.CallTo(() => courseDataService.GetDelegateCourseStatisticsAtCentre(string.Empty, 1, 1, true, true, string.Empty, string.Empty, string.Empty, string.Empty))
+                    .MustHaveHappenedOnceExactly();
+                result.Count().Should().BeGreaterOrEqualTo(0);
+            }
+        }
+
+        [Test]
+        public void GetDelegateAssessments_GetDelegateAssessments_ShouldBeInvokedAndReturnsDelegateAssessmentStatistics()
+        {
+            // Given
+            var delegateAssessments = Builder<DelegateAssessmentStatistics>.CreateListOfSize(5).Build();
+            A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(1)).Returns(delegateAssessments);
+
+            // When
+            var result = courseService.GetDelegateAssessments(1);
+
+            // Then
+            using (new AssertionScope())
+            {
+                A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(1))
+                    .MustHaveHappenedOnceExactly();
+                result.Count().Should().BeGreaterOrEqualTo(0);
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -246,5 +246,17 @@
                     : new SearchableTagViewModel(AddCourseToGroupDiagnosticFilterOptions.NoDiagnostic, true),
             };
         }
+
+        public static IEnumerable<SearchableTagViewModel> GetCurrentStatusTagsForDelegateAssessment(
+            DelegateAssessmentStatistics delegateAssessmentStatistics
+          )
+        {
+            return new List<SearchableTagViewModel>
+            {
+                delegateAssessmentStatistics.Active
+                    ? new SearchableTagViewModel(CourseStatusFilterOptions.IsActive)
+                    : new SearchableTagViewModel(CourseStatusFilterOptions.IsInactive)
+            };
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -110,6 +110,10 @@
 
         public (IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>, int) GetCentreCourses(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,
            string isActive, string categoryName, string courseTopic, string hasAdminFields);
+
+        public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> GetDelegateCourses(string searchString,int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,string isActive, string categoryName, string courseTopic, string hasAdminFields);
+
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(int centreId);
     }
 
     public class CourseService : ICourseService
@@ -396,8 +400,6 @@
             return new CentreCourseDetails(courses, categories, topics);
         }
 
-
-
         public (IEnumerable<CourseStatisticsWithAdminFieldResponseCounts>, int) GetCentreCourses(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,
            string isActive, string categoryName, string courseTopic, string hasAdminFields)
         {
@@ -519,6 +521,23 @@
             );
             info.CourseAdminFields = coursePrompts;
             return info;
+        }
+
+        public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> GetDelegateCourses(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields)
+        {
+            var allCourses = courseDataService.GetDelegateCourseStatisticsAtCentre(searchString, centreId, categoryId, allCentreCourses, hideInLearnerPortal,
+           isActive, categoryName, courseTopic, hasAdminFields);
+
+            return allCourses.Select(
+                c => new CourseStatisticsWithAdminFieldResponseCounts(
+                    c, courseAdminFieldsService.GetCourseAdminFieldsWithAnswerCountsForCourse(c.CustomisationId, centreId)
+                )
+            );
+        }
+
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(int centreId)
+        {
+            return courseDataService.GetDelegateAssessmentStatisticsAtCentre(centreId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesViewModel.cs
@@ -1,16 +1,16 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+    using System.Collections.Generic;
+    using System.Linq;
 
-    public class DelegateCoursesViewModel : BaseSearchablePageViewModel<CourseStatisticsWithAdminFieldResponseCounts>
+    public class DelegateCoursesViewModel : BaseSearchablePageViewModel<CourseStatistics>
     {
         public DelegateCoursesViewModel(
-            SearchSortFilterPaginationResult<CourseStatisticsWithAdminFieldResponseCounts> result,
+            SearchSortFilterPaginationResult<CourseStatistics> result,
             IEnumerable<FilterModel> availableFilters,
             string courseCategoryName
         ) : base(
@@ -21,30 +21,46 @@
         )
         {
             UpdateCourseActiveFlags(result);
-            Courses = result.ItemsToDisplay.Select(c => new SearchableDelegateCourseStatisticsViewModel(c));
+
+            Courses = result.ItemsToDisplay.Select<BaseSearchableItem, SearchableDelegateCourseStatisticsViewModel>(
+                activity =>
+                {
+                    return activity switch
+                    {
+                        CourseStatisticsWithAdminFieldResponseCounts currentCourse => new SearchableDelegateCourseStatisticsViewModel(currentCourse),
+                        _ => new SearchableDelegateAssessmentStatisticsViewModel((DelegateAssessmentStatistics)activity),
+                    };
+                }
+             );
+
             CourseCategoryName = courseCategoryName;
         }
 
-        private static void UpdateCourseActiveFlags(SearchSortFilterPaginationResult<CourseStatisticsWithAdminFieldResponseCounts> result)
+        private static void UpdateCourseActiveFlags(SearchSortFilterPaginationResult<CourseStatistics> result)
         {
             foreach (var course in result.ItemsToDisplay)
             {
-                if (course.Active && !course.Archived)
+                if (course is CourseStatisticsWithAdminFieldResponseCounts)
                 {
-                    course.Active = true;
-                }
-                else
-                {
-                    course.Active = false;
-                }
+                    CourseStatisticsWithAdminFieldResponseCounts courseStatisticsWithAdminFieldResponseCounts = (CourseStatisticsWithAdminFieldResponseCounts)course;
 
-                if (course.Archived)
-                {
-                    course.Archived = true;
-                }
-                else
-                {
-                    course.Archived = false;
+                    if (courseStatisticsWithAdminFieldResponseCounts.Active && !courseStatisticsWithAdminFieldResponseCounts.Archived)
+                    {
+                        courseStatisticsWithAdminFieldResponseCounts.Active = true;
+                    }
+                    else
+                    {
+                        courseStatisticsWithAdminFieldResponseCounts.Active = false;
+                    }
+
+                    if (courseStatisticsWithAdminFieldResponseCounts.Archived)
+                    {
+                        courseStatisticsWithAdminFieldResponseCounts.Archived = true;
+                    }
+                    else
+                    {
+                        courseStatisticsWithAdminFieldResponseCounts.Archived = false;
+                    }
                 }
             }
         }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateAssessmentStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateAssessmentStatisticsViewModel.cs
@@ -1,0 +1,24 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses
+{
+    using DigitalLearningSolutions.Data.Models.Courses;
+    using DigitalLearningSolutions.Web.Helpers;
+
+    public class SearchableDelegateAssessmentStatisticsViewModel : SearchableDelegateCourseStatisticsViewModel
+    {
+        public SearchableDelegateAssessmentStatisticsViewModel(DelegateAssessmentStatistics delegateAssessmentStatistics) : base (delegateAssessmentStatistics)
+        {
+            Name = delegateAssessmentStatistics.Name;
+            Category = delegateAssessmentStatistics.Category;
+            Tags = FilterableTagHelper.GetCurrentStatusTagsForDelegateAssessment(delegateAssessmentStatistics);
+            Supervised = delegateAssessmentStatistics.Supervised;
+            DelegateCount = delegateAssessmentStatistics.DelegateCount;
+            SubmittedSignedOffCount = delegateAssessmentStatistics.SubmittedSignedOffCount;
+        }
+
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public bool Supervised { get; set; }
+        public int DelegateCount { get; set; }
+        public int SubmittedSignedOffCount { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateCourses/SearchableDelegateCourseStatisticsViewModel.cs
@@ -10,6 +10,12 @@
 
     public class SearchableDelegateCourseStatisticsViewModel : BaseFilterableViewModel
     {
+        public DelegateAssessmentStatistics delegateAssessmentStatistics;
+        public SearchableDelegateCourseStatisticsViewModel(DelegateAssessmentStatistics delegateAssessmentStatistics)
+        {
+            this.delegateAssessmentStatistics = delegateAssessmentStatistics;
+        }
+
         public SearchableDelegateCourseStatisticsViewModel(CourseStatisticsWithAdminFieldResponseCounts courseStatistics)
         {
             CustomisationId = courseStatistics.CustomisationId;

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/Index.cshtml
@@ -1,63 +1,70 @@
-﻿@using DigitalLearningSolutions.Web.Models.Enums
+﻿@using DigitalLearningSolutions.Data.Models.Courses;
+@using DigitalLearningSolutions.Web.Models.Enums
 @using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses
 @model DelegateCoursesViewModel
 
 <link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/courseSetup.css")" asp-append-version="true">
 
 @{
-  ViewData["Title"] = "Delegate activities";
+    ViewData["Title"] = "Delegate activities";
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-one-quarter">
-    <nav class="side-nav-menu" aria-label="Side navigation bar">
-      <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateCourses" />
-    </nav>
-  </div>
-
-  <div class="nhsuk-grid-column-three-quarters">
-    <div id="no-js-styling">
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-two-thirds">
-          <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
-        </div>
-        <div class="nhsuk-grid-column-one-third heading-button-group">
-          <a class="nhsuk-button nhsuk-button--secondary heading-button"
-             id="export-all"
-             asp-controller="DelegateCourses"
-             asp-action="DownloadAll"
-             asp-route-searchString="@Model.SearchString"
-             asp-route-sortBy="@Model.SortBy"
-             asp-route-sortDirection="@Model.SortDirection"
-             asp-route-existingFilterString="@Model.ExistingFilterString"
-             role="button">
-            Export
-          </a>
-        </div>
-      </div>
-
-      <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
-
-      @if (Model.NoDataFound)
-      {
-               <p>The centre has no courses set up in the <span class="nhsuk-u-font-weight-bold">@Model.CourseCategoryName</span>  category yet.</p>
-
-      }
-      else
-      {
-        <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
-        <partial name="SearchablePage/_TopPagination" model="Model" />
-        <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
-
-        <div id="searchable-elements">
-          @foreach (var course in Model.Courses)
-          {
-            <partial name="_CentreCourseCard" model="course" />
-          }
-        </div>
-      }
-
-      <partial name="SearchablePage/_BottomPagination" model="Model" />
+    <div class="nhsuk-grid-column-one-quarter">
+        <nav class="side-nav-menu" aria-label="Side navigation bar">
+            <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateCourses" />
+        </nav>
     </div>
-  </div>
+
+    <div class="nhsuk-grid-column-three-quarters">
+        <div id="no-js-styling">
+            <div class="nhsuk-grid-row">
+                <div class="nhsuk-grid-column-two-thirds">
+                    <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
+                </div>
+                <div class="nhsuk-grid-column-one-third heading-button-group">
+                    <a class="nhsuk-button nhsuk-button--secondary heading-button"
+                       id="export-all"
+                       asp-controller="DelegateCourses"
+                       asp-action="DownloadAll"
+                       asp-route-searchString="@Model.SearchString"
+                       asp-route-sortBy="@Model.SortBy"
+                       asp-route-sortDirection="@Model.SortDirection"
+                       asp-route-existingFilterString="@Model.ExistingFilterString"
+                       role="button">
+                        Export
+                    </a>
+                </div>
+            </div>
+
+            <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
+
+            @if (Model.NoDataFound)
+            {
+                <p>The centre has no courses and assessments set up in the <span class="nhsuk-u-font-weight-bold">@Model.CourseCategoryName</span>  category yet.</p>
+            }
+            else
+            {
+                <partial name="SearchablePage/Configurations/_ResultsCountAndItemsPerPage" model="Model" />
+                <partial name="SearchablePage/_TopPagination" model="Model" />
+                <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
+
+                <div id="searchable-elements">
+                    @foreach (var course in Model.Courses)
+                    {
+                        if (course is SearchableDelegateAssessmentStatisticsViewModel)
+                        {
+                            <partial name="_CentreAssesmentCard" model="course" />
+                        }
+                        else if (course is SearchableDelegateCourseStatisticsViewModel)
+                        {
+                            <partial name="_CentreCourseCard" model="course" />
+                        }
+                    }
+                </div>
+            }
+
+            <partial name="SearchablePage/_BottomPagination" model="Model" />
+        </div>
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreAssesmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreAssesmentCard.cshtml
@@ -1,0 +1,27 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses
+@model SearchableDelegateAssessmentStatisticsViewModel
+
+<div class="searchable-element nhsuk-panel card-with-buttons word-break">
+  <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
+    <summary class="nhsuk-details__summary">
+      <span class="nhsuk-details__summary-text searchable-element-title" name="course-name">
+          @Model.Name
+      </span>
+    </summary>
+
+    <div class="nhsuk-details__text">
+      <partial name="SearchablePage/_StatusTags" model="@Model.Tags" />
+      <partial name="_CentreAssessmentCardDetails" model="@Model" />
+    </div>
+  </details>
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full nhsuk-u-margin-left-4">
+      <a class="nhsuk-button nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-2"
+         role="button">
+        View self assesment delegates
+      </a>
+    </div>
+  </div>
+</div>
+

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreAssessmentCardDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreAssessmentCardDetails.cshtml
@@ -1,0 +1,38 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses
+@model SearchableDelegateAssessmentStatisticsViewModel
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Category
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+        @Model.Category
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Supervised
+    </dt>
+    <partial name="_SummaryBooleanField" model="Model.Supervised" />
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Enrolled
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+        @Model.DelegateCount
+    </dd>
+  </div>
+
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Submitted/Signed off
+    </dt>
+    <dd class="nhsuk-summary-list__value" name="in-progress-count">
+        @Model.SubmittedSignedOffCount
+    </dd>
+  </div>
+</dl>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1568

### Description
Points addressed in this Commit :
1) Show self assessments published to the centre into the "Delegate activities" list by modifying the dataservices,models,controllers,services,viewmodel,tests and helpers.

### Screenshots
![Delegate-activities-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/93c834a4-ca44-448d-afd2-d850ec570f27)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/d62ae6b3-f05b-47b9-9b5b-64d01f0b9669)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
