### PR TITLE
TD-2286 Allow mp4 support ticket attachments

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/Support/RequestSupportTicket/RequestAttachmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Support/RequestSupportTicket/RequestAttachmentViewModel.cs
@@ -14,7 +14,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Support.RequestSupportTicket
             )
         {
             SizeLimit = 20;
-            AllowedExtensions = new string[] { ".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG" };
+            AllowedExtensions = new string[] { ".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG", ".mp4", ".MP4" };
         }
         public RequestAttachmentViewModel(RequestSupportTicketData data)
         {


### PR DESCRIPTION
### JIRA link
[TD-2286](https://hee-tis.atlassian.net/browse/TD-2286)

### Description
Fixes issue found in testing where attaching an mp4 to a support request triggers a validation error. This change simply adds mp4 to the list of allowed extensions in the ViewModel.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/89bbc61e-6be1-4a82-a205-a69fd8164e82)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2286]: https://hee-tis.atlassian.net/browse/TD-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ