### PR TITLE
TD-3616 Fix transaction deadlocks triggered by learning menu controller

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
@@ -240,12 +240,12 @@
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE Progress
                         SET LoginCount = (SELECT COALESCE(COUNT(*), 0)
-                            FROM Sessions AS S
+                            FROM Sessions AS S WITH (NOLOCK)
                             WHERE S.CandidateID = Progress.CandidateID
                               AND S.CustomisationID = Progress.CustomisationID
                               AND S.LoginTime >= Progress.FirstSubmittedTime),
                             Duration = (SELECT COALESCE(SUM(S1.Duration), 0)
-                            FROM Sessions AS S1
+                            FROM Sessions AS S1 WITH (NOLOCK)
                             WHERE S1.CandidateID = Progress.CandidateID
                               AND S1.CustomisationID = Progress.CustomisationID
                               AND S1.LoginTime >= Progress.FirstSubmittedTime),

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/CompletionSummaryTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/CompletionSummaryTests.cs
@@ -88,7 +88,7 @@
             controller.CompletionSummary(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._))
                 .WhenArgumentsMatch((int id) => id != progressId)
                 .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticAssessmentTests.cs
@@ -78,7 +78,7 @@
             controller.Diagnostic(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticContentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticContentTests.cs
@@ -83,7 +83,7 @@
             controller.DiagnosticContent(CustomisationId, SectionId, emptySelectedTutorials);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
@@ -147,7 +147,7 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(CandidateId, CustomisationId, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningAssessmentTests.cs
@@ -78,7 +78,7 @@
             controller.PostLearning(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningContentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningContentTests.cs
@@ -78,7 +78,7 @@
             controller.PostLearningContent(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/SectionTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/SectionTests.cs
@@ -78,7 +78,7 @@
             controller.Section(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialContentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialContentTests.cs
@@ -88,7 +88,7 @@
             controller.ContentViewer(CustomisationId, SectionId, TutorialId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._))
                 .WhenArgumentsMatch((int id) => id != progressId)
                 .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialTests.cs
@@ -132,7 +132,7 @@
             await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialVideoTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialVideoTests.cs
@@ -88,7 +88,7 @@
             controller.TutorialVideo(CustomisationId, SectionId, TutorialId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._))
                 .WhenArgumentsMatch((int id) => id != progressId)
                 .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -79,6 +79,7 @@
             {
                 return RedirectToAction("CoursePassword", "LearningMenu", new { customisationId });
             }
+
             if (courseContent.Sections.Count == 1)
             {
                 var sectionId = courseContent.Sections.First().Id;
@@ -92,8 +93,10 @@
                     $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
 
@@ -222,9 +225,10 @@
                     $"centre id: {centreId}, section id: {sectionId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
-
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
 
@@ -262,8 +266,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new DiagnosticAssessmentViewModel(diagnosticAssessment, customisationId, sectionId);
@@ -296,8 +302,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new DiagnosticContentViewModel(
@@ -343,8 +351,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new PostLearningAssessmentViewModel(postLearningAssessment, customisationId, sectionId);
@@ -377,8 +387,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) >= 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new PostLearningContentViewModel(
@@ -428,8 +440,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             /* Course progress doesn't get updated if the auth token expires by the end of the tutorials.
@@ -471,8 +485,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new ContentViewerViewModel(
@@ -515,8 +531,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new TutorialVideoViewModel(
@@ -556,8 +574,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new CourseCompletionViewModel(config, courseCompletion, progressId.Value);

--- a/DigitalLearningSolutions.Web/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Web/Services/SessionService.cs
@@ -6,7 +6,7 @@
 
     public interface ISessionService
     {
-        void StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession);
+        int StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession);
 
         void StopDelegateSession(int candidateId, ISession httpContextSession);
 
@@ -24,12 +24,13 @@
             this.sessionDataService = sessionDataService;
         }
 
-        public void StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession)
+        public int StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession)
         {
             var currentSessionId = httpContextSession.GetInt32($"SessionID-{customisationId}");
+            int returnValue = 0;
             if (currentSessionId != null)
             {
-                sessionDataService.UpdateDelegateSessionDuration(currentSessionId.Value, clockUtility.UtcNow);
+                returnValue = sessionDataService.UpdateDelegateSessionDuration(currentSessionId.Value, clockUtility.UtcNow);
             }
             else
             {
@@ -39,7 +40,9 @@
                 // Make and keep track of a new session starting at this request
                 var newSessionId = sessionDataService.StartOrRestartDelegateSession(candidateId, customisationId);
                 httpContextSession.SetInt32($"SessionID-{customisationId}", newSessionId);
+                returnValue = newSessionId;
             }
+            return returnValue;
         }
 
         public void StopDelegateSession(int candidateId, ISession httpContextSession)


### PR DESCRIPTION
### JIRA link
[TD-3616](https://hee-tis.atlassian.net/browse/TD-3616)

### Description
Waits for return value of update session call before executing update progress call (which counts session records that are otherwise locked). Add WITH (NOLOCK) to queries to avoid deadlocking. Updates related tests to check for update session call rather than update progress call which is now hidden in a conditional.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3616]: https://hee-tis.atlassian.net/browse/TD-3616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ