### PR TITLE
TD-752 Fix self assessment menu mobile view fixes

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -345,12 +345,6 @@ nav, .nhsuk-header__navigation, #header-navigation {
   }
 }
 
-@media only screen and (max-width: $mq-tablet) {
-  .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td li {
-    text-align: justify;
-  }
-}
-
 .dls-alert-banner {
   background-color: $color_nhsuk-dark-pink;
   color: #FFFFFF;

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -40,163 +40,167 @@
 }
 
 @section mobilebacklink
-    {
+{
     <p class="nhsuk-breadcrumb__back">
         <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
-       asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
             Back to @Model.SelfAssessment.Name
         </a>
     </p>
 }
 <h1>@Model.SelfAssessment.Name - @Model.VocabPlural()</h1>
-@if (Model.SelfAssessment.NonReportable)
-{
-    <partial name="_NonReportableSelfAssessment" />
-}
-@if (Model.SelfAssessment.IsSupervised && Model.CompetencyGroups.Count() > 5)
-{
-    <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-        <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-             model="@competencySummaries"
-             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
-    </div>
-}
-<partial name="SelfAssessments/_SearchSelfAssessmentOverview"
-         model="@Model.SearchViewModel"
-         view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
-<partial name="_OverviewActionButtons.cshtml" model=Model />
-<p><span role="alert">@Model.CompetencyGroups.Sum(g => g.Count()) matching @Model.VocabPlural().ToLower()</span></p>
-@if (Model.CompetencyGroups.Any())
-{
-    var competencySummariesEnumerator = competencySummaries.GetEnumerator();
-    foreach (var competencyGroup in Model.CompetencyGroups)
-    {
-        var groupDetails = competencyGroup.First();
-        var questions = competencyGroup.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
-        var selfAssessedCount = questions.Count(q => q.ResultId.HasValue);
-        var verifiedCount = questions.Count(q => q.Verified.HasValue);
-        competencySummariesEnumerator.MoveNext();
-        <div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
-            @{
-                var expanderOpen = Model.CompetencyGroups.Count() == 1
-                ? "open"
-                : ViewContext.RouteData.Values.ContainsKey("competencyGroupId")
-                ? ViewContext.RouteData.Values["competencyGroupId"].Equals(competencyGroup.First().CompetencyGroupID.ToString()) ? "open" : ""
-                : "";
-            }
-            <details class="nhsuk-details nhsuk-expander" @(expanderOpen)>
-                <summary class="nhsuk-details__summary">
-                    <span class="competency-group-title nhsuk-details__summary-text">
-                        @competencyGroup.Key
-                    </span>
-                </summary>
-                <div class="nhsuk-details__text">
-                    <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
-                    @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
-                    {
-                        <p class="nhsuk-body-l nhsuk-u-margin-left-7">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+        @if (Model.SelfAssessment.NonReportable)
+        {
+            <partial name="_NonReportableSelfAssessment" />
+        }
+        @if (Model.SelfAssessment.IsSupervised && Model.CompetencyGroups.Count() > 5)
+        {
+            <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+                <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+                         model="@competencySummaries"
+                         view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+            </div>
+        }
+        <partial name="SelfAssessments/_SearchSelfAssessmentOverview"
+                 model="@Model.SearchViewModel"
+                 view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
+        <partial name="_OverviewActionButtons.cshtml" model=Model />
+        <p><span role="alert">@Model.CompetencyGroups.Sum(g => g.Count()) matching @Model.VocabPlural().ToLower()</span></p>
+        @if (Model.CompetencyGroups.Any())
+        {
+            var competencySummariesEnumerator = competencySummaries.GetEnumerator();
+            foreach (var competencyGroup in Model.CompetencyGroups)
+            {
+                var groupDetails = competencyGroup.First();
+                var questions = competencyGroup.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
+                var selfAssessedCount = questions.Count(q => q.ResultId.HasValue);
+                var verifiedCount = questions.Count(q => q.Verified.HasValue);
+                competencySummariesEnumerator.MoveNext();
+                <div class="nhsuk-panel competency-group-panel nhsuk-u-padding-0">
+                    @{
+                        var expanderOpen = Model.CompetencyGroups.Count() == 1
+                        ? "open"
+                        : ViewContext.RouteData.Values.ContainsKey("competencyGroupId")
+                        ? ViewContext.RouteData.Values["competencyGroupId"].Equals(competencyGroup.First().CompetencyGroupID.ToString()) ? "open" : ""
+                        : "";
                     }
+                    <details class="nhsuk-details nhsuk-expander" @(expanderOpen)>
+                        <summary class="nhsuk-details__summary">
+                            <span class="competency-group-title nhsuk-details__summary-text">
+                                @competencyGroup.Key
+                            </span>
+                        </summary>
+                        <div class="nhsuk-details__text">
+                            <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
+                            @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
+                            {
+                                <p class="nhsuk-body-l nhsuk-u-margin-left-7">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
+                            }
+                            @if (Model.SelfAssessment.LinearNavigation)
+                            {
+                                <partial name="SelfAssessments/_MeanScores"
+                                         view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                            }
+                            <partial name="SelfAssessments/_OverviewTable"
+                                     view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation }, { "selfAssessment", Model.SelfAssessment }, { "ReviewerCommentsLabel", Model.SelfAssessment.ReviewerCommentsLabel } })"
+                                     model="competencyGroup" />
+
+
+                        </div>
+                    </details>
+                    <div class="outer-score-container">
+                        <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
+                    </div>
                     @if (Model.SelfAssessment.LinearNavigation)
                     {
-                        <partial name="SelfAssessments/_MeanScores"
-                     view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                        <div class="outer-score-container nhsuk-u-padding-bottom-4">
+                            <partial name="SelfAssessments/_MeanScores"
+                                     view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
+                        </div>
                     }
-                    <partial name="SelfAssessments/_OverviewTable"
-                     view-data="@(new ViewDataDictionary(ViewData) { { "linearNavigation", Model.SelfAssessment.LinearNavigation }, { "selfAssessment", Model.SelfAssessment }, { "ReviewerCommentsLabel", Model.SelfAssessment.ReviewerCommentsLabel } })"
-                     model="competencyGroup" />
-
-
-                </div>
-            </details>
-            <div class="outer-score-container">
-                <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
-            </div>
-            @if (Model.SelfAssessment.LinearNavigation)
-            {
-                <div class="outer-score-container nhsuk-u-padding-bottom-4">
-                    <partial name="SelfAssessments/_MeanScores"
-                 view-data="@(new ViewDataDictionary(ViewData) { { "competencyGroup", competencyGroup } })" />
                 </div>
             }
-        </div>
-    }
-    <partial name="_OverviewActionButtons.cshtml" model=Model />
-}
+            <partial name="_OverviewActionButtons.cshtml" model=Model />
+        }
 
-@if (Model.SelfAssessment.IncludesSignposting)
-{
-    <p class="nhsuk-u-reading-width">Once you are happy with your responses, submit your self-assessment to retrieve a list of recommended learning resources.</p>
-
-    @if (Configuration.IsSignpostingUsed())
-    {
-        <a class="nhsuk-button finish-review-button trigger-loader"
-   asp-controller="RecommendedLearning"
-   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-   role="button">
-            Submit results
-        </a>
-    }
-    else
-    {
-        <a class="nhsuk-button finish-review-button trigger-loader"
-   asp-controller="RecommendedLearning"
-   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
-   role="button">
-            Submit self assessment
-        </a>
-    }
-}
-@if (Model.SelfAssessment.IsSupervised)
-{
-    <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
-        <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
-             model="@competencySummaries"
-             view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
-        <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
-        <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
-             view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) }})" />
-        @if (Model.AllQuestionsVerifiedOrNotRequired)
+        @if (Model.SelfAssessment.IncludesSignposting)
         {
-            @if (!Model.SupervisorSignOffs.Any())
+            <p class="nhsuk-u-reading-width">Once you are happy with your responses, submit your self-assessment to retrieve a list of recommended learning resources.</p>
+
+            @if (Configuration.IsSignpostingUsed())
             {
-                <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
-            }
-            else if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any() && latestResult > latestSignoff)
-            {
-                <div class="nhsuk-warning-callout">
-                    <h3 class="nhsuk-warning-callout__label">
-                        <span role="text">
-                            <span class="nhsuk-u-visually-hidden">New self assessment results</span>
-                            New self assessment results
-                        </span>
-                    </h3>
-                    <p>
-                        You have submitted new self assessment results since this self assessment was signed off.
-                        Please resubmit your self assessment for sign off once these results are confirmed.
-                    </p>
-                </div>
-            }
-            @if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any()
-           && latestResult > latestSignoff
-           )
-            {
-                <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-                   asp-action="RequestSignOff"
-                   asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
+                <a class="nhsuk-button finish-review-button trigger-loader"
+                   asp-controller="RecommendedLearning"
                    asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+                   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
                    role="button">
-                    Request @Model.SelfAssessment.SignOffRoleName sign-off
+                    Submit results
+                </a>
+            }
+            else
+            {
+                <a class="nhsuk-button finish-review-button trigger-loader"
+                   asp-controller="RecommendedLearning"
+                   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+                   asp-action=@(Model.SelfAssessment.UnprocessedUpdates ? "SelfAssessmentResults" : "RecommendedLearning")
+                   role="button">
+                    Submit self assessment
                 </a>
             }
         }
-        else
+        @if (Model.SelfAssessment.IsSupervised)
         {
-            <p class="nhsuk-body-l">
-                All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
-                before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
-            </p>
+            <div class="nhsuk-panell competency-group-panel nhsuk-u-padding-4">
+                <partial name="SelfAssessments/_SelfAssessmentOverallProgress"
+                         model="@competencySummaries"
+                         view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
+                <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
+                <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
+                         view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) }})" />
+                @if (Model.AllQuestionsVerifiedOrNotRequired)
+                {
+                    @if (!Model.SupervisorSignOffs.Any())
+                    {
+                        <p class="nhsuk-body-l">You have not yet requested @Model.SelfAssessment.SignOffRoleName sign-off for this self assessment.</p>
+                    }
+                    else if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any() && latestResult > latestSignoff)
+                    {
+                        <div class="nhsuk-warning-callout">
+                            <h3 class="nhsuk-warning-callout__label">
+                                <span role="text">
+                                    <span class="nhsuk-u-visually-hidden">New self assessment results</span>
+                                    New self assessment results
+                                </span>
+                            </h3>
+                            <p>
+                                You have submitted new self assessment results since this self assessment was signed off.
+                                Please resubmit your self assessment for sign off once these results are confirmed.
+                            </p>
+                        </div>
+                    }
+                    @if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any()
+                   && latestResult > latestSignoff
+                   )
+                    {
+                        <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
+                           asp-action="RequestSignOff"
+                           asp-route-vocabulary="@Model.SelfAssessment.Vocabulary"
+                           asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+                           role="button">
+                            Request @Model.SelfAssessment.SignOffRoleName sign-off
+                        </a>
+                    }
+                }
+                else
+                {
+                    <p class="nhsuk-body-l">
+                        All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
+                        before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
+                    </p>
+                }
+            </div>
         }
     </div>
-}
+</div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -34,34 +34,39 @@
         <tbody class="nhsuk-table__body row-outer" id="comp-@competency.RowNo">
             <tr class="nhsuk-table__row first-row">
                 <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-text-align-left">
-                    <partial name="_CompetencyFlags"
-                             model="competency.CompetencyFlags"
-                             view-data="@(new ViewDataDictionary(ViewData) {{ "cssClass", $"{(competency.AlwaysShowDescription ? "" : "nhsuk-u-padding-left-4")}" }})" />
-                    @if (competency.Description != null && !competency.AlwaysShowDescription)
-                    {
-                        <details class="nhsuk-details">
-                            <summary class="nhsuk-details__summary nhsuk-u-padding-0">
-                                <span class="nhsuk-u-margin-bottom-0">
-                                    <span class="nhsuk-details__summary-text">@competency.Name</span>
-                                </span>
-                            </summary>
-                            <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
-                                @(Html.Raw(@competency.Description))
-                            </div>
-                        </details>
-                    }
-                    else
-                    {
-                        <p class="@(competency.Description != null ? "nhsuk-u-font-weight-bold" : "") nhsuk-u-margin-bottom-0">
-                            @competency.Name
-                        </p>
-                        @if (competency.Description != null)
-                        {
-                            <p class="nhsuk-u-margin-top-2">
-                                @(Html.Raw(competency.Description))
-                            </p>
-                        }
-                    }
+                  <div class="nhsuk-grid-row">
+                        <div class="nhsuk-grid-column-full">
+                            <partial name="_CompetencyFlags"
+                                     model="competency.CompetencyFlags" />
+                        </div>
+                        <div class="nhsuk-grid-column-full">
+                            @if (competency.Description != null && !competency.AlwaysShowDescription)
+                            {
+                                <details class="nhsuk-details">
+                                    <summary class="nhsuk-details__summary nhsuk-u-padding-0">
+                                        <span class="nhsuk-u-margin-bottom-0">
+                                            <span class="nhsuk-details__summary-text">@competency.Name</span>
+                                        </span>
+                                    </summary>
+                                    <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
+                                        @(Html.Raw(@competency.Description))
+                                    </div>
+                                </details>
+                            }
+                            else
+                            {
+                                <p class="@(competency.Description != null ? "nhsuk-u-font-weight-bold" : "") nhsuk-u-margin-bottom-0">
+                                    @competency.Name
+                                </p>
+                                @if (competency.Description != null)
+                                {
+                                    <p class="nhsuk-u-margin-top-2">
+                                        @(Html.Raw(competency.Description))
+                                    </p>
+                                }
+                            }
+                        </div>
+                  </div>                    
                 </td>
                 <partial name="Shared/_AssessmentQuestionOverviewCells" model="competency.AssessmentQuestions.First()" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo },{ "QuestionLabel", QuestionLabel } })" />
                 <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -1,85 +1,84 @@
 ﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
 @model IGrouping<string, Competency>;
 @{
-  string QuestionLabel = string.IsNullOrWhiteSpace(Model.FirstOrDefault().QuestionLabel) ?
-  "Question" : Model.FirstOrDefault().QuestionLabel;
+    string QuestionLabel = string.IsNullOrWhiteSpace(Model.FirstOrDefault().QuestionLabel) ?
+    "Question" : Model.FirstOrDefault().QuestionLabel;
 }
 
 <table class="nhsuk-table-responsive nhsuk-u-margin-top-4">
-  <thead class="nhsuk-table__head">
-    <tr>
-      <th class="" scope="col">
-        @Model.First().Vocabulary
-      </th>
-      <th class="" scope="col">
-        @QuestionLabel
-      </th>
-      <th class="" scope="col">
-        Self-assessment<br />status
-      </th>
-      @if (((CurrentSelfAssessment)ViewData["selfAssessment"])?.IsSupervisorResultsReviewed ?? true)
-      {
-        <th class="" scope="col">
-          Confirmation<br />status
-        </th>
-      }
-      <th class="" scope="col">
-        <span class="nhsuk-u-visually-hidden">Actions</span>
-      </th>
-    </tr>
-  </thead>
-
-  @foreach (var competency in Model)
-  {
-    <tbody class="nhsuk-table__body row-outer" id="comp-@competency.RowNo">
-      <tr class="nhsuk-table__row first-row">
-        <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
-          <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
-          <partial name="_CompetencyFlags"
-                 model="competency.CompetencyFlags"
-                 view-data="@(new ViewDataDictionary(ViewData) {{ "cssClass", $"{(competency.AlwaysShowDescription ? "" : "nhsuk-u-padding-left-4")}" }})" />
-          @if (competency.Description != null && !competency.AlwaysShowDescription)
-          {
-            <details class="nhsuk-details">
-              <summary class="nhsuk-details__summary">
-                <span class="nhsuk-u-margin-bottom-0">
-                  <span class="nhsuk-details__summary-text">@competency.Name</span>
-                </span>
-              </summary>
-              <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
-                @(Html.Raw(@competency.Description))
-              </div>
-            </details>
-          }
-          else
-          {
-            <p class="@(competency.Description != null ? "nhsuk-u-font-weight-bold" : "") nhsuk-u-margin-bottom-0">
-              @competency.Name
-            </p>
-            @if (competency.Description != null)
+    <thead class="nhsuk-table__head">
+        <tr>
+            <th class="" scope="col">
+                @Model.First().Vocabulary
+            </th>
+            <th class="" scope="col">
+                @QuestionLabel
+            </th>
+            <th class="" scope="col">
+                Self-assessment<br />status
+            </th>
+            @if (((CurrentSelfAssessment)ViewData["selfAssessment"])?.IsSupervisorResultsReviewed ?? true)
             {
-              <p class="nhsuk-u-margin-top-2">
-                @(Html.Raw(competency.Description))
-              </p>
+                <th class="" scope="col">
+                    Confirmation<br />status
+                </th>
             }
-          }
-        </td>
-        <partial name="Shared/_AssessmentQuestionOverviewCells" model="competency.AssessmentQuestions.First()" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo },{ "QuestionLabel", QuestionLabel } })" />
-        <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
-          <span class="nhsuk-table-responsive__heading">Action </span>
-          <a aria-label="Review @competency.Name" asp-action="SelfAssessmentCompetency" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]" asp-route-competencyNumber="@competency.RowNo">
-            Review <span class="nhsuk-u-visually-hidden">@competency.Name</span>
-          </a>
-        </td>
-      </tr>
-      @foreach (var question in competency.AssessmentQuestions.Skip(1))
-      {
-        <tr class="nhsuk-table__row">
-          <partial name="Shared/_AssessmentQuestionOverviewCells" model="question" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo },{ "QuestionLabel", QuestionLabel } })" />
-
+            <th class="" scope="col">
+                <span class="nhsuk-u-visually-hidden">Actions</span>
+            </th>
         </tr>
+    </thead>
 
-      }
-    </tbody>
-  }
+    @foreach (var competency in Model)
+    {
+        <tbody class="nhsuk-table__body row-outer" id="comp-@competency.RowNo">
+            <tr class="nhsuk-table__row first-row">
+                <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-text-align-left">
+                    <partial name="_CompetencyFlags"
+                             model="competency.CompetencyFlags"
+                             view-data="@(new ViewDataDictionary(ViewData) {{ "cssClass", $"{(competency.AlwaysShowDescription ? "" : "nhsuk-u-padding-left-4")}" }})" />
+                    @if (competency.Description != null && !competency.AlwaysShowDescription)
+                    {
+                        <details class="nhsuk-details">
+                            <summary class="nhsuk-details__summary nhsuk-u-padding-0">
+                                <span class="nhsuk-u-margin-bottom-0">
+                                    <span class="nhsuk-details__summary-text">@competency.Name</span>
+                                </span>
+                            </summary>
+                            <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
+                                @(Html.Raw(@competency.Description))
+                            </div>
+                        </details>
+                    }
+                    else
+                    {
+                        <p class="@(competency.Description != null ? "nhsuk-u-font-weight-bold" : "") nhsuk-u-margin-bottom-0">
+                            @competency.Name
+                        </p>
+                        @if (competency.Description != null)
+                        {
+                            <p class="nhsuk-u-margin-top-2">
+                                @(Html.Raw(competency.Description))
+                            </p>
+                        }
+                    }
+                </td>
+                <partial name="Shared/_AssessmentQuestionOverviewCells" model="competency.AssessmentQuestions.First()" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo },{ "QuestionLabel", QuestionLabel } })" />
+                <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                    <span class="nhsuk-table-responsive__heading">Action </span>
+                    <a aria-label="Review @competency.Name" asp-action="SelfAssessmentCompetency" asp-route-selfAssessmentId="@ViewContext.RouteData.Values["selfAssessmentId"]" asp-route-competencyNumber="@competency.RowNo">
+                        Review <span class="nhsuk-u-visually-hidden">@competency.Name</span>
+                    </a>
+                </td>
+            </tr>
+            @foreach (var question in competency.AssessmentQuestions.Skip(1))
+            {
+                <tr class="nhsuk-table__row">
+                    <partial name="Shared/_AssessmentQuestionOverviewCells" model="question" view-data="@(new ViewDataDictionary(ViewData) { { "competencyNumber", competency.RowNo },{ "QuestionLabel", QuestionLabel } })" />
+
+                </tr>
+
+            }
+        </tbody>
+    }
 </table>


### PR DESCRIPTION
### JIRA link
[TD-752](https://hee-tis.atlassian.net/browse/TD-752)

### Description
Fixes mobile view layout issues for the self assessment menu screen.

### Screenshots
![localhost_44363_LearningPortal_SelfAssessment_5_Proficiencies](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/830eea2e-f8b1-4b32-88dd-83414ae64bca)

![localhost_44363_LearningPortal_SelfAssessment_4_Proficiencies](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/dfd7c158-bcfd-4dc5-8044-5b0ff0df77c6)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-752]: https://hee-tis.atlassian.net/browse/TD-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ