### PR TITLE
TD-2286 Addresses issues with attaching more than 20 MB in separate uploads

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Support/RequestAttachment.cs
+++ b/DigitalLearningSolutions.Data/Models/Support/RequestAttachment.cs
@@ -10,6 +10,7 @@ namespace DigitalLearningSolutions.Data.Models.Support
     {
         public string? Id { get; set; }
         public string? FileName { get; set; }
+        public double? SizeMb { get; set; }
         public string? OriginalFileName { get; set; }
         public string? FullFileName { get; set; }
         public byte[] Content { get; set; }

--- a/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
@@ -170,10 +170,10 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
                 MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
                 TempData
             ).GetAwaiter().GetResult(); ;
-
+            requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
             if (requestAttachmentmodel.ImageFiles == null)
             {
-                requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
+                //requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
                 ModelState.AddModelError("ImageFiles", "Please select at least one image");
                 return View("RequestAttachment", requestAttachmentmodel);
             }
@@ -184,13 +184,13 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
             (bool? fileExtension, bool? fileSize) = validateUploadedImages(requestAttachmentmodel);
             if (fileExtension == true)
             {
-                requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
+                //requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
                 ModelState.AddModelError("FileExtensionError", "File must be in valid image formats jpg, jpeg, png, bmp or mp4 video format");
                 return View("RequestAttachment", requestAttachmentmodel);
             }
             if (fileSize == true)
             {
-                requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
+                //requestAttachmentmodel.RequestAttachment = data.RequestAttachment;
                 ModelState.AddModelError("FileSizeError", "Maximum allowed file size is 20MB");
                 return View("RequestAttachment", requestAttachmentmodel);
             }
@@ -202,7 +202,8 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
                 {
                     OriginalFileName = item.FileName,
                     FileName = fileName,
-                    FullFileName = uploadDir + fileName
+                    FullFileName = uploadDir + fileName,
+                    SizeMb = Convert.ToDouble(item.Length.ToSize(FileSizeCalc.SizeUnits.MB))
                 };
                 RequestAttachmentList.Add(RequestAttachment);
             }
@@ -370,6 +371,13 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
         private (bool, bool) validateUploadedImages(RequestAttachmentViewModel requestAttachmentmodel)
         {
             var totalFileSize = 0.00;
+            if (requestAttachmentmodel.RequestAttachment != null)
+            {
+                foreach (var item in requestAttachmentmodel.RequestAttachment)
+                {
+                    totalFileSize = totalFileSize + item.SizeMb??0;
+                }
+            }
             foreach (var item in requestAttachmentmodel.ImageFiles)
             {
                 var extension = Path.GetExtension(item.FileName);
@@ -380,10 +388,11 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
                 }
                 var fileSize = Convert.ToDouble(item.Length.ToSize(FileSizeCalc.SizeUnits.MB));
                 totalFileSize = totalFileSize + fileSize;
-                if (fileSize > requestAttachmentmodel.SizeLimit || totalFileSize > requestAttachmentmodel.SizeLimit)
-                {
-                    requestAttachmentmodel.FileSizeFlag = true;
-                }
+
+            }
+            if (totalFileSize > requestAttachmentmodel.SizeLimit)
+            {
+                requestAttachmentmodel.FileSizeFlag = true;
             }
             return (requestAttachmentmodel.FileExtensionFlag ?? false, requestAttachmentmodel.FileSizeFlag ?? false);
         }

--- a/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestAttachment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestAttachment.cshtml
@@ -34,7 +34,7 @@
                         </legend>
                         <div class="nhsuk-form-group">
                             <label class="nhsuk-label" for="ImageFiles">
-                                If you have any screenshots that help illustrate your request, attach them here. The maximum total file size for uploaded files is 20MB.
+                                If you have any screenshots that help illustrate your request, attach them here. The maximum total file size for uploaded files is 20 MB.
                             </label>
                             @if (!ViewData.ModelState.IsValid)
                             {
@@ -60,7 +60,7 @@
                             <div class="nhsuk-summary-list__row">
 
                                 <dd class="nhsuk-summary-list__value">
-                                    @a.OriginalFileName
+                                    @a.OriginalFileName (@a.SizeMb.ToString() MB)
                                 </dd>
                                 <dd class="nhsuk-summary-list__actions">
                                     <a asp-action="DeleteImage" asp-all-route-data="@cancelLinkData" asp-route-imageName="@a.FileName" asp-route-imageId="@a.Id">


### PR DESCRIPTION
### JIRA link
[TD-2286](https://hee-tis.atlassian.net/browse/TD-2286)

### Description
Adds the file size to the RequestAttachment model. This is now displayed on the list of uploaded attachments and used to calculate the total size of attached files when uploading in separate batches. This prevents circumventing the file size validation by uploading attachments in separate batches totalling more than 20 MB.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/acb13239-5851-4381-b1d4-b0d39708ebd6)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2286]: https://hee-tis.atlassian.net/browse/TD-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ