### PR TITLE
TD-2184: Excel report was not getting sorted when sorting is selected in UI

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.User;
+    using DocumentFormat.OpenXml.Drawing;
 
     public partial class UserDataService
     {
@@ -226,8 +227,17 @@
 
             string orderBy;
             string sortOrder;
-            sortOrder = " ASC ";
-            orderBy = " ORDER BY LTRIM(LastName) " + sortOrder + ", LTRIM(FirstName) OFFSET @exportQueryRowLimit * (@currentRun - 1) ROWS  FETCH NEXT @exportQueryRowLimit ROWS ONLY";
+            if (sortDirection == "Ascending")
+                sortOrder = " ASC ";
+            else
+                sortOrder = " DESC ";
+
+            if (sortBy == "SearchableName")
+                orderBy = " ORDER BY LTRIM(LastName) " + sortOrder + ", LTRIM(FirstName) ";
+            else
+                orderBy = " ORDER BY DateRegistered " + sortOrder;
+
+            orderBy += " OFFSET @exportQueryRowLimit * (@currentRun - 1) ROWS  FETCH NEXT @exportQueryRowLimit ROWS ONLY";
             var mainSql = "SELECT * FROM ( " + DelegateUserExportSelectQuery + " ) D " + DelegatewhereConditon + orderBy;
 
             IEnumerable<DelegateUserCard> delegateUserCard = connection.Query<DelegateUserCard>(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2184

### Description
Excel report was not getting sorted when sorting is selected in UI.

### Screenshots
**_UI_**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/fa6fea6a-19e4-4ce4-981b-2410a6d9168a)
**_Excel report_**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/120369940/ea3040a5-9f73-4558-b6d6-dd3465df4b90)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
