### PR TITLE
TD-3128- Supervise link 410 issue - when clicked for next self assessment immediately.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -31,6 +31,7 @@
         DelegateSelfAssessment? GetSelfAssessmentBySupervisorDelegateSelfAssessmentId(int selfAssessmentId, int supervisorDelegateId);
         DelegateSelfAssessment? GetSelfAssessmentBySupervisorDelegateCandidateAssessmentId(int candidateAssessmentId, int supervisorDelegateId);
         CandidateAssessmentSupervisor? GetCandidateAssessmentSupervisorById(int candidateAssessmentSupervisorId);
+        CandidateAssessmentSupervisor? GetCandidateAssessmentSupervisor(int candidateAssessmentID, int supervisorDelegateId, int selfAssessmentSupervisorRoleId);
         SelfAssessmentResultSummary? GetSelfAssessmentResultSummary(int candidateAssessmentId, int supervisorDelegateId);
         IEnumerable<CandidateAssessmentSupervisorVerificationSummary> GetCandidateAssessmentSupervisorVerificationSummaries(int candidateAssessmentId);
         IEnumerable<SupervisorForEnrolDelegate> GetSupervisorForEnrolDelegate(int CustomisationID, int CentreID);
@@ -951,6 +952,18 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                @"SELECT *
                   FROM   CandidateAssessmentSupervisors
                   WHERE (ID = @candidateAssessmentSupervisorId)", new { candidateAssessmentSupervisorId }
+               ).FirstOrDefault();
+        }
+
+        public CandidateAssessmentSupervisor? GetCandidateAssessmentSupervisor(int candidateAssessmentID, int supervisorDelegateId, int selfAssessmentSupervisorRoleId)
+        {
+            return connection.Query<CandidateAssessmentSupervisor>(
+               @"SELECT *
+                  FROM   CandidateAssessmentSupervisors
+                  WHERE (CandidateAssessmentID = @candidateAssessmentID 
+                        AND SupervisorDelegateId = @supervisorDelegateId 
+                        AND SelfAssessmentSupervisorRoleId = @selfAssessmentSupervisorRoleId)",
+               new { candidateAssessmentID, supervisorDelegateId, selfAssessmentSupervisorRoleId }
                ).FirstOrDefault();
         }
 

--- a/DigitalLearningSolutions.Data/Models/Supervisor/CandidateAssessmentSupervisor.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/CandidateAssessmentSupervisor.cs
@@ -1,4 +1,6 @@
-﻿namespace DigitalLearningSolutions.Data.Models.Supervisor
+﻿using System;
+
+namespace DigitalLearningSolutions.Data.Models.Supervisor
 {
     public class CandidateAssessmentSupervisor
     {
@@ -6,5 +8,6 @@
         public int CandidateAssessmentID { get; set; }
         public int SupervisorDelegateId { get; set; }
         public int SelfAssessmentSupervisorRoleID { get; set; }
+        public DateTime? Removed { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
@@ -1,22 +1,13 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.Support
 {
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
-    using DigitalLearningSolutions.Data.Models.Support;
     using DigitalLearningSolutions.Data.Services;
-    
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.SupervisorController;
-    using DigitalLearningSolutions.Web.Controllers.Support;
-    using DigitalLearningSolutions.Web.Models.Enums;
     using DigitalLearningSolutions.Web.Services;
-    using DigitalLearningSolutions.Web.ViewModels.Support.Faqs;
     using FakeItEasy;
-    using FluentAssertions;
-    using FluentAssertions.AspNetCore.Mvc;
     using GDS.MultiPageFormData;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
@@ -44,6 +35,7 @@
         private IEmailService emailService = null!;
         private IClockUtility clockUtility = null!;
         private ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService = null!;
+        private ISelfAssessmentDataService selfAssessmentDataService = null!;
 
         [SetUp]
         public void Setup()
@@ -67,6 +59,7 @@
             emailService = A.Fake<IEmailService>();
             clockUtility = A.Fake<IClockUtility>();
             candidateAssessmentDownloadFileService = A.Fake<ICandidateAssessmentDownloadFileService>();
+            selfAssessmentDataService = A.Fake<ISelfAssessmentDataService>();
 
             A.CallTo(() => candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(A<int>._, A<int>._, A<bool>._))
                 .Returns(new byte[] { });
@@ -96,6 +89,7 @@
                    emailGenerationService,
                    emailService,
                    candidateAssessmentDownloadFileService,
+                   selfAssessmentDataService,
                    clockUtility
                );
             string expectedFileName = $"{((selfAssessmentName.Length > 30) ? selfAssessmentName.Substring(0, 30) : selfAssessmentName)} - {delegateName} - {clockUtility.UtcNow:yyyy-MM-dd}.xlsx";

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1003,10 +1003,16 @@
             }
             else
             {
-                if (TempData["IsAssessmentsSupervise"] != null)
+
+                var candidateAssessmentId = selfAssessmentDataService.GetCandidateAssessments(delegateUserId, selfAssessmentId).SingleOrDefault()?.Id;
+                var roleId = supervisorRoles.Where(x => x.SelfAssessmentID == selfAssessmentId).Select(x => x.ID).FirstOrDefault();
+                if (candidateAssessmentId != null)
                 {
-                    TempData.Remove("IsAssessmentsSupervise");
-                    return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
+                    var candidateAssessmentSupervisor = supervisorService.GetCandidateAssessmentSupervisor((int)candidateAssessmentId, supervisorDelegateId, roleId);
+                    if (candidateAssessmentSupervisor != null && candidateAssessmentSupervisor.Removed == null)
+                    {
+                        return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
+                    }
                 }
 
                 var sessionEnrolOnRoleProfile = new SessionEnrolOnRoleProfile()
@@ -1096,7 +1102,6 @@
                     selfAssessmentId,
                     selfAssessmentSupervisorRoleId.Value
                 );
-                TempData["IsAssessmentsSupervise"] = true;
                 return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = supervisorDelegateId });
             }
         }
@@ -1111,10 +1116,6 @@
         public IActionResult RemoveDelegateSelfAssessmentsupervisor(int candidateAssessmentId, int supervisorDelegateId)
         {
             supervisorService.RemoveDelegateSelfAssessmentsupervisor(candidateAssessmentId, supervisorDelegateId);
-            if (TempData["IsAssessmentsSupervise"] != null)
-            {
-                TempData.Remove("IsAssessmentsSupervise");
-            }
             return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = supervisorDelegateId });
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/SupervisorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/SupervisorController.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.SupervisorController
 {
     using DigitalLearningSolutions.Data.DataServices;
+    using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Services;
     using DigitalLearningSolutions.Data.Utilities;
@@ -29,6 +30,7 @@
         private readonly IEmailGenerationService emailGenerationService;
         private readonly IEmailService emailService;
         private readonly ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService;
+        private readonly ISelfAssessmentDataService selfAssessmentDataService;
         private readonly IClockUtility clockUtility;
 
         public SupervisorController(
@@ -50,6 +52,7 @@
            IEmailGenerationService emailGenerationService,
            IEmailService emailService,
            ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService,
+           ISelfAssessmentDataService selfAssessmentDataService,
            IClockUtility clockUtility
            )
         {
@@ -67,6 +70,7 @@
             this.emailGenerationService = emailGenerationService;
             this.emailService = emailService;
             this.candidateAssessmentDownloadFileService = candidateAssessmentDownloadFileService;
+            this.selfAssessmentDataService = selfAssessmentDataService;
             this.clockUtility = clockUtility;
         }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3128

### Description
Removed existing TempData check used for browser post back operation and added check for candidate assessment supervisor if present which handles browser post back situation as well as added new supervisor.

### Screenshots
Issue resolved on the following page, when user supervise self assessments one by one.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c9064e1b-2d50-4235-afdd-26723d72552e)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
