### PR TITLE
TD-2958 Fixed heading and also added validation for duplicate group name not allowed

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -91,6 +91,7 @@
             string? option,
             int? jobGroupId
         );
+        bool IsDelegateGroupExist(string groupLabel);
     }
 
     public class GroupsDataService : IGroupsDataService
@@ -555,6 +556,16 @@
                             OR (Answer5 = @option AND @linkedToField = 6)
                             OR (Answer6 = @option AND @linkedToField = 7))",
                 new { groupId, addedDate, linkedToField, centreId, option, jobGroupId }
+            );
+        }
+
+        public bool IsDelegateGroupExist(string groupLabel)
+        {
+            return connection.QuerySingle<bool>(
+                @"SELECT CASE WHEN EXISTS (select * from Groups where GroupLabel like @groupLabel and RemovedDate is null)
+                THEN CAST(1 AS BIT)
+                ELSE CAST(0 AS BIT) END",
+                new { groupLabel }
             );
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using DigitalLearningSolutions.Data.Enums;
+﻿using DigitalLearningSolutions.Data.Enums;
 using DigitalLearningSolutions.Data.Helpers;
 using DigitalLearningSolutions.Data.Models.CustomPrompts;
 using DigitalLearningSolutions.Data.Models.DelegateGroups;
+using DigitalLearningSolutions.Data.Models.Frameworks;
 using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
 using DigitalLearningSolutions.Web.Attributes;
 using DigitalLearningSolutions.Web.Helpers;
@@ -12,12 +10,14 @@ using DigitalLearningSolutions.Web.Helpers.FilterOptions;
 using DigitalLearningSolutions.Web.Models.Enums;
 using DigitalLearningSolutions.Web.ServiceFilter;
 using DigitalLearningSolutions.Web.Services;
-using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateCourses;
 using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.FeatureManagement.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 {
@@ -215,13 +215,21 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 return View(model);
             }
 
-            groupsService.AddDelegateGroup(
+            if (!groupsService.IsDelegateGroupExist(model.GroupName))
+            {
+                groupsService.AddDelegateGroup(
                 User.GetCentreIdKnownNotNull(),
                 model.GroupName!,
                 model.GroupDescription,
                 User.GetAdminId()!.Value
             );
-            return RedirectToAction("Index");
+                return RedirectToAction("Index");
+            }
+            else
+            {
+                ModelState.AddModelError(nameof(model.GroupName), "Delegate Group with the same name already exists");
+                return View("AddDelegateGroup", model);
+            }
         }
 
         [HttpGet("{groupId:int}/EditDescription")]

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -134,6 +134,8 @@
             int newJobGroupId,
             AccountDetailsData accountDetailsData
         );
+
+        bool IsDelegateGroupExist(string groupLabel);
     }
 
     public class GroupsService : IGroupsService
@@ -890,6 +892,11 @@
         private static string GetGroupNameWithPrefix(string prefix, string groupName)
         {
             return $"{prefix} - {groupName}";
+        }
+
+        public bool IsDelegateGroupExist(string groupLabel)
+        {
+            return groupsDataService.IsDelegateGroupExist(groupLabel);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateGroups/Index.cshtml
@@ -5,58 +5,58 @@
 <link rel="stylesheet" href="@Url.Content("~/css/trackingSystem/delegates/delegateGroups.css")" asp-append-version="true">
 
 @{
-  ViewData["Title"] = "Groups";
+    ViewData["Title"] = "Delegate Groups";
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-one-quarter">
-    <nav class="side-nav-menu" aria-label="Side navigation bar">
-      <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateGroups" />
-    </nav>
-  </div>
-
-  <div class="nhsuk-grid-column-three-quarters">
-    <div id="no-js-styling">
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-one-third">
-          <h1 id="page-heading" class="nhsuk-heading-xl">@ViewData["Title"]</h1>
-        </div>
-        <div class="nhsuk-grid-column-two-thirds heading-button-group">
-          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button" asp-action="AddDelegateGroup">
-            Add
-          </a>
-          <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button" asp-action="GenerateGroups">
-            Generate
-          </a>
-        </div>
-      </div>
-
-      <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
-
-      @if (Model.NoDataFound)
-      {
-        <p class="nhsuk-u-margin-top-4" role="alert">
-          <b>No delegate groups found.</b>
-        </p>
-      }
-      else
-      {
-        <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-        <partial name="SearchablePage/_TopPagination" model="Model" />
-        <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
-
-        <div id="searchable-elements">
-          @foreach (var groupModel in Model.DelegateGroups)
-          {
-            <partial name="_SearchableDelegateGroupCard" model="groupModel" />
-          }
-        </div>
-      }
-
-      <partial name="SearchablePage/_BottomPagination" model="Model" />
+    <div class="nhsuk-grid-column-one-quarter">
+        <nav class="side-nav-menu" aria-label="Side navigation bar">
+            <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateGroups" />
+        </nav>
     </div>
-    <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
-      <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateGroups" />
-    </nav>
-  </div>
+
+    <div class="nhsuk-grid-column-three-quarters">
+        <div id="no-js-styling">
+            <div class="nhsuk-grid-row">
+                <div class="nhsuk-grid-column-two-thirds">
+                    <h1 id="page-heading" class="nhsuk-heading-xl">@ViewData["Title"]</h1>
+                </div>
+                <div class="nhsuk-grid-column-one-third heading-button-group">
+                    <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button" asp-action="AddDelegateGroup">
+                        Add
+                    </a>
+                    <a class="nhsuk-button nhsuk-button--secondary heading-button" role="button" asp-action="GenerateGroups">
+                        Generate
+                    </a>
+                </div>
+            </div>
+
+            <partial name="SearchablePage/Configurations/_ThreeQuarterWidthSearchSortAndFilter" model="Model" />
+
+            @if (Model.NoDataFound)
+            {
+                <p class="nhsuk-u-margin-top-4" role="alert">
+                    <b>No delegate groups found.</b>
+                </p>
+            }
+            else
+            {
+                <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+                <partial name="SearchablePage/_TopPagination" model="Model" />
+                <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
+
+                <div id="searchable-elements">
+                    @foreach (var groupModel in Model.DelegateGroups)
+                    {
+                        <partial name="_SearchableDelegateGroupCard" model="groupModel" />
+                    }
+                </div>
+            }
+
+            <partial name="SearchablePage/_BottomPagination" model="Model" />
+        </div>
+        <nav class="side-nav-menu-bottom" aria-label="Bottom navigation bar">
+            <partial name="~/Views/TrackingSystem/Delegates/Shared/_DelegatesSideNavMenu.cshtml" model="DelegatePage.DelegateGroups" />
+        </nav>
+    </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2958

### Description
Points addressed in this Commit :
1) Fixed heading and also added validation for duplicate group name not allowed by modifying dataservice,service,controller and view.

### Screenshots
![Add-new-delegate-group-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/a990e4b9-c659-4aa8-83ed-cd9f5af3e095)
![Delegate-Groups-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/4f2ef96a-8eaf-42a4-a74d-f36930629ac1)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/3e5bab54-da5c-4002-a5ae-6f81e516149c)
![WavePlugin-1](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/159dc106-bc90-4abc-a6df-a3edc0b8e7cc)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
