### PR TITLE
TD-3313- Issue with 'Delegates' count showing as '0' on 'Delegates Groups' screen for the listed groups

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -165,17 +165,14 @@
                         GroupID,
                         GroupLabel,
                         GroupDescription,
-                        (SELECT  COUNT(*) FROM ( SELECT
-							da.CentreID,
-							COALESCE(ucd.Email, u.PrimaryEmail) AS EmailAddress,
-							u.JobGroupId
-								FROM DelegateAccounts AS da WITH (NOLOCK)
-						INNER JOIN Centres AS c WITH (NOLOCK) ON c.CentreID = da.CentreID
-						INNER JOIN Users AS u WITH (NOLOCK) ON u.ID = da.UserID
-						LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
-						INNER JOIN JobGroups AS jg WITH (NOLOCK) ON jg.JobGroupID = u.JobGroupID  where c.CentreID = @centreId
-						AND u.JobGroupID = (select JobGroupID from JobGroups where JobGroupName = GroupLabel))  D  Where 
-						EmailAddress LIKE '%_@_%.__%') AS DelegateCount,
+                        (SELECT COUNT(*) 
+                            FROM GroupDelegates AS gd WITH (NOLOCK)
+                            JOIN DelegateAccounts AS da WITH (NOLOCK) ON da.ID = gd.DelegateID
+                            JOIN Users AS u WITH (NOLOCK) ON u.ID = da.UserID
+                            LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = u.ID AND ucd.CentreID = da.CentreID
+                            WHERE gd.GroupID = g.GroupID
+                                AND (u.PrimaryEmail like '%_@_%.__%' OR ucd.Email is NOT NULL)
+                                AND da.Approved = 1 AND da.Active = 1) AS DelegateCount,
                         ({CourseCountSql}) AS CoursesCount,
                         g.CreatedByAdminUserID AS AddedByAdminId,
                         au.Forename AS AddedByFirstName,
@@ -320,7 +317,9 @@
                     JOIN DelegateAccounts AS da ON da.ID = gd.DelegateID
                     JOIN Users AS u ON u.ID = da.UserID
                     LEFT JOIN UserCentreDetails AS ucd ON ucd.UserID = u.ID AND ucd.CentreID = da.CentreID
-                    WHERE gd.GroupID = @groupId",
+                    WHERE gd.GroupID = @groupId
+                        AND (u.PrimaryEmail like '%_@_%.__%' OR ucd.Email is NOT NULL)
+                        AND da.Approved = 1 AND da.Active = 1",
                 new { groupId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -347,6 +347,7 @@
                         WHERE da.CentreId = @centreId
                         AND da.Approved = 1
                         AND da.Active = 1
+                        AND (u.PrimaryEmail like '%_@_%.__%' OR ucd.Email IS NOT NULL)
                         AND NOT EXISTS (SELECT DelegateID FROM GroupDelegates WHERE DelegateID = da.ID
                                         AND GroupID = @groupId)",
                 new

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -524,7 +524,7 @@
 
         public IEnumerable<GroupDelegate> GetGroupDelegates(int groupId)
         {
-            return groupsDataService.GetGroupDelegates(groupId).Where(gd => gd.CentreEmail != null || !Guid.TryParse(gd.PrimaryEmail, out _));
+            return groupsDataService.GetGroupDelegates(groupId);
         }
 
         public IEnumerable<GroupCourse> GetUsableGroupCoursesForCentre(int groupId, int centreId)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3313

### Description
'View delegates' query used to show delegate count.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8546b4c7-715d-4e26-a7bb-8c5fcee22abf)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/dea8e4b4-3a82-4b68-bc15-ffe8a24ab2a3)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/fea711e3-436a-4a5d-a2f2-2ab9ad8188fa)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b1acdd2c-d49c-40d5-96e0-c2be1673011e)

-----
### Developer checks
I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
