### PR TITLE
TD-2992 Fixed the issue of spaces not trimming off when searching tex…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -59,6 +59,7 @@
             int? itemsPerPage = 10
         )
         {
+            searchString = searchString == null ? string.Empty : searchString.Trim();
             var loggedInSuperAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
             if (loggedInSuperAdmin.AdminAccount.Active == false)
             {

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -60,6 +60,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             int? itemsPerPage = 10
         )
         {
+            searchString = searchString == null ? string.Empty : searchString.Trim();
             if (string.IsNullOrEmpty(sortBy))
             {
                 sortBy = DefaultSortByOptions.Name.PropertyName;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2992

### Description
Points addressed in this Commit :
1. Trimmed leading/trailing end spaces on search field when text searched by modifying controllers.

### Screenshots
This is backend change so no screenshot available.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
