### PR TITLE
TD-3168 Changing Delegate courses Navigation breadcrumb links to Delegate activities

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesBreadcrumbs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesBreadcrumbs.cshtml
@@ -4,7 +4,7 @@
     <div class="nhsuk-width-container">
         <ol class="nhsuk-breadcrumb__list">
             <li class="nhsuk-breadcrumb__item">
-                <a class="nhsuk-breadcrumb__link" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Delegate courses</a>
+                <a class="nhsuk-breadcrumb__link" asp-controller="DelegateCourses" asp-action="Index" asp-route-customisationId="@Model">Delegate activities</a>
             </li>
             <li class="nhsuk-breadcrumb__item">
                 <a class="nhsuk-breadcrumb__link" asp-controller="ActivityDelegates" asp-action="Index" asp-route-customisationId="@Model">Activity delegates</a>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_CourseDelegatesProgressBreadcrumbs.cshtml
@@ -9,7 +9,7 @@
                    asp-controller="DelegateCourses"
                    asp-action="Index"
                    asp-route-customisationId="@Model.customisationId">
-                    Delegate courses
+                    Delegate activities
                 </a>
             </li>
             <li class="nhsuk-breadcrumb__item">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3168

### Description
I change Delegate courses navigation breadcrumb links to Delegate activities on Delegate Progress view and learning log view

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/fedc12de-2ea3-4317-a4e6-ed87dfb6492a)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/119814ea-e2f8-4054-854e-864f223055b0)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
