### PR TITLE
TD-3009 Remove redundant tracker GET endpoints

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202311060819_AspProgressAddLessonLocationColumn.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202311060819_AspProgressAddLessonLocationColumn.cs
@@ -10,7 +10,7 @@
         }
         public override void Down()
         {
-            Delete.Column("SuspendData").FromTable("LessonLocation");
+            Delete.Column("LessonLocation").FromTable("aspProgress");
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -78,13 +78,6 @@
             int tutTime
             );
 
-        void UpdateAspProgressTutStatAndTime(
-            int tutorialId,
-            int progressId,
-            int tutStat,
-            int tutTime
-            );
-
         void UpdateAspProgressSuspendData(
            int tutorialId,
            int progressId,

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -71,17 +71,12 @@
             string progressText
         );
 
-        void UpdateAspProgressTutTime(
+        void UpdateAspProgressTutStatAndTime(
             int tutorialId,
             int progressId,
+            int tutStat,
             int tutTime
-        );
-
-        void UpdateAspProgressTutStat(
-            int tutorialId,
-            int progressId,
-            int tutStat
-        );
+            );
 
         int GetCompletionStatusForProgress(int progressId);
 
@@ -541,33 +536,20 @@
             );
         }
 
-        public void UpdateAspProgressTutTime(
+        public void UpdateAspProgressTutStatAndTime(
             int tutorialId,
             int progressId,
+            int tutStat,
             int tutTime
         )
         {
             connection.Execute(
                 @"UPDATE aspProgress
-                    SET TutTime = TutTime + @tutTime
-                    WHERE (TutorialID = @tutorialId) AND (ProgressID = @progressId)",
-                new { tutorialId, progressId, tutTime }
-            );
-        }
-
-        public void UpdateAspProgressTutStat(
-            int tutorialId,
-            int progressId,
-            int tutStat
-        )
-        {
-            connection.Execute(
-                @"UPDATE aspProgress
-                    SET TutStat = @tutStat
+                    SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime
                     WHERE (TutorialID = @tutorialId)
                       AND (ProgressID = @progressId)
                       AND (TutStat < @tutStat)",
-                new { tutorialId, progressId, tutStat }
+                new { tutorialId, progressId, tutStat, tutTime }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -95,11 +95,6 @@
            int progressId,
            string? suspendData
        );
-        void UpdateAspProgressLessonLocation(
-           int tutorialId,
-           int progressId,
-           string? lessonLocation
-       );
 
         int GetCompletionStatusForProgress(int progressId);
 
@@ -117,7 +112,6 @@
         );
 
         string? GetAspProgressSuspendData(int progressId, int tutorialId);
-        string? GetAspProgressLessonLocation(int progressId, int tutorialId);
     }
 
     public class ProgressDataService : IProgressDataService
@@ -623,20 +617,6 @@
                 new { tutorialId, progressId, suspendData }
             );
         }
-        public void UpdateAspProgressLessonLocation(
-           int tutorialId,
-           int progressId,
-           string? lessonLocation
-       )
-        {
-            connection.Execute(
-                @"UPDATE aspProgress
-                    SET LessonLocation = @lessonLocation
-                    WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)",
-                new { tutorialId, progressId, lessonLocation }
-            );
-        }
 
         public int GetCompletionStatusForProgress(int progressId)
         {
@@ -691,16 +671,6 @@
             return connection.Query<string?>(
                 @"SELECT TOP(1)
                         SuspendData
-                    FROM dbo.aspProgress
-                    WHERE ProgressID = @progressId AND TutorialID = @tutorialId",
-                new { progressId, tutorialId }
-            ).FirstOrDefault();
-        }
-        public string? GetAspProgressLessonLocation(int progressId, int tutorialId)
-        {
-            return connection.Query<string?>(
-                @"SELECT TOP(1)
-                        LessonLocation
                     FROM dbo.aspProgress
                     WHERE ProgressID = @progressId AND TutorialID = @tutorialId",
                 new { progressId, tutorialId }

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -90,6 +90,11 @@
            int progressId,
            string? suspendData
        );
+        void UpdateAspProgressLessonLocation(
+           int tutorialId,
+           int progressId,
+           string? lessonLocation
+       );
 
         int GetCompletionStatusForProgress(int progressId);
 
@@ -595,6 +600,20 @@
                     WHERE (TutorialID = @tutorialId)
                       AND (ProgressID = @progressId)",
                 new { tutorialId, progressId, suspendData }
+            );
+        }
+        public void UpdateAspProgressLessonLocation(
+           int tutorialId,
+           int progressId,
+           string? lessonLocation
+       )
+        {
+            connection.Execute(
+                @"UPDATE aspProgress
+                    SET LessonLocation = @lessonLocation
+                    WHERE (TutorialID = @tutorialId)
+                      AND (ProgressID = @progressId)",
+                new { tutorialId, progressId, lessonLocation }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -564,23 +564,6 @@
             );
         }
 
-        public void UpdateAspProgressTutStatAndTime(
-            int tutorialId,
-            int progressId,
-            int tutStat,
-            int tutTime
-        )
-        {
-            connection.Execute(
-                @"UPDATE aspProgress
-                    SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime
-                    WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)
-                      AND (TutStat < @tutStat)",
-                new { tutorialId, progressId, tutStat, tutTime }
-            );
-        }
-
         public void UpdateAspProgressSuspendData(
            int tutorialId,
            int progressId,

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -83,19 +83,6 @@
             int tutStat
         );
 
-        void UpdateAspProgressTutStatAndTime(
-            int tutorialId,
-            int progressId,
-            int tutStat,
-            int tutTime
-            );
-
-        void UpdateAspProgressSuspendData(
-           int tutorialId,
-           int progressId,
-           string? suspendData
-       );
-
         int GetCompletionStatusForProgress(int progressId);
 
         IEnumerable<AssessAttempt> GetAssessAttemptsForProgressSection(int progressId, int sectionNumber);
@@ -581,38 +568,6 @@
                       AND (ProgressID = @progressId)
                       AND (TutStat < @tutStat)",
                 new { tutorialId, progressId, tutStat }
-            );
-        }
-
-        public void UpdateAspProgressTutStatAndTime(
-            int tutorialId,
-            int progressId,
-            int tutStat,
-            int tutTime
-        )
-        {
-            connection.Execute(
-                @"UPDATE aspProgress
-                    SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime
-                    WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)
-                      AND (TutStat < @tutStat)",
-                new { tutorialId, progressId, tutStat, tutTime }
-            );
-        }
-
-        public void UpdateAspProgressSuspendData(
-           int tutorialId,
-           int progressId,
-           string? suspendData
-       )
-        {
-            connection.Execute(
-                @"UPDATE aspProgress
-                    SET SuspendData = @suspendData
-                    WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)",
-                new { tutorialId, progressId, suspendData }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -110,8 +110,6 @@
             bool status,
             int progressId
         );
-
-        string? GetAspProgressSuspendData(int progressId, int tutorialId);
     }
 
     public class ProgressDataService : IProgressDataService
@@ -664,17 +662,6 @@
                     VALUES (@delegateId, @customisationId, @version, @insertionDate, 1, @sectionNumber, @score, @status, @progressId)",
                 new { delegateId, customisationId, version, insertionDate, sectionNumber, score, status, progressId }
             );
-        }
-
-        public string? GetAspProgressSuspendData(int progressId, int tutorialId)
-        {
-            return connection.Query<string?>(
-                @"SELECT TOP(1)
-                        SuspendData
-                    FROM dbo.aspProgress
-                    WHERE ProgressID = @progressId AND TutorialID = @tutorialId",
-                new { progressId, tutorialId }
-            ).FirstOrDefault();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -78,6 +78,19 @@
             int tutTime
             );
 
+        void UpdateAspProgressTutStatAndTime(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime
+            );
+
+        void UpdateAspProgressSuspendData(
+           int tutorialId,
+           int progressId,
+           string? suspendData
+       );
+
         int GetCompletionStatusForProgress(int progressId);
 
         IEnumerable<AssessAttempt> GetAssessAttemptsForProgressSection(int progressId, int sectionNumber);
@@ -550,6 +563,38 @@
                       AND (ProgressID = @progressId)
                       AND (TutStat < @tutStat)",
                 new { tutorialId, progressId, tutStat, tutTime }
+            );
+        }
+
+        public void UpdateAspProgressTutStatAndTime(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime
+        )
+        {
+            connection.Execute(
+                @"UPDATE aspProgress
+                    SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime
+                    WHERE (TutorialID = @tutorialId)
+                      AND (ProgressID = @progressId)
+                      AND (TutStat < @tutStat)",
+                new { tutorialId, progressId, tutStat, tutTime }
+            );
+        }
+
+        public void UpdateAspProgressSuspendData(
+           int tutorialId,
+           int progressId,
+           string? suspendData
+       )
+        {
+            connection.Execute(
+                @"UPDATE aspProgress
+                    SET SuspendData = @suspendData
+                    WHERE (TutorialID = @tutorialId)
+                      AND (ProgressID = @progressId)",
+                new { tutorialId, progressId, suspendData }
             );
         }
 

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -5,12 +5,10 @@
         getobjectivearray,
         getobjectivearraycc,
         getsuspenddata,
-        getlessonlocation,
         storediagnosticjson,
         storeaspprogressv2,
         storeaspprogressnosession,
         storeaspassessnosession,
         storesuspenddata,
-        storelessonlocation
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -8,5 +8,6 @@
         storeaspprogressv2,
         storeaspprogressnosession,
         storeaspassessnosession,
+        storesuspenddata,
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -4,11 +4,9 @@
     {
         getobjectivearray,
         getobjectivearraycc,
-        getsuspenddata,
         storediagnosticjson,
         storeaspprogressv2,
         storeaspprogressnosession,
         storeaspassessnosession,
-        storesuspenddata,
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -9,5 +9,6 @@
         storeaspprogressnosession,
         storeaspassessnosession,
         storesuspenddata,
+        storelessonlocation
     }
 }

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -26,9 +26,6 @@
         public static readonly TrackerEndpointResponse StoreDiagnosticScoreException =
             new TrackerEndpointResponse(-25, nameof(StoreDiagnosticScoreException));
 
-        public static readonly TrackerEndpointResponse StoreSuspendDataException =
-            new TrackerEndpointResponse(-26, nameof(StoreSuspendDataException));
-
         public TrackerEndpointResponse(int id, string name) : base(id, name) { }
 
         public static implicit operator string(TrackerEndpointResponse trackerEndpointResponse)

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -26,8 +26,8 @@
         public static readonly TrackerEndpointResponse StoreDiagnosticScoreException =
             new TrackerEndpointResponse(-25, nameof(StoreDiagnosticScoreException));
 
-        public static readonly TrackerEndpointResponse SuspendDataException =
-            new TrackerEndpointResponse(-26, nameof(SuspendDataException));
+        public static readonly TrackerEndpointResponse StoreSuspendDataException =
+            new TrackerEndpointResponse(-26, nameof(StoreSuspendDataException));
 
         public TrackerEndpointResponse(int id, string name) : base(id, name) { }
 

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -26,6 +26,9 @@
         public static readonly TrackerEndpointResponse StoreDiagnosticScoreException =
             new TrackerEndpointResponse(-25, nameof(StoreDiagnosticScoreException));
 
+        public static readonly TrackerEndpointResponse StoreSuspendDataException =
+            new TrackerEndpointResponse(-26, nameof(StoreSuspendDataException));
+
         public TrackerEndpointResponse(int id, string name) : base(id, name) { }
 
         public static implicit operator string(TrackerEndpointResponse trackerEndpointResponse)

--- a/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
+++ b/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
@@ -14,5 +14,6 @@
         public int? Version { get; set; }
         public int? TutorialId { get; set; }
         public int? Score { get; set; }
+        public string? SuspendData { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
+++ b/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
@@ -14,6 +14,5 @@
         public int? Version { get; set; }
         public int? TutorialId { get; set; }
         public int? Score { get; set; }
-        public string? SuspendData { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
+++ b/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
@@ -15,6 +15,5 @@
         public int? TutorialId { get; set; }
         public int? Score { get; set; }
         public string? SuspendData { get; set; }
-        public string? LessonLocation { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
+++ b/DigitalLearningSolutions.Data/Models/Tracker/TrackerEndpointQueryParams.cs
@@ -15,5 +15,6 @@
         public int? TutorialId { get; set; }
         public int? Score { get; set; }
         public string? SuspendData { get; set; }
+        public string? LessonLocation { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -202,16 +202,8 @@
                 timeNow,
                 progressText ?? string.Empty
             );
-            progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
-        }
-
-        public void StoreAspProgressSuspendData(
-            int progressId,
-            int tutorialId,
-            string? suspendData
-            )
-        {
-            progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
+            progressDataService.UpdateAspProgressTutTime(tutorialId, progressId, tutorialTime);
+            progressDataService.UpdateAspProgressTutStat(tutorialId, progressId, tutorialStatus);
         }
 
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -51,16 +51,6 @@
             int progressId,
             int tutorialId
             );
-        void StoreAspProgressLessonLocation(
-            int progressId,
-            int tutorialId,
-            string? lessonLocation
-            );
-
-        string? GetAspProgressLessonLocation(
-            int progressId,
-            int tutorialId
-            );
 
         void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress);
 
@@ -235,15 +225,6 @@
             progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
         }
 
-        public void StoreAspProgressLessonLocation(
-            int progressId,
-            int tutorialId,
-            string? lessonLocation
-            )
-        {
-            progressDataService.UpdateAspProgressLessonLocation(tutorialId, progressId, lessonLocation);
-        }
-
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)
         {
             if (progress.Completed != null)
@@ -276,10 +257,6 @@
         public string? GetAspProgressSuspendData(int progressId, int tutorialId)
         {
             return progressDataService.GetAspProgressSuspendData(progressId, tutorialId);
-        }
-        public string? GetAspProgressLessonLocation(int progressId, int tutorialId)
-        {
-            return progressDataService.GetAspProgressLessonLocation(progressId, tutorialId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -205,6 +205,15 @@
             progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
         }
 
+        public void StoreAspProgressSuspendData(
+            int progressId,
+            int tutorialId,
+            string? suspendData
+            )
+        {
+            progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
+        }
+
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)
         {
             if (progress.Completed != null)

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -41,6 +41,18 @@
             int tutorialStatus
         );
 
+        void StoreAspProgressSuspendData(
+            int progressId,
+            int tutorialId,
+            string? suspendData
+            );
+
+        void StoreAspProgressLessonLocation(
+            int progressId,
+            int tutorialId,
+            string? lessonLocation
+            );
+
         void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress);
 
         public SectionAndApplicationDetailsForAssessAttempts? GetSectionAndApplicationDetailsForAssessAttempts(
@@ -212,6 +224,15 @@
             )
         {
             progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
+        }
+
+        public void StoreAspProgressLessonLocation(
+            int progressId,
+            int tutorialId,
+            string? lessonLocation
+            )
+        {
+            progressDataService.UpdateAspProgressLessonLocation(tutorialId, progressId, lessonLocation);
         }
 
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -202,8 +202,7 @@
                 timeNow,
                 progressText ?? string.Empty
             );
-            progressDataService.UpdateAspProgressTutTime(tutorialId, progressId, tutorialTime);
-            progressDataService.UpdateAspProgressTutStat(tutorialId, progressId, tutorialStatus);
+            progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
         }
 
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -41,17 +41,6 @@
             int tutorialStatus
         );
 
-        void StoreAspProgressSuspendData(
-            int progressId,
-            int tutorialId,
-            string? suspendData
-            );
-
-        string? GetAspProgressSuspendData(
-            int progressId,
-            int tutorialId
-            );
-
         void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress);
 
         public SectionAndApplicationDetailsForAssessAttempts? GetSectionAndApplicationDetailsForAssessAttempts(
@@ -252,11 +241,6 @@
         )
         {
             return progressDataService.GetSectionAndApplicationDetailsForAssessAttempts(sectionId, customisationId);
-        }
-
-        public string? GetAspProgressSuspendData(int progressId, int tutorialId)
-        {
-            return progressDataService.GetAspProgressSuspendData(progressId, tutorialId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -50,17 +50,6 @@
             int tutorialId
             );
 
-        void StoreAspProgressLessonLocation(
-                int progressId,
-                int tutorialId,
-                string? lessonLocation
-            );
-
-        string? GetAspProgressLessonLocation(
-            int progressId,
-            int tutorialId
-            );
-
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -286,22 +275,6 @@
         public string? GetAspProgressSessionData(int progressId, int tutorialId)
         {
             return progressService.GetAspProgressSuspendData(
-                progressId,
-                tutorialId
-                );
-        }
-        public void StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
-        {
-            progressService.StoreAspProgressLessonLocation(
-                progressId,
-                tutorialId,
-                lessonLocation
-                );
-        }
-
-        public string? GetAspProgressLessonLocation(int progressId, int tutorialId)
-        {
-            return progressService.GetAspProgressLessonLocation(
                 progressId,
                 tutorialId
                 );

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -45,11 +45,6 @@
                 string? sessionData
             );
 
-        string? GetAspProgressSessionData(
-            int progressId,
-            int tutorialId
-            );
-
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -64,7 +59,7 @@
                 int customisationId
             );
         (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
+            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
                 int? progressId,
                 int? tutorialId,
                 int? candidateId,
@@ -240,7 +235,7 @@
         }
 
         public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
+            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
                 int? progressId,
                 int? tutorialId,
                 int? candidateId,
@@ -250,14 +245,14 @@
             if (progressId == null || tutorialId == null ||
                 candidateId == null || customisationId == null)
             {
-                return (TrackerEndpointResponse.SuspendDataException, null);
+                return (TrackerEndpointResponse.StoreSuspendDataException, null);
             }
 
             var progress = progressService.GetDetailedCourseProgress(progressId.Value);
             if (progress == null || progress.DelegateId != candidateId ||
                 progress.CustomisationId != customisationId.Value)
             {
-                return (TrackerEndpointResponse.SuspendDataException, null);
+                return (TrackerEndpointResponse.StoreSuspendDataException, null);
             }
 
             return (null, progress);
@@ -265,19 +260,7 @@
 
         public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
         {
-            progressService.StoreAspProgressSuspendData(
-                progressId,
-                tutorialId,
-                sessionData
-                );
-        }
-
-        public string? GetAspProgressSessionData(int progressId, int tutorialId)
-        {
-            return progressService.GetAspProgressSuspendData(
-                progressId,
-                tutorialId
-                );
+            throw new NotImplementedException();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -45,6 +45,12 @@
                 string? sessionData
             );
 
+        void StoreAspProgressLessonLocation(
+                int progressId,
+                int tutorialId,
+                string? lessonLocation
+            );
+
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -261,6 +267,14 @@
         public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
         {
             throw new NotImplementedException();
+        }
+        public void StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
+        {
+            progressService.StoreAspProgressLessonLocation(
+                progressId,
+                tutorialId,
+                lessonLocation
+                );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -39,12 +39,6 @@
             int tutorialStatus
         );
 
-        void StoreAspProgressSessionData(
-                int progressId,
-                int tutorialId,
-                string? sessionData
-            );
-
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -57,13 +51,6 @@
             GetAndValidateSectionAssessmentDetails(
                 int? sectionId,
                 int customisationId
-            );
-        (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
-                int? progressId,
-                int? tutorialId,
-                int? candidateId,
-                int? customisationId
             );
     }
 
@@ -232,35 +219,6 @@
             }
 
             return (null, assessmentDetails);
-        }
-
-        public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
-                int? progressId,
-                int? tutorialId,
-                int? candidateId,
-                int? customisationId
-            )
-        {
-            if (progressId == null || tutorialId == null ||
-                candidateId == null || customisationId == null)
-            {
-                return (TrackerEndpointResponse.StoreSuspendDataException, null);
-            }
-
-            var progress = progressService.GetDetailedCourseProgress(progressId.Value);
-            if (progress == null || progress.DelegateId != candidateId ||
-                progress.CustomisationId != customisationId.Value)
-            {
-                return (TrackerEndpointResponse.StoreSuspendDataException, null);
-            }
-
-            return (null, progress);
-        }
-
-        public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -39,6 +39,12 @@
             int tutorialStatus
         );
 
+        void StoreAspProgressSessionData(
+                int progressId,
+                int tutorialId,
+                string? sessionData
+            );
+
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
             GetProgressAndValidateInputsForStoreAspAssess(
                 int? version,
@@ -51,6 +57,13 @@
             GetAndValidateSectionAssessmentDetails(
                 int? sectionId,
                 int customisationId
+            );
+        (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+                int? progressId,
+                int? tutorialId,
+                int? candidateId,
+                int? customisationId
             );
     }
 
@@ -219,6 +232,35 @@
             }
 
             return (null, assessmentDetails);
+        }
+
+        public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
+            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+                int? progressId,
+                int? tutorialId,
+                int? candidateId,
+                int? customisationId
+            )
+        {
+            if (progressId == null || tutorialId == null ||
+                candidateId == null || customisationId == null)
+            {
+                return (TrackerEndpointResponse.StoreSuspendDataException, null);
+            }
+
+            var progress = progressService.GetDetailedCourseProgress(progressId.Value);
+            if (progress == null || progress.DelegateId != candidateId ||
+                progress.CustomisationId != customisationId.Value)
+            {
+                return (TrackerEndpointResponse.StoreSuspendDataException, null);
+            }
+
+            return (null, progress);
+        }
+
+        public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -266,7 +266,11 @@
 
         public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
         {
-            throw new NotImplementedException();
+            progressService.StoreAspProgressSuspendData(
+                progressId,
+                tutorialId,
+                sessionData
+                );
         }
         public void StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
         {

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -17,8 +17,6 @@
 
         TrackerObjectiveArrayCc? GetObjectiveArrayCc(int? customisationId, int? sectionId, bool? isPostLearning);
 
-        string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId);
-
         TrackerEndpointResponse StoreDiagnosticJson(int? progressId, string? diagnosticOutcome);
 
         TrackerEndpointResponse StoreAspProgressV2(
@@ -372,7 +370,7 @@
             string? suspendData
             )
         {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
                progressId,
                tutorialId,
                candidateId,
@@ -393,37 +391,10 @@
             catch (Exception ex)
             {
                 logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.SuspendDataException;
+                return TrackerEndpointResponse.StoreAspProgressException;
             }
 
             return TrackerEndpointResponse.Success;
-        }
-
-        public string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId)
-        {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
-               progressId,
-               tutorialId,
-               candidateId,
-               customisationId
-           );
-            if (validationResponse != null)
-            {
-                return validationResponse;
-            }
-            try
-            {
-                var suspendData = storeAspService.GetAspProgressSessionData(
-                     progressId!.Value,
-                     tutorialId!.Value
-                 );
-                return suspendData ?? "";
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreAspProgressException;
-            }
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -414,7 +414,7 @@
             string? lessonLocation
             )
         {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
                progressId,
                tutorialId,
                candidateId,
@@ -435,7 +435,7 @@
             catch (Exception ex)
             {
                 logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.SuspendDataException;
+                return TrackerEndpointResponse.StoreAspProgressException;
             }
 
             return TrackerEndpointResponse.Success;

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -17,12 +17,7 @@
 
         TrackerObjectiveArrayCc? GetObjectiveArrayCc(int? customisationId, int? sectionId, bool? isPostLearning);
 
-        string? GetSuspendData(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId
-            );
+        string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId);
 
         TrackerEndpointResponse StoreDiagnosticJson(int? progressId, string? diagnosticOutcome);
 
@@ -404,12 +399,7 @@
             return TrackerEndpointResponse.Success;
         }
 
-        public string? GetSuspendData(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId
-            )
+        public string? GetSuspendData(int? progressId, int? tutorialId, int? customisationId, int? candidateId)
         {
             var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
                progressId,

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -49,6 +49,13 @@
             int? customisationId,
             string? sessionId
         );
+        TrackerEndpointResponse StoreSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId,
+            string? suspendData
+            );
     }
 
     public class TrackerActionService : ITrackerActionService
@@ -350,6 +357,40 @@
             else
             {
                 progressService.CheckProgressForCompletionAndSendEmailIfCompleted(progress);
+            }
+
+            return TrackerEndpointResponse.Success;
+        }
+        public TrackerEndpointResponse StoreSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId,
+            string? suspendData
+            )
+        {
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+               progressId,
+               tutorialId,
+               candidateId,
+               customisationId
+           );
+            if (validationResponse != null)
+            {
+                return validationResponse;
+            }
+            try
+            {
+                storeAspService.StoreAspProgressSessionData(
+                    progressId!.Value,
+                    tutorialId!.Value,
+                    suspendData
+                );
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return TrackerEndpointResponse.StoreAspProgressException;
             }
 
             return TrackerEndpointResponse.Success;

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -17,6 +17,13 @@
 
         TrackerObjectiveArrayCc? GetObjectiveArrayCc(int? customisationId, int? sectionId, bool? isPostLearning);
 
+        string? GetSuspendData(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId
+            );
+
         TrackerEndpointResponse StoreDiagnosticJson(int? progressId, string? diagnosticOutcome);
 
         TrackerEndpointResponse StoreAspProgressV2(
@@ -50,35 +57,12 @@
             int? customisationId,
             string? sessionId
         );
-
         TrackerEndpointResponse StoreSuspendData(
             int? progressId,
             int? tutorialId,
             int? candidateId,
             int? customisationId,
             string? suspendData
-            );
-
-        string? GetSuspendData(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId
-            );
-
-        TrackerEndpointResponse StoreLessonLocation(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId,
-            string? suspendData
-            );
-
-        string? GetLessonLocation(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId
             );
     }
 
@@ -444,73 +428,6 @@
                      tutorialId!.Value
                  );
                 return suspendData ?? "";
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreAspProgressException;
-            }
-        }
-
-        public TrackerEndpointResponse StoreLessonLocation(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId,
-            string? lessonLocation
-            )
-        {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
-               progressId,
-               tutorialId,
-               candidateId,
-               customisationId
-           );
-            if (validationResponse != null)
-            {
-                return validationResponse;
-            }
-            try
-            {
-                storeAspService.StoreAspProgressLessonLocation(
-                    progressId!.Value,
-                    tutorialId!.Value,
-                    lessonLocation
-                );
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.SuspendDataException;
-            }
-
-            return TrackerEndpointResponse.Success;
-        }
-
-        public string? GetLessonLocation(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId
-            )
-        {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
-               progressId,
-               tutorialId,
-               candidateId,
-               customisationId
-           );
-            if (validationResponse != null)
-            {
-                return validationResponse;
-            }
-            try
-            {
-                var lessonLocation = storeAspService.GetAspProgressLessonLocation(
-                     progressId!.Value,
-                     tutorialId!.Value
-                 );
-                return lessonLocation ?? "";
             }
             catch (Exception ex)
             {

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -49,6 +49,7 @@
             int? customisationId,
             string? sessionId
         );
+
         TrackerEndpointResponse StoreSuspendData(
             int? progressId,
             int? tutorialId,
@@ -56,6 +57,15 @@
             int? customisationId,
             string? suspendData
             );
+
+        TrackerEndpointResponse StoreLessonLocation(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId,
+            string? suspendData
+            );
+            
     }
 
     public class TrackerActionService : ITrackerActionService
@@ -391,6 +401,41 @@
             {
                 logger.LogError(ex, ex.Message);
                 return TrackerEndpointResponse.StoreAspProgressException;
+            }
+
+            return TrackerEndpointResponse.Success;
+        }
+
+        public TrackerEndpointResponse StoreLessonLocation(
+            int? progressId,
+            int? tutorialId,
+            int? candidateId,
+            int? customisationId,
+            string? lessonLocation
+            )
+        {
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForSuspendDataEndpoints(
+               progressId,
+               tutorialId,
+               candidateId,
+               customisationId
+           );
+            if (validationResponse != null)
+            {
+                return validationResponse;
+            }
+            try
+            {
+                storeAspService.StoreAspProgressLessonLocation(
+                    progressId!.Value,
+                    tutorialId!.Value,
+                    lessonLocation
+                );
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return TrackerEndpointResponse.SuspendDataException;
             }
 
             return TrackerEndpointResponse.Success;

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -7,7 +7,6 @@
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.Tracker;
     using DigitalLearningSolutions.Data.Utilities;
-    using DocumentFormat.OpenXml.Bibliography;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
@@ -50,13 +49,6 @@
             int? customisationId,
             string? sessionId
         );
-        TrackerEndpointResponse StoreSuspendData(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId,
-            string? suspendData
-            );
     }
 
     public class TrackerActionService : ITrackerActionService
@@ -358,40 +350,6 @@
             else
             {
                 progressService.CheckProgressForCompletionAndSendEmailIfCompleted(progress);
-            }
-
-            return TrackerEndpointResponse.Success;
-        }
-        public TrackerEndpointResponse StoreSuspendData(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId,
-            string? suspendData
-            )
-        {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
-               progressId,
-               tutorialId,
-               candidateId,
-               customisationId
-           );
-            if (validationResponse != null)
-            {
-                return validationResponse;
-            }
-            try
-            {
-                storeAspService.StoreAspProgressSessionData(
-                    progressId!.Value,
-                    tutorialId!.Value,
-                    suspendData
-                );
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreAspProgressException;
             }
 
             return TrackerEndpointResponse.Success;

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -113,17 +113,6 @@
                         );
                     }
 
-                    if (action == TrackerEndpointAction.storesuspenddata)
-                    {
-                        return trackerActionService.StoreSuspendData(
-                            query.ProgressId,
-                            query.TutorialId,
-                            query.CandidateId,
-                            query.CustomisationId,
-                            query.SuspendData
-                            );
-                    }
-
                     throw new ArgumentOutOfRangeException();
                 }
 

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -124,6 +124,18 @@
                             );
                     }
 
+
+                    if (action == TrackerEndpointAction.storelessonlocation)
+                    {
+                        return trackerActionService.StoreLessonLocation(
+                            query.ProgressId,
+                            query.TutorialId,
+                            query.CandidateId,
+                            query.CustomisationId,
+                            query.LessonLocation
+                            );
+                    }
+
                     throw new ArgumentOutOfRangeException();
                 }
 

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -113,6 +113,17 @@
                         );
                     }
 
+                    if (action == TrackerEndpointAction.storesuspenddata)
+                    {
+                        return trackerActionService.StoreSuspendData(
+                            query.ProgressId,
+                            query.TutorialId,
+                            query.CandidateId,
+                            query.CustomisationId,
+                            query.SuspendData
+                            );
+                    }
+
                     throw new ArgumentOutOfRangeException();
                 }
 

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -124,16 +124,6 @@
                             );
                     }
 
-                    if (action == TrackerEndpointAction.getsuspenddata)
-                    {
-                        return trackerActionService.GetSuspendData(
-                            query.ProgressId,
-                            query.TutorialId,
-                            query.CandidateId,
-                            query.CustomisationId
-                            );
-                    }
-
                     throw new ArgumentOutOfRangeException();
                 }
 

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -134,26 +134,6 @@
                             );
                     }
 
-                    if (action == TrackerEndpointAction.storelessonlocation)
-                    {
-                        return trackerActionService.StoreLessonLocation(
-                            query.ProgressId,
-                            query.TutorialId,
-                            query.CandidateId,
-                            query.CustomisationId,
-                            query.LessonLocation
-                            );
-                    }
-
-                    if (action == TrackerEndpointAction.getlessonlocation)
-                    {
-                        return trackerActionService.GetLessonLocation(
-                            query.ProgressId,
-                            query.TutorialId,
-                            query.CandidateId,
-                            query.CustomisationId
-                            );
-                    }
                     throw new ArgumentOutOfRangeException();
                 }
 


### PR DESCRIPTION
### JIRA link
[TD-3009](https://hee-tis.atlassian.net/browse/TD-3009)

### Description
Reverts code implementing new endpoints in the Tracker API for getting suspend data and lesson location because they are no longer needed.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3009]: https://hee-tis.atlassian.net/browse/TD-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ