### PR TITLE
TD-3255 -Super Admin Centres page - search field if left blank results in 500 error 

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -66,6 +66,8 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                 page = 1;
             }
 
+            search = search == null ? string.Empty : search.Trim();
+
             int offSet = ((page - 1) * itemsPerPage) ?? 0;
             centreStatus = (string.IsNullOrEmpty(centreStatus) ? "Any" : centreStatus);
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3255

### Description
 Empty string  assigned to 'search' variable when it is null

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/025afa93-02e1-486f-8469-1a5ba010a8d0)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
