### PR TITLE
TD-2036 Migration to switch off period fields on system versioned tables

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202311270911_SwitchOffPeriodFields.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202311270911_SwitchOffPeriodFields.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202311270911)]
+    public class SwitchOffPeriodFields : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_2036_SwitchOffPeriodFields_UP);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql(Properties.Resources.TD_2036_SwitchOffPeriodFields_DOWN);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -478,8 +478,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///-- Create date: 15/10/2021
         ///-- Description:	Reorders the CompetencyAssessmentQuestions - moving the given competency question up or down.
         ///-- =============================================
-        ///CREATE OR ALTER   PROCEDURE [dbo].[ReorderCompetencyAssessmentQuestion]
-        /// [rest of string was truncated]&quot;;.
+        ///CREATE OR ALTER   PROCEDURE [dbo].[ReorderCompetencyAssessmentQuestion]        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DLSV2_379_ReorderCompetencyAssessmentQuestionsSP {
             get {
@@ -1034,24 +1033,6 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to -- Switch on versioning from FrameworkCompetencies table
-        ///ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetenciesHistory));
-        ///GO
-        ///
-        ///-- Switch on versioning from FrameworkCompetencyGroups table
-        ///ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetencyGroupsHistory));
-        ///GO
-        ///
-        ///-- Switch on versioning from Frameworks table
-        ///ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHisto [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string TD_2036_SwitchSystemVersioningOffAllTables_DOWN
-        {
-            get
-            {
-                return ResourceManager.GetString("TD_2036_SwitchSystemVersioningOffAllTables_DOWN", resourceCulture);
-            }
-        }
         ///   Looks up a localized string similar to &lt;div class=nhsuk-u-reading-width&gt;
         ///&lt;h2&gt;What are cookies?&lt;/h2&gt;
         ///&lt;p&gt;Cookies are files saved on your phone, tablet or computer when you visit a website.&lt;/p&gt;
@@ -1065,6 +1046,80 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         internal static string TD_1943_CookiePolicyContentHtml {
             get {
                 return ResourceManager.GetString("TD_1943_CookiePolicyContentHtml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;div class=nhsuk-u-reading-width&gt;&lt;h2&gt;What are cookies?&lt;/h2&gt;&lt;p&gt;Cookies are files saved on your phone, tablet or computer when you visit a website.&lt;p&gt;They store information about how you use the website, such as the pages you visit.&lt;p&gt;Cookies are not viruses or computer programs. They are very small so do not take up much space.&lt;h2&gt;How we use cookies&lt;/h2&gt;&lt;p&gt;We only use cookies to:&lt;ul&gt;&lt;li&gt;make our website work&lt;li&gt;measure how you use our website, such as which links you click on (analytics cookies), if you give [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_1943_CookiePolicyContentHtmlOldRecord {
+            get {
+                return ResourceManager.GetString("TD_1943_CookiePolicyContentHtmlOldRecord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to -- Remove period field from FrameworkCompetencies table
+        ///ALTER TABLE FrameworkCompetencies ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+        ///GO
+        ///
+        ///-- Remove period field from FrameworkCompetencyGroups table
+        ///ALTER TABLE FrameworkCompetencyGroups ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+        ///GO
+        ///
+        ///-- Remove period field from Frameworks table
+        ///ALTER TABLE Frameworks ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+        ///GO
+        ///
+        ///-- Remove period field from Competencies table
+        ///ALTER TABL [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_2036_SwitchOffPeriodFields_DOWN {
+            get {
+                return ResourceManager.GetString("TD_2036_SwitchOffPeriodFields_DOWN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to -- Remove period field from FrameworkCompetencies table
+        ///ALTER TABLE FrameworkCompetencies DROP PERIOD FOR SYSTEM_TIME; 
+        ///GO
+        ///
+        ///-- Remove period field from FrameworkCompetencyGroups table
+        ///ALTER TABLE FrameworkCompetencyGroups DROP PERIOD FOR SYSTEM_TIME; 
+        ///GO
+        ///
+        ///-- Remove period field from Frameworks table
+        ///ALTER TABLE Frameworks DROP PERIOD FOR SYSTEM_TIME; 
+        ///GO
+        ///
+        ///-- Remove period field from Competencies table
+        ///ALTER TABLE Competencies DROP PERIOD FOR SYSTEM_TIME; 
+        ///GO
+        ///
+        ///-- Remove period field from Comp [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_2036_SwitchOffPeriodFields_UP {
+            get {
+                return ResourceManager.GetString("TD_2036_SwitchOffPeriodFields_UP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to -- Switch on versioning from FrameworkCompetencies table
+        ///ALTER TABLE FrameworkCompetencies SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetenciesHistory));
+        ///GO
+        ///
+        ///-- Switch on versioning from FrameworkCompetencyGroups table
+        ///ALTER TABLE FrameworkCompetencyGroups SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworkCompetencyGroupsHistory));
+        ///GO
+        ///
+        ///-- Switch on versioning from Frameworks table
+        ///ALTER TABLE Frameworks SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].FrameworksHisto [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_2036_SwitchSystemVersioningOffAllTables_DOWN {
+            get {
+                return ResourceManager.GetString("TD_2036_SwitchSystemVersioningOffAllTables_DOWN", resourceCulture);
             }
         }
         
@@ -1087,18 +1142,9 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///
         ///-- Remove versioning from Competency [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string TD_2036_SwitchSystemVersioningOffAllTables_UP
-        {
-            get
-            {
-                return ResourceManager.GetString("TD_2036_SwitchSystemVersioningOffAllTables_UP", resourceCulture);
-            }
-        }
-        ///   Looks up a localized string similar to &lt;div class=nhsuk-u-reading-width&gt;&lt;h2&gt;What are cookies?&lt;/h2&gt;&lt;p&gt;Cookies are files saved on your phone, tablet or computer when you visit a website.&lt;p&gt;They store information about how you use the website, such as the pages you visit.&lt;p&gt;Cookies are not viruses or computer programs. They are very small so do not take up much space.&lt;h2&gt;How we use cookies&lt;/h2&gt;&lt;p&gt;We only use cookies to:&lt;ul&gt;&lt;li&gt;make our website work&lt;li&gt;measure how you use our website, such as which links you click on (analytics cookies), if you give [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string TD_1943_CookiePolicyContentHtmlOldRecord {
+        internal static string TD_2036_SwitchSystemVersioningOffAllTables_UP {
             get {
-                return ResourceManager.GetString("TD_1943_CookiePolicyContentHtmlOldRecord", resourceCulture);
+                return ResourceManager.GetString("TD_2036_SwitchSystemVersioningOffAllTables_UP", resourceCulture);
             }
         }
         

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -313,4 +313,10 @@
   <data name="TD_1943_CookiePolicyContentHtml" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\TD_1943_CookiePolicyContentHtml.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="TD_2036_SwitchOffPeriodFields_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-2036-SwitchOffPeriodFields-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_2036_SwitchOffPeriodFields_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-2036-SwitchOffPeriodFields-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchOffPeriodFields-DOWN.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchOffPeriodFields-DOWN.sql
@@ -1,0 +1,35 @@
+-- Remove period field from FrameworkCompetencies table
+ALTER TABLE FrameworkCompetencies ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from FrameworkCompetencyGroups table
+ALTER TABLE FrameworkCompetencyGroups ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from Frameworks table
+ALTER TABLE Frameworks ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from Competencies table
+ALTER TABLE Competencies ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from CompetencyGroups table
+ALTER TABLE CompetencyGroups ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from AssessmentQuestions table
+ALTER TABLE AssessmentQuestions ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from AssessmentQuestionLevels table
+ALTER TABLE AssessmentQuestionLevels ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from SelfAssessmentResults table
+ALTER TABLE SelfAssessmentResults ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO
+
+-- Remove period field from SelfAssessmentResultSupervisorVerifications table
+ALTER TABLE SelfAssessmentResultSupervisorVerifications ADD PERIOD FOR SYSTEM_TIME ( SysStartTime, SysEndTime ); 
+GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchOffPeriodFields-UP.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-2036-SwitchOffPeriodFields-UP.sql
@@ -1,0 +1,35 @@
+-- Remove period field from FrameworkCompetencies table
+ALTER TABLE FrameworkCompetencies DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from FrameworkCompetencyGroups table
+ALTER TABLE FrameworkCompetencyGroups DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from Frameworks table
+ALTER TABLE Frameworks DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from Competencies table
+ALTER TABLE Competencies DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from CompetencyGroups table
+ALTER TABLE CompetencyGroups DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from AssessmentQuestions table
+ALTER TABLE AssessmentQuestions DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from AssessmentQuestionLevels table
+ALTER TABLE AssessmentQuestionLevels DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from SelfAssessmentResults table
+ALTER TABLE SelfAssessmentResults DROP PERIOD FOR SYSTEM_TIME; 
+GO
+
+-- Remove period field from SelfAssessmentResultSupervisorVerifications table
+ALTER TABLE SelfAssessmentResultSupervisorVerifications DROP PERIOD FOR SYSTEM_TIME; 
+GO


### PR DESCRIPTION
### JIRA link
[TD-2036](https://hee-tis.atlassian.net/browse/TD-2036)

### Description
Switches off period fields on system versioned tables in preparation for replication.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2036]: https://hee-tis.atlassian.net/browse/TD-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ