### PR TITLE
TD-2185 Fixed records mismatch between delegates courses records shown in list and records which are exported to excel

### DIFF
--- a/DigitalLearningSolutions.Web/Services/CourseDelegatesDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseDelegatesDownloadFileService.cs
@@ -227,8 +227,7 @@
         )
         {
             var details = courseService.GetCentreCourseDetailsWithAllCentreCourses(centreId, adminCategoryId, searchString, sortBy, filterString, sortDirection);
-            var searchedCourses = GenericSearchHelper.SearchItems(details.Courses, searchString);
-            var filteredCourses = FilteringHelper.FilterItems(searchedCourses.AsQueryable(), filterString);
+            var filteredCourses = FilteringHelper.FilterItems(details.Courses.AsQueryable(), filterString);
             var sortedCourses = GenericSortingHelper.SortAllItems(
                 filteredCourses.AsQueryable(),
                 sortBy ?? nameof(CourseStatisticsWithAdminFieldResponseCounts.CourseName),

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -186,7 +186,7 @@
         {
             var exportQueryRowLimit = ConfigurationExtensions.GetExportQueryRowLimit(configuration);
 
-            int resultCount = courseDataService.GetCourseStatisticsAtCentreFilteredByCategoryResultCount(centreId, categoryId);
+            int resultCount = courseDataService.GetCourseStatisticsAtCentreFilteredByCategoryResultCount(centreId, categoryId, searchString);
 
             int totalRun = (int)(resultCount / exportQueryRowLimit) + ((resultCount % exportQueryRowLimit) > 0 ? 1 : 0);
             int currentRun = 1;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2185

### Description
Points addressed in this Commit :
1) Fixed records mismatch between delegates courses records shown in list and records which are exported to excel by modifying dataservice and service.

### Screenshots
This is backend change so no screenshot available.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
