### PR TITLE
TD-3121 - Implement search and filter of self assessments in the delegate activities screen

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -11,7 +11,6 @@ namespace DigitalLearningSolutions.Data.DataServices
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
-    using System.Threading.Tasks;
 
     public interface ICourseDataService
     {
@@ -135,7 +134,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
 
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(int centreId);
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive);
     }
 
     public class CourseDataService : ICourseDataService
@@ -696,7 +695,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                         FETCH NEXT @exportQueryRowLimit ROWS ONLY";
             return connection.Query<CourseStatistics>(
                 sql,
-                new { centreId, categoryId, exportQueryRowLimit, currentRun, orderBy,searchString}
+                new { centreId, categoryId, exportQueryRowLimit, currentRun, orderBy, searchString }
             );
         }
 
@@ -795,7 +794,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                 sortOrder = " DESC ";
 
             if (sortBy == "CourseName" || sortBy == "SearchableName")
-                orderBy = " ORDER BY ap.ApplicationName "+sortOrder+", cu.CustomisationName " + sortOrder;
+                orderBy = " ORDER BY ap.ApplicationName " + sortOrder + ", cu.CustomisationName " + sortOrder;
             else
                 orderBy = " ORDER BY " + sortBy + sortOrder + ", LTRIM(RTRIM(ap.ApplicationName)) + LTRIM(RTRIM(cu.CustomisationName))";
 
@@ -1554,7 +1553,7 @@ namespace DigitalLearningSolutions.Data.DataServices
         }
 
 
-        public  IEnumerable<CourseDelegateForExport> GetCourseDelegatesForExport(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
+        public IEnumerable<CourseDelegateForExport> GetCourseDelegatesForExport(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
             int customisationId, int centreId, bool? isDelegateActive, bool? isProgressLocked, bool? removed, bool? hasCompleted, string? answer1, string? answer2, string? answer3)
         {
             searchString = searchString == null ? string.Empty : searchString.Trim();
@@ -1701,7 +1700,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             );
         }
 
-        public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString,int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,string isActive, string categoryName, string courseTopic, string hasAdminFields
+        public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields
         )
         {
             string courseStatisticsSelect = @$" SELECT
@@ -1783,9 +1782,9 @@ namespace DigitalLearningSolutions.Data.DataServices
             return courseStatistics;
         }
 
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(int centreId)
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive)
         {
-                string assessmentStatisticsSelectQuery = $@"SELECT
+            string assessmentStatisticsSelectQuery = $@"SELECT
                         sa.Name AS Name,
                         cc.CategoryName AS Category,
                         CASE 
@@ -1807,10 +1806,15 @@ namespace DigitalLearningSolutions.Data.DataServices
                         from CentreSelfAssessments AS csa 
                         INNER join SelfAssessments AS sa ON csa.SelfAssessmentID = sa.ID
                         INNER JOIN CourseCategories AS cc ON sa.CategoryID = cc.CourseCategoryID
-                        WHERE csa.CentreID= @centreId";
+                        WHERE csa.CentreID= @centreId
+                                AND sa.[Name] LIKE '%' + @searchString + '%'
+		                        AND ((@categoryName = 'Any') OR (cc.CategoryName = @categoryName))
+		                        AND ((@isActive = 'Any') OR (@isActive = 'true' AND  sa.ArchivedDate IS NULL) OR (@isActive = 'false' AND sa.ArchivedDate IS NOT NULL))
+                                ";
 
-                IEnumerable<DelegateAssessmentStatistics> delegateAssessmentStatistics = connection.Query<DelegateAssessmentStatistics>(assessmentStatisticsSelectQuery, new { centreId }, commandTimeout: 3000);
-                return delegateAssessmentStatistics;
+            IEnumerable<DelegateAssessmentStatistics> delegateAssessmentStatistics = connection.Query<DelegateAssessmentStatistics>(assessmentStatisticsSelectQuery,
+                new { searchString, centreId, categoryName, isActive }, commandTimeout: 3000);
+            return delegateAssessmentStatistics;
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateCoursesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateCoursesControllerTests.cs
@@ -100,7 +100,7 @@
                 var delegateCourses = Builder<CourseStatisticsWithAdminFieldResponseCounts>.CreateListOfSize(5).Build();
                 A.CallTo(() => courseService.GetDelegateCourses(string.Empty, 1, 1, true, true, string.Empty, string.Empty, string.Empty, string.Empty)).Returns(delegateCourses);
 
-                A.CallTo(() => courseService.GetDelegateAssessments(A<int>._)).MustHaveHappened();
+                A.CallTo(() => courseService.GetDelegateAssessments(A<string>._, A<int>._, A<string>._, A<string>._)).MustHaveHappened();
                 A.CallTo(
                     () => paginateService.Paginate(A<IEnumerable<CourseStatistics>>._,
                          A<int>._,

--- a/DigitalLearningSolutions.Web.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/CourseServiceTests.cs
@@ -982,15 +982,15 @@
         {
             // Given
             var delegateAssessments = Builder<DelegateAssessmentStatistics>.CreateListOfSize(5).Build();
-            A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(1)).Returns(delegateAssessments);
+            A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(string.Empty, 1, string.Empty, string.Empty)).Returns(delegateAssessments);
 
             // When
-            var result = courseService.GetDelegateAssessments(1);
+            var result = courseService.GetDelegateAssessments(string.Empty, 1, string.Empty, string.Empty);
 
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(1))
+                A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(string.Empty, 1, string.Empty, string.Empty))
                     .MustHaveHappenedOnceExactly();
                 result.Count().Should().BeGreaterOrEqualTo(0);
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -144,17 +144,21 @@
 
             if (isCourse == "Any" && isSelfAssessment == "Any")
             {
-                delegateActivities = courseService.GetDelegateCourses(searchString ?? string.Empty, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
-                delegateAssessments = courseService.GetDelegateAssessments(centreId);
+                delegateActivities = courseService.GetDelegateCourses(searchString, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
+                delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
             }
 
             if (isCourse == "true")
                 delegateActivities = courseService.GetDelegateCourses(searchString ?? string.Empty, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
             if (isSelfAssessment == "true")
-                delegateAssessments = courseService.GetDelegateAssessments(centreId);
+                delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+
+            delegateAssessments = UpdateCompletedCount(delegateAssessments);
 
             var allItems = delegateActivities.Cast<CourseStatistics>().ToList();
             allItems.AddRange(delegateAssessments);
+
+            allItems = OrderActivities(allItems, sortBy, sortDirection);
 
             var availableFilters = DelegateCourseStatisticsViewModelFilterOptions
                 .GetFilterOptions(categoryId.HasValue ? new string[] { } : Categories, Topics).ToList();
@@ -210,8 +214,40 @@
             return File(
                 content,
                 FileHelper.GetContentTypeFromFileName(fileName),
-                fileName
+            fileName
             );
+        }
+
+        private IEnumerable<DelegateAssessmentStatistics> UpdateCompletedCount(IEnumerable<DelegateAssessmentStatistics> statistics)
+        {
+            foreach (var statistic in statistics)
+            {
+                statistic.CompletedCount = statistic.SubmittedSignedOffCount;
+            }
+            return statistics;
+        }
+
+        private List<CourseStatistics> OrderActivities(List<CourseStatistics> allItems, string sortBy, string sortDirection)
+        {
+            if (sortBy == "InProgressCount")
+            {
+                allItems = sortDirection == "Ascending"
+                            ? allItems.OrderBy(x => x.InProgressCount).ThenBy(n => n.SearchableName).ToList()
+                            : allItems.OrderByDescending(x => x.InProgressCount).ThenBy(n => n.SearchableName).ToList();
+            }
+            else if (sortBy == "CompletedCount")
+            {
+                allItems = sortDirection == "Ascending"
+                            ? allItems.OrderBy(x => x.CompletedCount).ThenBy(n => n.SearchableName).ToList()
+                            : allItems.OrderByDescending(x => x.CompletedCount).ThenBy(n => n.SearchableName).ToList();
+            }
+            else
+            {
+                allItems = sortDirection == "Ascending"
+                            ? allItems.OrderBy(x => x.SearchableName).ToList()
+                            : allItems.OrderByDescending(x => x.SearchableName).ToList();
+            }
+            return allItems;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -119,8 +119,7 @@
            string isActive, string categoryName, string courseTopic, string hasAdminFields);
 
         public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> GetDelegateCourses(string searchString,int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,string isActive, string categoryName, string courseTopic, string hasAdminFields);
-
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(int centreId);
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive);
     }
 
     public class CourseService : ICourseService
@@ -549,9 +548,9 @@
             );
         }
 
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(int centreId)
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive)
         {
-            return courseDataService.GetDelegateAssessmentStatisticsAtCentre(centreId);
+            return courseDataService.GetDelegateAssessmentStatisticsAtCentre(searchString, centreId, categoryName, isActive);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3121

### Description
Search, sort and filters applied to delegate activities. Sorting implemented by Linq as self assessments are appended to course object to create one common object.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2a52bc3d-406e-4a74-8edd-f042bd451599)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/e8fe32cc-4961-4f2b-93ab-43afd231a7f4)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/be2e8ece-857d-4768-a023-58ff8d51e54b)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings]
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
