### PR TITLE
TD-3187- Move latest self assessment result queries to stored procedures

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202311301431_CreateAssessmentResultsSP.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202311301431_CreateAssessmentResultsSP.cs
@@ -1,0 +1,20 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202311301431)]
+    public class CreateAssessmentResultsSP : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_3187_CreateGetCandidateAssessmentResultsById_SP);
+            Execute.Sql(Properties.Resources.TD_3187_CreateGetAssessmentResultsByDelegate_SP);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql(@$"DROP PROCEDURE [dbo].[GetCandidateAssessmentResultsById]");
+            Execute.Sql(@$"DROP PROCEDURE [dbo].[GetAssessmentResultsByDelegate]");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -1253,6 +1253,62 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SET ANSI_NULLS ON
+        ///GO
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///-- =============================================
+        ///-- Author:		Auldrin Possa
+        ///-- Create date: 30/11/2023
+        ///-- Description:	Returns assessment results for a delegate
+        ///-- =============================================
+        ///CREATE OR ALTER PROCEDURE [dbo].[GetAssessmentResultsByDelegate]
+        ///	@selfAssessmentId as Int = 0,
+        ///	@delegateId as int = 0
+        ///AS
+        ///BEGIN
+        ///
+        ///	SET NOCOUNT ON;
+        ///
+        ///	WITH LatestAssessmentResults AS
+        ///            (
+        ///                SELECT
+        ///                 [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_3187_CreateGetAssessmentResultsByDelegate_SP {
+            get {
+                return ResourceManager.GetString("TD_3187_CreateGetAssessmentResultsByDelegate_SP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SET ANSI_NULLS ON
+        ///GO
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///-- =============================================
+        ///-- Author:		Auldrin Possa
+        ///-- Create date: 30/11/2023
+        ///-- Description:	Returns candidate assessment results by candidateAssessmentId
+        ///-- =============================================
+        ///CREATE OR ALTER PROCEDURE [dbo].[GetCandidateAssessmentResultsById]
+        ///	@candidateAssessmentId as Int = 0,
+        ///	@adminId as int = 0,
+        ///	@selfAssessmentResultId as int = NULL
+        ///AS
+        ///BEGIN
+        ///
+        ///	SET NOCOUNT ON;
+        ///
+        ///	WITH LatestAssessmentR [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_3187_CreateGetCandidateAssessmentResultsById_SP {
+            get {
+                return ResourceManager.GetString("TD_3187_CreateGetCandidateAssessmentResultsById_SP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GetActiveAvailableCustomisationsForCentreFiltered_V6]    Script Date: 29/09/2022 19:11:04 ******/
         ///SET ANSI_NULLS ON
         ///GO

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -319,4 +319,10 @@
   <data name="TD_3000_CheckDelegateStatusForCustomisationFix_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-3000-CheckDelegateStatusForCustomisationFix_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
+  <data name="TD_3187_CreateGetAssessmentResultsByDelegate_SP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-3187-CreateGetAssessmentResultsByDelegate-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_3187_CreateGetCandidateAssessmentResultsById_SP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-3187-CreateGetCandidateAssessmentResultsById-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-3187-CreateGetAssessmentResultsByDelegate-SP.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-3187-CreateGetAssessmentResultsByDelegate-SP.sql
@@ -1,0 +1,121 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+-- =============================================
+-- Author:		Auldrin Possa
+-- Create date: 30/11/2023
+-- Description:	Returns assessment results for a delegate
+-- =============================================
+CREATE OR ALTER PROCEDURE [dbo].[GetAssessmentResultsByDelegate]
+	@selfAssessmentId as Int = 0,
+	@delegateId as int = 0
+AS
+BEGIN
+
+	SET NOCOUNT ON;
+
+	WITH LatestAssessmentResults AS
+            (
+                SELECT
+                    s.CompetencyID,
+                    s.AssessmentQuestionID,
+                    s.ID AS ResultID,
+                    s.DateTime AS ResultDateTime,
+                    s.Result,
+                    s.SupportingComments,
+                    sv.ID AS SelfAssessmentResultSupervisorVerificationId,
+                    sv.Requested,
+                    sv.Verified,
+                    sv.Comments,
+                    sv.SignedOff,
+                    adu.Forename + ' ' + adu.Surname AS SupervisorName,
+                    sv.CandidateAssessmentSupervisorID,
+                    sv.EmailSent,
+                    0 AS UserIsVerifier,
+                    COALESCE (rr.LevelRAG, 0) AS ResultRAG
+                FROM SelfAssessmentResults s
+                LEFT OUTER JOIN DelegateAccounts AS da ON s.DelegateUserID = da.UserID
+                LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
+                    ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
+                LEFT OUTER JOIN CandidateAssessmentSupervisors AS cas 
+                    ON sv.CandidateAssessmentSupervisorID = cas.ID
+                LEFT OUTER JOIN SupervisorDelegates AS sd
+                    ON cas.SupervisorDelegateId = sd.ID
+                LEFT OUTER JOIN AdminUsers AS adu
+					ON sd.SupervisorAdminID = adu.AdminID
+                LEFT OUTER JOIN CompetencyAssessmentQuestionRoleRequirements rr
+                    ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID
+                        AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
+                WHERE da.ID = @delegateId
+                AND s.SelfAssessmentID = @selfAssessmentId
+            )
+
+
+		SELECT C.ID AS Id,
+            DENSE_RANK() OVER (ORDER BY SAS.Ordering) as RowNo,
+            C.Name AS Name,
+            C.Description AS Description,
+            CG.Name AS CompetencyGroup,
+            CG.ID AS CompetencyGroupID,
+            CG.Description AS CompetencyGroupDescription,
+            COALESCE(
+                (SELECT TOP(1) FrameworkConfig
+                FROM Frameworks F
+                INNER JOIN FrameworkCompetencies AS FC
+                    ON FC.FrameworkID = F.ID
+                WHERE FC.CompetencyID = C.ID),
+            'Capability') AS Vocabulary,
+            CASE
+                WHEN (SELECT COUNT(*) FROM SelfAssessmentSupervisorRoles WHERE SelfAssessmentID = SAS.SelfAssessmentID) > 0
+                THEN 1
+                ELSE 0
+            END AS HasDelegateNominatedRoles,
+            SAS.Optional,
+            C.AlwaysShowDescription,
+            AQ.ID AS Id,
+            AQ.Question,
+            AQ.MaxValueDescription,
+            AQ.MinValueDescription,
+            AQ.ScoringInstructions,
+            AQ.MinValue,
+            AQ.MaxValue,
+            AQ.AssessmentQuestionInputTypeID,
+            AQ.IncludeComments,
+            AQ.CommentsPrompt,
+            AQ.CommentsHint,
+            CAQ.Required,
+            LAR.ResultId,
+            LAR.Result,
+            LAR.ResultDateTime,
+            LAR.SupportingComments,
+            LAR.SelfAssessmentResultSupervisorVerificationId,
+            LAR.Requested,
+            LAR.Verified,
+            LAR.Comments AS SupervisorComments,
+            LAR.SignedOff,
+            LAR.UserIsVerifier,
+            LAR.ResultRAG,
+            LAR.SupervisorName
+
+		FROM Competencies AS C
+            INNER JOIN CompetencyAssessmentQuestions AS CAQ
+                ON CAQ.CompetencyID = C.ID
+            INNER JOIN AssessmentQuestions AS AQ
+                ON AQ.ID = CAQ.AssessmentQuestionID
+            INNER JOIN CandidateAssessments AS CA
+                ON CA.SelfAssessmentID = @selfAssessmentId AND CA.RemovedDate IS NULL
+			INNER JOIN DelegateAccounts AS DA ON CA.DelegateUserID = DA.UserID AND DA.ID = @delegateId
+            LEFT OUTER JOIN LatestAssessmentResults AS LAR
+                ON LAR.CompetencyID = C.ID AND LAR.AssessmentQuestionID = AQ.ID
+            INNER JOIN SelfAssessmentStructure AS SAS
+                ON C.ID = SAS.CompetencyID AND SAS.SelfAssessmentID = @selfAssessmentId
+            INNER JOIN CompetencyGroups AS CG
+                ON SAS.CompetencyGroupID = CG.ID AND SAS.SelfAssessmentID = @selfAssessmentId
+            LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
+                ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
+
+		WHERE (CAOC.IncludedInSelfAssessment = 1) OR (SAS.Optional = 0)
+		ORDER BY SAS.Ordering, CAQ.Ordering
+END
+GO

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-3187-CreateGetCandidateAssessmentResultsById-SP.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-3187-CreateGetCandidateAssessmentResultsById-SP.sql
@@ -1,0 +1,124 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+-- =============================================
+-- Author:		Auldrin Possa
+-- Create date: 30/11/2023
+-- Description:	Returns candidate assessment results by candidateAssessmentId
+-- =============================================
+CREATE OR ALTER PROCEDURE [dbo].[GetCandidateAssessmentResultsById]
+	@candidateAssessmentId as Int = 0,
+	@adminId as int = 0,
+	@selfAssessmentResultId as int = NULL
+AS
+BEGIN
+
+	SET NOCOUNT ON;
+
+	WITH LatestAssessmentResults AS
+            (
+                SELECT
+                    s.CompetencyID,
+                    s.AssessmentQuestionID,
+                    s.ID AS ResultID,
+                    s.Result,
+                    s.DateTime AS ResultDateTime,
+                    s.SupportingComments,
+                    sv.ID AS SelfAssessmentResultSupervisorVerificationId,
+                    sv.Requested,
+                    sv.Verified,
+                    sv.Comments,
+                    sv.SignedOff,
+                    adu.Forename + ' ' + adu.Surname AS SupervisorName,
+                    CAST(CASE WHEN COALESCE(sd.SupervisorAdminID, 0) = @adminId THEN 1 ELSE 0 END AS Bit) AS UserIsVerifier,
+                    COALESCE (rr.LevelRAG, 0) AS ResultRAG
+                FROM CandidateAssessments ca
+                INNER JOIN SelfAssessmentResults s
+                    ON s.DelegateUserID = ca.DelegateUserID AND s.SelfAssessmentID = ca.SelfAssessmentID
+                LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
+                    ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
+                LEFT OUTER JOIN CandidateAssessmentSupervisors AS cas 
+                    ON sv.CandidateAssessmentSupervisorID = cas.ID AND cas.Removed IS NULL
+                LEFT OUTER JOIN SupervisorDelegates AS sd
+                    ON cas.SupervisorDelegateId = sd.ID
+                LEFT OUTER JOIN AdminUsers AS adu
+						     ON sd.SupervisorAdminID = adu.AdminID
+                LEFT OUTER JOIN CompetencyAssessmentQuestionRoleRequirements rr
+                    ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID
+                        AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
+                WHERE ca.ID = @candidateAssessmentId
+            )
+
+
+
+		SELECT C.ID AS Id,
+            DENSE_RANK() OVER (ORDER BY SAS.Ordering) as RowNo,
+            C.Name AS Name,
+            C.Description AS Description,
+            CG.Name AS CompetencyGroup,
+            CG.ID AS CompetencyGroupID,
+            CG.Description AS CompetencyGroupDescription,
+            COALESCE(
+                (SELECT TOP(1) FrameworkConfig
+                FROM Frameworks F
+                INNER JOIN FrameworkCompetencies AS FC
+                    ON FC.FrameworkID = F.ID
+                WHERE FC.CompetencyID = C.ID),
+            'Capability') AS Vocabulary,
+            CASE
+                WHEN (SELECT COUNT(*) FROM SelfAssessmentSupervisorRoles WHERE SelfAssessmentID = SAS.SelfAssessmentID) > 0
+                THEN 1
+                ELSE 0
+            END AS HasDelegateNominatedRoles,
+            SAS.Optional,
+            C.AlwaysShowDescription,
+            AQ.ID AS Id,
+            AQ.Question,
+            AQ.MaxValueDescription,
+            AQ.MinValueDescription,
+            AQ.ScoringInstructions,
+            AQ.MinValue,
+            AQ.MaxValue,
+            AQ.AssessmentQuestionInputTypeID,
+            AQ.IncludeComments,
+            AQ.CommentsPrompt,
+            AQ.CommentsHint,
+            CAQ.Required,
+            LAR.ResultId,
+            LAR.Result,
+            LAR.ResultDateTime,
+            LAR.SupportingComments,
+            LAR.SelfAssessmentResultSupervisorVerificationId,
+            LAR.Requested,
+            LAR.Verified,
+            LAR.Comments AS SupervisorComments,
+            LAR.SignedOff,
+            LAR.UserIsVerifier,
+            LAR.ResultRAG,
+            LAR.SupervisorName
+
+	FROM Competencies AS C
+            INNER JOIN CompetencyAssessmentQuestions AS CAQ
+                ON CAQ.CompetencyID = C.ID
+            INNER JOIN AssessmentQuestions AS AQ
+                ON AQ.ID = CAQ.AssessmentQuestionID
+            INNER JOIN CandidateAssessments AS CA
+                ON CA.ID = @candidateAssessmentId
+            LEFT OUTER JOIN LatestAssessmentResults AS LAR
+                ON LAR.CompetencyID = C.ID AND LAR.AssessmentQuestionID = AQ.ID
+            INNER JOIN SelfAssessmentStructure AS SAS
+                ON C.ID = SAS.CompetencyID AND SAS.SelfAssessmentID = CA.SelfAssessmentID
+            INNER JOIN CompetencyGroups AS CG
+                ON SAS.CompetencyGroupID = CG.ID AND SAS.SelfAssessmentID = CA.SelfAssessmentID
+            LEFT OUTER JOIN CandidateAssessmentOptionalCompetencies AS CAOC
+                ON CA.ID = CAOC.CandidateAssessmentID AND C.ID = CAOC.CompetencyID AND CG.ID = CAOC.CompetencyGroupID
+
+
+	WHERE (CAOC.IncludedInSelfAssessment = 1 OR SAS.Optional = 0)
+			AND (@selfAssessmentResultId IS NULL OR 
+			(@selfAssessmentResultId IS NOT NULL AND ResultID = @selfAssessmentResultId))
+
+	ORDER BY SAS.Ordering, CAQ.Ordering
+END
+GO

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService
 {
     using System.Collections.Generic;
+    using System.Data;
     using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.Frameworks;
@@ -214,37 +215,29 @@
         public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateId)
         {
             var result = connection.Query<Competency, AssessmentQuestion, Competency>(
-                $@"WITH {LatestAssessmentResults}
-                    SELECT {CompetencyFields}
-                    FROM {CompetencyTables}
-                    WHERE (CAOC.IncludedInSelfAssessment = 1) OR (SAS.Optional = 0)
-                    ORDER BY SAS.Ordering, CAQ.Ordering",
+                $@"GetAssessmentResultsByDelegate",
                 (competency, assessmentQuestion) =>
                 {
                     competency.AssessmentQuestions.Add(assessmentQuestion);
                     return competency;
                 },
-                new { selfAssessmentId, delegateId }
+                new { selfAssessmentId, delegateId },
+                commandType: CommandType.StoredProcedure
             );
             return GroupCompetencyAssessmentQuestions(result);
         }
 
         public IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int adminId, int? selfAssessmentResultId = null)
         {
-            var resultIdFilter = selfAssessmentResultId.HasValue ? $"ResultID = {selfAssessmentResultId.Value}" : "1=1";
             var result = connection.Query<Competency, AssessmentQuestion, Competency>(
-                $@"WITH {SpecificAssessmentResults}
-                    SELECT {CompetencyFields},
-                    LAR.SupervisorName
-                    FROM {SpecificCompetencyTables}
-                    WHERE (CAOC.IncludedInSelfAssessment = 1 OR SAS.Optional = 0) AND {resultIdFilter}
-                    ORDER BY SAS.Ordering, CAQ.Ordering",
+                $@"GetCandidateAssessmentResultsById",
                 (competency, assessmentQuestion) =>
                 {
                     competency.AssessmentQuestions.Add(assessmentQuestion);
                     return competency;
                 },
-                new { candidateAssessmentId, adminId }
+                new { candidateAssessmentId, adminId, selfAssessmentResultId },
+                commandType: CommandType.StoredProcedure
             );
             return GroupCompetencyAssessmentQuestions(result);
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3187

### Description
Converted SQL queries to stored procedure. These stored procedure are being used in the views attached in screenshots section.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/9ae9ab14-dacb-4c17-97de-67e1bede6480)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/52142800-a645-456c-9578-39b16333c2dc)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/a91218ef-5b42-4d4e-9bbd-5dad987abb8d)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
