### PR TITLE
TD-3128 Fixing problems with assigning Educator/Manager and Accessor

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1111,6 +1111,10 @@
         public IActionResult RemoveDelegateSelfAssessmentsupervisor(int candidateAssessmentId, int supervisorDelegateId)
         {
             supervisorService.RemoveDelegateSelfAssessmentsupervisor(candidateAssessmentId, supervisorDelegateId);
+            if (TempData["IsAssessmentsSupervise"] != null)
+            {
+                TempData.Remove("IsAssessmentsSupervise");
+            }
             return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = supervisorDelegateId });
         }
 

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
@@ -58,7 +58,7 @@
                         {
                             <a asp-action="RemoveDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Remove</a>
                         }
-                        else
+                        @if (delegateSelfAssessment.CompletedDate == null && delegateSelfAssessment.LaunchCount != 0 && delegateSelfAssessment.SupervisorRoleTitle == "Educator/Manager")
                         {
                             <a asp-action="RemoveDelegateSelfAssessmentsupervisor" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Stop supervising</a>
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3128

### Description
Fixing the bug when clicking ‘supervise’/'Not supervising' links multiple times 
Ensuring the stop supervising link shows only when ‘Educator/Manager’ role is assign to self assessment
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/99528565-5798-4ca5-a1d3-0fd81954503a)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
