### PR TITLE
TD-2932 Removed proficiencies confirmation requests when a learner removes a supervisor from a self assessment or supervisor removes a staff member from their staff list

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -404,6 +404,20 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 
         public bool RemoveSupervisorDelegateById(int supervisorDelegateId, int delegateUserId, int adminId)
         {
+
+            connection.Execute(
+                @"DELETE FROM sarsv FROM SelfAssessmentResultSupervisorVerifications as sarsv
+                    LEFT JOIN CandidateAssessmentSupervisors AS cas ON cas.ID = sarsv.CandidateAssessmentSupervisorID
+                    WHERE cas.SupervisorDelegateId IN (SELECT sd.ID
+					FROM SupervisorDelegates sd
+					JOIN (
+					  SELECT DelegateEmail
+					  FROM SupervisorDelegates
+					  WHERE ID = @supervisorDelegateId
+					) sds
+					ON sd.SupervisorEmail = sds.DelegateEmail) AND cas.Removed IS NULL AND sarsv.Verified IS NULL", new { supervisorDelegateId }
+            );
+
             var numberOfAffectedRows = connection.Execute(
          @"UPDATE SupervisorDelegates SET Removed = getUTCDate()
             WHERE ID = @supervisorDelegateId AND Removed IS NULL AND (DelegateUserID = @delegateUserId OR SupervisorAdminID = @adminId)",
@@ -834,6 +848,12 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         }
         public bool RemoveCandidateAssessmentSupervisor(int selfAssessmentId, int supervisorDelegateId)
         {
+            connection.Execute(
+                @"DELETE FROM sarsv FROM SelfAssessmentResultSupervisorVerifications as sarsv
+                    LEFT JOIN CandidateAssessmentSupervisors AS cas ON cas.ID = sarsv.CandidateAssessmentSupervisorID
+                    WHERE cas.SupervisorDelegateId = @supervisorDelegateId AND cas.Removed IS NULL AND sarsv.Verified IS NULL", new { supervisorDelegateId }
+                );
+
             var deletedCandidateAssessmentSupervisors = connection.Execute(
                 @"DELETE FROM cas
 	                FROM CandidateAssessmentSupervisors AS cas


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2932

### Description
Points addressed in this Commit :
1) Removed proficiencies confirmation requests when a learner removes a supervisor from a self assessment or supervisor removes a staff member from their staff list by modifying the dataservice.

### Screenshots
[Self-Assessment---Digital-Learning-Solutions.webm](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/a899ee44-885e-44c3-b17f-e82237041f8d)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
