### PR TITLE
TD-3025 Add assessment types table primary key

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202310191439_AddAssessmentTypesPK.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202310191439_AddAssessmentTypesPK.cs
@@ -1,0 +1,20 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202310191439)]
+    public class AddAssessmentTypesPrimaryKey : Migration
+    {
+        public override void Up()
+        {
+            if (!Schema.Table("AssessmentTypes").Constraint("PK_AssessmentTypes").Exists())
+            {
+                Create.PrimaryKey("PK_AssessmentTypes").OnTable("AssessmentTypes").Column("AssessmentTypeID");
+            }
+        }
+        public override void Down()
+        {
+            Delete.PrimaryKey("PK_AssessmentTypes").FromTable("AssessmentTypes");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-3025](https://hee-tis.atlassian.net/browse/TD-3025)

### Description
Migration to add the missing primary key to the AssessmentTypes table on the existing AssessmentTypeID column.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3025]: https://hee-tis.atlassian.net/browse/TD-3025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ