### PR TITLE
TD-2286 Fix testing fails - tweak label and fix remove attachment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
@@ -98,7 +98,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
                 ModelState.AddModelError("Id", "Please choose a request type");
                 return View("TypeOfRequest", model1);
             }
-            return RedirectToAction("RequestSummary", new { dlsSubApplication } );
+            return RedirectToAction("RequestSummary", new { dlsSubApplication });
         }
 
         [Route("/{dlsSubApplication}/RequestSupport/RequestSummary")]
@@ -184,20 +184,29 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
                 };
                 RequestAttachmentList.Add(RequestAttachment);
             }
-            
+
             data.setImageFiles(RequestAttachmentList);
             TempData.Set(data);
             return RedirectToAction("RequestAttachment", new { dlsSubApplication });
         }
+
         [Route("/{dlsSubApplication}/RequestSupport/SetAttachment/DeleteImage")]
-        public IActionResult DeleteImage(DlsSubApplication dlsSubApplication, string imageName, string imageId)
+        public IActionResult DeleteImage(DlsSubApplication dlsSubApplication, string imageName)
         {
             var data = TempData.Peek<RequestSupportTicketData>()!;
             if (data.RequestAttachment != null)
             {
-                DeleteFilesAfterSubmitSupportTicket(data.RequestAttachment);
+                var attachmentToRemove = data.RequestAttachment.FirstOrDefault(a => a.FileName == imageName);
+                if (attachmentToRemove != null)
+                {
+                    data.RequestAttachment.Remove(attachmentToRemove);
+                    var uploadDir = Path.Combine(webHostEnvironment.WebRootPath, "Uploads", attachmentToRemove.FullFileName);
+                    if (System.IO.File.Exists(uploadDir))
+                    {
+                        System.IO.File.Delete(uploadDir);
+                    }
+                }
             }
-            data.RequestAttachment.RemoveAll((x) => x.FileName == imageName && x.Id == imageId);
             TempData.Set(data);
             return RedirectToAction("RequestAttachment", new { dlsSubApplication });
         }

--- a/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestSummary.cshtml
@@ -34,7 +34,7 @@
             <h1 class="nhsuk-heading-xl">@Model.RequestType</h1>
             <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="SetRequestSummary" asp-all-route-data="@cancelLinkData">
                 <vc:text-input asp-for="RequestSubject"
-                               label="Summary of your problem or request"
+                               label="Enter a summary of your problem or request"
                                populate-with-current-value="true"
                                type="text"
                                spell-check="false"


### PR DESCRIPTION
### JIRA link
[TD-2286](https://hee-tis.atlassian.net/browse/TD-2286)

### Description
Fixes error when one of many attachments is removed from the ticket before submitting. The code was removing all attachment files when a file was removed. We now match the filename and delete only that file. Also tweaks label of the "summary" field to make it closer to the wireframe.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2286]: https://hee-tis.atlassian.net/browse/TD-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ