### PR TITLE
TD-3202-filter issue for Delegate activity export - fixed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -225,8 +225,17 @@
                         if (filter.Contains("CategoryName"))
                             categoryName = filterValue;
 
+                        if (filter.Contains("CourseTopic"))
+                            courseTopic = filterValue;
+
                         if (filter.Contains("Active"))
                             isActive = filterValue;
+
+                        if (filter.Contains("NotActive"))
+                            isActive = "false";
+
+                        if (filter.Contains("HasAdminFields"))
+                            hasAdminFields = filterValue;
 
                         if (filter.Contains("Course|"))
                             isCourse = filterValue;
@@ -240,6 +249,8 @@
             if (!string.IsNullOrEmpty(existingFilterString))
             {
                 var filters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
+                if (existingFilterString.Contains("NotActive"))
+                    existingFilterString = existingFilterString.Replace("NotActive|true", "Active|false");
 
                 foreach (var filter in filters)
                 {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3202

### Description
Filter variable assigned "NotActive" and "HasAdminFields" filters.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/23803204-d660-415c-8bb6-2671535eae29)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2b24461f-4012-4004-88ec-f00ec0035b80)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
