### PR TITLE
TD-2988 overlapping action links- Issue Fix

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
@@ -39,7 +39,7 @@
     <table role="table" class="nhsuk-table-responsive">
         <thead role="rowgroup" class="nhsuk-table__head">
             <tr role="row">
-                <th role="columnheader" class="nhsuk-u-width-one-half" scope="col">
+                <th role="columnheader" scope="col">
                     Competency
                 </th>
                 <th role="columnheader" scope="col">
@@ -48,7 +48,7 @@
                 <th role="columnheader" scope="col">
                     Response
                 </th>
-                <th role="columnheader" scope="col">
+                <th role="columnheader" scope="col" style="width: 17% !important">
                     Request
                 </th>
             </tr>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2988

### Description
Increased width of table column 'Request'.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/cea86a50-951a-4cc0-b348-655951709b59)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1232c1c7-130a-4cb2-be42-0972015d357a)

-----
### Developer checks

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
