### PR TITLE
TD-3032 Fixed downloaded reports file name in self assessment from Learning Portal

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1534,10 +1534,10 @@
             };
             return View("SelfAssessments/SignOffHistory", model);
         }
-        public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string vocabulary)
+        public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string vocabulary,string candidateAssessmentName)
         {
             var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, User.GetUserIdKnownNotNull(), true);
-            var fileName = $"DLS {vocabulary} Assessment Export {clockUtility.UtcNow:yyyy-MM-dd}.xlsx";
+            var fileName = $"{((candidateAssessmentName.Length > 30) ? candidateAssessmentName.Substring(0, 30) : candidateAssessmentName)} {vocabulary} Assessment Export {clockUtility.UtcNow:yyyy-MM-dd}.xlsx";
             return File(
                 content,
                 FileHelper.GetContentTypeFromFileName(fileName),

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
@@ -23,6 +23,7 @@
 <feature name="@(FeatureFlags.CandidateAssessmentExcelExport)">
   <a class="nhsuk-button nhsuk-button--secondary"
      asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
+     asp-route-candidateAssessmentName="@Model.SelfAssessment.Name"
      asp-route-vocabulary="@Model.VocabPlural()"
      asp-action="ExportCandidateAssessment"
      role="button">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3032

### Description
Points addressed in this Commit :
1) Fixed downloaded reports file name in self assessment from Learning Portal by modifying view and controller.

### Screenshots
This is backend change so no screenshot available.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
