### PR TITLE
TD-3009 Fix parameter mapping and query clause

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -574,8 +574,7 @@
                 @"UPDATE aspProgress
                     SET TutStat = Case WHEN TutStat < @tutStat THEN @tutStat ELSE TutStat END, TutTime = TutTime + @tutTime, SuspendData = @suspendData, LessonLocation = @lessonLocation
                     WHERE (TutorialID = @tutorialId)
-                      AND (ProgressID = @progressId)
-                      AND (TutStat < @tutStat)",
+                      AND (ProgressID = @progressId)",
                 new { tutorialId, progressId, tutStat, tutTime, suspendData, lessonLocation }
             );
         }

--- a/DigitalLearningSolutions.Web/Services/TrackerService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerService.cs
@@ -121,8 +121,8 @@
                             query.ProgressId,
                             query.CandidateId,
                             query.CustomisationId,
-                            Convert.ToInt32(query.TutorialTime),
                             query.TutorialStatus,
+                            Convert.ToInt32(query.TutorialTime),
                             query.SuspendData,
                             query.LessonLocation
                             );


### PR DESCRIPTION
### JIRA link
[TD-3009](https://hee-tis.atlassian.net/browse/TD-3009)

### Description
UAT testing revealed that tutorial status and time parameters were being swapped and that an unnecessary clause in the update query was preventing aspProgress records from being updated in most scenarios. This change fixes the mapping of the endpoint and service parameters and removes the unnecessary clause in the update query.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3009]: https://hee-tis.atlassian.net/browse/TD-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ