### PR TITLE
TD-1570 implement remove from self assessment functionality

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -343,9 +343,10 @@
                  @"Select
                     ca.Id AS CandidateAssessmentsId,
                     ca.SelfAssessmentID,
-                    da.FirstName_deprecated AS FirstName, 
-                    da.LastName_deprecated AS LastName, 
-                    COALESCE(ucd.Email, u.PrimaryEmail) AS Email
+                    u.FirstName, 
+                    u.LastName, 
+                    COALESCE(ucd.Email, u.PrimaryEmail) AS Email,
+                    sa.Name AS SelfAssessmentsName
                   FROM  dbo.SelfAssessments AS sa 
 				INNER JOIN dbo.CandidateAssessments AS ca WITH (NOLOCK) ON sa.ID = ca.SelfAssessmentID 
 				INNER JOIN dbo.CentreSelfAssessments AS csa  WITH (NOLOCK) ON sa.ID = csa.SelfAssessmentID 

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/RemoveSelfAssessmentDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/RemoveSelfAssessmentDelegate.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DigitalLearningSolutions.Data.Models.SelfAssessments
+{
+    public class RemoveSelfAssessmentDelegate
+    {
+        public int CandidateAssessmentsId { get; set; }
+        public int SelfAssessmentID { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/RemoveSelfAssessmentDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/RemoveSelfAssessmentDelegate.cs
@@ -13,5 +13,7 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
         public string? FirstName { get; set; }
         public string? LastName { get; set; }
         public string? Email { get; set; }
+        public string? SelfAssessmentsName { get; set; }
+
     }
 }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentDelegate.cs
@@ -39,8 +39,10 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
             EnrolledByAdminActive = delegateInfo.EnrolledByAdminActive;
             SelfAssessed = delegateInfo.SelfAssessed;
             Confirmed = delegateInfo.Confirmed;
+            CandidateAssessmentsId = delegateInfo.CandidateAssessmentsId;
         }
         public int DelegateId { get; set; }
+        public int CandidateAssessmentsId { get; set; }
         public string? DelegateFirstName { get; set; }
         public string DelegateLastName { get; set; }
         public string? DelegateEmail { get; set; }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -1,21 +1,28 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 {
+    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.CourseDelegates;
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
+    using DigitalLearningSolutions.Data.Models.Supervisor;
     using DigitalLearningSolutions.Web.Attributes;
+    using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Helpers.FilterOptions;
     using DigitalLearningSolutions.Web.Models.Enums;
     using DigitalLearningSolutions.Web.ServiceFilter;
     using DigitalLearningSolutions.Web.Services;
+    using DigitalLearningSolutions.Web.ViewModels.Supervisor;
+    using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.CourseDelegates;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.FeatureManagement.Mvc;
+    using Pipelines.Sockets.Unofficial;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -327,5 +334,41 @@
                         fileName
             );
         }
+
+        [Route("TrackingSystem/Delegates/ActivityDelegates/{candidateAssessmentsId}/Remove")]
+        [HttpGet]
+        public IActionResult RemoveDelegateSelfAssessment(int candidateAssessmentsId)
+        {
+            var centreId = User.GetCentreIdKnownNotNull();
+          var selfAssessmentDelegate = selfAssessmentService.GetDelegateSelfAssessmentByCandidateAssessmentsId(candidateAssessmentsId);
+
+            if (selfAssessmentDelegate == null)
+            {
+                return new NotFoundResult();
+            }
+            var model = new DelegateSelfAssessmenteViewModel(selfAssessmentDelegate);
+            return View(model);
+        }
+
+        [Route("TrackingSystem/Delegates/ActivityDelegates/{candidateAssessmentsId}/Remove")]
+        [HttpPost]
+        public IActionResult RemoveDelegateSelfAssessment(DelegateSelfAssessmenteViewModel delegateSelfAssessmenteViewModel)
+        {
+            if (ModelState.IsValid && delegateSelfAssessmenteViewModel.ActionConfirmed)
+            {
+                selfAssessmentService.RemoveDelegateSelfAssessment(delegateSelfAssessmenteViewModel.CandidateAssessmentsId);
+                return RedirectToAction("Index", new { selfAssessmentId = delegateSelfAssessmenteViewModel.SelfAssessmentID });
+            }
+            else
+            {
+                if (delegateSelfAssessmenteViewModel.ConfirmedRemove)
+                {
+                    delegateSelfAssessmenteViewModel.ConfirmedRemove = false;
+                    ModelState.ClearErrorsOnField("ActionConfirmed");
+                }
+                return View(delegateSelfAssessmenteViewModel);
+            }
+        }
     }
 }
+

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -130,6 +130,8 @@
         void RemoveEnrolment(int selfAssessmentId, int delegateUserId);
         public (SelfAssessmentDelegatesData, int) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
             int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
+        RemoveSelfAssessmentDelegate GetDelegateSelfAssessmentByCandidateAssessmentsId(int candidateAssessmentsId);
+       void RemoveDelegateSelfAssessment(int candidateAssessmentsId);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -441,6 +443,14 @@
                 selfAssessmentDelegateList.Add(new SelfAssessmentDelegate(delegateInfo));
             }
             return (new SelfAssessmentDelegatesData(selfAssessmentDelegateList), resultCount);
+        }
+        public RemoveSelfAssessmentDelegate GetDelegateSelfAssessmentByCandidateAssessmentsId(int candidateAssessmentsId)
+        {
+            return selfAssessmentDataService.GetDelegateSelfAssessmentByCandidateAssessmentsId(candidateAssessmentsId);
+        }
+        public void RemoveDelegateSelfAssessment(int candidateAssessmentsId)
+        {
+            selfAssessmentDataService.RemoveDelegateSelfAssessment(candidateAssessmentsId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateSelfAssessmenteViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateSelfAssessmenteViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
 using DigitalLearningSolutions.Data.Models.SelfAssessments;
 using DigitalLearningSolutions.Web.Attributes;
+using DigitalLearningSolutions.Web.Helpers;
 using FluentMigrator.Infrastructure;
 using System.ComponentModel;
 
@@ -19,12 +20,19 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates
             FirstName= removeSelfAssessmentDelegate.FirstName;
             LastName= removeSelfAssessmentDelegate.LastName;
             Email= removeSelfAssessmentDelegate.Email;
+            SelfAssessmentsName = removeSelfAssessmentDelegate.SelfAssessmentsName;
+            Name = DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(
+                removeSelfAssessmentDelegate.FirstName,
+                removeSelfAssessmentDelegate.LastName
+            );
         }
         public int CandidateAssessmentsId { get; set; }
         public int SelfAssessmentID { get; set; }
         public string? FirstName { get; set; }
         public string? LastName { get; set; }
+        public string? Name { get; set; }
         public string? Email { get; set; }
+        public string? SelfAssessmentsName { get; set; }
         [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm you wish to perform this action")]
         public bool ActionConfirmed { get; set; }
         [DefaultValue(false)]

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateSelfAssessmenteViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateSelfAssessmenteViewModel.cs
@@ -1,0 +1,33 @@
+﻿using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+using DigitalLearningSolutions.Data.Models.SelfAssessments;
+using DigitalLearningSolutions.Web.Attributes;
+using FluentMigrator.Infrastructure;
+using System.ComponentModel;
+
+namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates
+{
+    public class DelegateSelfAssessmenteViewModel
+    {
+        public DelegateSelfAssessmenteViewModel()
+        {
+
+        }
+        public DelegateSelfAssessmenteViewModel(RemoveSelfAssessmentDelegate removeSelfAssessmentDelegate)
+        {
+            CandidateAssessmentsId = removeSelfAssessmentDelegate.CandidateAssessmentsId;
+            SelfAssessmentID = removeSelfAssessmentDelegate.SelfAssessmentID;
+            FirstName= removeSelfAssessmentDelegate.FirstName;
+            LastName= removeSelfAssessmentDelegate.LastName;
+            Email= removeSelfAssessmentDelegate.Email;
+        }
+        public int CandidateAssessmentsId { get; set; }
+        public int SelfAssessmentID { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm you wish to perform this action")]
+        public bool ActionConfirmed { get; set; }
+        [DefaultValue(false)]
+        public bool ConfirmedRemove { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
@@ -24,6 +24,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
 
         private DelegateSelfAssessmentInfoViewModel(SelfAssessmentDelegate delegateInfo)
         {
+            CandidateAssessmentsId = delegateInfo.CandidateAssessmentsId;
             DelegateId = delegateInfo.DelegateId;
             SelfAssessmentId = delegateInfo.SelfAssessmentId;
             CandidateNumber = delegateInfo.CandidateNumber;
@@ -57,6 +58,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
         }
         public DelegateAccessRoute AccessedVia { get; set; }
         public ReturnPageQuery? ReturnPageQuery { get; set; }
+        public int CandidateAssessmentsId { get; set; }
         public int DelegateId { get; set; }
         public int SelfAssessmentId { get; set; }
         public string? CandidateNumber { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -25,7 +25,7 @@
 </div>
 
 <vc:field-name-value-display display-name="Delegate" field-value="@Model.Name" />
-<vc:field-name-value-display display-name="Self_Assessment" field-value="@Model.SelfAssessmentsName" />
+<vc:field-name-value-display display-name="Self Assessment" field-value="@Model.SelfAssessmentsName" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
     

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -5,6 +5,9 @@
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "Delegate Self Assessment - Confirm Remove";
+    var cancelLinkRouteData = new Dictionary<string, string>();
+    cancelLinkRouteData.Add("selfAssessmentId", Model.SelfAssessmentID.ToString());
+
 }
 
 @section NavMenuItems {
@@ -12,47 +15,42 @@
 }
 
 <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full word-break">
+    <div class="nhsuk-grid-column-full">
         @if (errorHasOccurred)
         {
             <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
         }
-        <h1 id="page-heading">Confirm Remove Delegate Self Assessment</h1>
-        <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
-                <div class="nhsuk-u-font-weight-bold">
-                    Delegate self assessment:
-                </div>
-            </div>
-            <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
-                @Model.FirstName @Model.LastName (@Model.Email)
-            </div>
-        </div>
+        <h1 class="nhsuk-heading-xl">Remove from self assessment</h1>
+    </div>
+</div>
 
-        <form method="post" asp-controller="ActivityDelegates">
-            <div class="nhsuk-checkboxes__item">
+<vc:field-name-value-display display-name="Delegate" field-value="@Model.Name" />
+<vc:field-name-value-display display-name="Self_Assessment" field-value="@Model.SelfAssessmentsName" />
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+    
+
+        <form class="nhsuk-u-margin-bottom-3"  asp-controller="ActivityDelegates">
+           
                 <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
-                                    label="I am sure that I wish to remove @Model.FirstName @Model.LastName from this self assessment."
-                                    hint-text="This action will remove the delegate from the self assessment. Their progress will be archived but can be reinstated by enrolling them on the self assessment again." />
-            </div>
+                                label="I am sure that I wish to remove @Model.FirstName @Model.LastName from this self assessment."
+                                hint-text="This action will remove the delegate from the self assessment. Their progress will be archived but can be reinstated by enrolling them on the self assessment again." />
+           
+            
             <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveDelegateSelfAssessment">
-                Remove
+                Remove from self assessment
             </button>
             @Html.HiddenFor(m => m.CandidateAssessmentsId)
             @Html.HiddenFor(m => m.FirstName)
             @Html.HiddenFor(m => m.LastName)
             @Html.HiddenFor(m => m.Email)
             @Html.HiddenFor(m => m.SelfAssessmentID)
+            @Html.HiddenFor(m => m.SelfAssessmentsName)
+            @Html.HiddenFor(m => m.Name)
         </form>
-        <div class="nhsuk-back-link">
-            <a class="nhsuk-back-link__link"
-               asp-controller="ActivityDelegates" asp-action="Index" asp-route-SelfAssessmentID="@Model.SelfAssessmentID">
-                <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-                </svg>
-                Cancel
-            </a>
-        </div>
+        <br/>
+       
+        <vc:cancel-link asp-controller=ActivityDelegates asp-action="Index" asp-all-route-data="@cancelLinkRouteData" />
 
     </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -1,0 +1,58 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates
+@using Microsoft.Extensions.Configuration
+@model DelegateSelfAssessmenteViewModel;
+@inject IConfiguration Configuration;
+@{
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "Delegate Self Assessment - Confirm Remove";
+}
+
+@section NavMenuItems {
+  <partial name="Shared/_NavMenuItems" />
+}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full word-break">
+      @if (errorHasOccurred)
+    {
+      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
+    }
+        <h1 id="page-heading">Confirm Remove Delegate Self Assessment</h1>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
+        <div class="nhsuk-u-font-weight-bold">
+                    Delegate self assessment:
+        </div>
+      </div>
+      <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
+        @Model.FirstName @Model.LastName (@Model.Email)
+      </div>
+    </div>
+
+        <form method="post" asp-controller="ActivityDelegates">
+      <div class="nhsuk-checkboxes__item">
+        <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
+                                    label="I am sure that I wish to remove @Model.FirstName @Model.LastName from self assessment"
+                                    hint-text="This action will remove the delegate from your self assessment list and you will no longer be able to view this delegate from self assessments." />
+      </div>
+            <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveDelegateSelfAssessment">
+        Remove
+      </button>
+      @Html.HiddenFor(m => m.CandidateAssessmentsId)
+      @Html.HiddenFor(m => m.FirstName)
+      @Html.HiddenFor(m => m.LastName)
+      @Html.HiddenFor(m => m.Email)
+      @Html.HiddenFor(m => m.SelfAssessmentID)
+    </form>
+     <div class="nhsuk-back-link">
+            <a class="nhsuk-back-link__link"
+               asp-controller="ActivityDelegates" asp-action="Index" asp-route-SelfAssessmentID="@Model.SelfAssessmentID">
+                <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+                </svg>
+                Cancel
+            </a>
+        </div>
+       
+  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -32,8 +32,8 @@
         <form method="post" asp-controller="ActivityDelegates">
             <div class="nhsuk-checkboxes__item">
                 <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
-                                    label="I am sure that I wish to remove @Model.FirstName @Model.LastName from self assessment"
-                                    hint-text="This action will remove the delegate from your self assessment list and you will no longer be able to view this delegate from self assessments." />
+                                    label="I am sure that I wish to remove @Model.FirstName @Model.LastName from this self assessment."
+                                    hint-text="This action will remove the delegate from the self assessment. Their progress will be archived but can be reinstated by enrolling them on the self assessment again." />
             </div>
             <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveDelegateSelfAssessment">
                 Remove

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -3,48 +3,48 @@
 @model DelegateSelfAssessmenteViewModel;
 @inject IConfiguration Configuration;
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "Delegate Self Assessment - Confirm Remove";
 }
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  <div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full word-break">
-      @if (errorHasOccurred)
-    {
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
-    }
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
+        }
         <h1 id="page-heading">Confirm Remove Delegate Self Assessment</h1>
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
-        <div class="nhsuk-u-font-weight-bold">
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
+                <div class="nhsuk-u-font-weight-bold">
                     Delegate self assessment:
+                </div>
+            </div>
+            <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
+                @Model.FirstName @Model.LastName (@Model.Email)
+            </div>
         </div>
-      </div>
-      <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
-        @Model.FirstName @Model.LastName (@Model.Email)
-      </div>
-    </div>
 
         <form method="post" asp-controller="ActivityDelegates">
-      <div class="nhsuk-checkboxes__item">
-        <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
+            <div class="nhsuk-checkboxes__item">
+                <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
                                     label="I am sure that I wish to remove @Model.FirstName @Model.LastName from self assessment"
                                     hint-text="This action will remove the delegate from your self assessment list and you will no longer be able to view this delegate from self assessments." />
-      </div>
+            </div>
             <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveDelegateSelfAssessment">
-        Remove
-      </button>
-      @Html.HiddenFor(m => m.CandidateAssessmentsId)
-      @Html.HiddenFor(m => m.FirstName)
-      @Html.HiddenFor(m => m.LastName)
-      @Html.HiddenFor(m => m.Email)
-      @Html.HiddenFor(m => m.SelfAssessmentID)
-    </form>
-     <div class="nhsuk-back-link">
+                Remove
+            </button>
+            @Html.HiddenFor(m => m.CandidateAssessmentsId)
+            @Html.HiddenFor(m => m.FirstName)
+            @Html.HiddenFor(m => m.LastName)
+            @Html.HiddenFor(m => m.Email)
+            @Html.HiddenFor(m => m.SelfAssessmentID)
+        </form>
+        <div class="nhsuk-back-link">
             <a class="nhsuk-back-link__link"
                asp-controller="ActivityDelegates" asp-action="Index" asp-route-SelfAssessmentID="@Model.SelfAssessmentID">
                 <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -53,6 +53,6 @@
                 Cancel
             </a>
         </div>
-       
-  </div>
+
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -116,7 +116,14 @@
         {
             <div class="nhsuk-grid-row nhsuk-u-padding-top-5">
                 <div class="nhsuk-grid-column-full">
-                    <button class="nhsuk-button delete-button nhsuk-button--secondary">Remove from self assessment</button>
+                    @*<button class="nhsuk-button delete-button nhsuk-button--secondary">Remove from self assessment</button>*@
+                    <a class="nhsuk-button delete-button nhsuk-button--secondary"
+               role="button"
+               asp-controller="ActivityDelegates"
+               asp-action="RemoveDelegateSelfAssessment"
+               asp-route-candidateAssessmentsId="@Model.CandidateAssessmentsId">
+                        Remove from self assessment
+                    </a>
                 </div>
             </div>
         }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -116,7 +116,6 @@
         {
             <div class="nhsuk-grid-row nhsuk-u-padding-top-5">
                 <div class="nhsuk-grid-column-full">
-                    @*<button class="nhsuk-button delete-button nhsuk-button--secondary">Remove from self assessment</button>*@
                     <a class="nhsuk-button delete-button nhsuk-button--secondary"
                role="button"
                asp-controller="ActivityDelegates"


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1570

### Description
Adding RemoveDelegateSelfAssesment page to user to confirm the action and adding a query which update the status of the delegate from one to two

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/3863d5d0-4f13-4db6-b634-c04e9aacfd61)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/9bd48a0e-8ff8-4356-b407-3d7f432ca649)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/d7e41d82-1cfc-4d46-bb77-a35193b94243)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
