### PR TITLE
TD-3271- migration - Date min value is set to null in the CandatateAssessments table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202401161703_UpdateCandidateAssessments_SetDateMinValueToNull.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202401161703_UpdateCandidateAssessments_SetDateMinValueToNull.cs
@@ -1,0 +1,21 @@
+﻿using FluentMigrator;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    [Migration(202401161703)]
+    public class UpdateCandidateAssessments_SetDateMinValueToNull : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(
+                @$"UPDATE CandidateAssessments SET CompleteByDate = NULL
+                    WHERE CompleteByDate = '1900-01-01 00:00:00.000';"
+            );
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}
+

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -435,7 +435,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             IClockUtility clockUtility = new ClockUtility();
             DateTime startedDate = clockUtility.UtcNow;
             DateTime lastAccessed = startedDate;
-            dynamic completeByDateDynamic = "";
+            dynamic? completeByDateDynamic = null;
             if (completeByDate == null || completeByDate.GetValueOrDefault().Year > 1753)
             {
                 completeByDateDynamic = completeByDate!;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3271

### Description
This issue was resolved  by TD-1992 and working as expected.
completeByDateDynamic variable is set to null to avoid any chances of inserting empty value (1900-01-01 00:00:00.000) to completeByDate.

Migration code added which updates CandatateAssessments and sets completeByDate date as NULL to '1900-01-01 00:00:00.000'


### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/813d9262-0fb8-4279-b53a-cd5903b2cf03)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
