### PR TITLE
TD-1570 implement remove from self assessment functionality

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -161,6 +161,7 @@
        void RemoveDelegateSelfAssessment(int candidateAssessmentsId);
         int? GetSupervisorsCountFromCandidateAssessmentId(int candidateAssessmentsId);
         bool CheckForSameCentre(int centreId, int candidateAssessmentsId);
+        int CheckDelegateSelfAssessment(int candidateAssessmentsId);
     }
 
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
@@ -596,6 +597,14 @@ public IEnumerable<SelfAssessmentDelegate> GetSelfAssessmentActivityDelegatesExp
                 new { centreId, candidateAssessmentsId }
             );
             return ResultCount == 1 ? true : false;
+        }
+        public int CheckDelegateSelfAssessment(int candidateAssessmentsId)
+        {
+            return connection.QueryFirstOrDefault<int>(
+                  @"SELECT COUNT(ID) Num FROM CandidateAssessments 
+                      WHERE (ID = @candidateAssessmentsId) AND ( RemovalMethodID =2)",
+                  new { candidateAssessmentsId }
+              );
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -363,7 +363,7 @@
             string? sortBy = null,
             string sortDirection = GenericSortingHelper.Ascending,
             string? existingFilterString = null)
-          {
+        {
             var centreId = User.GetCentreIdKnownNotNull();
             searchString = searchString == null ? string.Empty : searchString.Trim();
             sortBy ??= DefaultSortByOptions.Name.PropertyName;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -27,6 +27,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
 
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
@@ -448,6 +449,12 @@
         [HttpPost]
         public IActionResult RemoveDelegateSelfAssessment(DelegateSelfAssessmenteViewModel delegateSelfAssessmenteViewModel)
         {
+            var checkselfAssessmentDelegate = selfAssessmentService.CheckDelegateSelfAssessment(delegateSelfAssessmenteViewModel.CandidateAssessmentsId);
+
+            if (checkselfAssessmentDelegate > 0)
+            {
+                return StatusCode((int)HttpStatusCode.Gone);
+            }
             if (ModelState.IsValid && delegateSelfAssessmenteViewModel.ActionConfirmed)
             {
                 selfAssessmentService.RemoveDelegateSelfAssessment(delegateSelfAssessmenteViewModel.CandidateAssessmentsId);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -440,7 +440,6 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             }
             var selfAssessmentDelegate = selfAssessmentService.GetDelegateSelfAssessmentByCandidateAssessmentsId(candidateAssessmentsId);
-
             if (selfAssessmentDelegate == null)
             {
                 return new NotFoundResult();

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -434,7 +434,11 @@
         [HttpGet]
         public IActionResult RemoveDelegateSelfAssessment(int candidateAssessmentsId)
         {
-            var centreId = User.GetCentreIdKnownNotNull();
+            var checkselfAssessmentDelegate = selfAssessmentService.CheckDelegateSelfAssessment(candidateAssessmentsId);
+            if (checkselfAssessmentDelegate > 0)
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
+            }
             var selfAssessmentDelegate = selfAssessmentService.GetDelegateSelfAssessmentByCandidateAssessmentsId(candidateAssessmentsId);
 
             if (selfAssessmentDelegate == null)
@@ -453,7 +457,7 @@
 
             if (checkselfAssessmentDelegate > 0)
             {
-                return StatusCode((int)HttpStatusCode.Gone);
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             }
             if (ModelState.IsValid && delegateSelfAssessmenteViewModel.ActionConfirmed)
             {

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -139,6 +139,7 @@
        void RemoveDelegateSelfAssessment(int candidateAssessmentsId);
        public int? GetSupervisorsCountFromCandidateAssessmentId(int candidateAssessmentsId);
         public bool CheckForSameCentre(int centreId, int candidateAssessmentsId);
+        int CheckDelegateSelfAssessment(int candidateAssessmentsId);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -502,6 +503,10 @@
         public bool CheckForSameCentre(int centreId, int candidateAssessmentsId)
         {
             return selfAssessmentDataService.CheckForSameCentre(centreId, candidateAssessmentsId);
+        }
+        public int CheckDelegateSelfAssessment(int candidateAssessmentsId)
+        {
+            return selfAssessmentDataService.CheckDelegateSelfAssessment(candidateAssessmentsId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -12,11 +12,11 @@
 <style>
     .nhsuk-grid-column-three-quarters {
         float: left;
-        width: 72%;
+        width: 70%;
     }
     .nhsuk-grid-column-one-quarter {
         float: left;
-        width: 28%;
+        width: 30%;
     }
 </style>
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -14,6 +14,7 @@
         float: left;
         width: 70%;
     }
+
     .nhsuk-grid-column-one-quarter {
         float: left;
         width: 30%;
@@ -37,15 +38,15 @@
 <vc:field-name-value-display display-name="Self Assessment" field-value="@Model.SelfAssessmentsName" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-    
 
-        <form class="nhsuk-u-margin-bottom-3"  asp-controller="ActivityDelegates">
-           
-                <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
+
+        <form class="nhsuk-u-margin-bottom-3" asp-controller="ActivityDelegates">
+
+            <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
                                 label="I am sure that I wish to remove @Model.FirstName @Model.LastName from this self assessment."
                                 hint-text="This action will remove the delegate from the self assessment. Their progress will be archived but can be reinstated by enrolling them on the self assessment again." />
-           
-            
+
+
             <button type="submit" class="nhsuk-button nhsuk-button--danger nhsuk-u-margin-top-4" asp-action="RemoveDelegateSelfAssessment">
                 Remove from self assessment
             </button>
@@ -57,8 +58,8 @@
             @Html.HiddenFor(m => m.SelfAssessmentsName)
             @Html.HiddenFor(m => m.Name)
         </form>
-        <br/>
-       
+        <br />
+
         <vc:cancel-link asp-controller=ActivityDelegates asp-action="Index" asp-all-route-data="@cancelLinkRouteData" />
 
     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/ActivityDelegates/RemoveDelegateSelfAssessment.cshtml
@@ -9,7 +9,16 @@
     cancelLinkRouteData.Add("selfAssessmentId", Model.SelfAssessmentID.ToString());
 
 }
-
+<style>
+    .nhsuk-grid-column-three-quarters {
+        float: left;
+        width: 72%;
+    }
+    .nhsuk-grid-column-one-quarter {
+        float: left;
+        width: 28%;
+    }
+</style>
 @section NavMenuItems {
     <partial name="Shared/_NavMenuItems" />
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1570

### Description
Implemented the back button and expand the width of the column

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/7d585c7b-aaf9-4347-9b67-dafc6d2af309)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/a2bded25-1ca1-43b2-815e-a0a831ce9b56)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
