### PR TITLE
TD-2933 supervise my staff list view selfassessments page not loading correct data 

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -203,7 +203,8 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 	                    ON cp6.CustomPromptID = ct.CustomField6PromptID 
 	                    LEFT OUTER JOIN AdminAccounts AS au2 
 		                    ON da.UserID = au2.UserID AND da.CentreID = au2.CentreID
-                    WHERE (sd.SupervisorAdminID = @adminId) AND (sd.Removed IS NULL)
+                    WHERE (sd.SupervisorAdminID = @adminId) AND (sd.Removed IS NULL) AND 
+                     (u.ID = da.UserID OR sd.DelegateUserID IS NULL)
                     ORDER BY u.LastName, COALESCE (u.FirstName, sd.DelegateEmail)
                     ", new { adminId }
                 );


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2933

### Description
Need to edit  query to ensure that  delegate that  did not have the same centre Id  with the supervisor did not appear

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/11d16e82-d0d8-48f2-8ff9-d8e17c6288c4)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/d8026aec-8b79-4101-a229-456795d88501)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.