### PR TITLE
TD 2958 Fixed edit same group name issue

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -92,6 +92,7 @@
             int? jobGroupId
         );
         bool IsDelegateGroupExist(string groupLabel);
+        string GetDelegateGroupNameFromId(int groupId);
     }
 
     public class GroupsDataService : IGroupsDataService
@@ -573,6 +574,15 @@
                 ELSE CAST(0 AS BIT) END",
                 new { groupLabel }
             );
+        }
+        
+        public string GetDelegateGroupNameFromId(int groupId)
+        {
+            string groupName = connection.QuerySingle<string>(
+                @"SELECT GroupLabel from Groups where GroupID = @groupId",
+                new { groupId }
+            );
+            return groupName;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -296,7 +296,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 return NotFound();
             }
 
-            if (!groupsService.IsDelegateGroupExist(model.GroupName.Trim()))
+            if (!groupsService.IsDelegateGroupExist(model.GroupName.Trim()) || (groupsService.GetDelegateGroupNameFromId(groupId).Trim() == model.GroupName.Trim()))
             {
                 groupsService.UpdateGroupName(
                 groupId,

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -136,6 +136,7 @@
         );
 
         bool IsDelegateGroupExist(string groupLabel);
+        string GetDelegateGroupNameFromId(int groupId);
     }
 
     public class GroupsService : IGroupsService
@@ -897,6 +898,11 @@
         public bool IsDelegateGroupExist(string groupLabel)
         {
             return groupsDataService.IsDelegateGroupExist(groupLabel);
+        }
+
+        public string GetDelegateGroupNameFromId(int groupId)
+        {
+            return groupsDataService.GetDelegateGroupNameFromId(groupId);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-2958](https://hee-tis.atlassian.net/browse/TD-2958)

### Description
Introduced a new method 'GetDelegateGroupNameFromId' to get the group name from the group ID. Then compared this group name with the group name in the existing model. If it is the same (no changes made in group name on edit screen), then proceeded with an update otherwise shows error.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2958]: https://hee-tis.atlassian.net/browse/TD-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ