### PR TITLE
TD-2988 Fixed overlapping action links on Manage confirmation requests screen

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
@@ -79,11 +79,11 @@
                             <span class="nhsuk-table-responsive__heading">Request </span>
                             @competency.SupervisorName<br />
                             @competency.SupervisorVerificationRequested?.ToString("dd/MM/yyyy")<br />
-                            <div class="nhsuk-grid-column-two-thirds" style="white-space: nowrap;">
+                            <div class="nhsuk-u-one-half-tablet" style="white-space: nowrap;">
                                 <div class="nhsuk-grid-row nhsuk-u-padding-0">
                                     @if (competency.EmailSent.HasValue && clockUtility.UtcNow.Subtract(competency.EmailSent.Value) > TimeSpan.FromHours(1))
                                     {
-                                        <div class="nhsuk-grid-column-one-half nhsuk-u-padding-0">
+                                        <div class="nhsuk-grid-column-one-half">
                                             <a asp-action="ResendSupervisorVerificationRequest"
                                asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
                                asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
@@ -94,7 +94,7 @@
                                             </a>
                                         </div>
                                     }
-                                    <div class="nhsuk-grid-column-one-half nhsuk-u-padding-0">
+                                    <div class="nhsuk-grid-column-one-half">
                                         <a asp-action="WithdrawSupervisorVerificationRequest"
                                asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
                                asp-route-supervisorVerificationId="@competency.SupervisorVerificationId">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2988

### Description
Points addressed in this Commit :
1) Fixed overlapping action links on Manage confirmation requests screen by modifying view.

### Screenshots
![Self-Assessment-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/0284ee60-fc5e-482c-aabe-145094056561)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/d9292493-715e-4afd-a39f-472c56152d20)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
