### PR TITLE
TD-3304-Delegate activities export issue when filters Type: Couse and Staus: Inactive/archived - Fixed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -248,9 +248,10 @@
 
             if (!string.IsNullOrEmpty(existingFilterString))
             {
-                var filters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
                 if (existingFilterString.Contains("NotActive"))
                     existingFilterString = existingFilterString.Replace("NotActive|true", "Active|false");
+
+                var filters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
 
                 foreach (var filter in filters)
                 {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3304

### Description
Updated the filter string before removing the Type filter.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/0577a617-52e3-4338-b5e2-a8241f5a2fd2)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/a8ec509f-2a94-4789-83b1-7d24b6ecd5f3)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
