### PR TITLE
TD-2972-Activity Delegates sort and filter options -'submitted' filter issue fixed.

### DIFF
--- a/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
@@ -214,29 +214,15 @@
             nameof(SelfAssessmentDelegate.StartedDate)
         );
 
-        public static readonly SelfAssessmentDelegatesSortByOption SelfAssessed = new SelfAssessmentDelegatesSortByOption(
-            4,
-            nameof(SelfAssessed),
-            "Competencies self assessed",
-            nameof(SelfAssessmentDelegate.SelfAssessed)
-        );
-
-        public static readonly SelfAssessmentDelegatesSortByOption Confirmed = new SelfAssessmentDelegatesSortByOption(
-            5,
-            nameof(Confirmed),
-            "Competencies confirmed",
-            nameof(SelfAssessmentDelegate.Confirmed)
-        );
-
         public static readonly SelfAssessmentDelegatesSortByOption SignedOff = new SelfAssessmentDelegatesSortByOption(
-            6,
+            4,
             nameof(SignedOff),
             "Signed off",
             nameof(SelfAssessmentDelegate.SignedOff)
         );
 
         public static readonly SelfAssessmentDelegatesSortByOption Submitted = new SelfAssessmentDelegatesSortByOption(
-            7,
+            5,
             nameof(Submitted),
             "Submitted",
             nameof(SelfAssessmentDelegate.SubmittedDate)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -166,10 +166,10 @@
                             removed = filterValue;
 
                         if (filter.Contains("CompletionStatus"))
-                            submitted = filterValue;
+                            hasCompleted = filterValue;
 
                         if (filter.Contains("Submitted"))
-                            signedOff = filterValue;
+                            submitted = filterValue;
 
                         if (filter.Contains("SignedOff"))
                             signedOff = filterValue;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2972

### Description
'Submitted' filter issue fixed. 'Self assessed' and 'Confirmed' sort by options has been removed.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/fcbaf29b-23cb-403c-af8b-6934923e7b54)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/264bd873-5b15-4d1f-8728-58663aedf12a)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
