### PR TITLE
TD-2969 Displayed centre name of the 'Educator' when requesting sign off

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
@@ -46,7 +46,7 @@
             <div class="nhsuk-radios__item">
               <input class="nhsuk-radios__input" id="radio-@supervisor.ID" asp-for="CandidateAssessmentSupervisorId" type="radio" value="@supervisor.ID">
               <label class="nhsuk-label nhsuk-radios__label" for="radio-@supervisor.ID">
-                @supervisor.SupervisorName (@supervisor.SupervisorEmail) - @supervisor.RoleName
+                  @supervisor.SupervisorName - @supervisor.SupervisorEmail - @supervisor.RoleName (@supervisor.CentreName)
               </label>
             </div>
           }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2969

### Description
Points addressed in this Commit :
1) Displayed centre name of the 'Educator' when requesting sign off by modifying view.

### Screenshots
![Self-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/68285ea5-057b-4a7e-8cc3-12f174bd2063)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/3e33c1d9-36af-4254-8e80-c0511e1f5cc0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
