### PR TITLE
TD-2318 Super admin centre self assessments view

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CentreSelfAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CentreSelfAssessmentsDataService.cs
@@ -1,0 +1,38 @@
+﻿namespace DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService
+{
+    using Dapper;
+    using DigitalLearningSolutions.Data.Models.SuperAdmin;
+    using Microsoft.Extensions.Logging;
+    using System.Collections.Generic;
+    using System.Data;
+
+    public interface ICentreSelfAssessmentsDataService
+    {
+        IEnumerable<CentreSelfAssessment> GetCentreSelfAssessments(int centreId);
+    }
+    public class CentreSelfAssessmentsDataService : ICentreSelfAssessmentsDataService
+    {
+        private readonly IDbConnection connection;
+        private readonly ILogger<SelfAssessmentDataService> logger;
+        public CentreSelfAssessmentsDataService(IDbConnection connection, ILogger<SelfAssessmentDataService> logger)
+        {
+            this.connection = connection;
+            this.logger = logger;
+        }
+        public IEnumerable<CentreSelfAssessment> GetCentreSelfAssessments(int centreId)
+        {
+            return connection.Query<CentreSelfAssessment>(
+                @"SELECT csa.SelfAssessmentID, csa.CentreID, sa.Name AS SelfAssessmentName,
+                                 (SELECT COUNT(1) AS DelegateCount
+                                 FROM    CandidateAssessments AS ca INNER JOIN
+                                                  Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+                                                  DelegateAccounts AS da ON da.UserID = u.ID
+                                     WHERE (ca.SelfAssessmentID = sa.ID) AND (da.CentreID = @centreId) AND (ca.RemovedDate IS NULL) AND (u.Active = 1) AND (da.Active = 1)) AS DelegateCount, csa.AllowEnrolment AS SelfEnrol
+                    FROM   CentreSelfAssessments AS csa INNER JOIN
+                                 SelfAssessments AS sa ON csa.SelfAssessmentID = sa.ID
+                    WHERE (csa.CentreID = @centreId) AND (sa.ArchivedDate IS NULL)
+                    ORDER BY SelfAssessmentName", new { centreId }
+                );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SuperAdmin/CentreSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SuperAdmin/CentreSelfAssessment.cs
@@ -1,0 +1,11 @@
+﻿namespace DigitalLearningSolutions.Data.Models.SuperAdmin
+{
+    public class CentreSelfAssessment
+    {
+        public int SelfAssessmentId { get; set; }
+        public int CentreId { get; set; }
+        public string? SelfAssessmentName { get; set; }
+        public int DelegateCount { get; set; }
+        public bool SelfEnrol { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Data/Models/SuperAdmin/SuperAdminDelegateAccount.cs
+++ b/DigitalLearningSolutions.Data/Models/SuperAdmin/SuperAdminDelegateAccount.cs
@@ -1,10 +1,4 @@
 ﻿using DigitalLearningSolutions.Data.Models.User;
-using Serilog.Debugging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DigitalLearningSolutions.Data.Models.SuperAdmin
 {

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseDetailsAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/EditCourseDetailsAccessibilityTests.cs
@@ -24,8 +24,7 @@
             // Exclude conditional radios, see: https://github.com/alphagov/govuk-frontend/issues/979#issuecomment-872300557
             var editResult = new AxeBuilder(Driver).Exclude("div.nhsuk-radios--conditional div.nhsuk-radios__item input.nhsuk-radios__input").Analyze();
 
-            // Expect an axe violation caused by having an aria-expanded attribute on an input
-            // The target inputs are nhs-tested components so ignore these violation
+            // then
             editResult.Violations.Should().BeEmpty();
         }
     }

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/SuperAdminAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/SuperAdminAccessibilityTests.cs
@@ -1,0 +1,54 @@
+﻿namespace DigitalLearningSolutions.Web.AutomatedUiTests.AccessibilityTests
+{
+    using DigitalLearningSolutions.Web.AutomatedUiTests.TestFixtures;
+    using Xunit;
+    public class SuperAdminAccessibilityTests : AccessibilityTestsBase,
+        IClassFixture<AuthenticatedAccessibilityTestsFixture<Startup>>
+    {
+        public SuperAdminAccessibilityTests(AuthenticatedAccessibilityTestsFixture<Startup> fixture) : base(
+            fixture
+        )
+        { }
+        [Theory]
+        [InlineData("/SuperAdmin/Users", "User Accounts")]
+        [InlineData("/SuperAdmin/Users/2251/EditUserDetails", "Edit user details")]
+        [InlineData("/SuperAdmin/Users/2251/CentreAccounts#2251-name", "User centre roles")]
+        [InlineData("/SuperAdmin/Users/SuperAdminUserSetPassword/2251", "Set user password")]
+
+        [InlineData("/SuperAdmin/AdminAccounts", "Administrators")]
+        [InlineData("/SuperAdmin/Admins/4256/ManageRoles", "Edit Administrator roles")]
+        [InlineData("/SuperAdmin/AdminAccounts/4256/DeactivateAdmin?returnPageQuery=pageNumber%3D1", "Are you sure you would like to deactivate this admin account?")]
+
+        [InlineData("/SuperAdmin/Delegates", "Delegates")]
+        [InlineData("/SuperAdmin/Delegates/2/InactivateDelegateConfirmation", "Inactivate Delegate")]
+
+        [InlineData("/SuperAdmin/Centres", "Centres")]
+        [InlineData("/SuperAdmin/Centres/AddCentre", "Add new centre")]
+        [InlineData("/SuperAdmin/Centres/409/Manage", "2gether NHS Foundation Trust IT/Clinical Systems (409)")]
+        [InlineData("/SuperAdmin/Centres/409/EditCentreDetails", "Edit centre details")]
+        [InlineData("/SuperAdmin/Centres/409/ManageCentreManager", "Edit centre manager details")]
+        [InlineData("/SuperAdmin/Centres/409/EditContractInfo", "Edit contract info for 2gether NHS Foundation Trust IT/Clinical Systems")]
+        [InlineData("/SuperAdmin/Centres/409/CentreRoleLimits", "Customise role limits for 2gether NHS Foundation Trust IT/Clinical Systems")]
+        [InlineData("/SuperAdmin/Centres/374/Courses", "Courses - NHS Digital (374)")]
+        [InlineData("/SuperAdmin/Centres/374/Courses/Add", "Add courses to centre - NHS Digital (374)")]
+        [InlineData("/SuperAdmin/Centres/374/Courses/Add/Other?searchTerm=de", "Add other courses to centre - NHS Digital (374)")]
+        [InlineData("/SuperAdmin/Centres/374/Courses/818/ConfirmRemove", "Are you sure you want to remove Assessment attempts from NHS Digital?")]
+
+        [InlineData("/SuperAdmin/Reports", "Platform usage summary")]
+        [InlineData("/SuperAdmin/Reports/CourseUsage", "Course usage")]
+        [InlineData("/SuperAdmin/Reports/CourseUsage/EditFilters", "Edit report filters")]
+        [InlineData("/SuperAdmin/Reports/SelfAssessments/Independent", "Independent self assessments")]
+        [InlineData("/SuperAdmin/Reports/SelfAssessments/Independent/EditFilters", "Edit report filters")]
+        [InlineData("/SuperAdmin/Reports/SelfAssessments/Supervised", "Supervised self assessments")]
+        [InlineData("/SuperAdmin/Reports/SelfAssessments/Supervised/EditFilters", "Edit report filters")]
+        [InlineData("/SuperAdmin/System/Faqs", "FAQs")]
+        public void SuperAdmin_page_has_no_accessibility_errors(string url, string pageTitle)
+        {
+            // when
+            Driver.Navigate().GoToUrl(BaseUrl + url);
+
+            // then
+            AnalyzePageHeadingAndAccessibility(pageTitle);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/SuperAdminAccessibilityTests.cs
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/AccessibilityTests/SuperAdminAccessibilityTests.cs
@@ -33,6 +33,7 @@
         [InlineData("/SuperAdmin/Centres/374/Courses/Add", "Add courses to centre - NHS Digital (374)")]
         [InlineData("/SuperAdmin/Centres/374/Courses/Add/Other?searchTerm=de", "Add other courses to centre - NHS Digital (374)")]
         [InlineData("/SuperAdmin/Centres/374/Courses/818/ConfirmRemove", "Are you sure you want to remove Assessment attempts from NHS Digital?")]
+        [InlineData("/SuperAdmin/Centres/101/SelfAssessments", "Self assessments - Test Centre NHSD (101)")]
 
         [InlineData("/SuperAdmin/Reports", "Platform usage summary")]
         [InlineData("/SuperAdmin/Reports/CourseUsage", "Course usage")]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using DigitalLearningSolutions.Data.DataServices;
+using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
 using DigitalLearningSolutions.Data.Models;
 using DigitalLearningSolutions.Data.Models.Centres;
 using DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres;
@@ -28,6 +29,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
         private readonly IContractTypesDataService contractTypesDataService = A.Fake<IContractTypesDataService>();
         private readonly ICourseDataService courseDataService = A.Fake<ICourseDataService>();
         private readonly ICentresDownloadFileService centresDownloadFileService = A.Fake<ICentresDownloadFileService>();
+        private readonly ICentreSelfAssessmentsService centreSelfAssessmentsService = A.Fake<ICentreSelfAssessmentsService>();
         private CentresController controller = null!;
 
         [SetUp]
@@ -41,7 +43,8 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             centresDataService,
             contractTypesDataService,
             courseDataService,
-            centresDownloadFileService
+            centresDownloadFileService,
+            centreSelfAssessmentsService
             )
             .WithDefaultContext()
             .WithMockUser(true);
@@ -476,7 +479,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
         [Test]
         public void CourseAddCommit_ShouldInsertCentreApplicationsAndRedirectToCourses()
         {
-            // When
+            // Given
             
             var model = new CourseAddViewModel
             {
@@ -484,10 +487,10 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
                 ApplicationIds = new List<int> { 2,3,4 },
             };
 
-            // Act
+            // When
             var result = controller.CourseAddCommit(model) as RedirectToActionResult;
 
-            // Assert
+            // Then
             result.Should().NotBeNull().And.BeOfType<RedirectToActionResult>().Which
                 .ActionName.Should().Be("Courses");
             result!.RouteValues!["centreId"].Should().Be(1);
@@ -495,6 +498,24 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             foreach (var id in model.ApplicationIds)
             {
                 A.CallTo(() => centreApplicationsService.InsertCentreApplication(1, id)).MustHaveHappenedOnceExactly();
+            }
+        }
+
+        [Test]
+        public void Get_with_centreId_shows_SelfAssessments_page()
+        {
+            // Given
+            const int centreId = 1;           
+
+            // When
+            var result = controller.SelfAssessments(centreId);
+
+            // Then
+            using (new AssertionScope())
+            {
+                A.CallTo(() => centreSelfAssessmentsService.GetCentreSelfAssessments(centreId)).MustHaveHappenedOnceExactly();
+                result.Should().BeViewResult().ModelAs<CentreSelfAssessmentsViewModel>();
+                result.Should().BeViewResult();
             }
         }
     }

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -666,7 +666,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                     return RedirectToAction(nameof(CourseAddCore), new { centreId = model.CentreId });
 
                 case "Other":
-                    return RedirectToAction(nameof(CourseAddOther), new { centreId = model.CentreId, searchTerm = model.SearchTerm.Replace(" ", "%") });
+                    return RedirectToAction(nameof(CourseAddOther), new { centreId = model.CentreId, searchTerm = (model.SearchTerm != null ? model.SearchTerm.Replace(" ", "%") : "") });
 
                 case "Pathways":
                     return RedirectToAction(nameof(CourseAddPathways), new { centreId = model.CentreId });

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -37,8 +37,9 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         private readonly IContractTypesDataService contractTypesDataService;
         private readonly ICourseDataService courseDataService;
         private readonly ICentresDownloadFileService centresDownloadFileService;
+        private readonly ICentreSelfAssessmentsService centreSelfAssessmentsService;
         public CentresController(ICentresService centresService, ICentreApplicationsService centreApplicationsService, ISearchSortFilterPaginateService searchSortFilterPaginateService,
-            IRegionDataService regionDataService, ICentresDataService centresDataService, IContractTypesDataService contractTypesDataService, ICourseDataService courseDataService, ICentresDownloadFileService centresDownloadFileService)
+            IRegionDataService regionDataService, ICentresDataService centresDataService, IContractTypesDataService contractTypesDataService, ICourseDataService courseDataService, ICentresDownloadFileService centresDownloadFileService, ICentreSelfAssessmentsService centreSelfAssessmentsService)
         {
             this.centresService = centresService;
             this.centreApplicationsService = centreApplicationsService;
@@ -48,6 +49,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
             this.contractTypesDataService = contractTypesDataService;
             this.courseDataService = courseDataService;
             this.centresDownloadFileService = centresDownloadFileService;
+            this.centreSelfAssessmentsService = centreSelfAssessmentsService;
         }
 
         [Route("SuperAdmin/Centres/{page=0:int}")]
@@ -713,6 +715,15 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                 centreApplicationsService.InsertCentreApplication(model.CentreId, id);
             }
             return RedirectToAction("Courses", new { centreId = model.CentreId });
+        }
+
+        [Route("SuperAdmin/Centres/{centreId=0:int}/SelfAssessments")]
+        public IActionResult SelfAssessments(int centreId = 0)
+        {
+            var selfAssessments = centreSelfAssessmentsService.GetCentreSelfAssessments(centreId);
+            var model = new CentreSelfAssessmentsViewModel() { CentreSelfAssessments = selfAssessments };
+            ViewBag.CentreName = centresDataService.GetCentreName(centreId) + "  (" + centreId + ")";
+            return View(model);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/CentreSelfAssessmentsService.cs
+++ b/DigitalLearningSolutions.Web/Services/CentreSelfAssessmentsService.cs
@@ -1,0 +1,27 @@
+﻿namespace DigitalLearningSolutions.Web.Services
+{
+    using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.Models.SuperAdmin;
+    using System.Collections.Generic;
+
+    public interface ICentreSelfAssessmentsService
+    {
+        IEnumerable<CentreSelfAssessment> GetCentreSelfAssessments(int centreId);
+        public class CentreSelfAssessmentsService : ICentreSelfAssessmentsService
+        {
+            private readonly ICentreSelfAssessmentsDataService centreSelfAssessmentsDataService;
+            public CentreSelfAssessmentsService(
+                ICentreSelfAssessmentsDataService centreSelfAssessmentsDataService
+        )
+            {
+                this.centreSelfAssessmentsDataService = centreSelfAssessmentsDataService;
+            }
+
+            public IEnumerable<CentreSelfAssessment> GetCentreSelfAssessments(int centreId)
+            {
+                return centreSelfAssessmentsDataService.GetCentreSelfAssessments(centreId);
+            }
+        }
+    }
+
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -46,6 +46,7 @@ namespace DigitalLearningSolutions.Web
     using AspNetCoreRateLimit;
     using static DigitalLearningSolutions.Data.DataServices.ICentreApplicationsDataService;
     using static DigitalLearningSolutions.Web.Services.ICentreApplicationsService;
+    using static DigitalLearningSolutions.Web.Services.ICentreSelfAssessmentsService;
 
     public class Startup
     {
@@ -289,6 +290,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IFreshdeskService, FreshdeskService>();
             services.AddScoped<IPlatformUsageSummaryDownloadFileService, PlatformUsageSummaryDownloadFileService>();
             services.AddScoped<ICentreApplicationsService, CentreApplicationsService>();
+            services.AddScoped<ICentreSelfAssessmentsService, CentreSelfAssessmentsService>();
         }
 
         private static void RegisterDataServices(IServiceCollection services)
@@ -345,6 +347,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IDelegateActivityDownloadFileService, DelegateActivityDownloadFileService>();
             services.AddScoped<IRequestSupportTicketDataService, RequestSupportTicketDataService>();
             services.AddScoped<ICentreApplicationsDataService, CentreApplicationsDataService>();
+            services.AddScoped<ICentreSelfAssessmentsDataService, CentreSelfAssessmentsDataService>();
         }
 
         private static void RegisterHelpers(IServiceCollection services)

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreSelfAssessmentsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CentreSelfAssessmentsViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Centres
+{
+    using DigitalLearningSolutions.Data.Models.SuperAdmin;
+    using System.Collections.Generic;
+
+    public class CentreSelfAssessmentsViewModel
+    {
+        public IEnumerable<CentreSelfAssessment> CentreSelfAssessments { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/CourseAdd.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/CourseAdd.cshtml
@@ -106,8 +106,8 @@
 }
 else
 {
-    <h1>All core DLS ourses published to centre - @ViewBag.CentreName</h1>
-    <p>There are no core courses available to add to this centre.</p>
+    <h1>No courses available</h1>
+    <p>There are no core courses available to add to the centre @ViewBag.CentreName.</p>
 }
 
 <vc:cancel-link asp-controller="Centres" asp-action="Courses" asp-all-route-data="@cancelLinkData" />

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/SelfAssessments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/SelfAssessments.cshtml
@@ -33,7 +33,7 @@
     {
         <div class="nhsuk-grid-column-full">
             
-                <table role="table" class="nhsuk-table-responsive">
+                <table class="nhsuk-table-responsive">
                     <caption class="nhsuk-table__caption">Self assessments published to @ViewBag.CentreName</caption>
                     <thead role="rowgroup" class="nhsuk-table__head">
                         <tr role="row">
@@ -55,16 +55,16 @@
                     @foreach (var selfAssessment in Model.CentreSelfAssessments)
                     {
                         <tr role="row" class="nhsuk-table__row">
-                            <td role="cell" class="nhsuk-table__cell">
+                            <td class="nhsuk-table__cell">
                                 <span class="nhsuk-table-responsive__heading">Self assessment </span>@selfAssessment.SelfAssessmentName
                             </td>
-                            <td role="cell" class="nhsuk-table__cell">
+                            <td class="nhsuk-table__cell">
                                 <span class="nhsuk-table-responsive__heading">Enrolled learners </span>@selfAssessment.DelegateCount
                             </td>
-                            <td role="cell" class="nhsuk-table__cell">
+                            <td class="nhsuk-table__cell">
                                 <span class="nhsuk-table-responsive__heading">Self enrolment enabled </span>@selfAssessment.SelfEnrol
                             </td>
-                            <td role="cell" class="nhsuk-table__cell">
+                            <td class="nhsuk-table__cell">
                                 <span class="nhsuk-table-responsive__heading">Action </span>
                                 <a class="nhsuk-button delete-button nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
                                    role="button"

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/SelfAssessments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/SelfAssessments.cshtml
@@ -1,0 +1,87 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Centres
+@model CentreSelfAssessmentsViewModel
+@{
+    ViewData["Title"] = "Self assessments";
+}
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Centres" asp-action="Index">Centres</a></li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__backlink"
+                   asp-controller="Centres" asp-action="Index">Back to Centres</a>
+            </p>
+        </div>
+    </nav>
+}
+<link rel="stylesheet" href="@Url.Content("~/css/superAdmin/centres.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/shared/headingButtons.css")" asp-append-version="true">
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+        <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">@ViewData["Title"] - @ViewBag.CentreName</h1>
+    </div>
+    <div class="nhsuk-grid-column-one-third heading-button-group">
+        <a class="nhsuk-button heading-button" id="add-course" asp-action="SelfAssessmentAddChooseFlow" asp-controller="Centres" role="button" asp-route-centreId="@ViewContext.RouteData.Values["centreId"]">
+            Add self assessment
+        </a>
+    </div>
+</div>
+<div class="nhsuk-grid-row">
+    @if (Model.CentreSelfAssessments.Any())
+    {
+        <div class="nhsuk-grid-column-full">
+            
+                <table role="table" class="nhsuk-table-responsive">
+                    <caption class="nhsuk-table__caption">Self assessments published to @ViewBag.CentreName</caption>
+                    <thead role="rowgroup" class="nhsuk-table__head">
+                        <tr role="row">
+                            <th role="columnheader" class="" scope="col">
+                                Self assessment
+                            </th>
+                            <th role="columnheader" class="" scope="col">
+                                Enrolled learners
+                            </th>
+                            <th role="columnheader" class="" scope="col">
+                                Self enrolment enabled
+                            </th>
+                            <th role="columnheader" class="" scope="col">
+                                Action
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="nhsuk-table__body">
+                    @foreach (var selfAssessment in Model.CentreSelfAssessments)
+                    {
+                        <tr role="row" class="nhsuk-table__row">
+                            <td role="cell" class="nhsuk-table__cell">
+                                <span class="nhsuk-table-responsive__heading">Self assessment </span>@selfAssessment.SelfAssessmentName
+                            </td>
+                            <td role="cell" class="nhsuk-table__cell">
+                                <span class="nhsuk-table-responsive__heading">Enrolled learners </span>@selfAssessment.DelegateCount
+                            </td>
+                            <td role="cell" class="nhsuk-table__cell">
+                                <span class="nhsuk-table-responsive__heading">Self enrolment enabled </span>@selfAssessment.SelfEnrol
+                            </td>
+                            <td role="cell" class="nhsuk-table__cell">
+                                <span class="nhsuk-table-responsive__heading">Action </span>
+                                <a class="nhsuk-button delete-button nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-2"
+                                   role="button"
+                                   asp-action="@(selfAssessment.DelegateCount > 0 ? "ConfirmRemoveSelfAssessment" : "RemoveSelfAssessment")"
+                                   asp-action="ConfirmRemoveCourse" asp-controller="Centres" asp-route-selfAssessmentId="@selfAssessment.SelfAssessmentId" asp-route-centreId="@ViewContext.RouteData.Values["centreId"]">
+                                    Remove<span class="nhsuk-u-visually-hidden">self assessment @selfAssessment.SelfAssessmentName from centre</span>
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+           
+        </div>
+    }
+    else
+    {
+        <p>No Self Assessments have been published to this centre.</p>
+    }
+</div>

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/_CentreCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/_CentreCard.cshtml
@@ -68,10 +68,15 @@
                asp-controller="Centres" asp-action="ManageCentre" asp-route-centreId="@Model.CentreId">
                 Manage centre
             </a>
-            <a class="nhsuk-button nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-2"
+            <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-2"
                role="button"
                asp-controller="Centres" asp-action="Courses" asp-route-centreId="@Model.CentreId">
                 View courses
+            </a>
+            <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-2"
+               role="button"
+               asp-controller="Centres" asp-action="SelfAssessments" asp-route-centreId="@Model.CentreId">
+                View self assessments
             </a>
             @if (Model.Active)
             {

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/InactivateDelegateConfirmation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Delegates/InactivateDelegateConfirmation.cshtml
@@ -29,7 +29,7 @@
             @Html.HiddenFor(x=>x.SearchString)
             @Html.HiddenFor(x=>x.ExistingFilterString)
             @Html.HiddenFor(x=>x.Page)
-            <h3>User: @Model.DisplayName</h3>
+            <h2>User: @Model.DisplayName</h2>
             <p id="IsChecked-hint">
                 <vc:single-checkbox asp-for="@nameof(Model.IsChecked)"
                                     label="I am sure that I wish to inactivate this delegate account." hint-text="This action will inactivate the delegate account. It will not inactivate any associated user accounts or admin accounts."></vc:single-checkbox>


### PR DESCRIPTION
### JIRA link
TD-2318

### Description
Implements a super admin -> centres -> self assessments view to list the self assessments published to a centre. Also adds a super admin UI accessibility tests class to test existing super admin UI (and fix associated issues) as well as the new view.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/eba1f579-9bc2-446d-81ff-ba12a3043200)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/2e7ee312-46e2-42a9-bdcb-42e33173b268)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
