### PR TITLE
TD-3128-fix problems with user permissions for removing supervisors from self assessments test failed issue

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1006,7 +1006,6 @@
                 if (TempData["IsAssessmentsSupervise"] != null)
                 {
                     TempData.Remove("IsAssessmentsSupervise");
-                    return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
                 }
 
                 var sessionEnrolOnRoleProfile = new SessionEnrolOnRoleProfile()


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3128

### Description
removing the redirect to error 410 page

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/392b2cfc-a8e2-40ea-8aea-9052f0ba24f7)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c3914607-c9a8-4662-b3c4-2f52b8fb1b9b)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
