### PR TITLE
TD-2483 Fix Learning Hub SSO base URL setting

### DIFF
--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -24,7 +24,7 @@
     "HashIterations": 10000,
     "ByteLength": 32,
     "SecretKey": "",
-    "BaseUrl": "https://auth-test.test-learninghub.org.uk/sso",
+    "BaseUrl": "https://auth.learninghub.org.uk/sso",
     "LoginEndpoint": "/login",
     "LinkingEndpoint": "/create-user",
     "ClientCode": "DigitalLearningSolutions",


### PR DESCRIPTION
### JIRA link
[TD-2483](https://hee-tis.atlassian.net/browse/TD-2483)

### Description
Appsettings contained a base URL for the Learning Hub Test Auth instance. This change replaces it with a reference to the production Auth service.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2483]: https://hee-tis.atlassian.net/browse/TD-2483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ