### PR TITLE
TD 2973 Added competencies count and implemented filters

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -154,9 +154,9 @@
         IEnumerable<SelfAssessmentDelegate> GetDelegatesOnSelfAssessmentForExport(int? selfAssessmentId, int centreId);
 
         IEnumerable<SelfAssessmentDelegate> GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
-           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun);
+           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff);
         int GetSelfAssessmentActivityDelegatesExportCount(string searchString, string sortBy, string sortDirection,
-          int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed);
+          int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
         string GetSelfAssessmentActivityDelegatesSupervisor(int selfAssessmentId, int delegateUserId);
 
         RemoveSelfAssessmentDelegate GetDelegateSelfAssessmentByCandidateAssessmentsId(int candidateAssessmentsId);
@@ -414,11 +414,12 @@
             return delegates;
         }
         public IEnumerable<SelfAssessmentDelegate> GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
-                    int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun)
+                    int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff)
         {
             searchString = searchString == null ? string.Empty : searchString.Trim();
             var selectColumnQuery = $@"SELECT
                 da.CandidateNumber,
+                ca.Id AS CandidateAssessmentsId,
                 u.ID AS DelegateUserId,
                 u.ProfessionalRegistrationNumber,
                 ca.SelfAssessmentID As SelfAssessmentId,
@@ -459,10 +460,12 @@
                 AND ( u.FirstName + ' ' + u.LastName + ' ' + COALESCE(ucd.Email, u.PrimaryEmail) + ' ' + COALESCE(da.CandidateNumber, '') LIKE N'%' + @searchString + N'%')
                 AND ((@isDelegateActive IS NULL) OR (@isDelegateActive = 1 AND (da.Active = 1)) OR (@isDelegateActive = 0 AND (da.Active = 0)))
 				AND ((@removed IS NULL) OR (@removed = 1 AND (ca.RemovedDate IS NOT NULL)) OR (@removed = 0 AND (ca.RemovedDate IS NULL)))
+                AND ((@submitted IS NULL) OR (@submitted = 1 AND (ca.SubmittedDate IS NOT NULL)) OR (@submitted = 0 AND (ca.SubmittedDate IS NULL)))
                 AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%.__%' ";
 
             var groupBy = $@" GROUP BY 
 				da.CandidateNumber,
+                ca.Id,
                 u.ID,
                 u.ProfessionalRegistrationNumber,
                 ca.SelfAssessmentID,
@@ -489,6 +492,11 @@
                 da.Answer5,
                 da.Answer6";
 
+            if (signedOff != null)
+            {
+                groupBy += (bool)signedOff ? " HAVING MAX(casv.Verified) IS NOT NULL " : " HAVING MAX(casv.Verified) IS NULL ";
+            }
+
             string orderBy;
             string sortOrder = sortDirection == "Ascending" ? "ASC" : "DESC";
 
@@ -500,6 +508,10 @@
                 orderBy = " ORDER BY ca.CompletedDate " + sortOrder + ", LTRIM(u.LastName)";
             else if (sortBy == "CandidateNumber")
                 orderBy = " ORDER BY da.CandidateNumber " + sortOrder + ", LTRIM(u.LastName)";
+            else if (sortBy == "SubmittedDate")
+                orderBy = " ORDER BY ca.SubmittedDate " + sortOrder;
+            else if (sortBy == "SignedOff")
+                orderBy = " ORDER BY SignedOff " + sortOrder;
             else
                 orderBy = " ORDER BY LTRIM(u.LastName) " + sortOrder + ", LTRIM(u.FirstName) ";
 
@@ -519,7 +531,9 @@
                     centreId,
                     isDelegateActive,
                     removed,
-                    currentRun
+                    currentRun,
+                    submitted,
+                    signedOff
                 },
                 commandTimeout: 3000
             );
@@ -528,7 +542,7 @@
             return delegateUserCard;
         }
         public int GetSelfAssessmentActivityDelegatesExportCount(string searchString, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed)
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff)
         {
             searchString = searchString == null ? string.Empty : searchString.Trim();
 
@@ -550,6 +564,7 @@
                 AND ( u.FirstName + ' ' + u.LastName + ' ' + COALESCE(ucd.Email, u.PrimaryEmail) + ' ' + COALESCE(da.CandidateNumber, '') LIKE N'%' + @searchString + N'%')
                 AND ((@isDelegateActive IS NULL) OR (@isDelegateActive = 1 AND (da.Active = 1)) OR (@isDelegateActive = 0 AND (da.Active = 0)))
 				AND ((@removed IS NULL) OR (@removed = 1 AND (ca.RemovedDate IS NOT NULL)) OR (@removed = 0 AND (ca.RemovedDate IS NULL)))
+                AND ((@submitted IS NULL) OR (@submitted = 1 AND (ca.SubmittedDate IS NOT NULL)) OR (@submitted = 0 AND (ca.SubmittedDate IS NULL)))
                 AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%.__%' ";
 
             var groupBy = $@" GROUP BY 
@@ -574,6 +589,10 @@
                 COALESCE(ucd.Email, u.PrimaryEmail),
                 da.Active";
 
+            if (signedOff != null)
+            {
+                groupBy += (bool)signedOff ? " HAVING MAX(casv.Verified) IS NOT NULL " : " HAVING MAX(casv.Verified) IS NULL ";
+            }
 
             var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches " + fromTableQuery + whereQuery;
 
@@ -587,7 +606,9 @@
                     selfAssessmentId,
                     centreId,
                     isDelegateActive,
-                    removed
+                    removed,
+                    submitted,
+                    signedOff
                 },
                 commandTimeout: 3000
             );

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -371,8 +371,8 @@
             sortDirection ??= GenericSortingHelper.Ascending;
 
 
-            bool? isDelegateActive, isProgressLocked, removed, hasCompleted;
-            isDelegateActive = isProgressLocked = removed = hasCompleted = null;
+            bool? isDelegateActive, isProgressLocked, removed, hasCompleted, submitted, signedOff;
+            isDelegateActive = isProgressLocked = removed = hasCompleted = submitted = signedOff = null;
 
             string? answer1, answer2, answer3;
             answer1 = answer2 = answer3 = null;
@@ -417,12 +417,19 @@
 
                         if (filter.Contains("Answer3"))
                             answer3 = filterValue;
+
+                        if (filter.Contains("Submitted"))
+                            submitted = filterValue;
+
+                        if (filter.Contains("SignedOff"))
+                            signedOff = filterValue;
                     }
                 }
             }
+            var adminId = User.GetCustomClaimAsRequiredInt(CustomClaimTypes.UserAdminId);
             var itemsPerPage = Data.Extensions.ConfigurationExtensions.GetExportQueryRowLimit(configuration);
             var content = delegateActivityDownloadFileService.GetSelfAssessmentsInActivityDelegatesDownloadFile(searchString ?? string.Empty, itemsPerPage, sortBy, sortDirection,
-                        selfAssessmentId, centreId, isDelegateActive, removed
+                        selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff, adminId
             );
 
             string fileName = $"{selfAssessmentService.GetSelfAssessmentNameById(selfAssessmentId)} delegates - {clockUtility.UtcNow:dd-MM-yyyy}.xlsx";

--- a/DigitalLearningSolutions.Web/Services/DelegateActivityDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateActivityDownloadFileService.cs
@@ -151,8 +151,8 @@ namespace DigitalLearningSolutions.Web.Services
                     new DataColumn(SubmittedDate),
                     new DataColumn(SignedOffDate),
                     new DataColumn(SignedOffBy),
-                    new DataColumn(SelfAssessedCompetenciesCount),
-                    new DataColumn(ConfirmedCompetenciesCount),
+                    new DataColumn(SelfAssessedCompetenciesCount, typeof(int)),
+                    new DataColumn(ConfirmedCompetenciesCount, typeof(int)),
                 }
             );
 

--- a/DigitalLearningSolutions.Web/Services/DelegateActivityDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateActivityDownloadFileService.cs
@@ -3,16 +3,20 @@ using DigitalLearningSolutions.Data.Helpers;
 using DigitalLearningSolutions.Data.Models.CourseDelegates;
 using DigitalLearningSolutions.Data.Models.CustomPrompts;
 using DigitalLearningSolutions.Data.Models.SelfAssessments;
+using DigitalLearningSolutions.Data.Models.User;
+using DigitalLearningSolutions.Web.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
+using System.Linq;
 
 namespace DigitalLearningSolutions.Web.Services
 {
     public interface IDelegateActivityDownloadFileService
     {
         public byte[] GetSelfAssessmentsInActivityDelegatesDownloadFile(string searchString, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int adminId
        );
     }
     public class DelegateActivityDownloadFileService : IDelegateActivityDownloadFileService
@@ -42,7 +46,7 @@ namespace DigitalLearningSolutions.Web.Services
             this.registrationPromptsService = registrationPromptsService;
         }
         public byte[] GetSelfAssessmentsInActivityDelegatesDownloadFile(string searchString, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int adminId
        )
         {
             using var workbook = new XLWorkbook();
@@ -52,7 +56,7 @@ namespace DigitalLearningSolutions.Web.Services
                 centreId,
                 searchString,
                 sortBy,
-                sortDirection, selfAssessmentId, isDelegateActive, removed, itemsPerPage
+                sortDirection, selfAssessmentId, isDelegateActive, removed, itemsPerPage, submitted, signedOff, adminId
             );
 
             using var stream = new MemoryStream();
@@ -64,20 +68,35 @@ namespace DigitalLearningSolutions.Web.Services
            int centreId,
            string? searchString,
        string? sortBy,
-       string sortDirection, int? selfAssessmentId, bool? isDelegateActive, bool? removed, int itemsPerPage
+       string sortDirection, int? selfAssessmentId, bool? isDelegateActive, bool? removed, int itemsPerPage, bool? submitted, bool? signedOff, int adminId
        )
         {
             var selfAssessmentDelegatesData = new SelfAssessmentDelegatesData();
             var resultCount = 0;
             resultCount = selfAssessmentService.GetSelfAssessmentActivityDelegatesExportCount(searchString ?? string.Empty, sortBy, sortDirection,
-                        selfAssessmentId, centreId, isDelegateActive, removed);
+                        selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
             int totalRun = (int)(resultCount / itemsPerPage) + ((resultCount % itemsPerPage) > 0 ? 1 : 0);
             int currentRun = 1;
             List<SelfAssessmentDelegatesData> SelfAssessmentDelegatesDataList = new List<SelfAssessmentDelegatesData>();
             while (totalRun >= currentRun)
             {
                 (selfAssessmentDelegatesData) = selfAssessmentService.GetSelfAssessmentActivityDelegatesExport(searchString ?? string.Empty, itemsPerPage, sortBy, sortDirection,
-                        selfAssessmentId, centreId, isDelegateActive, removed, currentRun);
+                        selfAssessmentId, centreId, isDelegateActive, removed, currentRun, submitted, signedOff);                
+                foreach (var delagate in selfAssessmentDelegatesData.Delegates ?? Enumerable.Empty<SelfAssessmentDelegate>())
+                {
+                    var competencies = selfAssessmentService.GetCandidateAssessmentResultsById(delagate.CandidateAssessmentsId, adminId).ToList();
+                    if (competencies?.Count() > 0)
+                    {
+                        var questions = competencies.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
+                        var selfAssessedCount = questions.Count(q => q.Result.HasValue);
+                        var verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required));
+
+                        delagate.Progress = "Self assessed: " + selfAssessedCount + " / " + questions.Count() + Environment.NewLine +
+                                            "Confirmed: " + verifiedCount + " / " + questions.Count();
+                        delagate.SelfAssessed = selfAssessedCount;
+                        delagate.Confirmed = verifiedCount;
+                    }
+                }
                 SelfAssessmentDelegatesDataList.Add(selfAssessmentDelegatesData);
                 currentRun++;
             }
@@ -132,6 +151,8 @@ namespace DigitalLearningSolutions.Web.Services
                     new DataColumn(SubmittedDate),
                     new DataColumn(SignedOffDate),
                     new DataColumn(SignedOffBy),
+                    new DataColumn(SelfAssessedCompetenciesCount),
+                    new DataColumn(ConfirmedCompetenciesCount),
                 }
             );
 
@@ -175,7 +196,8 @@ namespace DigitalLearningSolutions.Web.Services
             row[SignedOffDate] = selfAssessmentDelegatesActivityRecord.SignedOff;
             row[SignedOffBy] = selfAssessmentService.GetSelfAssessmentActivityDelegatesSupervisor
                                                     (selfAssessmentDelegatesActivityRecord.SelfAssessmentId, selfAssessmentDelegatesActivityRecord.DelegateUserId);
-
+            row[SelfAssessedCompetenciesCount] = selfAssessmentDelegatesActivityRecord.SelfAssessed;
+            row[ConfirmedCompetenciesCount] = selfAssessmentDelegatesActivityRecord.Confirmed;
             dataTable.Rows.Add(row);
         }
         private static void AddSheetToWorkbook(IXLWorkbook workbook, string sheetName, IEnumerable<object>? dataObjects)

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -131,9 +131,9 @@
         public (SelfAssessmentDelegatesData, int) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
             int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
         public SelfAssessmentDelegatesData GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
-           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun);
+           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff);
         public int GetSelfAssessmentActivityDelegatesExportCount(string searchString,  string sortBy, string sortDirection,
-           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed);
+           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
         public string GetSelfAssessmentActivityDelegatesSupervisor(int selfAssessmentId, int delegateUserId);
         RemoveSelfAssessmentDelegate GetDelegateSelfAssessmentByCandidateAssessmentsId(int candidateAssessmentsId);
        void RemoveDelegateSelfAssessment(int candidateAssessmentsId);
@@ -457,10 +457,10 @@
             return (new SelfAssessmentDelegatesData(selfAssessmentDelegateList), resultCount);
         }
         public SelfAssessmentDelegatesData GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun)
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff)
         {
             var delegateselfAssessments = selfAssessmentDataService.GetSelfAssessmentActivityDelegatesExport(searchString, itemsPerPage, sortBy, sortDirection,
-            selfAssessmentId, centreId, isDelegateActive, removed, currentRun);
+            selfAssessmentId, centreId, isDelegateActive, removed, currentRun, submitted, signedOff);
 
             List<SelfAssessmentDelegate> selfAssessmentDelegateList = new List<SelfAssessmentDelegate>();
             foreach (var delegateInfo in delegateselfAssessments)
@@ -476,10 +476,10 @@
             return new SelfAssessmentDelegatesData(selfAssessmentDelegateList);
         }
         public int GetSelfAssessmentActivityDelegatesExportCount(string searchString, string sortBy, string sortDirection,
-           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed)
+           int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff)
         {
             int resultCount = selfAssessmentDataService.GetSelfAssessmentActivityDelegatesExportCount(searchString, sortBy, sortDirection,
-            selfAssessmentId, centreId, isDelegateActive, removed);
+            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
 
 
             return resultCount;


### PR DESCRIPTION
### JIRA link
[TD-2973](https://hee-tis.atlassian.net/browse/TD-2973)

### Description
Added competencies count and implemented filters

### Screenshots
Activities Delegates screen - 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/b3fd9cf4-6e52-4990-a31a-aa154cf8ab8f)

Exported file- 
Contains only 1 record as per above screenshot (signed off filter applied). Also shows the competencies count
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/767ee8ca-d672-4696-a283-10e5368870c4)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2973]: https://hee-tis.atlassian.net/browse/TD-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ