### PR TITLE
TD 2958 Fixed edit same group name issue and included centre in condition

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -91,7 +91,7 @@
             string? option,
             int? jobGroupId
         );
-        bool IsDelegateGroupExist(string groupLabel);
+        bool IsDelegateGroupExist(string groupLabel, int centreId);
     }
 
     public class GroupsDataService : IGroupsDataService
@@ -565,13 +565,13 @@
             );
         }
 
-        public bool IsDelegateGroupExist(string groupLabel)
+        public bool IsDelegateGroupExist(string groupLabel, int centreId)
         {
             return connection.QuerySingle<bool>(
-                @"SELECT CASE WHEN EXISTS (select * from Groups where GroupLabel like @groupLabel and RemovedDate is null)
+                @"SELECT CASE WHEN EXISTS (select * from Groups where GroupLabel = @groupLabel and RemovedDate is null and CentreID = @centreId)
                 THEN CAST(1 AS BIT)
                 ELSE CAST(0 AS BIT) END",
-                new { groupLabel }
+                new { groupLabel, centreId }
             );
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -215,8 +215,8 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             {
                 return View(model);
             }
-
-            if (!groupsService.IsDelegateGroupExist(model.GroupName.Trim()))
+            var centreId = User.GetCentreIdKnownNotNull();
+            if (!groupsService.IsDelegateGroupExist(model.GroupName.Trim(), centreId))
             {
                 groupsService.AddDelegateGroup(
                 User.GetCentreIdKnownNotNull(),
@@ -296,7 +296,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 return NotFound();
             }
 
-            if (!groupsService.IsDelegateGroupExist(model.GroupName.Trim()))
+            if ( (!groupsService.IsDelegateGroupExist(model.GroupName.Trim(), centreId)) || (group.GroupLabel.Trim()== model.GroupName.Trim()) )
             {
                 groupsService.UpdateGroupName(
                 groupId,

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -135,7 +135,7 @@
             AccountDetailsData accountDetailsData
         );
 
-        bool IsDelegateGroupExist(string groupLabel);
+        bool IsDelegateGroupExist(string groupLabel, int centreId);
     }
 
     public class GroupsService : IGroupsService
@@ -894,9 +894,9 @@
             return $"{prefix} - {groupName}";
         }
 
-        public bool IsDelegateGroupExist(string groupLabel)
+        public bool IsDelegateGroupExist(string groupLabel, int centreId)
         {
-            return groupsDataService.IsDelegateGroupExist(groupLabel);
+            return groupsDataService.IsDelegateGroupExist(groupLabel, centreId);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-2958](https://hee-tis.atlassian.net/browse/TD-2958)

### Description
1. Compared group name from group ID with the group name in the existing model. If it is the same (no changes made in group name on edit screen), then proceeded with an update otherwise shows error.
2. Introduced centreID in IsDelegateGroupExist method to check for groups within same centre.
### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2958]: https://hee-tis.atlassian.net/browse/TD-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ