### PR TITLE
TD-3121-Restricted self assessments when topic and/or admin fields filters are selected

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -145,12 +145,13 @@
             if (isCourse == "Any" && isSelfAssessment == "Any")
             {
                 delegateActivities = courseService.GetDelegateCourses(searchString, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
-                delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+                if (courseTopic == "Any" && hasAdminFields == "Any")
+                    delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
             }
 
             if (isCourse == "true")
                 delegateActivities = courseService.GetDelegateCourses(searchString ?? string.Empty, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
-            if (isSelfAssessment == "true")
+            if (isSelfAssessment == "true" && courseTopic == "Any" && hasAdminFields == "Any")
                 delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
 
             delegateAssessments = UpdateCompletedCount(delegateAssessments);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3121

### Description
Restricted self assessments when topic and/or admin fields filters are selected.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f2207bc3-db65-4730-a3a1-7e3c118413c6)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/dbc142a3-8c45-4610-8e31-476c6ce68e66)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/6f26a1a4-9884-4946-a022-e394acd9e6bc)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
