### PR TITLE
TD-3222 Tracking system dashboard and delegates page count mismatch solved

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserDataService.cs
@@ -343,13 +343,6 @@
             transaction.Complete();
         }
 
-        public int GetNumberOfApprovedDelegatesAtCentre(int centreId)
-        {
-            return (int)connection.ExecuteScalar(
-                @"SELECT COUNT(*) FROM Candidates WHERE Active = 1 AND Approved = 1 AND CentreID = @centreId",
-                new { centreId }
-            );
-        }
 
         public void UpdateDelegateAccount(
             int delegateId,

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -86,7 +86,6 @@
 
         void RemoveDelegateAccount(int delegateId);
 
-        int GetNumberOfApprovedDelegatesAtCentre(int centreId);
 
         void DeactivateDelegateUser(int delegateId);
 

--- a/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
@@ -9,6 +9,7 @@
     using FakeItEasy;
     using FluentAssertions;
     using NUnit.Framework;
+    using System.Collections.Generic;
 
     public class DashboardInformationServiceTests
     {
@@ -126,7 +127,12 @@
             A.CallTo(() => centresDataService.GetCentreDetailsById(CentreId))
                 .Returns(CentreTestHelper.GetDefaultCentre(CentreId));
             A.CallTo(() => userDataService.GetAdminUserById(AdminId))
-                .Returns(adminUser);
+            .Returns(adminUser);
+
+            A.CallTo(() => userDataService.GetDelegateUserCards("", 0, 10, "SearchableName", "Ascending", CentreId,
+            "Any", "Any", "Any", "Any", "Any", "Any", 0, "Any", "Any", "Any", "Any", "Any", "Any"))
+                .Returns((new List<DelegateUserCard>(), delegateCount)
+                );
 
             A.CallTo(
                 () =>

--- a/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
@@ -128,7 +128,6 @@
             A.CallTo(() => userDataService.GetAdminUserById(AdminId))
                 .Returns(adminUser);
 
-            A.CallTo(() => userDataService.GetNumberOfApprovedDelegatesAtCentre(CentreId)).Returns(delegateCount);
             A.CallTo(
                 () =>
                     courseDataService.GetNumberOfActiveCoursesAtCentreFilteredByCategory(

--- a/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
+++ b/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
@@ -41,7 +41,8 @@
                 return null;
             }
 
-            var delegateCount = userDataService.GetNumberOfApprovedDelegatesAtCentre(centreId);
+            (var delegates, var delegateCount) = userDataService.GetDelegateUserCards("", 0, 10, "SearchableName", "Ascending", centreId,
+            "Any", "Any", "Any", "Any", "Any", "Any", 0, "Any", "Any", "Any", "Any", "Any", "Any");
             var courseCount =
                 courseDataService.GetNumberOfActiveCoursesAtCentreFilteredByCategory(
                     centreId,


### PR DESCRIPTION
### JIRA link
[TD-3222](https://hee-tis.atlassian.net/browse/TD-3222)

### Description
For the count mismatch on the dashboard, we have used the same service as used for getting delegates count on the delegates page. Now both places will show only the approved delegates that have properly formatted email like (''%@%.__%'')

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/372af04c-f785-4333-b34d-7b7a40732d77)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/bd7d85ec-ec21-4398-a406-2a3b9060a90b)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3222]: https://hee-tis.atlassian.net/browse/TD-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ