### PR TITLE
TD-3009 store and get scorm suspend data Tracker endpoints

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202310181537_AspProgressAddSuspenDataColumn.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202310181537_AspProgressAddSuspenDataColumn.cs
@@ -1,0 +1,16 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+    [Migration(202310181537)]
+    public class AspProgressAddSuspenDataColumn : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("aspProgress").AddColumn("SuspendData").AsString(4096).Nullable();
+        }
+        public override void Down()
+        {
+            Delete.Column("SuspendData").FromTable("aspProgress");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -83,6 +83,19 @@
             int tutStat
         );
 
+        void UpdateAspProgressTutStatAndTime(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime
+            );
+
+        void UpdateAspProgressSuspendData(
+           int tutorialId,
+           int progressId,
+           string? suspendData
+       );
+
         int GetCompletionStatusForProgress(int progressId);
 
         IEnumerable<AssessAttempt> GetAssessAttemptsForProgressSection(int progressId, int sectionNumber);
@@ -568,6 +581,38 @@
                       AND (ProgressID = @progressId)
                       AND (TutStat < @tutStat)",
                 new { tutorialId, progressId, tutStat }
+            );
+        }
+
+        public void UpdateAspProgressTutStatAndTime(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime
+        )
+        {
+            connection.Execute(
+                @"UPDATE aspProgress
+                    SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime
+                    WHERE (TutorialID = @tutorialId)
+                      AND (ProgressID = @progressId)
+                      AND (TutStat < @tutStat)",
+                new { tutorialId, progressId, tutStat, tutTime }
+            );
+        }
+
+        public void UpdateAspProgressSuspendData(
+           int tutorialId,
+           int progressId,
+           string? suspendData
+       )
+        {
+            connection.Execute(
+                @"UPDATE aspProgress
+                    SET SuspendData = @suspendData
+                    WHERE (TutorialID = @tutorialId)
+                      AND (ProgressID = @progressId)",
+                new { tutorialId, progressId, suspendData }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -110,6 +110,8 @@
             bool status,
             int progressId
         );
+
+        string? GetAspProgressSuspendData(int progressId, int tutorialId);
     }
 
     public class ProgressDataService : IProgressDataService
@@ -662,6 +664,17 @@
                     VALUES (@delegateId, @customisationId, @version, @insertionDate, 1, @sectionNumber, @score, @status, @progressId)",
                 new { delegateId, customisationId, version, insertionDate, sectionNumber, score, status, progressId }
             );
+        }
+
+        public string? GetAspProgressSuspendData(int progressId, int tutorialId)
+        {
+            return connection.Query<string?>(
+                @"SELECT TOP(1)
+                        SuspendData
+                    FROM dbo.aspProgress
+                    WHERE ProgressID = @progressId AND TutorialID = @tutorialId",
+                new { progressId, tutorialId }
+            ).FirstOrDefault();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -4,9 +4,11 @@
     {
         getobjectivearray,
         getobjectivearraycc,
+        getsuspenddata,
         storediagnosticjson,
         storeaspprogressv2,
         storeaspprogressnosession,
         storeaspassessnosession,
+        storesuspenddata,
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -26,6 +26,9 @@
         public static readonly TrackerEndpointResponse StoreDiagnosticScoreException =
             new TrackerEndpointResponse(-25, nameof(StoreDiagnosticScoreException));
 
+        public static readonly TrackerEndpointResponse StoreSuspendDataException =
+            new TrackerEndpointResponse(-26, nameof(StoreSuspendDataException));
+
         public TrackerEndpointResponse(int id, string name) : base(id, name) { }
 
         public static implicit operator string(TrackerEndpointResponse trackerEndpointResponse)

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -26,8 +26,8 @@
         public static readonly TrackerEndpointResponse StoreDiagnosticScoreException =
             new TrackerEndpointResponse(-25, nameof(StoreDiagnosticScoreException));
 
-        public static readonly TrackerEndpointResponse StoreSuspendDataException =
-            new TrackerEndpointResponse(-26, nameof(StoreSuspendDataException));
+        public static readonly TrackerEndpointResponse SuspendDataException =
+            new TrackerEndpointResponse(-26, nameof(SuspendDataException));
 
         public TrackerEndpointResponse(int id, string name) : base(id, name) { }
 

--- a/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
+++ b/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
@@ -14,5 +14,6 @@
         public int? Version { get; set; }
         public int? TutorialId { get; set; }
         public int? Score { get; set; }
+        public string? SuspendData { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -376,9 +376,7 @@
                     )
                 )
                 .MustHaveHappenedOnceExactly();
-            A.CallTo(() => progressDataService.UpdateAspProgressTutTime(tutorialId, progressId, tutorialTime))
-                .MustHaveHappenedOnceExactly();
-            A.CallTo(() => progressDataService.UpdateAspProgressTutStat(tutorialId, progressId, tutorialStatus))
+            A.CallTo(() => progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime))
                 .MustHaveHappenedOnceExactly();
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -6,7 +6,7 @@
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
-    using DigitalLearningSolutions.Data.Models.Progress;    
+    using DigitalLearningSolutions.Data.Models.Progress;
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -41,6 +41,17 @@
             int tutorialStatus
         );
 
+        void StoreAspProgressSuspendData(
+            int progressId,
+            int tutorialId,
+            string? suspendData
+            );
+
+        string? GetAspProgressSuspendData(
+            int progressId,
+            int tutorialId
+            );
+
         void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress);
 
         public SectionAndApplicationDetailsForAssessAttempts? GetSectionAndApplicationDetailsForAssessAttempts(
@@ -241,6 +252,11 @@
         )
         {
             return progressDataService.GetSectionAndApplicationDetailsForAssessAttempts(sectionId, customisationId);
+        }
+
+        public string? GetAspProgressSuspendData(int progressId, int tutorialId)
+        {
+            return progressDataService.GetAspProgressSuspendData(progressId, tutorialId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -202,8 +202,16 @@
                 timeNow,
                 progressText ?? string.Empty
             );
-            progressDataService.UpdateAspProgressTutTime(tutorialId, progressId, tutorialTime);
-            progressDataService.UpdateAspProgressTutStat(tutorialId, progressId, tutorialStatus);
+            progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
+        }
+
+        public void StoreAspProgressSuspendData(
+            int progressId,
+            int tutorialId,
+            string? suspendData
+            )
+        {
+            progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
         }
 
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -39,6 +39,12 @@
             int tutorialStatus
         );
 
+        void StoreAspProgressSessionData(
+                int progressId,
+                int tutorialId,
+                string? sessionData
+            );
+
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -51,6 +57,13 @@
             GetAndValidateSectionAssessmentDetails(
                 int? sectionId,
                 int customisationId
+            );
+        (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+                int? progressId,
+                int? tutorialId,
+                int? candidateId,
+                int? customisationId
             );
     }
 
@@ -219,6 +232,35 @@
             }
 
             return (null, assessmentDetails);
+        }
+
+        public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+                int? progressId,
+                int? tutorialId,
+                int? candidateId,
+                int? customisationId
+            )
+        {
+            if (progressId == null || tutorialId == null ||
+                candidateId == null || customisationId == null)
+            {
+                return (TrackerEndpointResponse.StoreSuspendDataException, null);
+            }
+
+            var progress = progressService.GetDetailedCourseProgress(progressId.Value);
+            if (progress == null || progress.DelegateId != candidateId ||
+                progress.CustomisationId != customisationId.Value)
+            {
+                return (TrackerEndpointResponse.StoreSuspendDataException, null);
+            }
+
+            return (null, progress);
+        }
+
+        public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -45,6 +45,11 @@
                 string? sessionData
             );
 
+        string? GetAspProgressSessionData(
+            int progressId,
+            int tutorialId
+            );
+
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -59,7 +64,7 @@
                 int customisationId
             );
         (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+            GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
                 int? progressId,
                 int? tutorialId,
                 int? candidateId,
@@ -235,7 +240,7 @@
         }
 
         public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+            GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
                 int? progressId,
                 int? tutorialId,
                 int? candidateId,
@@ -245,14 +250,14 @@
             if (progressId == null || tutorialId == null ||
                 candidateId == null || customisationId == null)
             {
-                return (TrackerEndpointResponse.StoreSuspendDataException, null);
+                return (TrackerEndpointResponse.SuspendDataException, null);
             }
 
             var progress = progressService.GetDetailedCourseProgress(progressId.Value);
             if (progress == null || progress.DelegateId != candidateId ||
                 progress.CustomisationId != customisationId.Value)
             {
-                return (TrackerEndpointResponse.StoreSuspendDataException, null);
+                return (TrackerEndpointResponse.SuspendDataException, null);
             }
 
             return (null, progress);
@@ -260,7 +265,19 @@
 
         public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
         {
-            throw new NotImplementedException();
+            progressService.StoreAspProgressSuspendData(
+                progressId,
+                tutorialId,
+                sessionData
+                );
+        }
+
+        public string? GetAspProgressSessionData(int progressId, int tutorialId)
+        {
+            return progressService.GetAspProgressSuspendData(
+                progressId,
+                tutorialId
+                );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -17,6 +17,8 @@
 
         TrackerObjectiveArrayCc? GetObjectiveArrayCc(int? customisationId, int? sectionId, bool? isPostLearning);
 
+        string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId);
+
         TrackerEndpointResponse StoreDiagnosticJson(int? progressId, string? diagnosticOutcome);
 
         TrackerEndpointResponse StoreAspProgressV2(
@@ -370,7 +372,7 @@
             string? suspendData
             )
         {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
                progressId,
                tutorialId,
                candidateId,
@@ -391,10 +393,37 @@
             catch (Exception ex)
             {
                 logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreAspProgressException;
+                return TrackerEndpointResponse.SuspendDataException;
             }
 
             return TrackerEndpointResponse.Success;
+        }
+
+        public string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId)
+        {
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
+               progressId,
+               tutorialId,
+               candidateId,
+               customisationId
+           );
+            if (validationResponse != null)
+            {
+                return validationResponse;
+            }
+            try
+            {
+               var suspendData = storeAspService.GetAspProgressSessionData(
+                    progressId!.Value,
+                    tutorialId!.Value
+                );
+                return suspendData ?? "";
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return TrackerEndpointResponse.StoreAspProgressException;
+            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -7,6 +7,7 @@
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.Tracker;
     using DigitalLearningSolutions.Data.Utilities;
+    using DocumentFormat.OpenXml.Bibliography;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
@@ -49,6 +50,13 @@
             int? customisationId,
             string? sessionId
         );
+        TrackerEndpointResponse StoreSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId,
+            string? suspendData
+            );
     }
 
     public class TrackerActionService : ITrackerActionService
@@ -350,6 +358,40 @@
             else
             {
                 progressService.CheckProgressForCompletionAndSendEmailIfCompleted(progress);
+            }
+
+            return TrackerEndpointResponse.Success;
+        }
+        public TrackerEndpointResponse StoreSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId,
+            string? suspendData
+            )
+        {
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+               progressId,
+               tutorialId,
+               candidateId,
+               customisationId
+           );
+            if (validationResponse != null)
+            {
+                return validationResponse;
+            }
+            try
+            {
+                storeAspService.StoreAspProgressSessionData(
+                    progressId!.Value,
+                    tutorialId!.Value,
+                    suspendData
+                );
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return TrackerEndpointResponse.StoreAspProgressException;
             }
 
             return TrackerEndpointResponse.Success;

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -17,7 +17,12 @@
 
         TrackerObjectiveArrayCc? GetObjectiveArrayCc(int? customisationId, int? sectionId, bool? isPostLearning);
 
-        string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId);
+        string? GetSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId
+            );
 
         TrackerEndpointResponse StoreDiagnosticJson(int? progressId, string? diagnosticOutcome);
 
@@ -399,7 +404,12 @@
             return TrackerEndpointResponse.Success;
         }
 
-        public string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId)
+        public string? GetSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId
+            )
         {
             var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
                progressId,

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -423,10 +423,10 @@
             }
             try
             {
-               var suspendData = storeAspService.GetAspProgressSessionData(
-                    progressId!.Value,
-                    tutorialId!.Value
-                );
+                var suspendData = storeAspService.GetAspProgressSessionData(
+                     progressId!.Value,
+                     tutorialId!.Value
+                 );
                 return suspendData ?? "";
             }
             catch (Exception ex)

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -113,6 +113,17 @@
                         );
                     }
 
+                    if (action == TrackerEndpointAction.storesuspenddata)
+                    {
+                        return trackerActionService.StoreSuspendData(
+                            query.ProgressId,
+                            query.TutorialId,
+                            query.CandidateId,
+                            query.CustomisationId,
+                            query.SuspendData
+                            );
+                    }
+
                     throw new ArgumentOutOfRangeException();
                 }
 

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -124,6 +124,16 @@
                             );
                     }
 
+                    if (action == TrackerEndpointAction.getsuspenddata)
+                    {
+                        return trackerActionService.GetSuspendData(
+                            query.ProgressId,
+                            query.TutorialId,
+                            query.CandidateId,
+                            query.CustomisationId
+                            );
+                    }
+
                     throw new ArgumentOutOfRangeException();
                 }
 


### PR DESCRIPTION
### JIRA link
[TD-3009](https://hee-tis.atlassian.net/browse/TD-3009)

### Description
Adds a new field `SuspendData` to the aspProgress table. Implements new StoreSuspendData and GetSuspendData endpoints to store and retrieve bookmark data in the new field.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3009]: https://hee-tis.atlassian.net/browse/TD-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ