### PR TITLE
TD-752 Competency flag fix on mobile view

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -37,7 +37,7 @@
           <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
           <partial name="_CompetencyFlags"
                  model="competency.CompetencyFlags"
-                 view-data="@(new ViewDataDictionary(ViewData) {{ "cssClass", $"{(competency.AlwaysShowDescription ? "" : "nhsuk-u-padding-left-4")}" }})" />
+                             view-data="@(new ViewDataDictionary(ViewData) {{ "cssClass", $"{(competency.AlwaysShowDescription ? "" : "nhsuk-u-padding-left-4 competency-status-tag")}" }})" />
           @if (competency.Description != null && !competency.AlwaysShowDescription)
           {
             <details class="nhsuk-details">


### PR DESCRIPTION
### JIRA link
[TD-752](https://hee-tis.atlassian.net/browse/TD-752)

### Description
css fix for competency flag

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-752]: https://hee-tis.atlassian.net/browse/TD-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ