### PR TITLE
TD-2408 Making add centre and edit centre consistent in validations

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -250,6 +250,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                 ViewBag.CentreTypes = SelectListHelper.MapOptionsToSelectListItems(
                     centreTypes, model.CentreTypeId
                 );
+                model.CentreName = model.CentreName == null ? string.Empty : model.CentreName.Trim();
                 return View(model);
             }
 
@@ -480,7 +481,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         public IActionResult AddCentre(AddCentreSuperAdminViewModel model)
         {
             var centres = centresDataService.GetAllCentres().ToList();
-            bool isCentreNamePresent = centres.Any(center => center.Item2 == model.CentreName);
+            bool isCentreNamePresent = centres.Any(center => string.Equals(center.Item2.Trim(), model.CentreName?.Trim(), StringComparison.OrdinalIgnoreCase));
             if (isCentreNamePresent)
             {
                 ModelState.AddModelError("CentreName", CommonValidationErrorMessages.CentreNameAlreadyExist);

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -492,6 +492,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                 var regions = regionDataService.GetRegionsAlphabetical().ToList();
                 model.RegionNameOptions = SelectListHelper.MapOptionsToSelectListItems(regions, model.RegionId);
                 model.CentreTypeOptions = SelectListHelper.MapOptionsToSelectListItems(centreTypes, model.CentreTypeId);
+                model.CentreName = model.CentreName == null ? string.Empty : model.CentreName.Trim();
                 return View(model);
             }
 

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/AddCentreSuperAdminViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/AddCentreSuperAdminViewModel.cs
@@ -31,6 +31,7 @@
             ShowOnMap = centre.ShowOnMap;
         }
 
+        [MaxLength(250, ErrorMessage = "Centre name must be 250 characters or fewer")]
         [Required(ErrorMessage = "Enter a centre name")]
         public string CentreName { get; set; }
 
@@ -49,6 +50,7 @@
         [NoWhitespace(ErrorMessage = "Email must not contain any whitespace characters")]
         public string? CentreEmail { get; set; }
 
+        [RegularExpression(@"^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$", ErrorMessage = "Enter an Ip in the correct format.")]
         public string? IpPrefix { get; set; }
         public bool ShowOnMap { get; set; }
         public string? ContactFirstName { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/EditCentreDetailsSuperAdminViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/EditCentreDetailsSuperAdminViewModel.cs
@@ -34,7 +34,7 @@
         [NoWhitespace(ErrorMessage = "Email must not contain any whitespace characters")]
         public string? CentreEmail { get; set; }
 
-        [RegularExpression(@"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}", ErrorMessage = "Enter an Ip in the correct format.")]
+        [RegularExpression(@"^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$", ErrorMessage = "Enter an Ip in the correct format.")]
         public string? IpPrefix { get; set; }
         public bool ShowOnMap { get; set; }
     }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2408

### Description
1. Placed 250 character limit on Add centre screen
2. Placed consistent IP address validation on both Add centre and Edit Centre so that it accepts IP address as well as IP address Prefix
3. Resolved case sensitive duplicate centres name in add centre screen
4. Trimmed leading and trailing whitespace while entering centre name


### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/8ab59f2e-d721-4d3f-b505-54de60bab9b0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
