### PR TITLE
TD-3073- Filters applied in one centre affects the other centres

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -32,6 +32,7 @@
         private ICourseService courseService = null!;
         private IDelegateActivityDownloadFileService delegateActivityDownloadFileService = null!;
         private IUserService userService = null!;
+        private ICourseAdminFieldsService courseAdminFieldsService = null!;
 
         [SetUp]
         public void SetUp()
@@ -43,6 +44,7 @@
             selfAssessmentDelegatesService = A.Fake<ISelfAssessmentService>();
             courseService = A.Fake<ICourseService>();
             userService = A.Fake<IUserService>();
+            courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
 
             controller = new ActivityDelegatesController(
                     courseDelegatesService,
@@ -52,7 +54,8 @@
                     selfAssessmentDelegatesService,
                     courseService,
                     delegateActivityDownloadFileService,
-                    userService
+                    userService,
+                    courseAdminFieldsService
                 )
                 .WithDefaultContext()
                  .WithMockHttpContextSession()
@@ -190,7 +193,8 @@
                     selfAssessmentDelegatesService,
                     courseService,
                     delegateActivityDownloadFileService,
-                    userService
+                    userService,
+                    courseAdminFieldsService
                 )
                 .WithMockHttpContext(httpRequest, cookieName, cookieValue, httpResponse)
                 .WithMockUser(true, UserCentreId)

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptionsTests.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
-    using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups;
     using FluentAssertions;
     using FluentAssertions.Execution;
@@ -32,17 +31,17 @@
             {
                 result.Count.Should().Be(8);
                 result.Single(f => f.DisplayText == "Prompt 1").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|1");
+                    .Be("LinkedToField|Prompt 1|1");
                 result.Single(f => f.DisplayText == "Prompt 2").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|2");
+                    .Be("LinkedToField|Prompt 2|2");
                 result.Single(f => f.DisplayText == "Prompt 3").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|3");
+                    .Be("LinkedToField|Prompt 3|3");
                 result.Single(f => f.DisplayText == "Prompt 4").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|5");
+                    .Be("LinkedToField|Prompt 4|5");
                 result.Single(f => f.DisplayText == "Prompt 5").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|6");
+                    .Be("LinkedToField|Prompt 5|6");
                 result.Single(f => f.DisplayText == "Prompt 6").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|7");
+                    .Be("LinkedToField|Prompt 6|7");
             }
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -44,6 +44,7 @@
         private readonly ICourseService courseService;
         private readonly IDelegateActivityDownloadFileService delegateActivityDownloadFileService;
         private readonly IUserService userService;
+        private readonly ICourseAdminFieldsService courseAdminFieldsService;
         private static readonly IClockUtility clockUtility = new ClockUtility();
 
         public ActivityDelegatesController(
@@ -54,7 +55,8 @@
             ISelfAssessmentService selfAssessmentService,
             ICourseService courseService,
             IDelegateActivityDownloadFileService delegateActivityDownloadFileService,
-            IUserService userService
+            IUserService userService,
+            ICourseAdminFieldsService courseAdminFieldsService
         )
         {
             this.courseDelegatesService = courseDelegatesService;
@@ -65,6 +67,7 @@
             this.courseService = courseService;
             this.delegateActivityDownloadFileService = delegateActivityDownloadFileService;
             this.userService = userService;
+            this.courseAdminFieldsService = courseAdminFieldsService;
         }
 
         [NoCaching]
@@ -104,11 +107,16 @@
                 CourseDelegateAccountStatusFilterOptions.Active.FilterValue
             );
 
-            if (existingFilterString != null && existingFilterString.Contains("Answer"))
+            if (isCourseDelegate)
             {
-                var filtersWithoutPromo = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("Answer")).ToList();
-                existingFilterString = filtersWithoutPromo.Any() ? string.Join(FilteringHelper.FilterSeparator, filtersWithoutPromo) : null;
+                if (TempData["actDelCustomisationId"] != null && TempData["actDelCustomisationId"].ToString() != customisationId.ToString()
+                        && existingFilterString != null && existingFilterString.Contains("Answer"))
+                {
+                    var availableCourseFilters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels(courseAdminFieldsService.GetCourseAdminFieldsForCourse(customisationId.Value).AdminFields);
+                    existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableCourseFilters, existingFilterString);
+                }
             }
+
             int offSet = ((page - 1) * itemsPerPage) ?? 0;
 
             var centreId = User.GetCentreIdKnownNotNull();
@@ -200,8 +208,7 @@
 
                     if (courseDelegatesData?.Delegates.Count() == 0 && resultCount > 0)
                     {
-                        page = 1;
-                        offSet = 0;
+                        page = 1; offSet = 0;
                         (courseDelegatesData, resultCount) = courseDelegatesService.GetCoursesAndCourseDelegatesPerPageForCentre(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
                             customisationId, centreId, adminCategoryId, isDelegateActive, isProgressLocked, removed, hasCompleted, answer1, answer2, answer3);
                     }
@@ -213,8 +220,7 @@
 
                     if (selfAssessmentDelegatesData?.Delegates?.Count() == 0 && resultCount > 0)
                     {
-                        page = 1;
-                        offSet = 0;
+                        page = 1; offSet = 0;
                         (selfAssessmentDelegatesData, resultCount) = selfAssessmentService.GetSelfAssessmentDelegatesPerPage(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
                             selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
                     }
@@ -260,6 +266,7 @@
                     TempData["Page"] = result.Page;
                     Response.UpdateFilterCookie(filterCookieName, result.FilterString);
                     var model = new ActivityDelegatesViewModel(courseDelegatesData, result, availableFilters, "customisationId", activityName, true);
+                    TempData["actDelCustomisationId"] = customisationId;
                     return View(model);
                 }
                 else

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -77,31 +77,30 @@
                 DelegateActiveStatusFilterOptions.IsActive.FilterValue
             );
 
-            int offSet = ((page - 1) * itemsPerPage) ?? 0;            
+            int offSet = ((page - 1) * itemsPerPage) ?? 0;
 
             var centreId = User.GetCentreIdKnownNotNull();
             var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
             var customPrompts = promptsService.GetCentreRegistrationPrompts(centreId).ToList();
 
-            string isActive = "Any";
-            string isPasswordSet = "Any";
-            string isAdmin = "Any";
-            string isUnclaimed = "Any";
-            string isEmailVerified = "Any";
-            string registrationType = "Any";
+            var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
+            var availableFilters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(jobGroups, promptsWithOptions);
+
+            if (TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString()
+                    && existingFilterString != null && existingFilterString.Contains("Answer"))
+            {
+                existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableFilters, existingFilterString);
+            }
+
+            string isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, answer1, answer2, answer3, answer4, answer5, answer6;
+            isActive = isPasswordSet = isAdmin = isUnclaimed = isEmailVerified = registrationType = answer1 = answer2 = answer3 = answer4 = answer5 = answer6 = "Any";
             int jobGroupId = 0;
-            string answer1 = "Any";
-            string answer2 = "Any";
-            string answer3 = "Any";
-            string answer4 = "Any";
-            string answer5 = "Any";
-            string answer6 = "Any";
 
             if (!string.IsNullOrEmpty(existingFilterString))
             {
                 var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
 
-                if(!string.IsNullOrEmpty(newFilterToAdd))
+                if (!string.IsNullOrEmpty(newFilterToAdd))
                 {
                     var filterHeader = newFilterToAdd.Split(FilteringHelper.Separator)[1];
                     var dupfilters = selectedFilters.Where(x => x.Contains(filterHeader));
@@ -112,7 +111,7 @@
                             if (filter.Contains(filterHeader))
                             {
                                 selectedFilters.Remove(filter);
-                                existingFilterString= string.Join(FilteringHelper.FilterSeparator,selectedFilters);
+                                existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
                                 break;
                             }
                         }
@@ -125,10 +124,10 @@
                     {
                         var filterArr = filter.Split(FilteringHelper.Separator);
                         var filterValue = filterArr[2];
-                        if (filterValue == "╳") filterValue = "No option selected";
+                        if (filterValue == FilteringHelper.EmptyValue) filterValue = "No option selected";
 
                         if (filter.Contains("IsPasswordSet"))
-                            isPasswordSet= filterValue;
+                            isPasswordSet = filterValue;
 
                         if (filter.Contains("IsAdmin"))
                             isAdmin = filterValue;
@@ -168,7 +167,6 @@
                     }
                 }
             }
-            
 
             (var delegates, var resultCount) = this.userDataService.GetDelegateUserCards(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection, centreId,
                                                 isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
@@ -176,18 +174,11 @@
 
             if (delegates.Count() == 0 && resultCount > 0)
             {
-                page = 1;
-                offSet = 0;
+                page = 1; offSet = 0;
                 (delegates, resultCount) = this.userDataService.GetDelegateUserCards(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection, centreId,
                                                 isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
                                                 answer1, answer2, answer3, answer4, answer5, answer6);
             }
-
-            var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
-            var availableFilters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(
-            jobGroups,
-            promptsWithOptions
-            );
 
             var result = paginateService.Paginate(
                 delegates,
@@ -213,6 +204,7 @@
 
             Response.UpdateFilterCookie(DelegateFilterCookieName, existingFilterString);
             TempData.Remove("delegateRegistered");
+            TempData["allDelegatesCentreId"] = User.GetCentreId().ToString();
             return View(model);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -2,7 +2,6 @@
 using DigitalLearningSolutions.Data.Helpers;
 using DigitalLearningSolutions.Data.Models.CustomPrompts;
 using DigitalLearningSolutions.Data.Models.DelegateGroups;
-using DigitalLearningSolutions.Data.Models.Frameworks;
 using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
 using DigitalLearningSolutions.Web.Attributes;
 using DigitalLearningSolutions.Web.Helpers;
@@ -92,6 +91,16 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 );
             }
 
+            var registrationPrompts = GetRegistrationPromptsWithSetOptions(centreId);
+            var availableFilters = DelegateGroupsViewModelFilterOptions
+                .GetDelegateGroupFilterModels(addedByAdmins, registrationPrompts).ToList();
+
+            if (TempData["DelegateGroupCentreId"] != null && TempData["DelegateGroupCentreId"].ToString() != User.GetCentreId().ToString()
+                    && existingFilterString != null)
+            {
+                existingFilterString = FilterHelper.RemoveNonExistingGroupFilters(availableFilters, existingFilterString);
+            }
+
             int offSet = ((page - 1) * itemsPerPage) ?? 0;
             string filterAddedBy = "";
             string filterLinkedField = "";
@@ -161,10 +170,6 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     filterLinkedField);
             }
 
-            var registrationPrompts = GetRegistrationPromptsWithSetOptions(centreId);
-            var availableFilters = DelegateGroupsViewModelFilterOptions
-                .GetDelegateGroupFilterModels(addedByAdmins, registrationPrompts).ToList();
-
             var result = paginateService.Paginate(
                 groups,
                 resultCount,
@@ -186,6 +191,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             model.TotalPages = (int)(resultCount / itemsPerPage) + ((resultCount % itemsPerPage) > 0 ? 1 : 0);
             model.MatchingSearchResults = resultCount;
             Response.UpdateFilterCookie(DelegateGroupsFilterCookieName, result.FilterString);
+            TempData["DelegateGroupCentreId"] = centreId;
 
             return View(model);
         }
@@ -296,7 +302,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 return NotFound();
             }
 
-            if ( (!groupsService.IsDelegateGroupExist(model.GroupName.Trim(), centreId)) || (group.GroupLabel.Trim()== model.GroupName.Trim()) )
+            if ((!groupsService.IsDelegateGroupExist(model.GroupName.Trim(), centreId)) || (group.GroupLabel.Trim() == model.GroupName.Trim()))
             {
                 groupsService.UpdateGroupName(
                 groupId,

--- a/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
@@ -1,0 +1,115 @@
+﻿using DigitalLearningSolutions.Data.Helpers;
+using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DigitalLearningSolutions.Web.Helpers
+{
+    public static class FilterHelper
+    {
+        public static string? RemoveNonExistingPromptFilters(List<FilterModel> availableFilters, string existingFilterString)
+        {
+            if (existingFilterString != null && existingFilterString.Contains("Answer"))
+            {
+                if (availableFilters.Where(x => x.FilterGroupKey == "prompts").ToList().Any())
+                {
+                    var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
+                    var existingPromptFilters = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => filter.Contains("Answer")).ToList();
+
+                    foreach (var existingPromptFilter in existingPromptFilters)
+                    {
+                        bool isFound = false;
+                        var splitFilter = existingPromptFilter.Split(FilteringHelper.Separator);
+                        var filterHeaderArr = splitFilter[0].SkipWhile(c => c != '(').Skip(1).TakeWhile(c => c != ')').ToArray();
+                        var filterHeader = string.Join("", filterHeaderArr); //prompt header
+                        var filterOptionText = splitFilter[2] == FilteringHelper.EmptyValue ?
+                                                            "No option selected" : splitFilter[2]; //prompt option text
+                        var promptDbText = splitFilter[1]; //filter db text eg. Answer1
+
+                        var availableFilterOptions = availableFilters.Where(x => x.FilterGroupKey == "prompts" && x.FilterName == filterHeader)
+                                                                     .Select(o => o.FilterOptions).ToList();
+
+                        foreach (var filterOption in availableFilterOptions)
+                        {
+                            if (filterOption.Any(x => x.DisplayText.Contains(filterOptionText)))
+                            {
+                                var filter = filterOption.Where(x => x.DisplayText.Contains(filterOptionText)).ToList().Select(x => x.FilterValue).FirstOrDefault();
+                                if (!filter.Contains(promptDbText))
+                                { //when prompt filter header and selected option match but db coulum (eg. Answer1) does not match
+                                  //remove from existing filter and add from available filter
+                                    selectedFilters.Remove(existingPromptFilter);
+                                    selectedFilters.Add(filter);
+                                    existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                                }
+                                isFound = true; break;
+                            }
+                        }
+                        if (!isFound)
+                        {
+                            selectedFilters.Remove(existingPromptFilter);
+                            existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                            if (existingFilterString == "") existingFilterString = null;
+                        }
+                    }
+                }
+                else
+                {
+                    var filtersExceptPrompts = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("Answer")).ToList();
+                    existingFilterString = filtersExceptPrompts.Any() ? string.Join(FilteringHelper.FilterSeparator, filtersExceptPrompts) : null;
+                }
+            }
+            return existingFilterString;
+        }
+
+        public static string? RemoveNonExistingGroupFilters(List<FilterModel> availableFilters, string existingFilterString)
+        {
+            var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
+            string[] filterGroups = { "AddedByAdminId", "LinkedToField" };
+            foreach (var filterGroup in filterGroups)
+            {
+                var existingFilters = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => filter.Contains(filterGroup)).ToList();
+
+                foreach (var existingFilter in existingFilters)
+                {
+                    bool isFound = false;
+                    var splitFilter = existingFilter.Split(FilteringHelper.Separator);
+                    var filterHeader = splitFilter[1];
+                    var filterOptionText = splitFilter[2];
+                    var availableFilterOptions = availableFilters.Where(x => x.FilterProperty == filterGroup).Select(o => o.FilterOptions).ToList();
+                    foreach (var availableFilterOption in availableFilterOptions)
+                    {
+                        if (filterGroup == "AddedByAdminId")
+                        {
+                            if (availableFilterOption.Any(x => x.FilterValue.Contains(filterOptionText)))
+                            {
+                                isFound = true; break;
+                            }
+                        }
+                        else
+                        {
+                            if (availableFilterOption.Any(x => x.FilterValue.Contains(filterHeader)))
+                            {
+                                var filter = availableFilterOption.Where(x => x.FilterValue.Contains(filterHeader)).ToList().Select(x => x.FilterValue).FirstOrDefault();
+                                if (!filter.Contains(filterOptionText))
+                                {
+                                    selectedFilters.Remove(existingFilter);
+                                    selectedFilters.Add(filter);
+                                    existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                                }
+                                isFound = true; break;
+                            }
+                        }
+                    }
+
+                    if (!isFound)
+                    {
+                        selectedFilters.Remove(existingFilter);
+                        existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                    }
+                }
+            }
+            if (existingFilterString == "") existingFilterString = null;
+            return existingFilterString;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateGroupFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateGroupFilterOptions.cs
@@ -13,13 +13,13 @@
 
         public static readonly FilterOptionModel None = new FilterOptionModel(
             "None",
-            FilteringHelper.BuildFilterValueString(GroupName, nameof(Group.LinkedToField), "0"),
+            FilteringHelper.BuildFilterValueString(GroupName, "None", "0"),
             FilterStatus.Default
         );
 
         public static readonly FilterOptionModel JobGroup = new FilterOptionModel(
             "Job group",
-            FilteringHelper.BuildFilterValueString(GroupName, nameof(Group.LinkedToField), "4"),
+            FilteringHelper.BuildFilterValueString(GroupName, "Job group", "4"),
             FilterStatus.Default
         );
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptions.cs
@@ -4,15 +4,10 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
-    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
-    using DigitalLearningSolutions.Data.Models.User;
-    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Helpers.FilterOptions;
-    using DigitalLearningSolutions.Web.Models.Enums;
-    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public static class DelegateGroupsViewModelFilterOptions
     {
@@ -29,7 +24,7 @@
             var promptOptions = registrationPrompts.Select(
                 prompt => new FilterOptionModel(
                     prompt.PromptText,
-                    nameof(Group.LinkedToField) + FilteringHelper.Separator + nameof(Group.LinkedToField) +
+                    nameof(Group.LinkedToField) + FilteringHelper.Separator + prompt.PromptText +
                     FilteringHelper.Separator + prompt.RegistrationField.LinkedToFieldId,
                     FilterStatus.Default
                 )


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3073

### Description
Check added to compare selected and available filters and remove filter/s if not exist.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/11e76578-2a90-4ec4-b309-afd048eccbd8)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c3b5112b-5da2-4634-8afa-bebe4140f7d3)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/be474b78-ca88-4803-ac55-0db937716f99)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c1138da4-8e2e-42a9-bf64-ec3495c54a91)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2af18bc1-46a4-4286-8cff-3862b424c937)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/91a23c70-ab3b-4580-83e4-c1b67a456b5b)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
