### PR TITLE
TD-3033 Issue with delegates not appearing in the delegate group & not being assigned the courses

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -164,11 +164,17 @@
                         GroupID,
                         GroupLabel,
                         GroupDescription,
-                        (SELECT COUNT(*) FROM GroupDelegates as gd 
-                        INNER JOIN DelegateAccounts AS da ON gd.DelegateID = da.ID
-                        INNER JOIN Users AS u ON da.UserID=u.ID 
-                        LEFT JOIN UserCentreDetails AS ucd ON ucd.UserID = u.ID AND ucd.CentreID = da.CentreID
-                        where gd.GroupID = g.GroupID AND (TRY_CAST(u.PrimaryEmail AS UNIQUEIDENTIFIER) IS NULL OR ucd.Email IS NOT NULL)) AS DelegateCount,
+                        (SELECT  COUNT(*) FROM ( SELECT
+							da.CentreID,
+							COALESCE(ucd.Email, u.PrimaryEmail) AS EmailAddress,
+							u.JobGroupId
+								FROM DelegateAccounts AS da WITH (NOLOCK)
+						INNER JOIN Centres AS c WITH (NOLOCK) ON c.CentreID = da.CentreID
+						INNER JOIN Users AS u WITH (NOLOCK) ON u.ID = da.UserID
+						LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
+						INNER JOIN JobGroups AS jg WITH (NOLOCK) ON jg.JobGroupID = u.JobGroupID  where c.CentreID = @centreId
+						AND u.JobGroupID = (select JobGroupID from JobGroups where JobGroupName = GroupLabel))  D  Where 
+						EmailAddress LIKE '%_@_%.__%') AS DelegateCount,
                         ({CourseCountSql}) AS CoursesCount,
                         g.CreatedByAdminUserID AS AddedByAdminId,
                         au.Forename AS AddedByFirstName,


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3033

### Description
Points addressed in this Commit :
1) Fixed data mismatch in delegates list with group filter and delegate count data in delegate groups by modifying dataservice.

### Screenshots
![Delegates-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/7a406f2b-6bca-4462-9ff1-5f6e637e1267)
![Delegate-Groups-Digital-Learning-Solutions](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/111436026/1c8845f3-187d-4d21-bd47-e005e393f8e5)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
