### PR TITLE
TD-3009 Tracker API adds no row updated error

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -58,32 +58,32 @@
             int customisationId
         );
 
-        void UpdateCourseAdminFieldForDelegate(
+        int UpdateCourseAdminFieldForDelegate(
             int progressId,
             int promptNumber,
             string? answer
         );
 
-        void UpdateProgressDetailsForStoreAspProgressV2(
+        int UpdateProgressDetailsForStoreAspProgressV2(
             int progressId,
             int customisationVersion,
             DateTime submittedTime,
             string progressText
         );
 
-        void UpdateAspProgressTutStatAndTime(
+        int UpdateAspProgressTutStatAndTime(
             int tutorialId,
             int progressId,
             int tutStat,
             int tutTime
             );
 
-        void UpdateAspProgressSuspendData(
+        int UpdateAspProgressSuspendData(
            int tutorialId,
            int progressId,
            string? suspendData
        );
-        void UpdateAspProgressLessonLocation(
+        int UpdateAspProgressLessonLocation(
            int tutorialId,
            int progressId,
            string? lessonLocation
@@ -93,7 +93,7 @@
 
         IEnumerable<AssessAttempt> GetAssessAttemptsForProgressSection(int progressId, int sectionNumber);
 
-        void InsertAssessAttempt(
+        int InsertAssessAttempt(
             int delegateId,
             int customisationId,
             int version,
@@ -505,28 +505,28 @@
             ).SingleOrDefault();
         }
 
-        public void UpdateCourseAdminFieldForDelegate(
+        public int UpdateCourseAdminFieldForDelegate(
             int progressId,
             int promptNumber,
             string? answer
         )
         {
-            connection.Execute(
+            return connection.Execute(
                 $@"UPDATE Progress
                         SET Answer{promptNumber} = @answer
                         WHERE ProgressID = @progressId",
                 new { progressId, promptNumber, answer }
-            );
+            ); 
         }
 
-        public void UpdateProgressDetailsForStoreAspProgressV2(
+        public int UpdateProgressDetailsForStoreAspProgressV2(
             int progressId,
             int customisationVersion,
             DateTime submittedTime,
             string progressText
         )
         {
-            connection.Execute(
+            return connection.Execute(
                 @"UPDATE Progress
                     SET
                         CustomisationVersion = @customisationVersion,
@@ -547,14 +547,14 @@
             );
         }
 
-        public void UpdateAspProgressTutStatAndTime(
+        public int UpdateAspProgressTutStatAndTime(
             int tutorialId,
             int progressId,
             int tutStat,
             int tutTime
         )
         {
-            connection.Execute(
+            return connection.Execute(
                 @"UPDATE aspProgress
                     SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime
                     WHERE (TutorialID = @tutorialId)
@@ -564,13 +564,13 @@
             );
         }
 
-        public void UpdateAspProgressSuspendData(
+        public int UpdateAspProgressSuspendData(
            int tutorialId,
            int progressId,
            string? suspendData
        )
         {
-            connection.Execute(
+            return connection.Execute(
                 @"UPDATE aspProgress
                     SET SuspendData = @suspendData
                     WHERE (TutorialID = @tutorialId)
@@ -578,13 +578,13 @@
                 new { tutorialId, progressId, suspendData }
             );
         }
-        public void UpdateAspProgressLessonLocation(
+        public int UpdateAspProgressLessonLocation(
            int tutorialId,
            int progressId,
            string? lessonLocation
        )
         {
-            connection.Execute(
+            return connection.Execute(
                 @"UPDATE aspProgress
                     SET LessonLocation = @lessonLocation
                     WHERE (TutorialID = @tutorialId)
@@ -622,7 +622,7 @@
             );
         }
 
-        public void InsertAssessAttempt(
+        public int InsertAssessAttempt(
             int delegateId,
             int customisationId,
             int version,
@@ -633,7 +633,7 @@
             int progressId
         )
         {
-            connection.Execute(
+            return connection.Execute(
                 @"INSERT INTO AssessAttempts
                         (CandidateID, CustomisationID, CustomisationVersion, Date, AssessInstance, SectionNumber, Score, Status, ProgressID)
                     VALUES (@delegateId, @customisationId, @version, @insertionDate, 1, @sectionNumber, @score, @status, @progressId)",

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointResponse.cs
@@ -11,6 +11,9 @@
         public static readonly TrackerEndpointResponse InvalidAction =
             new TrackerEndpointResponse(-2, nameof(InvalidAction));
 
+        public static readonly TrackerEndpointResponse NoRowUpdated =
+            new TrackerEndpointResponse(-3, nameof(NoRowUpdated));
+
         public static readonly TrackerEndpointResponse StoreAspAssessException =
             new TrackerEndpointResponse(-6, nameof(StoreAspAssessException));
 
@@ -28,6 +31,9 @@
 
         public static readonly TrackerEndpointResponse StoreSuspendDataException =
             new TrackerEndpointResponse(-26, nameof(StoreSuspendDataException));
+
+        public static readonly TrackerEndpointResponse StoreLessonLocationException =
+            new TrackerEndpointResponse(-27, nameof(StoreLessonLocationException));
 
         public TrackerEndpointResponse(int id, string name) : base(id, name) { }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateProgressControllerTests.cs
@@ -242,7 +242,7 @@
             };
 
             A.CallTo(() => progressService.UpdateCourseAdminFieldForDelegate(A<int>._, A<int>._, A<string>._))
-                .DoesNothing();
+                .Returns(0);
 
             // When
             var result = delegateProgressController.EditDelegateCourseAdminField(

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -329,7 +329,7 @@
             const string answer = "Test answer";
 
             A.CallTo(() => progressDataService.UpdateCourseAdminFieldForDelegate(A<int>._, A<int>._, A<string>._))
-                .DoesNothing();
+                .Returns(0);
 
             // When
             progressService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, answer);
@@ -352,7 +352,7 @@
             var timeNow = new DateTime(2022, 1, 1, 1, 1, 1, 1);
 
             A.CallTo(() => progressDataService.UpdateCourseAdminFieldForDelegate(A<int>._, A<int>._, A<string>._))
-                .DoesNothing();
+                .Returns(0);
             A.CallTo(() => clockUtility.UtcNow)
                 .Returns(timeNow);
 

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -26,13 +26,13 @@
 
         DelegateCourseProgressInfo? GetCourseProgressInfo(int progressId);
 
-        void UpdateCourseAdminFieldForDelegate(
+        int UpdateCourseAdminFieldForDelegate(
             int progressId,
             int promptNumber,
             string? answer
         );
 
-        void StoreAspProgressV2(
+        int StoreAspProgressV2(
             int progressId,
             int version,
             string? progressText,
@@ -41,13 +41,13 @@
             int tutorialStatus
         );
 
-        void StoreAspProgressSuspendData(
+        int StoreAspProgressSuspendData(
             int progressId,
             int tutorialId,
             string? suspendData
             );
 
-        void StoreAspProgressLessonLocation(
+        int StoreAspProgressLessonLocation(
             int progressId,
             int tutorialId,
             string? lessonLocation
@@ -189,16 +189,16 @@
             return (delegateCourseProgess);
         }
 
-        public void UpdateCourseAdminFieldForDelegate(
+        public int UpdateCourseAdminFieldForDelegate(
             int progressId,
             int promptNumber,
             string? answer
         )
         {
-            progressDataService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, answer);
+            return progressDataService.UpdateCourseAdminFieldForDelegate(progressId, promptNumber, answer);
         }
 
-        public void StoreAspProgressV2(
+        public int StoreAspProgressV2(
             int progressId,
             int version,
             string? progressText,
@@ -214,25 +214,25 @@
                 timeNow,
                 progressText ?? string.Empty
             );
-            progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
+            return progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
         }
 
-        public void StoreAspProgressSuspendData(
+        public int StoreAspProgressSuspendData(
             int progressId,
             int tutorialId,
             string? suspendData
             )
         {
-            progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
+            return progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
         }
 
-        public void StoreAspProgressLessonLocation(
+        public int StoreAspProgressLessonLocation(
             int progressId,
             int tutorialId,
             string? lessonLocation
             )
         {
-            progressDataService.UpdateAspProgressLessonLocation(tutorialId, progressId, lessonLocation);
+            return progressDataService.UpdateAspProgressLessonLocation(tutorialId, progressId, lessonLocation);
         }
 
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -266,19 +266,19 @@
 
         public int StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
         {
-           return progressService.StoreAspProgressSuspendData(
-                progressId,
-                tutorialId,
-                sessionData
-                );
+            return progressService.StoreAspProgressSuspendData(
+                 progressId,
+                 tutorialId,
+                 sessionData
+                 );
         }
         public int StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
         {
-           return progressService.StoreAspProgressLessonLocation(
-                progressId,
-                tutorialId,
-                lessonLocation
-                );
+            return progressService.StoreAspProgressLessonLocation(
+                 progressId,
+                 tutorialId,
+                 lessonLocation
+                 );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -39,13 +39,13 @@
             int tutorialStatus
         );
 
-        void StoreAspProgressSessionData(
+        int StoreAspProgressSessionData(
                 int progressId,
                 int tutorialId,
                 string? sessionData
             );
 
-        void StoreAspProgressLessonLocation(
+        int StoreAspProgressLessonLocation(
                 int progressId,
                 int tutorialId,
                 string? lessonLocation
@@ -264,17 +264,17 @@
             return (null, progress);
         }
 
-        public void StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
+        public int StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
         {
-            progressService.StoreAspProgressSuspendData(
+           return progressService.StoreAspProgressSuspendData(
                 progressId,
                 tutorialId,
                 sessionData
                 );
         }
-        public void StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
+        public int StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
         {
-            progressService.StoreAspProgressLessonLocation(
+           return progressService.StoreAspProgressLessonLocation(
                 progressId,
                 tutorialId,
                 lessonLocation

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -65,7 +65,7 @@
             int? customisationId,
             string? suspendData
             );
-            
+
     }
 
     public class TrackerActionService : ITrackerActionService
@@ -392,11 +392,11 @@
             int rowsUpdated = 0;
             try
             {
-              rowsUpdated = storeAspService.StoreAspProgressSessionData(
-                    progressId!.Value,
-                    tutorialId!.Value,
-                    suspendData
-                );
+                rowsUpdated = storeAspService.StoreAspProgressSessionData(
+                      progressId!.Value,
+                      tutorialId!.Value,
+                      suspendData
+                  );
             }
             catch (Exception ex)
             {
@@ -445,7 +445,7 @@
                 logger.LogError(ex, ex.Message);
                 return TrackerEndpointResponse.StoreLessonLocationException;
             }
-            if (rowsUpdated > 0 )
+            if (rowsUpdated > 0)
             {
                 return TrackerEndpointResponse.Success;
             }

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -346,7 +346,7 @@
             {
                 var assessmentPassed = score >= assessmentDetails.PlaPassThreshold;
 
-                progressDataService.InsertAssessAttempt(
+                var i = progressDataService.InsertAssessAttempt(
                     candidateId!.Value,
                     customisationId.Value,
                     version!.Value,
@@ -389,9 +389,10 @@
             {
                 return validationResponse;
             }
+            int rowsUpdated = 0;
             try
             {
-                storeAspService.StoreAspProgressSessionData(
+              rowsUpdated = storeAspService.StoreAspProgressSessionData(
                     progressId!.Value,
                     tutorialId!.Value,
                     suspendData
@@ -400,10 +401,16 @@
             catch (Exception ex)
             {
                 logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreAspProgressException;
+                return TrackerEndpointResponse.StoreSuspendDataException;
             }
-
-            return TrackerEndpointResponse.Success;
+            if (rowsUpdated > 0)
+            {
+                return TrackerEndpointResponse.Success;
+            }
+            else
+            {
+                return TrackerEndpointResponse.NoRowUpdated;
+            }
         }
 
         public TrackerEndpointResponse StoreLessonLocation(
@@ -424,9 +431,10 @@
             {
                 return validationResponse;
             }
+            int rowsUpdated = 0;
             try
             {
-                storeAspService.StoreAspProgressLessonLocation(
+                rowsUpdated = storeAspService.StoreAspProgressLessonLocation(
                     progressId!.Value,
                     tutorialId!.Value,
                     lessonLocation
@@ -435,10 +443,16 @@
             catch (Exception ex)
             {
                 logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreAspProgressException;
+                return TrackerEndpointResponse.StoreLessonLocationException;
             }
-
-            return TrackerEndpointResponse.Success;
+            if (rowsUpdated > 0 )
+            {
+                return TrackerEndpointResponse.Success;
+            }
+            else
+            {
+                return TrackerEndpointResponse.NoRowUpdated;
+            }
         }
     }
 }


### PR DESCRIPTION
[TD-3009](https://hee-tis.atlassian.net/browse/TD-3009)

### Description
The tracker calls are fire and forget, calling void methods in the data service to update progress records. This changes the methods to return an int count of number of records updated. When this is 0 the API returns a new -3 no row updated error. This is needed to test calls to the API effectively.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3009]: https://hee-tis.atlassian.net/browse/TD-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ