### PR TITLE
TD-2993 Made status filter dropdown second word first letter of the second word first letter of the status filter headings in lower case

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
@@ -54,17 +54,17 @@
         {
             var filters = new List<FilterModel>
             {
-                new FilterModel("PasswordStatus", "Password Status", PasswordStatusOptions,"status"),
-                new FilterModel("AdminStatus", "Admin Status", AdminStatusOptions,"status"),
-                new FilterModel("ActiveStatus", "Active Status", ActiveStatusOptions,"status"),
+                new FilterModel("PasswordStatus", "Password status", PasswordStatusOptions,"status"),
+                new FilterModel("AdminStatus", "Admin status", AdminStatusOptions,"status"),
+                new FilterModel("ActiveStatus", "Active status", ActiveStatusOptions,"status"),
                 new FilterModel(
                     "JobGroupId",
                     "Job Group",
                     DelegatesViewModelFilters.GetJobGroupOptions(jobGroups)
                 ),
-                new FilterModel("RegistrationType", "Registration Type", RegistrationTypeOptions,"status"),
-                new FilterModel("AccountStatus", "Account Status", AccountStatusOptions,"status"),
-                new FilterModel("EmailStatus", "Email Status", EmailStatusOptions,"status"),
+                new FilterModel("RegistrationType", "Registration type", RegistrationTypeOptions,"status"),
+                new FilterModel("AccountStatus", "Account status", AccountStatusOptions,"status"),
+                new FilterModel("EmailStatus", "Email status", EmailStatusOptions,"status"),
             };
             filters.AddRange(
                 promptsWithOptions.Select(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2993

### Description
Points addressed in this Commit :
1) Made status filter dropdown second word first letter of the status filter headings in lower case by modifying viewmodel.

### Screenshots
![Screenshot 2023-10-19 122632](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/45ae0926-36fa-4a18-aef1-99dd3e7b46ad)
![WavePlugin](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/06d63719-b9c3-4348-8b58-e7d13fc6258c)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
