### PR TITLE
TD-936 super admin reports overall usage download

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/PlatformReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/PlatformReports/PlatformReportsController.cs
@@ -24,6 +24,7 @@
         private readonly IPlatformReportsService platformReportsService;
         private readonly IClockUtility clockUtility;
         private readonly IReportFilterService reportFilterService;
+        private readonly IPlatformUsageSummaryDownloadFileService platformUsageSummaryDownloadFileService = null!;
 
         private SelfAssessmentReportsFilterOptions GetDropdownValues(bool supervised)
         {
@@ -33,12 +34,14 @@
         public PlatformReportsController(
             IPlatformReportsService platformReportsService,
             IClockUtility clockUtility,
-            IReportFilterService reportFilterService
+            IReportFilterService reportFilterService,
+            IPlatformUsageSummaryDownloadFileService platformUsageSummaryDownloadFileService
             )
         {
             this.platformReportsService = platformReportsService;
             this.clockUtility = clockUtility;
             this.reportFilterService = reportFilterService;
+            this.platformUsageSummaryDownloadFileService = platformUsageSummaryDownloadFileService;
         }
 
         public IActionResult Index()
@@ -61,6 +64,17 @@
                 p => new SelfAssessmentActivityDataRowModel(p, DateHelper.GetFormatStringForGraphLabel(p.DateInformation.Interval))
             );
         }
+        [Route("Export")]
+        public IActionResult Export()
+        {
+            var content = this.platformUsageSummaryDownloadFileService.GetPlatformUsageSummaryFile();
 
+            const string fileName = "Digital Learning Solutions Platform usage summary.xlsx";
+            return File(
+                content,
+                FileHelper.GetContentTypeFromFileName(fileName),
+                fileName
+            );
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/PlatformUsageSummaryDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/PlatformUsageSummaryDownloadFileService.cs
@@ -1,0 +1,139 @@
+﻿namespace DigitalLearningSolutions.Web.Services
+{
+    using ClosedXML.Excel;
+    using DigitalLearningSolutions.Data.DataServices.UserDataService;
+    using DigitalLearningSolutions.Data.Helpers;
+    using DigitalLearningSolutions.Data.Models.Centres;
+    using DigitalLearningSolutions.Data.Models.PlatformReports;
+    using DigitalLearningSolutions.Data.Models.User;
+    using DocumentFormat.OpenXml.Spreadsheet;
+    using Microsoft.Extensions.Configuration;
+    using StackExchange.Redis;
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using ConfigurationExtensions = DigitalLearningSolutions.Data.Extensions.ConfigurationExtensions;
+    public interface IPlatformUsageSummaryDownloadFileService
+    {
+        public byte[] GetPlatformUsageSummaryFile();
+    }
+    public class PlatformUsageSummaryDownloadFileService: IPlatformUsageSummaryDownloadFileService
+    {
+        public const string PlatformUsageSheetName = "PlatformUsage";
+
+        private const string ActiveCentres = "Active centres";
+        private const string learners = "Active learners";
+        private const string LearnerLogins = "Learner logins";
+        private const string CourseLearningTime = "Course learning time (hours)";
+
+        private const string CourseEnrolments = "Course enrolments";
+        private const string CourseCompletions = "Course completions";
+        private const string IndependentSelfAssessmentEnrolments = "Independent self assessment enrolments";
+        private const string IndependentSelfAssessmentCompletions = "Independent self assessment completions";
+        private const string SupervisedSelfAssessmentEnrolments = "Supervised self assessment enrolments";
+        private const string SupervisedSelfAssessmentCompletions = "Supervised self assessment completions";
+        private readonly IPlatformReportsService platformReportsService;
+        public PlatformUsageSummaryDownloadFileService(
+            IPlatformReportsService platformReportsService
+        )
+        {
+            this.platformReportsService = platformReportsService;
+        }
+
+        public byte[] GetPlatformUsageSummaryFile()
+        {
+            using var workbook = new XLWorkbook();
+
+            PopulatePlatformUsageSummarySheet(workbook);
+
+            using var stream = new MemoryStream();
+            workbook.SaveAs(stream);
+            return stream.ToArray();
+        }
+
+        private void PopulatePlatformUsageSummarySheet(IXLWorkbook workbook)
+        {
+           var platformUsageSummaryToExport = platformReportsService.GetPlatformUsageSummary(); ;
+            var dataTable = new DataTable();
+            SetUpDataTableColumnsForAllAdmins(dataTable);
+           SetPlatformUsageSummaryRowValues(dataTable, platformUsageSummaryToExport);
+          
+            if (dataTable.Rows.Count == 0)
+            {
+                var row = dataTable.NewRow();
+                dataTable.Rows.Add(row);
+            }
+
+            ClosedXmlHelper.AddSheetToWorkbook(
+                workbook,
+                PlatformUsageSheetName,
+                dataTable.AsEnumerable(),
+                XLTableTheme.None
+            );
+
+            FormatAllDelegateWorksheetColumns(workbook, dataTable);
+        }
+        private static void SetUpDataTableColumnsForAllAdmins(
+            DataTable dataTable
+        )
+        {
+
+            dataTable.Columns.AddRange(
+                new[]
+                {
+                    new DataColumn(ActiveCentres),
+                    new DataColumn(learners),
+                    new DataColumn(LearnerLogins),
+
+                    new DataColumn(CourseLearningTime),
+                    new DataColumn(CourseEnrolments),
+                    new DataColumn(CourseCompletions),
+                    new DataColumn(IndependentSelfAssessmentEnrolments),
+
+                    new DataColumn(IndependentSelfAssessmentCompletions),
+                    new DataColumn(SupervisedSelfAssessmentEnrolments),
+                    new DataColumn(SupervisedSelfAssessmentCompletions),
+
+                  
+                }
+            );
+        }
+
+        private static void SetPlatformUsageSummaryRowValues(
+            DataTable dataTable,
+            PlatformUsageSummary platformUsageSummary
+        )
+        {
+            var row = dataTable.NewRow();
+
+            row[ActiveCentres] = platformUsageSummary.ActiveCentres;
+            row[learners] = platformUsageSummary.Learners;
+            row[LearnerLogins] = platformUsageSummary.LearnerLogins;
+            row[CourseLearningTime] = platformUsageSummary.CourseLearningTime;
+            row[CourseEnrolments] = platformUsageSummary.CourseEnrolments;
+            row[CourseCompletions] = platformUsageSummary.CourseCompletions;
+
+            
+            row[IndependentSelfAssessmentEnrolments] = platformUsageSummary.IndependentSelfAssessmentEnrolments;
+            row[IndependentSelfAssessmentCompletions] = platformUsageSummary.IndependentSelfAssessmentCompletions;
+            row[SupervisedSelfAssessmentEnrolments] = platformUsageSummary.SupervisedSelfAssessmentEnrolments;
+
+            row[SupervisedSelfAssessmentCompletions] = platformUsageSummary.SupervisedSelfAssessmentCompletions;
+            dataTable.Rows.Add(row);
+        }
+
+        private static void FormatAllDelegateWorksheetColumns(IXLWorkbook workbook, DataTable dataTable)
+        {
+            var integerColumns = new[] { ActiveCentres, learners, LearnerLogins, CourseLearningTime, CourseEnrolments, CourseCompletions,
+                                IndependentSelfAssessmentEnrolments, IndependentSelfAssessmentCompletions, SupervisedSelfAssessmentEnrolments,SupervisedSelfAssessmentCompletions };
+            foreach (var columnName in integerColumns)
+            {
+                ClosedXmlHelper.FormatWorksheetColumn(workbook, dataTable, columnName, XLDataType.Number);
+            }
+           
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -273,6 +273,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IPlatformReportsService, PlatformReportsService>();
             services.AddScoped<IReportFilterService, ReportFilterService>();
             services.AddScoped<IPdfService, PdfService>();
+            services.AddScoped<IPlatformUsageSummaryDownloadFileService, PlatformUsageSummaryDownloadFileService>();
         }
 
         private static void RegisterDataServices(IServiceCollection services)

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/PlatformReports/Index.cshtml
@@ -14,9 +14,20 @@
                     </nav>
                 </div>
                 <div class="nhsuk-grid-column-three-quarters">
-                    <div class="nhsuk-u-margin-bottom-4">
+                    <div class="nhsuk-grid-row">
+                        <div class="nhsuk-grid-column-one-half">
                         <h1 class="nhsuk-heading-xl">@ViewData["Title"]</h1>
                     </div>
+                    <div class="nhsuk-grid-column-one-half">
+                        <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-float-right"
+                           id="export"
+                           asp-controller="PlatformReports"
+                           asp-action="Export"
+                            role="button">
+                            Export to Excel
+                        </a>
+                    </div>
+                     </div>
                     <ul class="nhsuk-card-group">
                         <li class="nhsuk-card-group__item">
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-936

### Description
Added export button to platform usage summary page to export the usage summary to excel file

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/92e5326a-c76f-41df-8628-bd4a0f06f054)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
