### PR TITLE
TD-752 Mobile view tag alignment fix

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/index.scss
+++ b/DigitalLearningSolutions.Web/Styles/index.scss
@@ -163,6 +163,10 @@ h1#page-heading {
   }
 }
 
+.nhsuk-tag {
+    text-align: center;
+}
+
 .right-align-tag-column {
   padding: 0;
 


### PR DESCRIPTION
### JIRA link
[TD-752](https://hee-tis.atlassian.net/browse/TD-752)

### Description
Site wide scss fix to ensure tag text is always centre aligned.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-752]: https://hee-tis.atlassian.net/browse/TD-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ