### PR TITLE
TD-2930 Added Max/Min character limit validation for 'Contact phone' is missing on 'Edit centre manager details' screen of 'Super Admin' interface

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/EditCentreManagerDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Configuration/EditCentreManagerDetailsViewModel.cs
@@ -31,8 +31,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Configur
         [NoWhitespace(ErrorMessage = "Email must not contain any whitespace characters")]
         public string? Email { get; set; }
 
-        [MaxLength(250, ErrorMessage = "Telephone number must be 250 characters or fewer")]
-        [RegularExpression(@"[0-9 ]+", ErrorMessage = "Enter a Telephone number in the correct format.")]
+        [RegularExpression(@"^(?:\d\s*?){10,11}$", ErrorMessage = "Enter a Telephone number in the correct format.")]
         public string? Telephone { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2930

### Description
Points addressed in this Commit :
1) Added Max/Min character limit validation for 'Contact phone' is missing on 'Edit centre manager details' screen of 'Super Admin' interface by modifying viewmodel.

### Screenshots
![Edit-centre-manager-details-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/da3df40e-fb72-4ada-a7b6-7b9cc3856a51)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
