### PR TITLE
TD-3620 revert tracker url for non-SCORM learning content to point to legacy tracker

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
@@ -240,12 +240,12 @@
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE Progress
                         SET LoginCount = (SELECT COALESCE(COUNT(*), 0)
-                            FROM Sessions AS S
+                            FROM Sessions AS S WITH (NOLOCK)
                             WHERE S.CandidateID = Progress.CandidateID
                               AND S.CustomisationID = Progress.CustomisationID
                               AND S.LoginTime >= Progress.FirstSubmittedTime),
                             Duration = (SELECT COALESCE(SUM(S1.Duration), 0)
-                            FROM Sessions AS S1
+                            FROM Sessions AS S1 WITH (NOLOCK)
                             WHERE S1.CandidateID = Progress.CandidateID
                               AND S1.CustomisationID = Progress.CustomisationID
                               AND S1.LoginTime >= Progress.FirstSubmittedTime),

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -1097,13 +1097,13 @@ namespace DigitalLearningSolutions.Data.DataServices
 				AND ((@hasCompleted IS NULL) OR (@hasCompleted = 1 AND pr.Completed IS NOT NULL) OR (@hasCompleted = 0 AND pr.Completed IS NULL))
 
                 AND ((@answer1 IS NULL) OR ((@answer1 = 'No option selected' OR @answer1 = 'FREETEXTBLANKVALUE') AND (pr.Answer1 IS NULL OR LTRIM(RTRIM(pr.Answer1)) = '')) 
-							OR (@answer1 = 'FREETEXTNOTBLANKVALUE' AND (pr.Answer1 IS NOT NULL OR pr.Answer1 = @answer1)))
+					OR ((@answer1 = 'FREETEXTNOTBLANKVALUE' OR (@answer1 != 'No option selected' AND @answer1 != 'FREETEXTBLANKVALUE')) AND (pr.Answer1 IS NOT NULL AND pr.Answer1 = @answer1)))
 
 				AND ((@answer2 IS NULL) OR ((@answer2 = 'No option selected' OR @answer2 = 'FREETEXTBLANKVALUE') AND (pr.Answer2 IS NULL OR LTRIM(RTRIM(pr.Answer2)) = '')) 
-							OR (@answer2 = 'FREETEXTNOTBLANKVALUE' AND (pr.Answer2 IS NOT NULL OR pr.Answer2 = @answer2)))
+					OR ((@answer2 = 'FREETEXTNOTBLANKVALUE' OR (@answer2 != 'No option selected' AND @answer2 != 'FREETEXTBLANKVALUE')) AND (pr.Answer2 IS NOT NULL AND pr.Answer2 = @answer2)))
 
 				AND ((@answer3 IS NULL) OR ((@answer3 = 'No option selected' OR @answer3 = 'FREETEXTBLANKVALUE') AND (pr.Answer3 IS NULL OR LTRIM(RTRIM(pr.Answer3)) = '')) 
-							OR (@answer3 = 'FREETEXTNOTBLANKVALUE' AND (pr.Answer3 IS NOT NULL OR pr.Answer3 = @answer3)))
+					OR ((@answer3 = 'FREETEXTNOTBLANKVALUE' OR (@answer3 != 'No option selected' AND @answer3 != 'FREETEXTBLANKVALUE')) AND (pr.Answer3 IS NOT NULL AND pr.Answer3 = @answer3)))
                 
                 AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%.__%'";
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/CompletionSummaryTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/CompletionSummaryTests.cs
@@ -88,7 +88,7 @@
             controller.CompletionSummary(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._))
                 .WhenArgumentsMatch((int id) => id != progressId)
                 .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticAssessmentTests.cs
@@ -78,7 +78,7 @@
             controller.Diagnostic(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticContentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/DiagnosticContentTests.cs
@@ -83,7 +83,7 @@
             controller.DiagnosticContent(CustomisationId, SectionId, emptySelectedTutorials);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
@@ -147,7 +147,7 @@
             controller.Index(CustomisationId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(CandidateId, CustomisationId, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningAssessmentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningAssessmentTests.cs
@@ -78,7 +78,7 @@
             controller.PostLearning(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningContentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/PostLearningContentTests.cs
@@ -78,7 +78,7 @@
             controller.PostLearningContent(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/SectionTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/SectionTests.cs
@@ -78,7 +78,7 @@
             controller.Section(CustomisationId, SectionId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialContentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialContentTests.cs
@@ -88,7 +88,7 @@
             controller.ContentViewer(CustomisationId, SectionId, TutorialId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._))
                 .WhenArgumentsMatch((int id) => id != progressId)
                 .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialTests.cs
@@ -132,7 +132,7 @@
             await controller.Tutorial(CustomisationId, SectionId, TutorialId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialVideoTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/TutorialVideoTests.cs
@@ -88,7 +88,7 @@
             controller.TutorialVideo(CustomisationId, SectionId, TutorialId);
 
             // Then
-            A.CallTo(() => courseContentService.UpdateProgress(progressId)).MustHaveHappened();
+            A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustHaveHappened();
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._))
                 .WhenArgumentsMatch((int id) => id != progressId)
                 .MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -32,6 +32,7 @@
         private ICourseService courseService = null!;
         private IDelegateActivityDownloadFileService delegateActivityDownloadFileService = null!;
         private IUserService userService = null!;
+        private ICourseAdminFieldsService courseAdminFieldsService = null!;
 
         [SetUp]
         public void SetUp()
@@ -43,6 +44,7 @@
             selfAssessmentDelegatesService = A.Fake<ISelfAssessmentService>();
             courseService = A.Fake<ICourseService>();
             userService = A.Fake<IUserService>();
+            courseAdminFieldsService = A.Fake<ICourseAdminFieldsService>();
 
             controller = new ActivityDelegatesController(
                     courseDelegatesService,
@@ -52,7 +54,8 @@
                     selfAssessmentDelegatesService,
                     courseService,
                     delegateActivityDownloadFileService,
-                    userService
+                    userService,
+                    courseAdminFieldsService
                 )
                 .WithDefaultContext()
                  .WithMockHttpContextSession()
@@ -190,7 +193,8 @@
                     selfAssessmentDelegatesService,
                     courseService,
                     delegateActivityDownloadFileService,
-                    userService
+                    userService,
+                    courseAdminFieldsService
                 )
                 .WithMockHttpContext(httpRequest, cookieName, cookieValue, httpResponse)
                 .WithMockUser(true, UserCentreId)

--- a/DigitalLearningSolutions.Web.Tests/Helpers/SystemEndpointHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/SystemEndpointHelperTests.cs
@@ -34,7 +34,7 @@
         public void GetTrackingUrl_returns_expected()
         {
             // Given
-            const string expected = "https://www.dls.nhs.uk/v2/tracking/tracker";
+            const string expected = "https://www.dls.nhs.uk/tracking/tracker";
 
             // Then
             SystemEndpointHelper.GetTrackingUrl(config).Should().Be(expected);

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/ContentViewerViewModelTests.cs
@@ -253,7 +253,7 @@
             const int customisationId = 24861;
             var expectedHtmlUrl = "https://www.dls.nhs.uk/CMS/CMSContent/Course508/Section1904/Tutorials/Intro to Social Media/itspplayer.html"
                                 + "?CentreID=101&CustomisationID=24861&TutorialID=4&CandidateID=254480&Version=2&ProgressID=276837&type=learn"
-                                + $"&TrackURL={AppRootPathUrl}/tracking/tracker";
+                                + $"&TrackURL={BaseUrl}/tracking/tracker";
 
             // Given
             var expectedTutorialContent = TutorialContentHelper.CreateDefaultTutorialContent(

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/DiagnosticContentViewModelTests.cs
@@ -163,7 +163,7 @@
             diagnosticContentViewModel.ContentSource.Should().Be(
                 "https://www.dls.nhs.uk/CMS/CMSContent/Course119/Diagnostic/07DiagnosticTesting/itspplayer.html" +
                 "?CentreID=6&CustomisationID=5&CandidateID=8&SectionID=7&Version=55&ProgressID=9" +
-                $"&type=diag&TrackURL={AppRootPathUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
+                $"&type=diag&TrackURL={BaseUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
             );
         }
 
@@ -199,7 +199,7 @@
             diagnosticContentViewModel.ContentSource.Should().Be(
                 "https://www.dls.nhs.uk/CMS/CMSContent/Course119/Diagnostic/07DiagnosticTesting/itspplayer.html" +
                 "?CentreID=6&CustomisationID=5&CandidateID=8&SectionID=7&Version=55&ProgressID=9" +
-                $"&type=diag&TrackURL={AppRootPathUrl}/tracking/tracker&objlist=[1,2,3,4]&plathresh=77"
+                $"&type=diag&TrackURL={BaseUrl}/tracking/tracker&objlist=[1,2,3,4]&plathresh=77"
             );
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningContentViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/LearningMenu/PostLearningContentViewModelTests.cs
@@ -151,7 +151,7 @@
             postLearningContentViewModel.ContentSource.Should().Be(
                 "https://www.dls.nhs.uk/CMS/CMSContent/Course120/PLAssess/03-PLA-Working-with-files/itspplayer.html" +
                 "?CentreID=6&CustomisationID=5&CandidateID=8&SectionID=7&Version=55&ProgressID=9" +
-                $"&type=pl&TrackURL={AppRootPathUrl}/tracking/tracker&objlist=[1,2,3]&plathresh=77"
+                $"&type=pl&TrackURL={BaseUrl}/tracker&objlist=[1,2,3]&plathresh=77"
             );
         }
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptionsTests.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
-    using DigitalLearningSolutions.Data.Tests.TestHelpers;
     using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DelegateGroups;
     using FluentAssertions;
     using FluentAssertions.Execution;
@@ -32,17 +31,17 @@
             {
                 result.Count.Should().Be(8);
                 result.Single(f => f.DisplayText == "Prompt 1").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|1");
+                    .Be("LinkedToField|Prompt 1|1");
                 result.Single(f => f.DisplayText == "Prompt 2").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|2");
+                    .Be("LinkedToField|Prompt 2|2");
                 result.Single(f => f.DisplayText == "Prompt 3").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|3");
+                    .Be("LinkedToField|Prompt 3|3");
                 result.Single(f => f.DisplayText == "Prompt 4").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|5");
+                    .Be("LinkedToField|Prompt 4|5");
                 result.Single(f => f.DisplayText == "Prompt 5").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|6");
+                    .Be("LinkedToField|Prompt 5|6");
                 result.Single(f => f.DisplayText == "Prompt 6").FilterValue.Should()
-                    .Be("LinkedToField|LinkedToField|7");
+                    .Be("LinkedToField|Prompt 6|7");
             }
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -79,6 +79,7 @@
             {
                 return RedirectToAction("CoursePassword", "LearningMenu", new { customisationId });
             }
+
             if (courseContent.Sections.Count == 1)
             {
                 var sectionId = courseContent.Sections.First().Id;
@@ -92,8 +93,10 @@
                     $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
 
@@ -222,9 +225,10 @@
                     $"centre id: {centreId}, section id: {sectionId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
-
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
 
@@ -262,8 +266,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new DiagnosticAssessmentViewModel(diagnosticAssessment, customisationId, sectionId);
@@ -296,8 +302,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new DiagnosticContentViewModel(
@@ -343,8 +351,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new PostLearningAssessmentViewModel(postLearningAssessment, customisationId, sectionId);
@@ -377,8 +387,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) >= 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new PostLearningContentViewModel(
@@ -428,8 +440,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             /* Course progress doesn't get updated if the auth token expires by the end of the tutorials.
@@ -471,8 +485,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new ContentViewerViewModel(
@@ -515,8 +531,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new TutorialVideoViewModel(
@@ -556,8 +574,10 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
 
-            sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session);
-            courseContentService.UpdateProgress(progressId.Value);
+            if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
+            {
+                courseContentService.UpdateProgress(progressId.Value);
+            };
 
             SetTempData(candidateId, customisationId);
             var model = new CourseCompletionViewModel(config, courseCompletion, progressId.Value);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -109,7 +109,7 @@
 
             if (isCourseDelegate)
             {
-                if (TempData["actDelCustomisationId"] != null && TempData["actDelCustomisationId"].ToString() != customisationId.ToString()
+                if (TempData["actDelCustomisationId"]?.ToString() != customisationId.ToString()
                         && existingFilterString != null && existingFilterString.Contains("Answer"))
                 {
                     var availableCourseFilters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels(courseAdminFieldsService.GetCourseAdminFieldsForCourse(customisationId.Value).AdminFields);
@@ -509,7 +509,7 @@
             }
 
             var delegateEntity = userService.GetUserById(delegateUserId)!;
-            string delegateName = delegateEntity != null ? delegateEntity.UserAccount.FirstName.ToString() + " " + delegateEntity.UserAccount.LastName.ToString() : ""; 
+            string delegateName = delegateEntity != null ? delegateEntity.UserAccount.FirstName.ToString() + " " + delegateEntity.UserAccount.LastName.ToString() : "";
 
             var model = new EditCompleteByDateViewModel(
                 assessment.Name,
@@ -552,8 +552,8 @@
             ReturnPageQuery? returnPageQuery = formData.ReturnPageQuery;
             var routeData = returnPageQuery!.Value.ToRouteDataDictionary();
             routeData.Add("selfAssessmentId", selfAssessmentId.ToString());
-            
-            if (accessedVia.Id==1 && accessedVia.Name == "ViewDelegate")
+
+            if (accessedVia.Id == 1 && accessedVia.Name == "ViewDelegate")
             {
                 var centreId = User.GetCentreIdKnownNotNull();
                 var delegateAccountId = selfAssessmentService.GetDelegateAccountId(centreId, delegateUserId);
@@ -563,7 +563,7 @@
             {
                 return RedirectToAction("Index", "ActivityDelegates", routeData, returnPageQuery.Value.ItemIdToReturnTo);
             }
-        }        
+        }
     }
 }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -44,6 +44,7 @@
         private readonly ICourseService courseService;
         private readonly IDelegateActivityDownloadFileService delegateActivityDownloadFileService;
         private readonly IUserService userService;
+        private readonly ICourseAdminFieldsService courseAdminFieldsService;
         private static readonly IClockUtility clockUtility = new ClockUtility();
 
         public ActivityDelegatesController(
@@ -54,7 +55,8 @@
             ISelfAssessmentService selfAssessmentService,
             ICourseService courseService,
             IDelegateActivityDownloadFileService delegateActivityDownloadFileService,
-            IUserService userService
+            IUserService userService,
+            ICourseAdminFieldsService courseAdminFieldsService
         )
         {
             this.courseDelegatesService = courseDelegatesService;
@@ -65,6 +67,7 @@
             this.courseService = courseService;
             this.delegateActivityDownloadFileService = delegateActivityDownloadFileService;
             this.userService = userService;
+            this.courseAdminFieldsService = courseAdminFieldsService;
         }
 
         [NoCaching]
@@ -104,11 +107,16 @@
                 CourseDelegateAccountStatusFilterOptions.Active.FilterValue
             );
 
-            if (existingFilterString != null && existingFilterString.Contains("Answer"))
+            if (isCourseDelegate)
             {
-                var filtersWithoutPromo = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("Answer")).ToList();
-                existingFilterString = filtersWithoutPromo.Any() ? string.Join(FilteringHelper.FilterSeparator, filtersWithoutPromo) : null;
+                if (TempData["actDelCustomisationId"] != null && TempData["actDelCustomisationId"].ToString() != customisationId.ToString()
+                        && existingFilterString != null && existingFilterString.Contains("Answer"))
+                {
+                    var availableCourseFilters = CourseDelegateViewModelFilterOptions.GetAllCourseDelegatesFilterViewModels(courseAdminFieldsService.GetCourseAdminFieldsForCourse(customisationId.Value).AdminFields);
+                    existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableCourseFilters, existingFilterString);
+                }
             }
+
             int offSet = ((page - 1) * itemsPerPage) ?? 0;
 
             var centreId = User.GetCentreIdKnownNotNull();
@@ -200,8 +208,7 @@
 
                     if (courseDelegatesData?.Delegates.Count() == 0 && resultCount > 0)
                     {
-                        page = 1;
-                        offSet = 0;
+                        page = 1; offSet = 0;
                         (courseDelegatesData, resultCount) = courseDelegatesService.GetCoursesAndCourseDelegatesPerPageForCentre(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
                             customisationId, centreId, adminCategoryId, isDelegateActive, isProgressLocked, removed, hasCompleted, answer1, answer2, answer3);
                     }
@@ -213,8 +220,7 @@
 
                     if (selfAssessmentDelegatesData?.Delegates?.Count() == 0 && resultCount > 0)
                     {
-                        page = 1;
-                        offSet = 0;
+                        page = 1; offSet = 0;
                         (selfAssessmentDelegatesData, resultCount) = selfAssessmentService.GetSelfAssessmentDelegatesPerPage(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
                             selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
                     }
@@ -260,6 +266,7 @@
                     TempData["Page"] = result.Page;
                     Response.UpdateFilterCookie(filterCookieName, result.FilterString);
                     var model = new ActivityDelegatesViewModel(courseDelegatesData, result, availableFilters, "customisationId", activityName, true);
+                    TempData["actDelCustomisationId"] = customisationId;
                     return View(model);
                 }
                 else

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -86,7 +86,7 @@
             var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
             var availableFilters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(jobGroups, promptsWithOptions);
 
-            if (TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString()
+            if (TempData["allDelegatesCentreId"]?.ToString() != centreId.ToString()
                     && existingFilterString != null && existingFilterString.Contains("Answer"))
             {
                 existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableFilters, existingFilterString);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -77,31 +77,30 @@
                 DelegateActiveStatusFilterOptions.IsActive.FilterValue
             );
 
-            int offSet = ((page - 1) * itemsPerPage) ?? 0;            
+            int offSet = ((page - 1) * itemsPerPage) ?? 0;
 
             var centreId = User.GetCentreIdKnownNotNull();
             var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
             var customPrompts = promptsService.GetCentreRegistrationPrompts(centreId).ToList();
 
-            string isActive = "Any";
-            string isPasswordSet = "Any";
-            string isAdmin = "Any";
-            string isUnclaimed = "Any";
-            string isEmailVerified = "Any";
-            string registrationType = "Any";
+            var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
+            var availableFilters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(jobGroups, promptsWithOptions);
+
+            if (TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString()
+                    && existingFilterString != null && existingFilterString.Contains("Answer"))
+            {
+                existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableFilters, existingFilterString);
+            }
+
+            string isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, answer1, answer2, answer3, answer4, answer5, answer6;
+            isActive = isPasswordSet = isAdmin = isUnclaimed = isEmailVerified = registrationType = answer1 = answer2 = answer3 = answer4 = answer5 = answer6 = "Any";
             int jobGroupId = 0;
-            string answer1 = "Any";
-            string answer2 = "Any";
-            string answer3 = "Any";
-            string answer4 = "Any";
-            string answer5 = "Any";
-            string answer6 = "Any";
 
             if (!string.IsNullOrEmpty(existingFilterString))
             {
                 var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
 
-                if(!string.IsNullOrEmpty(newFilterToAdd))
+                if (!string.IsNullOrEmpty(newFilterToAdd))
                 {
                     var filterHeader = newFilterToAdd.Split(FilteringHelper.Separator)[1];
                     var dupfilters = selectedFilters.Where(x => x.Contains(filterHeader));
@@ -112,7 +111,7 @@
                             if (filter.Contains(filterHeader))
                             {
                                 selectedFilters.Remove(filter);
-                                existingFilterString= string.Join(FilteringHelper.FilterSeparator,selectedFilters);
+                                existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
                                 break;
                             }
                         }
@@ -125,10 +124,10 @@
                     {
                         var filterArr = filter.Split(FilteringHelper.Separator);
                         var filterValue = filterArr[2];
-                        if (filterValue == "╳") filterValue = "No option selected";
+                        if (filterValue == FilteringHelper.EmptyValue) filterValue = "No option selected";
 
                         if (filter.Contains("IsPasswordSet"))
-                            isPasswordSet= filterValue;
+                            isPasswordSet = filterValue;
 
                         if (filter.Contains("IsAdmin"))
                             isAdmin = filterValue;
@@ -168,7 +167,6 @@
                     }
                 }
             }
-            
 
             (var delegates, var resultCount) = this.userDataService.GetDelegateUserCards(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection, centreId,
                                                 isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
@@ -176,18 +174,11 @@
 
             if (delegates.Count() == 0 && resultCount > 0)
             {
-                page = 1;
-                offSet = 0;
+                page = 1; offSet = 0;
                 (delegates, resultCount) = this.userDataService.GetDelegateUserCards(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection, centreId,
                                                 isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
                                                 answer1, answer2, answer3, answer4, answer5, answer6);
             }
-
-            var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
-            var availableFilters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(
-            jobGroups,
-            promptsWithOptions
-            );
 
             var result = paginateService.Paginate(
                 delegates,
@@ -213,6 +204,7 @@
 
             Response.UpdateFilterCookie(DelegateFilterCookieName, existingFilterString);
             TempData.Remove("delegateRegistered");
+            TempData["allDelegatesCentreId"] = User.GetCentreId().ToString();
             return View(model);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -95,7 +95,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             var availableFilters = DelegateGroupsViewModelFilterOptions
                 .GetDelegateGroupFilterModels(addedByAdmins, registrationPrompts).ToList();
 
-            if (TempData["DelegateGroupCentreId"] != null && TempData["DelegateGroupCentreId"].ToString() != User.GetCentreId().ToString()
+            if (TempData["DelegateGroupCentreId"]?.ToString() != centreId.ToString()
                     && existingFilterString != null)
             {
                 existingFilterString = FilterHelper.RemoveNonExistingGroupFilters(availableFilters, existingFilterString);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -2,7 +2,6 @@
 using DigitalLearningSolutions.Data.Helpers;
 using DigitalLearningSolutions.Data.Models.CustomPrompts;
 using DigitalLearningSolutions.Data.Models.DelegateGroups;
-using DigitalLearningSolutions.Data.Models.Frameworks;
 using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
 using DigitalLearningSolutions.Web.Attributes;
 using DigitalLearningSolutions.Web.Helpers;
@@ -92,6 +91,16 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 );
             }
 
+            var registrationPrompts = GetRegistrationPromptsWithSetOptions(centreId);
+            var availableFilters = DelegateGroupsViewModelFilterOptions
+                .GetDelegateGroupFilterModels(addedByAdmins, registrationPrompts).ToList();
+
+            if (TempData["DelegateGroupCentreId"] != null && TempData["DelegateGroupCentreId"].ToString() != User.GetCentreId().ToString()
+                    && existingFilterString != null)
+            {
+                existingFilterString = FilterHelper.RemoveNonExistingGroupFilters(availableFilters, existingFilterString);
+            }
+
             int offSet = ((page - 1) * itemsPerPage) ?? 0;
             string filterAddedBy = "";
             string filterLinkedField = "";
@@ -161,10 +170,6 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     filterLinkedField);
             }
 
-            var registrationPrompts = GetRegistrationPromptsWithSetOptions(centreId);
-            var availableFilters = DelegateGroupsViewModelFilterOptions
-                .GetDelegateGroupFilterModels(addedByAdmins, registrationPrompts).ToList();
-
             var result = paginateService.Paginate(
                 groups,
                 resultCount,
@@ -186,6 +191,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             model.TotalPages = (int)(resultCount / itemsPerPage) + ((resultCount % itemsPerPage) > 0 ? 1 : 0);
             model.MatchingSearchResults = resultCount;
             Response.UpdateFilterCookie(DelegateGroupsFilterCookieName, result.FilterString);
+            TempData["DelegateGroupCentreId"] = centreId;
 
             return View(model);
         }
@@ -296,7 +302,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 return NotFound();
             }
 
-            if ( (!groupsService.IsDelegateGroupExist(model.GroupName.Trim(), centreId)) || (group.GroupLabel.Trim()== model.GroupName.Trim()) )
+            if ((!groupsService.IsDelegateGroupExist(model.GroupName.Trim(), centreId)) || (group.GroupLabel.Trim() == model.GroupName.Trim()))
             {
                 groupsService.UpdateGroupName(
                 groupId,

--- a/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
@@ -31,9 +31,9 @@ namespace DigitalLearningSolutions.Web.Helpers
 
                         foreach (var filterOption in availableFilterOptions)
                         {
-                            if (filterOption.Any(x => x.DisplayText.Contains(filterOptionText)))
+                            if (filterOption.Any(x => x.DisplayText == filterOptionText))
                             {
-                                var filter = filterOption.Where(x => x.DisplayText.Contains(filterOptionText)).ToList().Select(x => x.FilterValue).FirstOrDefault();
+                                var filter = filterOption.Where(x => x.DisplayText == filterOptionText).ToList().Select(x => x.FilterValue).FirstOrDefault();
                                 if (!filter.Contains(promptDbText))
                                 { //when prompt filter header and selected option match but db coulum (eg. Answer1) does not match
                                   //remove from existing filter and add from available filter

--- a/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
@@ -1,0 +1,115 @@
+﻿using DigitalLearningSolutions.Data.Helpers;
+using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DigitalLearningSolutions.Web.Helpers
+{
+    public static class FilterHelper
+    {
+        public static string? RemoveNonExistingPromptFilters(List<FilterModel> availableFilters, string existingFilterString)
+        {
+            if (existingFilterString != null && existingFilterString.Contains("Answer"))
+            {
+                if (availableFilters.Where(x => x.FilterGroupKey == "prompts").ToList().Any())
+                {
+                    var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
+                    var existingPromptFilters = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => filter.Contains("Answer")).ToList();
+
+                    foreach (var existingPromptFilter in existingPromptFilters)
+                    {
+                        bool isFound = false;
+                        var splitFilter = existingPromptFilter.Split(FilteringHelper.Separator);
+                        var filterHeaderArr = splitFilter[0].SkipWhile(c => c != '(').Skip(1).TakeWhile(c => c != ')').ToArray();
+                        var filterHeader = string.Join("", filterHeaderArr); //prompt header
+                        var filterOptionText = splitFilter[2] == FilteringHelper.EmptyValue ?
+                                                            "No option selected" : splitFilter[2]; //prompt option text
+                        var promptDbText = splitFilter[1]; //filter db text eg. Answer1
+
+                        var availableFilterOptions = availableFilters.Where(x => x.FilterGroupKey == "prompts" && x.FilterName == filterHeader)
+                                                                     .Select(o => o.FilterOptions).ToList();
+
+                        foreach (var filterOption in availableFilterOptions)
+                        {
+                            if (filterOption.Any(x => x.DisplayText.Contains(filterOptionText)))
+                            {
+                                var filter = filterOption.Where(x => x.DisplayText.Contains(filterOptionText)).ToList().Select(x => x.FilterValue).FirstOrDefault();
+                                if (!filter.Contains(promptDbText))
+                                { //when prompt filter header and selected option match but db coulum (eg. Answer1) does not match
+                                  //remove from existing filter and add from available filter
+                                    selectedFilters.Remove(existingPromptFilter);
+                                    selectedFilters.Add(filter);
+                                    existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                                }
+                                isFound = true; break;
+                            }
+                        }
+                        if (!isFound)
+                        {
+                            selectedFilters.Remove(existingPromptFilter);
+                            existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                            if (existingFilterString == "") existingFilterString = null;
+                        }
+                    }
+                }
+                else
+                {
+                    var filtersExceptPrompts = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("Answer")).ToList();
+                    existingFilterString = filtersExceptPrompts.Any() ? string.Join(FilteringHelper.FilterSeparator, filtersExceptPrompts) : null;
+                }
+            }
+            return existingFilterString;
+        }
+
+        public static string? RemoveNonExistingGroupFilters(List<FilterModel> availableFilters, string existingFilterString)
+        {
+            var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
+            string[] filterGroups = { "AddedByAdminId", "LinkedToField" };
+            foreach (var filterGroup in filterGroups)
+            {
+                var existingFilters = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => filter.Contains(filterGroup)).ToList();
+
+                foreach (var existingFilter in existingFilters)
+                {
+                    bool isFound = false;
+                    var splitFilter = existingFilter.Split(FilteringHelper.Separator);
+                    var filterHeader = splitFilter[1];
+                    var filterOptionText = splitFilter[2];
+                    var availableFilterOptions = availableFilters.Where(x => x.FilterProperty == filterGroup).Select(o => o.FilterOptions).ToList();
+                    foreach (var availableFilterOption in availableFilterOptions)
+                    {
+                        if (filterGroup == "AddedByAdminId")
+                        {
+                            if (availableFilterOption.Any(x => x.FilterValue.Contains(filterOptionText)))
+                            {
+                                isFound = true; break;
+                            }
+                        }
+                        else
+                        {
+                            if (availableFilterOption.Any(x => x.FilterValue.Contains(filterHeader)))
+                            {
+                                var filter = availableFilterOption.Where(x => x.FilterValue.Contains(filterHeader)).ToList().Select(x => x.FilterValue).FirstOrDefault();
+                                if (!filter.Contains(filterOptionText))
+                                {
+                                    selectedFilters.Remove(existingFilter);
+                                    selectedFilters.Add(filter);
+                                    existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                                }
+                                isFound = true; break;
+                            }
+                        }
+                    }
+
+                    if (!isFound)
+                    {
+                        selectedFilters.Remove(existingFilter);
+                        existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
+                    }
+                }
+            }
+            if (existingFilterString == "") existingFilterString = null;
+            return existingFilterString;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateGroupFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateGroupFilterOptions.cs
@@ -13,13 +13,13 @@
 
         public static readonly FilterOptionModel None = new FilterOptionModel(
             "None",
-            FilteringHelper.BuildFilterValueString(GroupName, nameof(Group.LinkedToField), "0"),
+            FilteringHelper.BuildFilterValueString(GroupName, "None", "0"),
             FilterStatus.Default
         );
 
         public static readonly FilterOptionModel JobGroup = new FilterOptionModel(
             "Job group",
-            FilteringHelper.BuildFilterValueString(GroupName, nameof(Group.LinkedToField), "4"),
+            FilteringHelper.BuildFilterValueString(GroupName, "Job group", "4"),
             FilterStatus.Default
         );
     }

--- a/DigitalLearningSolutions.Web/Helpers/SystemEndpointHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SystemEndpointHelper.cs
@@ -12,7 +12,7 @@
 
         public static string GetTrackingUrl(IConfiguration config)
         {
-            return $"{config.GetAppRootPath()}/tracking/tracker";
+            return $"{config.GetCurrentSystemBaseUrl()}/tracking/tracker";
         }
 
         public static string GetScormPlayerUrl(IConfiguration config)

--- a/DigitalLearningSolutions.Web/Services/SessionService.cs
+++ b/DigitalLearningSolutions.Web/Services/SessionService.cs
@@ -6,7 +6,7 @@
 
     public interface ISessionService
     {
-        void StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession);
+        int StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession);
 
         void StopDelegateSession(int candidateId, ISession httpContextSession);
 
@@ -24,12 +24,13 @@
             this.sessionDataService = sessionDataService;
         }
 
-        public void StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession)
+        public int StartOrUpdateDelegateSession(int candidateId, int customisationId, ISession httpContextSession)
         {
             var currentSessionId = httpContextSession.GetInt32($"SessionID-{customisationId}");
+            int returnValue = 0;
             if (currentSessionId != null)
             {
-                sessionDataService.UpdateDelegateSessionDuration(currentSessionId.Value, clockUtility.UtcNow);
+                returnValue = sessionDataService.UpdateDelegateSessionDuration(currentSessionId.Value, clockUtility.UtcNow);
             }
             else
             {
@@ -39,7 +40,9 @@
                 // Make and keep track of a new session starting at this request
                 var newSessionId = sessionDataService.StartOrRestartDelegateSession(candidateId, customisationId);
                 httpContextSession.SetInt32($"SessionID-{customisationId}", newSessionId);
+                returnValue = newSessionId;
             }
+            return returnValue;
         }
 
         public void StopDelegateSession(int candidateId, ISession httpContextSession)

--- a/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
+++ b/DigitalLearningSolutions.Web/Services/TrackerActionService.cs
@@ -410,6 +410,7 @@
             }
             if (rowsUpdated > 0)
             {
+                progressService.CheckProgressForCompletionAndSendEmailIfCompleted(progress);
                 return TrackerEndpointResponse.Success;
             }
             else

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/DelegateGroups/DelegateGroupsViewModelFilterOptions.cs
@@ -4,15 +4,10 @@
     using System.Linq;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
-    using DigitalLearningSolutions.Data.Models.Courses;
     using DigitalLearningSolutions.Data.Models.CustomPrompts;
     using DigitalLearningSolutions.Data.Models.DelegateGroups;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
-    using DigitalLearningSolutions.Data.Models.User;
-    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Helpers.FilterOptions;
-    using DigitalLearningSolutions.Web.Models.Enums;
-    using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
 
     public static class DelegateGroupsViewModelFilterOptions
     {
@@ -29,7 +24,7 @@
             var promptOptions = registrationPrompts.Select(
                 prompt => new FilterOptionModel(
                     prompt.PromptText,
-                    nameof(Group.LinkedToField) + FilteringHelper.Separator + nameof(Group.LinkedToField) +
+                    nameof(Group.LinkedToField) + FilteringHelper.Separator + prompt.PromptText +
                     FilteringHelper.Separator + prompt.RegistrationField.LinkedToFieldId,
                     FilterStatus.Default
                 )


### PR DESCRIPTION
### JIRA link
[TD-3620](https://hee-tis.atlassian.net/browse/TD-3620)

### Description
Changes the tracker URL passed to non-SCORM learning content to use the URL for the legacy application. This change needs to be coupled with a tweak to the itsp-tracking JavaScript file to revert changes to use the new version of the Tracker which were not working properly in release .23.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
