### PR TITLE
TD-3035 - Progress summary added into self assessment card

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -55,7 +55,9 @@
                     }
                 }
                 else
-                {@("-")}
+                {
+                    @("-")
+                }
             </dd>
             <dd class="nhsuk-summary-list__actions"></dd>
         </div>
@@ -87,6 +89,15 @@
             </dt>
             <dd class="nhsuk-summary-list__value" data-name-for-sorting="launch-count">
                 @Model.LaunchCount
+            </dd>
+            <dd class="nhsuk-summary-list__actions"></dd>
+        </div>
+        <div class="nhsuk-summary-list__row details-list-with-button__row">
+            <dt class="nhsuk-summary-list__key">
+                Progress
+            </dt>
+            <dd class="nhsuk-summary-list__value" data-name-for-sorting="progress">
+                <span style="white-space:pre">@Model.Progress</span>
             </dd>
             <dd class="nhsuk-summary-list__actions"></dd>
         </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3035

### Description
 Existing data service used to load the latest assessment results for the candidate assessment and count of 'questions', 'self assessed' and 'confirmed' retried from the result.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1fae7ed8-74d5-4133-8355-80a6f939a3d0)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/d6c1510a-22de-46f6-9a8d-6d69ef769bc7)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
