### PR TITLE
TD-2972-Activity Delegates- Sort and filter options added to self assessment activities

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -148,7 +148,7 @@
 
         void RemoveEnrolment(int selfAssessmentId, int delegateUserId);
         (IEnumerable<SelfAssessmentDelegate>, int) GetSelfAssessmentDelegates(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed);
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
     }
 
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
@@ -175,11 +175,25 @@
         }
 
         public (IEnumerable<SelfAssessmentDelegate>, int) GetSelfAssessmentDelegates(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed)
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff)
         {
             searchString = searchString == null ? string.Empty : searchString.Trim();
-            var selectColumnQuery = $@"SELECT
-                da.CandidateNumber,
+            var cteAssessmentResults = $@"
+                WITH LatestAssessmentResults AS
+					(
+						SELECT	s.DelegateUserID
+								, CASE WHEN COALESCE (rr.LevelRAG, 0) = 3 THEN s.ID ELSE NULL END AS SelfAssessed
+								, CASE WHEN sv.Verified IS NOT NULL AND sv.SignedOff = 1 AND COALESCE (rr.LevelRAG, 0) = 3 THEN s.ID ELSE NULL END AS Confirmed
+								, CASE WHEN sas.Optional = 1  THEN s.CompetencyID ELSE NULL END AS Optional
+						FROM   SelfAssessmentResults AS s LEFT OUTER JOIN
+										SelfAssessmentStructure AS sas ON s.SelfAssessmentID = sas.SelfAssessmentID AND s.CompetencyID = sas.CompetencyID LEFT OUTER JOIN
+										SelfAssessmentResultSupervisorVerifications AS sv ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0 LEFT OUTER JOIN
+										CompetencyAssessmentQuestionRoleRequirements AS rr ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
+						WHERE (s.SelfAssessmentID = @selfAssessmentId)
+					)";
+
+            var selectColumnQuery = $@"
+                SELECT da.CandidateNumber,
                 u.ID AS DelegateUserId,
                 u.ProfessionalRegistrationNumber,
                 ca.SelfAssessmentID As SelfAssessmentId,
@@ -198,9 +212,11 @@
                 u.FirstName AS DelegateFirstName,
                 u.LastName AS DelegateLastName,
                 COALESCE(ucd.Email, u.PrimaryEmail) AS DelegateEmail,
-                da.Active AS IsDelegateActive ";
-
-            selectColumnQuery += ",MAX(casv.Verified) as SignedOff";
+                da.Active AS IsDelegateActive,
+                sa.Name AS Name,
+                COALESCE(COUNT(DISTINCT LAR.SelfAssessed), NULL) AS SelfAssessed,
+                COALESCE(COUNT(DISTINCT LAR.Confirmed), NULL) AS Confirmed,
+                MAX(casv.Verified) as SignedOff";
 
             var fromTableQuery = $@" FROM  dbo.SelfAssessments AS sa 
 				INNER JOIN dbo.CandidateAssessments AS ca WITH (NOLOCK) ON sa.ID = ca.SelfAssessmentID 
@@ -209,17 +225,19 @@
                 INNER JOIN dbo.Users u WITH (NOLOCK) ON DA.UserID = u.ID
                 LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = da.UserID AND ucd.centreID = da.CentreID
 				LEFT OUTER JOIN AdminAccounts AS aaEnrolledBy WITH (NOLOCK) ON aaEnrolledBy.ID = ca.EnrolledByAdminID
-                LEFT OUTER JOIN Users AS uEnrolledBy WITH (NOLOCK) ON uEnrolledBy.ID = aaEnrolledBy.UserID ";
+                LEFT OUTER JOIN Users AS uEnrolledBy WITH (NOLOCK) ON uEnrolledBy.ID = aaEnrolledBy.UserID
+                LEFT JOIN dbo.CandidateAssessmentSupervisors AS cas WITH (NOLOCK) ON ca.ID = cas.CandidateAssessmentID
+                LEFT JOIN dbo.CandidateAssessmentSupervisorVerifications AS casv WITH (NOLOCK) ON cas.ID = casv.CandidateAssessmentSupervisorID AND
+                (casv.Verified IS NOT NULL AND casv.SignedOff = 1)
+                LEFT OUTER JOIN LatestAssessmentResults AS LAR ON LAR.DelegateUserID = ca.DelegateUserID
 
-            var signedOffJoin = $@" LEFT JOIN dbo.CandidateAssessmentSupervisors AS cas WITH (NOLOCK) ON ca.ID = cas.CandidateAssessmentID
-                LEFT JOIN dbo.CandidateAssessmentSupervisorVerifications AS casv WITH (NOLOCK) ON cas.ID = casv.CandidateAssessmentSupervisorID AND(casv.Verified IS NOT NULL AND casv.SignedOff = 1) ";
-
-            var whereQuery = $@" WHERE sa.ID = @selfAssessmentId 
+                WHERE sa.ID = @selfAssessmentId 
                 AND da.CentreID = @centreID AND csa.CentreID = @centreID
                 AND (ca.RemovedDate IS NULL)
                 AND ( u.FirstName + ' ' + u.LastName + ' ' + COALESCE(ucd.Email, u.PrimaryEmail) + ' ' + COALESCE(da.CandidateNumber, '') LIKE N'%' + @searchString + N'%')
                 AND ((@isDelegateActive IS NULL) OR (@isDelegateActive = 1 AND (da.Active = 1)) OR (@isDelegateActive = 0 AND (da.Active = 0)))
 				AND ((@removed IS NULL) OR (@removed = 1 AND (ca.RemovedDate IS NOT NULL)) OR (@removed = 0 AND (ca.RemovedDate IS NULL)))
+                AND ((@submitted IS NULL) OR (@submitted = 1 AND (ca.SubmittedDate IS NOT NULL)) OR (@submitted = 0 AND (ca.SubmittedDate IS NULL)))
                 AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%.__%' ";
 
             var groupBy = $@" GROUP BY 
@@ -242,25 +260,36 @@
                 u.FirstName,
                 u.LastName,
                 COALESCE(ucd.Email, u.PrimaryEmail),
-                da.Active";
+                da.Active,
+                sa.Name";
+
+            if (signedOff != null)
+            {
+                groupBy += (bool)signedOff ? " HAVING MAX(casv.Verified) IS NOT NULL " : " HAVING MAX(casv.Verified) IS NULL ";
+            }
 
             string orderBy;
-            string sortOrder = sortDirection == "Ascending" ? "ASC" : "DESC";
+            sortDirection = sortDirection == "Ascending" ? "ASC" : "DESC";
+            string sortOrder = sortDirection + ", LTRIM(u.LastName)" + sortDirection;
 
-            if (sortBy == "Enrolled")
-                orderBy = " ORDER BY ca.StartedDate " + sortOrder + ", LTRIM(u.LastName)";
-            else if (sortBy == "CompleteBy")
-                orderBy = " ORDER BY ca.CompleteByDate " + sortOrder + ", LTRIM(u.LastName)";
-            else if (sortBy == "Completed")
-                orderBy = " ORDER BY ca.CompletedDate " + sortOrder + ", LTRIM(u.LastName)";
-            else if (sortBy == "CandidateNumber")
-                orderBy = " ORDER BY da.CandidateNumber " + sortOrder + ", LTRIM(u.LastName)";
+            if (sortBy == "LastAccessed")
+                orderBy = " ORDER BY ca.LastAccessed " + sortOrder;
+            else if (sortBy == "StartedDate")
+                orderBy = " ORDER BY ca.StartedDate " + sortOrder;
+            else if (sortBy == "SignedOff")
+                orderBy = " ORDER BY SignedOff " + sortOrder;
+            else if (sortBy == "SubmittedDate")
+                orderBy = " ORDER BY ca.SubmittedDate " + sortOrder;
+            else if (sortBy == "SelfAssessed")
+                orderBy = " ORDER BY SelfAssessed " + sortOrder;
+            else if (sortBy == "Confirmed")
+                orderBy = " ORDER BY Confirmed " + sortOrder;
             else
-                orderBy = " ORDER BY LTRIM(u.LastName) " + sortOrder + ", LTRIM(u.FirstName) ";
+                orderBy = " ORDER BY LTRIM(u.LastName) " + sortDirection + ", LTRIM(u.FirstName) ";
 
             orderBy += " OFFSET " + offSet + " ROWS FETCH NEXT " + itemsPerPage + " ROWS ONLY ";
 
-            var delegateQuery = selectColumnQuery + fromTableQuery + signedOffJoin + whereQuery + groupBy + orderBy;
+            var delegateQuery = cteAssessmentResults + selectColumnQuery + fromTableQuery + groupBy + orderBy;
 
             IEnumerable<SelfAssessmentDelegate> delegateUserCard = connection.Query<SelfAssessmentDelegate>(
                 delegateQuery,
@@ -274,12 +303,15 @@
                     selfAssessmentId,
                     centreId,
                     isDelegateActive,
-                    removed
+                    removed,
+                    submitted,
+                    signedOff
                 },
                 commandTimeout: 3000
             );
 
-            var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches " + fromTableQuery + whereQuery;
+            var delegateCountQuery = cteAssessmentResults + @$"SELECT COUNT(Matches) from(
+                                    SELECT  COUNT(*) AS Matches " + fromTableQuery + groupBy + ") AS ct";
 
             int ResultCount = connection.ExecuteScalar<int>(
                 delegateCountQuery,
@@ -293,7 +325,9 @@
                     selfAssessmentId,
                     centreId,
                     isDelegateActive,
-                    removed
+                    removed,
+                    submitted,
+                    signedOff
                 },
                 commandTimeout: 3000
             );

--- a/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
@@ -10,6 +10,7 @@
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.Frameworks;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+    using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Data.Models.User;
 
     public static class GenericSortingHelper
@@ -196,35 +197,49 @@
             1,
             nameof(FullName),
             "Name",
-            nameof(CourseDelegate.FullNameForSearchingSorting)
+            nameof(SelfAssessmentDelegate.FullNameForSearchingSorting)
         );
 
-        public static readonly SelfAssessmentDelegatesSortByOption EnrolledDate = new SelfAssessmentDelegatesSortByOption(
+        public static readonly SelfAssessmentDelegatesSortByOption LastAccessed = new SelfAssessmentDelegatesSortByOption(
+            2,
+            nameof(LastAccessed),
+            "Last accessed",
+            nameof(SelfAssessmentDelegate.LastAccessed)
+        );
+
+        public static readonly SelfAssessmentDelegatesSortByOption StartedDate = new SelfAssessmentDelegatesSortByOption(
             3,
-            nameof(EnrolledDate),
-            "Enrolled date",
-            nameof(CourseDelegate.Enrolled)
+            nameof(StartedDate),
+            "Enrolled",
+            nameof(SelfAssessmentDelegate.StartedDate)
         );
 
-        public static readonly SelfAssessmentDelegatesSortByOption CompleteByDate = new SelfAssessmentDelegatesSortByOption(
+        public static readonly SelfAssessmentDelegatesSortByOption SelfAssessed = new SelfAssessmentDelegatesSortByOption(
             4,
-            nameof(CompleteByDate),
-            "Complete by date",
-            nameof(CourseDelegate.CompleteBy)
+            nameof(SelfAssessed),
+            "Competencies self assessed",
+            nameof(SelfAssessmentDelegate.SelfAssessed)
         );
 
-        public static readonly SelfAssessmentDelegatesSortByOption CompletedDate = new SelfAssessmentDelegatesSortByOption(
+        public static readonly SelfAssessmentDelegatesSortByOption Confirmed = new SelfAssessmentDelegatesSortByOption(
             5,
-            nameof(CompletedDate),
-            "Completed date",
-            nameof(CourseDelegate.Completed)
+            nameof(Confirmed),
+            "Competencies confirmed",
+            nameof(SelfAssessmentDelegate.Confirmed)
         );
 
-        public static readonly SelfAssessmentDelegatesSortByOption DelegateId = new SelfAssessmentDelegatesSortByOption(
+        public static readonly SelfAssessmentDelegatesSortByOption SignedOff = new SelfAssessmentDelegatesSortByOption(
+            6,
+            nameof(SignedOff),
+            "Signed off",
+            nameof(SelfAssessmentDelegate.SignedOff)
+        );
+
+        public static readonly SelfAssessmentDelegatesSortByOption Submitted = new SelfAssessmentDelegatesSortByOption(
             7,
-            nameof(DelegateId),
-            "Delegate ID",
-            nameof(CourseDelegate.CandidateNumber)
+            nameof(Submitted),
+            "Submitted",
+            nameof(SelfAssessmentDelegate.SubmittedDate)
         );
 
         public readonly string DisplayText;

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentDelegate.cs
@@ -37,6 +37,8 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
             EnrolledByForename = delegateInfo.EnrolledByForename;
             EnrolledBySurname = delegateInfo.EnrolledBySurname;
             EnrolledByAdminActive = delegateInfo.EnrolledByAdminActive;
+            SelfAssessed = delegateInfo.SelfAssessed;
+            Confirmed = delegateInfo.Confirmed;
         }
         public int DelegateId { get; set; }
         public string? DelegateFirstName { get; set; }
@@ -59,6 +61,8 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
         public string? EnrolledByForename { get; set; }
         public string? EnrolledBySurname { get; set; }
         public bool? EnrolledByAdminActive { get; set; }
+        public int SelfAssessed { get; set; }
+        public int Confirmed { get; set; }
         public bool Removed => RemovedDate.HasValue;
 
         public List<SelfAssessmentSupervisor> Supervisors { get; set; } =

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -39,7 +39,7 @@
             paginateService = A.Fake<IPaginateService>();
             configuration = A.Fake<IConfiguration>();
             selfAssessmentDelegatesService = A.Fake<ISelfAssessmentService>();
-            courseService= A.Fake<ICourseService>();
+            courseService = A.Fake<ICourseService>();
 
             controller = new ActivityDelegatesController(
                     courseDelegatesService,
@@ -86,7 +86,7 @@
             var selfAssessmentDelegate = new SelfAssessmentDelegate(6, "Lname");
 
             A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentDelegatesPerPage("", 0, 10, "SearchableName", "Ascending",
-                6, UserCentreId, null, null))
+                6, UserCentreId, null, null, null, null))
                 .Returns((new SelfAssessmentDelegatesData(
                         new List<SelfAssessmentDelegate> { selfAssessmentDelegate }
                     ), 1)
@@ -128,7 +128,7 @@
             var selfAssessmentDelegate = new SelfAssessmentDelegate(6, "Lname");
 
             A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentDelegatesPerPage("", 0, 10, "SearchableName", "Ascending",
-                10, UserCentreId, null, null))
+                10, UserCentreId, null, null, null, null))
                 .Returns((new SelfAssessmentDelegatesData(
                         new List<SelfAssessmentDelegate> { selfAssessmentDelegate }
                     ), 0)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -100,8 +100,8 @@
             var centreId = User.GetCentreIdKnownNotNull();
             var adminCategoryId = User.GetAdminCategoryId();
 
-            bool? isDelegateActive, isProgressLocked, removed, hasCompleted;
-            isDelegateActive = isProgressLocked = removed = hasCompleted = null;
+            bool? isDelegateActive, isProgressLocked, removed, hasCompleted, submitted, signedOff;
+            isDelegateActive = isProgressLocked = removed = hasCompleted = submitted = signedOff = null;
 
             string? answer1, answer2, answer3;
             answer1 = answer2 = answer3 = null;
@@ -154,7 +154,13 @@
                             removed = filterValue;
 
                         if (filter.Contains("CompletionStatus"))
-                            hasCompleted = filterValue;
+                            submitted = filterValue;
+
+                        if (filter.Contains("Submitted"))
+                            signedOff = filterValue;
+
+                        if (filter.Contains("SignedOff"))
+                            signedOff = filterValue;
 
                         if (filter.Contains("Answer1"))
                             answer1 = filterValue;
@@ -189,14 +195,14 @@
                 else
                 {
                     (selfAssessmentDelegatesData, resultCount) = selfAssessmentService.GetSelfAssessmentDelegatesPerPage(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
-                        selfAssessmentId, centreId, isDelegateActive, removed);
+                        selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
 
                     if (selfAssessmentDelegatesData?.Delegates?.Count() == 0 && resultCount > 0)
                     {
                         page = 1;
                         offSet = 0;
                         (selfAssessmentDelegatesData, resultCount) = selfAssessmentService.GetSelfAssessmentDelegatesPerPage(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
-                            selfAssessmentId, centreId, isDelegateActive, removed);
+                            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
                     }
                 }
 

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/SelfAssessmentDelegateFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/SelfAssessmentDelegateFilterOptions.cs
@@ -2,7 +2,6 @@
 {
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
-    using DigitalLearningSolutions.Data.Models.CourseDelegates;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
 
@@ -22,7 +21,6 @@
             FilterStatus.Warning
         );
     }
-    
 
     public static class SelfAssessmentDelegateRemovedFilterOptions
     {
@@ -41,7 +39,38 @@
         );
     }
 
-    
+    public static class SelfAssessmentAssessmentSubmittedFilterOptions
+    {
+        private const string Group = "AssessmentSubmitted";
 
+        public static readonly FilterOptionModel Submitted = new FilterOptionModel(
+            "Submitted",
+            FilteringHelper.BuildFilterValueString(Group, nameof(SelfAssessmentDelegate.SubmittedDate), "true"),
+            FilterStatus.Warning
+        );
+
+        public static readonly FilterOptionModel NotSubmitted = new FilterOptionModel(
+            "Not submitted",
+            FilteringHelper.BuildFilterValueString(Group, nameof(SelfAssessmentDelegate.SubmittedDate), "false"),
+            FilterStatus.Default
+        );
+    }
+
+    public static class SelfAssessmentSignedOffFilterOptions
+    {
+        private const string Group = "AssessmentSignedOff";
+
+        public static readonly FilterOptionModel SignedOff = new FilterOptionModel(
+            "Signed off",
+            FilteringHelper.BuildFilterValueString(Group, nameof(SelfAssessmentDelegate.SignedOff), "true"),
+            FilterStatus.Warning
+        );
+
+        public static readonly FilterOptionModel NotSignedOff = new FilterOptionModel(
+            "Not signed off",
+            FilteringHelper.BuildFilterValueString(Group, nameof(SelfAssessmentDelegate.SignedOff), "false"),
+            FilterStatus.Default
+        );
+    }
 
 }

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -129,7 +129,7 @@
 
         void RemoveEnrolment(int selfAssessmentId, int delegateUserId);
         public (SelfAssessmentDelegatesData, int) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed);
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -424,10 +424,10 @@
         }
 
         public (SelfAssessmentDelegatesData, int) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed)
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff)
         {
             (var delegateselfAssessments, int resultCount) = selfAssessmentDataService.GetSelfAssessmentDelegates(searchString, offSet, itemsPerPage, sortBy, sortDirection,
-            selfAssessmentId, centreId, isDelegateActive, removed);
+            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
 
             List<SelfAssessmentDelegate> selfAssessmentDelegateList = new List<SelfAssessmentDelegate>();
             foreach (var delegateInfo in delegateselfAssessments)

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelfAssessmentDelegateViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelfAssessmentDelegateViewModelFilterOptions.cs
@@ -7,10 +7,10 @@
     public class SelfAssessmentDelegateViewModelFilterOptions
     {
         public static readonly IEnumerable<FilterOptionModel> ActiveStatusOptions = new[]
-        {            
+        {
             SelfAssessmentDelegateAccountStatusFilterOptions.Active,
             SelfAssessmentDelegateAccountStatusFilterOptions.Inactive,
-        };        
+        };
 
         public static readonly IEnumerable<FilterOptionModel> RemovedStatusOptions = new[]
         {
@@ -18,12 +18,26 @@
             SelfAssessmentDelegateRemovedFilterOptions.NotRemoved,
         };
 
+        public static readonly IEnumerable<FilterOptionModel> SubmittedStatusOptions = new[]
+        {
+            SelfAssessmentAssessmentSubmittedFilterOptions.Submitted,
+            SelfAssessmentAssessmentSubmittedFilterOptions.NotSubmitted,
+        };
+
+        public static readonly IEnumerable<FilterOptionModel> SignedOffStatusOptions = new[]
+        {
+            SelfAssessmentSignedOffFilterOptions.SignedOff,
+            SelfAssessmentSignedOffFilterOptions.NotSignedOff,
+        };
+
         public static List<FilterModel> GetAllSelfAssessmentDelegatesFilterViewModels()
         {
             var filters = new List<FilterModel>
             {
-                new FilterModel("ActiveStatus", "Active status", ActiveStatusOptions,"status"),
+                new FilterModel("ActiveStatus", "Delegate active status", ActiveStatusOptions,"status"),
                 new FilterModel("RemovedStatus", "Removed status", RemovedStatusOptions, "status"),
+                new FilterModel("SubmittedStatus", "Submitted status", SubmittedStatusOptions,"status"),
+                new FilterModel("SignedOffStatus", "Signed off status", SignedOffStatusOptions, "status"),
             };
             return filters;
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2972

### Description
TD-2972- Feature "Activity Delegates sort and filter options specific to self assessment activities" implemented.
New sort and filter options created for self assessment activities. Modified SQL query accordingly.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/de2b2abf-40ad-4db9-9977-f55a17fe7eea)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/d8d26367-ceb3-4bf7-849e-5b36dd08c9cf)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/307e51aa-4d17-463c-a6bb-e85c15bd7c02)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f14d16b3-e5d9-45f0-9cd0-912ef9a59a4a)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin]
- [ ] Updated/added documentation in [Confluence]
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
