### PR TITLE
TD-3009 Implements combined UpdateLessonState endpoint

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -78,16 +78,14 @@
             int tutTime
             );
 
-        int UpdateAspProgressSuspendData(
-           int tutorialId,
-           int progressId,
-           string? suspendData
-       );
-        int UpdateAspProgressLessonLocation(
-           int tutorialId,
-           int progressId,
+        int UpdateLessonState(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime,
+           string? suspendData,
            string? lessonLocation
-       );
+        );
 
         int GetCompletionStatusForProgress(int progressId);
 
@@ -516,7 +514,7 @@
                         SET Answer{promptNumber} = @answer
                         WHERE ProgressID = @progressId",
                 new { progressId, promptNumber, answer }
-            ); 
+            );
         }
 
         public int UpdateProgressDetailsForStoreAspProgressV2(
@@ -563,33 +561,22 @@
                 new { tutorialId, progressId, tutStat, tutTime }
             );
         }
-
-        public int UpdateAspProgressSuspendData(
-           int tutorialId,
-           int progressId,
-           string? suspendData
-       )
-        {
-            return connection.Execute(
-                @"UPDATE aspProgress
-                    SET SuspendData = @suspendData
-                    WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)",
-                new { tutorialId, progressId, suspendData }
-            );
-        }
-        public int UpdateAspProgressLessonLocation(
-           int tutorialId,
-           int progressId,
+        public int UpdateLessonState(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime,
+           string? suspendData,
            string? lessonLocation
-       )
+        )
         {
             return connection.Execute(
                 @"UPDATE aspProgress
-                    SET LessonLocation = @lessonLocation
+                    SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime, SuspendData = @suspendData, LessonLocation = @lessonLocation
                     WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)",
-                new { tutorialId, progressId, lessonLocation }
+                      AND (ProgressID = @progressId)
+                      AND (TutStat < @tutStat)",
+                new { tutorialId, progressId, tutStat, tutTime, suspendData, lessonLocation }
             );
         }
 

--- a/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
+++ b/DigitalLearningSolutions.Data/Enums/TrackerEndpointAction.cs
@@ -8,7 +8,6 @@
         storeaspprogressv2,
         storeaspprogressnosession,
         storeaspassessnosession,
-        storesuspenddata,
-        storelessonlocation
+        updatelessonstate
     }
 }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -41,16 +41,13 @@
             int tutorialStatus
         );
 
-        int StoreAspProgressSuspendData(
-            int progressId,
+        int UpdateLessonState(
             int tutorialId,
-            string? suspendData
-            );
-
-        int StoreAspProgressLessonLocation(
             int progressId,
-            int tutorialId,
-            string? lessonLocation
+            int tutStat,
+            int tutTime,
+           string? suspendData,
+           string? lessonLocation
             );
 
         void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress);
@@ -217,22 +214,16 @@
             return progressDataService.UpdateAspProgressTutStatAndTime(tutorialId, progressId, tutorialStatus, tutorialTime);
         }
 
-        public int StoreAspProgressSuspendData(
-            int progressId,
+        public int UpdateLessonState(
             int tutorialId,
-            string? suspendData
+            int progressId,
+            int tutStat,
+            int tutTime,
+           string? suspendData,
+           string? lessonLocation
             )
         {
-            return progressDataService.UpdateAspProgressSuspendData(tutorialId, progressId, suspendData);
-        }
-
-        public int StoreAspProgressLessonLocation(
-            int progressId,
-            int tutorialId,
-            string? lessonLocation
-            )
-        {
-            return progressDataService.UpdateAspProgressLessonLocation(tutorialId, progressId, lessonLocation);
+            return progressDataService.UpdateLessonState(tutorialId, progressId, tutStat, tutTime, suspendData, lessonLocation);
         }
 
         public void CheckProgressForCompletionAndSendEmailIfCompleted(DelegateCourseInfo progress)

--- a/DigitalLearningSolutions.Web/Services/StoreAspService.cs
+++ b/DigitalLearningSolutions.Web/Services/StoreAspService.cs
@@ -39,16 +39,13 @@
             int tutorialStatus
         );
 
-        int StoreAspProgressSessionData(
-                int progressId,
-                int tutorialId,
-                string? sessionData
-            );
-
-        int StoreAspProgressLessonLocation(
-                int progressId,
-                int tutorialId,
-                string? lessonLocation
+        int UpdateLessonState(
+            int tutorialId,
+            int progressId,
+            int tutStat,
+            int tutTime,
+           string? suspendData,
+           string? lessonLocation
             );
 
         (TrackerEndpointResponse? validationResponse, DelegateCourseInfo? progress)
@@ -65,7 +62,7 @@
                 int customisationId
             );
         (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+            GetProgressAndValidateCommonInputsForUpdateLessonStateEndpoints(
                 int? progressId,
                 int? tutorialId,
                 int? candidateId,
@@ -241,7 +238,7 @@
         }
 
         public (TrackerEndpointResponse? validationResponse, DetailedCourseProgress? progress)
-            GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+            GetProgressAndValidateCommonInputsForUpdateLessonStateEndpoints(
                 int? progressId,
                 int? tutorialId,
                 int? candidateId,
@@ -264,21 +261,9 @@
             return (null, progress);
         }
 
-        public int StoreAspProgressSessionData(int progressId, int tutorialId, string? sessionData)
+        public int UpdateLessonState(int progressId, int tutorialId, int tutStat, int tutTime, string? suspendData, string? lessonLocation)
         {
-            return progressService.StoreAspProgressSuspendData(
-                 progressId,
-                 tutorialId,
-                 sessionData
-                 );
-        }
-        public int StoreAspProgressLessonLocation(int progressId, int tutorialId, string? lessonLocation)
-        {
-            return progressService.StoreAspProgressLessonLocation(
-                 progressId,
-                 tutorialId,
-                 lessonLocation
-                 );
+            return progressService.UpdateLessonState(tutorialId, progressId, tutStat, tutTime, suspendData, lessonLocation);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
+    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.Tracker;
     using DigitalLearningSolutions.Data.Utilities;
     using Microsoft.Extensions.Logging;
@@ -50,20 +51,15 @@
             string? sessionId
         );
 
-        TrackerEndpointResponse StoreSuspendData(
-            int? progressId,
+        TrackerEndpointResponse UpdateLessonState(
             int? tutorialId,
+            int? progressId,
             int? candidateId,
             int? customisationId,
-            string? suspendData
-            );
-
-        TrackerEndpointResponse StoreLessonLocation(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId,
-            string? suspendData
+            int? tutStat,
+            int? tutTime,
+            string? suspendData,
+            string? lessonLocation
             );
 
     }
@@ -371,15 +367,18 @@
 
             return TrackerEndpointResponse.Success;
         }
-        public TrackerEndpointResponse StoreSuspendData(
-            int? progressId,
+        public TrackerEndpointResponse UpdateLessonState(
             int? tutorialId,
+            int? progressId,
             int? candidateId,
             int? customisationId,
-            string? suspendData
+            int? tutStat,
+            int? tutTime,
+            string? suspendData,
+            string? lessonLocation
             )
         {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
+            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForUpdateLessonStateEndpoints(
                progressId,
                tutorialId,
                candidateId,
@@ -392,58 +391,19 @@
             int rowsUpdated = 0;
             try
             {
-                rowsUpdated = storeAspService.StoreAspProgressSessionData(
-                      progressId!.Value,
+                rowsUpdated = storeAspService.UpdateLessonState(
                       tutorialId!.Value,
-                      suspendData
+                       progressId!.Value,
+                       tutStat!.Value,
+                       tutTime!.Value,
+                      suspendData,
+                      lessonLocation
                   );
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, ex.Message);
                 return TrackerEndpointResponse.StoreSuspendDataException;
-            }
-            if (rowsUpdated > 0)
-            {
-                return TrackerEndpointResponse.Success;
-            }
-            else
-            {
-                return TrackerEndpointResponse.NoRowUpdated;
-            }
-        }
-
-        public TrackerEndpointResponse StoreLessonLocation(
-            int? progressId,
-            int? tutorialId,
-            int? candidateId,
-            int? customisationId,
-            string? lessonLocation
-            )
-        {
-            var (validationResponse, progress) = storeAspService.GetProgressAndValidateCommonInputsForStoreSuspendDataEndpoints(
-               progressId,
-               tutorialId,
-               candidateId,
-               customisationId
-           );
-            if (validationResponse != null)
-            {
-                return validationResponse;
-            }
-            int rowsUpdated = 0;
-            try
-            {
-                rowsUpdated = storeAspService.StoreAspProgressLessonLocation(
-                    progressId!.Value,
-                    tutorialId!.Value,
-                    lessonLocation
-                );
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, ex.Message);
-                return TrackerEndpointResponse.StoreLessonLocationException;
             }
             if (rowsUpdated > 0)
             {

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.Tracker;
+    using DocumentFormat.OpenXml.Office2013.Excel;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
@@ -113,25 +114,16 @@
                         );
                     }
 
-                    if (action == TrackerEndpointAction.storesuspenddata)
+                    if (action == TrackerEndpointAction.updatelessonstate)
                     {
-                        return trackerActionService.StoreSuspendData(
-                            query.ProgressId,
+                        return trackerActionService.UpdateLessonState(
                             query.TutorialId,
+                            query.ProgressId,
                             query.CandidateId,
                             query.CustomisationId,
-                            query.SuspendData
-                            );
-                    }
-
-
-                    if (action == TrackerEndpointAction.storelessonlocation)
-                    {
-                        return trackerActionService.StoreLessonLocation(
-                            query.ProgressId,
-                            query.TutorialId,
-                            query.CandidateId,
-                            query.CustomisationId,
+                            Convert.ToInt32(query.TutorialTime),
+                            query.TutorialStatus,
+                            query.SuspendData,
                             query.LessonLocation
                             );
                     }


### PR DESCRIPTION
### JIRA link
[TD-3009](https://hee-tis.atlassian.net/browse/TD-3009)

### Description
Previous implementations stored changes to aspProgress fields in separate endpoint calls. This resulted in lots of database traffic and SQL transaction deadlocks. This new implementation combines updates to all fields into a single UpdateLessonState endpoint which will be called only once to reduce transaction traffic and avoid deadlocks.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3009]: https://hee-tis.atlassian.net/browse/TD-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ