### PR TITLE
TD-2878- UAR: Showing incorrect msg on 'Edit details' screen - Fixed

### DIFF
--- a/DigitalLearningSolutions.Web/Views/VerifyYourEmail/_EmailChanged.cshtml
+++ b/DigitalLearningSolutions.Web/Views/VerifyYourEmail/_EmailChanged.cshtml
@@ -3,47 +3,36 @@
 @model VerifyYourEmailViewModel
 
 @{
-  var primaryEmailIsVerified = Model.PrimaryEmail == null;
-  var endingText = Model.SingleUnverifiedEmail
-    ? VerifyYourEmailTextHelper.DirectionsToResendLinkByVisitingMyAccountPage(false)
-    : VerifyYourEmailTextHelper.VerifyEmailLinkCommonInfo(true) + " " +
-      VerifyYourEmailTextHelper.DirectionsToResendLinkByVisitingMyAccountPage(true);
+    var primaryEmailIsVerified = Model.PrimaryEmail == null;
+    var endingText = Model.SingleUnverifiedEmail
+      ? VerifyYourEmailTextHelper.DirectionsToResendLinkByVisitingMyAccountPage(false)
+      : VerifyYourEmailTextHelper.VerifyEmailLinkCommonInfo(true) + " " +
+        VerifyYourEmailTextHelper.DirectionsToResendLinkByVisitingMyAccountPage(true);
 }
 
 @if (!primaryEmailIsVerified)
 {
-  var primaryEmailOnlyExplanation = VerifyYourEmailTextHelper.VerifyEmailLinkCommonInfo(false);
+    var primaryEmailOnlyExplanation = VerifyYourEmailTextHelper.VerifyEmailLinkCommonInfo(false);
 
-  <p class="nhsuk-body-m">
-    You've updated your primary email address: <strong>@Model.PrimaryEmail</strong>.
-    @(Model.SingleUnverifiedEmail ? primaryEmailOnlyExplanation : "")
-    You will not be able to access any centre accounts until it is verified.
-  </p>
-}
-
-@if (primaryEmailIsVerified && Model.SingleUnverifiedEmail)
-{
-  <p>
-    You've updated your email address
-    for your account at <strong>@Model.CentreSpecificEmails.First().centreName</strong>.
-    An email with a verification link has been sent to <strong>@Model.CentreSpecificEmails.First().centreEmail</strong>.
-    Please click the link to verify your email address.
-    @VerifyYourEmailTextHelper.UnverifiedCentreEmailConsequences
-  </p>
+    <p class="nhsuk-body-m">
+        You've updated your primary email address: <strong>@Model.PrimaryEmail</strong>.
+        @(Model.SingleUnverifiedEmail ? primaryEmailOnlyExplanation : "")
+        You will not be able to access any centre accounts until it is verified.
+    </p>
 }
 
 @if (Model.CentreSpecificEmails.Count() > 0)
 {
-  foreach (var ((_, centreName, centreEmail), index) in Model.CentreSpecificEmails
-    .Select((emailAndCentreNames, index) => (emailAndCentreNames, index)))
-  {
-    var isTheFirstEmailListed = primaryEmailIsVerified && index == 0;
-    <p>
+    foreach (var ((_, centreName, centreEmail), index) in Model.CentreSpecificEmails
+      .Select((emailAndCentreNames, index) => (emailAndCentreNames, index)))
+    {
+        var isTheFirstEmailListed = primaryEmailIsVerified && index == 0;
+        <p>
             You've @(isTheFirstEmailListed ? "" : "also") updated your centre email address
-      for your account at <strong>@centreName</strong>: <strong>@centreEmail</strong>.
-      @VerifyYourEmailTextHelper.UnverifiedCentreEmailConsequences
-    </p>
-  }
+            for your account at <strong>@centreName</strong>: <strong>@centreEmail</strong>.
+            @VerifyYourEmailTextHelper.UnverifiedCentreEmailConsequences
+        </p>
+    }
 
-  <p class="nhsuk-body-m">@endingText</p>
+    <p class="nhsuk-body-m">@endingText</p>
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2878

### Description
Extra message removed.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/9de9b4af-427f-40a7-96a2-b2c1e5bc95f5)


-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
