### PR TITLE
TD-3172-Label name changed

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -24,7 +24,7 @@
         </div>
         <div class="nhsuk-summary-list__row details-list-with-button__row">
             <dt class="nhsuk-summary-list__key">
-                Enrolled
+                First enrolled
             </dt>
             <dd class="nhsuk-summary-list__value" data-name-for-sorting="enrolled-date">
                 @Model.StartedDate


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3172

### Description
Enrolled label changed to 'First enrolled'

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/dc7c1f40-8df2-4c1d-8d9c-123efdef8ee2)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
