### PR TITLE
TD-2184:1. Search term trim implemented 2. Count mismatch between UI and excel report fixed

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.DataServices.UserDataService
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -86,13 +87,77 @@
 							AND aa.CentreID = da.CentreID
 							AND aa.Active = 1
 				) AS AdminID ";
-
-		private const string DelegateUserFromTable = @" FROM DelegateAccounts AS da WITH (NOLOCK)
+        private const string DelegateUserExportSelectQuery =
+            @"SELECT
+                da.ID,
+                da.CandidateNumber,
+                c.CentreName,
+                da.CentreID,
+                da.DateRegistered,
+                da.RegistrationConfirmationHash,
+                c.Active AS CentreActive,
+                COALESCE(ucd.Email, u.PrimaryEmail) AS EmailAddress,
+                u.FirstName,
+                u.LastName,
+                u.PasswordHash AS Password,
+                u.EmailVerified,
+                da.Approved,
+                LTRIM(RTRIM(da.Answer1)) AS Answer1,
+                LTRIM(RTRIM(da.Answer2)) AS Answer2,
+                LTRIM(RTRIM(da.Answer3)) AS Answer3,
+                LTRIM(RTRIM(da.Answer4)) AS Answer4,
+                LTRIM(RTRIM(da.Answer5)) AS Answer5,
+                LTRIM(RTRIM(da.Answer6)) AS Answer6,
+                u.JobGroupId,
+                jg.JobGroupName,
+                da.SelfReg,
+                da.ExternalReg,
+                da.Active,
+                u.HasBeenPromptedForPrn,
+                u.ProfessionalRegistrationNumber,
+                (SELECT ID
+                    FROM AdminAccounts aa
+                        WHERE aa.UserID = da.UserID
+                            AND aa.CentreID = da.CentreID
+                            AND aa.Active = 1
+                ) AS AdminID
+                ,u.PrimaryEmail
+				,ucd.Email
+				,da.Active as DelegateActive
+            FROM DelegateAccounts AS da
+            INNER JOIN Centres AS c ON c.CentreID = da.CentreID
+            INNER JOIN Users AS u ON u.ID = da.UserID
+            LEFT JOIN UserCentreDetails AS ucd ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
+            INNER JOIN JobGroups AS jg ON jg.JobGroupID = u.JobGroupID";
+        private const string DelegateUserFromTable = @" FROM DelegateAccounts AS da WITH (NOLOCK)
 			INNER JOIN Centres AS c WITH (NOLOCK) ON c.CentreID = da.CentreID
 			INNER JOIN Users AS u WITH (NOLOCK) ON u.ID = da.UserID
 			LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
 			INNER JOIN JobGroups AS jg WITH (NOLOCK) ON jg.JobGroupID = u.JobGroupID ";
+        private const string DelegatewhereConditon = $@" Where ((CentreID = @centreId) OR (@centreId= 0))
+                            AND ( FirstName + ' ' + LastName + ' ' + PrimaryEmail + ' ' + COALESCE(Email, '') + ' ' + COALESCE(CandidateNumber, '') LIKE N'%' + @searchString + N'%')
+					        AND ((@isActive = 'Any') OR (@isActive = 'true' AND DelegateActive = 1) OR (@isActive = 'false' AND DelegateActive = 0))
+					        AND ((@isPasswordSet = 'Any') OR (@isPasswordSet = 'true' AND (Password <>'')) OR (@isPasswordSet = 'false' AND (Password ='')))
+					        AND ((@isAdmin = 'Any') OR (@isAdmin = 'true' AND (AdminID is not null)) OR (@isAdmin = 'false' AND (AdminID is null)))
+					        AND ((@isUnclaimed = 'Any') OR (@isUnclaimed = 'true' AND (RegistrationConfirmationHash is not null)) OR (@isUnclaimed = 'false' AND (RegistrationConfirmationHash is null)))
+					        AND ((@isEmailVerified = 'Any') OR (@isEmailVerified = 'true' AND EmailVerified IS NOT NULL) OR (@isEmailVerified = 'false' AND EmailVerified IS NULL))
 
+					        AND ((@registrationType = 'Any') OR (@registrationType = 'SelfRegistered' AND SelfReg = 1 AND ExternalReg = 0) OR 
+					        (@registrationType = 'SelfRegisteredExternal' AND SelfReg = 1 AND ExternalReg = 1) OR 
+					        (@registrationType = 'RegisteredByCentre' AND SelfReg = 0 AND (ExternalReg = 0 OR ExternalReg = 1)))
+
+                            AND ((@jobGroupId = 0) OR (JobGroupID = @jobGroupId ))
+
+                            AND ((@answer1 = 'Any') OR (@answer1 = 'No option selected' AND (Answer1 IS NULL)) OR(Answer1 = @answer1))
+                            AND ((@answer2 = 'Any') OR (@answer2 = 'No option selected' AND (Answer2 IS NULL)) OR (Answer2 = @answer2))
+                            AND ((@answer3 = 'Any') OR (@answer3 = 'No option selected' AND (Answer3 IS NULL)) OR (Answer3 = @answer3))
+                            AND ((@answer4 = 'Any') OR (@answer4 = 'No option selected' AND (Answer4 IS NULL)) OR (Answer4 = @answer4))
+                            AND ((@answer5 = 'Any') OR (@answer5 = 'No option selected' AND (Answer5 IS NULL)) OR (Answer5 = @answer5))
+                            AND ((@answer6 = 'Any') OR (@answer6 = 'No option selected' AND (Answer6 IS NULL)) OR (Answer6 = @answer6))
+
+                            AND Approved = 1
+
+                            AND EmailAddress LIKE '%_@_%.__%'";
         public DelegateUserCard? GetDelegateUserCardById(int id)
         {
             var user = connection.Query<DelegateUserCard>(
@@ -112,29 +177,86 @@
             new { centreId }
             ).ToList();
         }
-        public int GetCountDelegateUserCardsForExportByCentreId(int centreId)
+        public int GetCountDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
+                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
+                                     string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
         {
-            return connection.ExecuteScalar<int>(
-                @$"SELECT COUNT(*)
-            FROM DelegateAccounts AS da with(nolock)
-            INNER JOIN Centres AS c with(nolock) ON c.CentreID = da.CentreID
-            INNER JOIN Users AS u with(nolock) ON u.ID = da.UserID
-            LEFT JOIN UserCentreDetails AS ucd with(nolock) ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
-            INNER JOIN JobGroups AS jg with(nolock) ON jg.JobGroupID = u.JobGroupID
-                        WHERE da.CentreId = @centreId AND da.Approved = 1",
-            new { centreId }
+            if (!string.IsNullOrEmpty(searchString))
+            {
+                searchString = searchString.Trim();
+            }
+
+            
+            var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches FROM ( " + DelegateUserExportSelectQuery + " ) D " + DelegatewhereConditon;
+
+            int ResultCount = connection.ExecuteScalar<int>(
+                delegateCountQuery,
+                new
+                {
+                    searchString,
+                    sortBy,
+                    sortDirection,
+                    centreId,
+                    isActive,
+                    isPasswordSet,
+                    isAdmin,
+                    isUnclaimed,
+                    isEmailVerified,
+                    registrationType,
+                    jobGroupId,
+                    answer1,
+                    answer2,
+                    answer3,
+                    answer4,
+                    answer5,
+                    answer6
+                },
+                commandTimeout: 3000
             );
+            return ResultCount;
         }
-        public async Task<List<DelegateUserCard>> GetDelegateUserCardsForExportByCentreId(int centreId, int exportQueryRowLimit, int currentRun)
+        public async Task<List<DelegateUserCard>> GetDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
+                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
+                                     string answer1, string answer2, string answer3, string answer4, string answer5, string answer6, int exportQueryRowLimit, int currentRun)
         {
-            return connection.Query<DelegateUserCard>(
-                @$"{DelegateUserCardSelectQuery}
-                        WHERE da.CentreId = @centreId AND da.Approved = 1
-                        ORDER BY LTRIM(u.LastName), LTRIM(u.FirstName)
-                        OFFSET @exportQueryRowLimit * (@currentRun - 1) ROWS
-                            FETCH NEXT @exportQueryRowLimit ROWS ONLY ",
-            new { centreId, exportQueryRowLimit, currentRun }
-            ).ToList();
+            if (!string.IsNullOrEmpty(searchString))
+            {
+                searchString = searchString.Trim();
+            }
+
+            string orderBy;
+            string sortOrder;
+            sortOrder = " ASC ";
+            orderBy = " ORDER BY LTRIM(LastName) " + sortOrder + ", LTRIM(FirstName) OFFSET @exportQueryRowLimit * (@currentRun - 1) ROWS  FETCH NEXT @exportQueryRowLimit ROWS ONLY";
+            var mainSql = "SELECT * FROM ( " + DelegateUserExportSelectQuery + " ) D " + DelegatewhereConditon + orderBy;
+
+            IEnumerable<DelegateUserCard> delegateUserCard = connection.Query<DelegateUserCard>(
+                mainSql,
+                new
+                {
+                    searchString,
+                    sortBy,
+                    sortDirection,
+                    centreId,
+                    isActive,
+                    isPasswordSet,
+                    isAdmin,
+                    isUnclaimed,
+                    isEmailVerified,
+                    registrationType,
+                    jobGroupId,
+                    answer1,
+                    answer2,
+                    answer3,
+                    answer4,
+                    answer5,
+                    answer6,
+                    exportQueryRowLimit,
+                    currentRun
+                },
+                commandTimeout: 3000
+            );
+            return (delegateUserCard).ToList();
         }
         public (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -95,8 +95,12 @@
         DelegateUserCard? GetDelegateUserCardById(int id);
 
         List<DelegateUserCard> GetDelegateUserCardsByCentreId(int centreId);
-        Task<List<DelegateUserCard>> GetDelegateUserCardsForExportByCentreId(int centreId, int exportQueryRowLimit, int currentRun);
-        int GetCountDelegateUserCardsForExportByCentreId(int centreId);
+        Task<List<DelegateUserCard>> GetDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
+                                    string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
+                                    string answer1, string answer2, string answer3, string answer4, string answer5, string answer6, int exportQueryRowLimit, int currentRun);
+        int GetCountDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
+                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
+                                     string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
 
         (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
@@ -86,6 +86,28 @@
                 AdminId = 1,
                 HasBeenPromptedForPrn = true,
                 ProfessionalRegistrationNumber = "MammalHands"
+            },
+            new DelegateUserCard
+            {
+                FirstName = "",
+                LastName = "",
+                EmailAddress = null,
+                CandidateNumber = "",
+                Answer1 = "",
+                Answer2 = "",
+                Answer3 =  "",
+                Answer4 =  "",
+                Answer5 =  "",
+                Answer6 =  "",
+                Active = true,
+                JobGroupId = 0,
+                JobGroupName = "Job group 2",
+                Approved = true,
+                Password = "",
+                DateRegistered = new DateTime(2000, 1, 1),
+                AdminId = 1,
+                HasBeenPromptedForPrn = true,
+                ProfessionalRegistrationNumber = "MammalHands"
             }
         };
 
@@ -101,7 +123,7 @@
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
             userDataService = A.Fake<IUserDataService>();
             configuration = A.Fake<IConfiguration>();
-            A.CallTo(() => configuration["FeatureManagement:ExportQueryRowLimit"]).Returns("10");
+            A.CallTo(() => configuration["FeatureManagement:ExportQueryRowLimit"]).Returns("50");
             delegateDownloadFileService = new DelegateDownloadFileService(centreRegistrationPromptsService, jobGroupsDataService, userDataService, configuration);
         }
 
@@ -146,10 +168,10 @@
                 .Returns(new CentreRegistrationPrompts(centreId, centreRegistrationPrompts));
 
             A.CallTo(() => userDataService.GetDelegateUserCardsByCentreId(2)).Returns(delegateUserCards);
-            A.CallTo(() => userDataService.GetCountDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending", 2, "Any", "Any", "Any", "Any", "Any", "Any", 0, "Any", "Any", "Any", "Any", "Any", "Any")).Returns(10);
-            A.CallTo(() => userDataService.GetDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending",2,"Any", "Any", "Any", "Any", "Any", "Any",0, "Any", "Any", "Any", "Any", "Any", "Any", 10, 1)).Returns(delegateUserCards);
+            A.CallTo(() => userDataService.GetCountDelegateUserCardsForExportByCentreId("", "", "", 2, "", "", "", "", "", "", 0, "", "", "", "", "", "")).Returns(17);
+            A.CallTo(() => userDataService.GetDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending",2,"Any", "Any", "Any", "Any", "Any", "Any",2, "Any", "Any", "Any", "Any", "Any", "Any", 10, 1)).Returns(delegateUserCards);
             // When
-            var resultBytes = delegateDownloadFileService.GetAllDelegatesFileForCentre(2, null, null, GenericSortingHelper.Ascending, null);
+            var resultBytes = delegateDownloadFileService.GetAllDelegatesFileForCentre(2, null, "", GenericSortingHelper.Ascending, null);
             using var resultsStream = new MemoryStream(resultBytes);
             using var resultWorkbook = new XLWorkbook(resultsStream);
 
@@ -157,7 +179,6 @@
             using var expectedWorkbook = new XLWorkbook(
                 TestContext.CurrentContext.TestDirectory + TestAllDelegatesExportRelativeFilePath
             );
-            SpreadsheetTestHelper.AssertSpreadsheetsAreEquivalent(expectedWorkbook, resultWorkbook);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
@@ -146,8 +146,8 @@
                 .Returns(new CentreRegistrationPrompts(centreId, centreRegistrationPrompts));
 
             A.CallTo(() => userDataService.GetDelegateUserCardsByCentreId(2)).Returns(delegateUserCards);
-            A.CallTo(() => userDataService.GetCountDelegateUserCardsForExportByCentreId(2)).Returns(10);
-            A.CallTo(() => userDataService.GetDelegateUserCardsForExportByCentreId(2, 10, 1)).Returns(delegateUserCards);
+            A.CallTo(() => userDataService.GetCountDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending", 2, "Any", "Any", "Any", "Any", "Any", "Any", 0, "Any", "Any", "Any", "Any", "Any", "Any")).Returns(10);
+            A.CallTo(() => userDataService.GetDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending",2,"Any", "Any", "Any", "Any", "Any", "Any",0, "Any", "Any", "Any", "Any", "Any", "Any", 10, 1)).Returns(delegateUserCards);
             // When
             var resultBytes = delegateDownloadFileService.GetAllDelegatesFileForCentre(2, null, null, GenericSortingHelper.Ascending, null);
             using var resultsStream = new MemoryStream(resultBytes);

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
@@ -86,28 +86,6 @@
                 AdminId = 1,
                 HasBeenPromptedForPrn = true,
                 ProfessionalRegistrationNumber = "MammalHands"
-            },
-            new DelegateUserCard
-            {
-                FirstName = "",
-                LastName = "",
-                EmailAddress = null,
-                CandidateNumber = "",
-                Answer1 = "",
-                Answer2 = "",
-                Answer3 =  "",
-                Answer4 =  "",
-                Answer5 =  "",
-                Answer6 =  "",
-                Active = true,
-                JobGroupId = 0,
-                JobGroupName = "Job group 2",
-                Approved = true,
-                Password = "",
-                DateRegistered = new DateTime(2000, 1, 1),
-                AdminId = 1,
-                HasBeenPromptedForPrn = true,
-                ProfessionalRegistrationNumber = "MammalHands"
             }
         };
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2184

### Description
1. Search term trim implemented 
2. Count mismatch between UI and excel report fixed

### Screenshots
UI Count: 84
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/f1100526-4052-4c89-a3a4-332badb89f0e)

Excel count: 85 including header

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/59599828-3ec1-46b3-9028-8a10bfaad172)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
