### PR TITLE
TD-3166- Mismatch of Enrolled and Submitted/Signed off count

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -1928,14 +1928,17 @@ namespace DigitalLearningSolutions.Data.DataServices
                         END AS Supervised,
                         (SELECT COUNT(can.ID)
                         FROM dbo.CandidateAssessments AS can WITH (NOLOCK)
-                        WHERE can.CentreID = @centreId AND can.SelfAssessmentID = csa.SelfAssessmentID) AS DelegateCount,
-                        (SELECT COUNT(can.ID)
-                        FROM dbo.CandidateAssessments AS can WITH (NOLOCK)
-                        LEFT JOIN dbo.CandidateAssessmentSupervisors AS cas ON can.ID = cas.CandidateAssessmentID
-                        LEFT JOIN dbo.CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
-                        WHERE can.CentreID = @centreId AND can.SelfAssessmentID = CSA.SelfAssessmentID 
-                        AND (can.SubmittedDate IS NOT NULL OR casv.SignedOff = 1)
-                        ) AS SubmittedSignedOffCount,
+                            INNER JOIN Users AS u WITH (NOLOCK) ON u.ID = can.DelegateUserID 
+						    LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = u.ID AND ucd.centreID = can.CentreID
+                        WHERE can.CentreID = @centreId AND can.SelfAssessmentID = csa.SelfAssessmentID
+                            AND can.RemovedDate IS NULL AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%.__%') AS DelegateCount,
+                        (Select COUNT(*) FROM
+                            (SELECT can.ID FROM dbo.CandidateAssessments AS can WITH (NOLOCK)
+                                LEFT JOIN dbo.CandidateAssessmentSupervisors AS cas ON can.ID = cas.CandidateAssessmentID
+                                LEFT JOIN dbo.CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID
+                                WHERE can.CentreID = @centreId AND can.SelfAssessmentID = CSA.SelfAssessmentID AND can.RemovedDate IS NULL
+                                AND (can.SubmittedDate IS NOT NULL OR (casv.SignedOff = 1 AND casv.Verified IS NOT NULL)) GROUP BY can.ID) A
+                                ) AS SubmittedSignedOffCount,
                         CC.Active AS Active,
                         sa.ID AS SelfAssessmentId
                         from CentreSelfAssessments AS csa 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3166

### Description
Delegate assessment statistics query modified to return correct count of Enrolled and Submitted/Signed off delegates.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/7a7e1e20-c9ab-4bf6-89ce-9414645fb740)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f6cce335-9415-4cc9-9393-968be7a1600c)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8acbf156-9a34-41fb-b283-fd70133789f9)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/da3e9a27-24f6-4e6a-be3e-88f19877e41f)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
