### PR TITLE
TD-3611- prompts filter not working

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -1097,13 +1097,13 @@ namespace DigitalLearningSolutions.Data.DataServices
 				AND ((@hasCompleted IS NULL) OR (@hasCompleted = 1 AND pr.Completed IS NOT NULL) OR (@hasCompleted = 0 AND pr.Completed IS NULL))
 
                 AND ((@answer1 IS NULL) OR ((@answer1 = 'No option selected' OR @answer1 = 'FREETEXTBLANKVALUE') AND (pr.Answer1 IS NULL OR LTRIM(RTRIM(pr.Answer1)) = '')) 
-					OR ((@answer1 = 'FREETEXTNOTBLANKVALUE' OR (@answer1 != 'No option selected' AND @answer1 != 'FREETEXTBLANKVALUE')) AND (pr.Answer1 IS NOT NULL AND pr.Answer1 = @answer1)))
+					OR ((@answer1 = 'FREETEXTNOTBLANKVALUE' AND pr.Answer1 IS NOT NULL AND LTRIM(RTRIM(pr.Answer1)) != '') OR (pr.Answer1 IS NOT NULL AND pr.Answer1 = @answer1)))
 
 				AND ((@answer2 IS NULL) OR ((@answer2 = 'No option selected' OR @answer2 = 'FREETEXTBLANKVALUE') AND (pr.Answer2 IS NULL OR LTRIM(RTRIM(pr.Answer2)) = '')) 
-					OR ((@answer2 = 'FREETEXTNOTBLANKVALUE' OR (@answer2 != 'No option selected' AND @answer2 != 'FREETEXTBLANKVALUE')) AND (pr.Answer2 IS NOT NULL AND pr.Answer2 = @answer2)))
+					OR ((@answer2 = 'FREETEXTNOTBLANKVALUE' AND pr.Answer2 IS NOT NULL AND LTRIM(RTRIM(pr.Answer2)) != '') OR (pr.Answer2 IS NOT NULL AND pr.Answer2 = @answer2)))
 
 				AND ((@answer3 IS NULL) OR ((@answer3 = 'No option selected' OR @answer3 = 'FREETEXTBLANKVALUE') AND (pr.Answer3 IS NULL OR LTRIM(RTRIM(pr.Answer3)) = '')) 
-					OR ((@answer3 = 'FREETEXTNOTBLANKVALUE' OR (@answer3 != 'No option selected' AND @answer3 != 'FREETEXTBLANKVALUE')) AND (pr.Answer3 IS NOT NULL AND pr.Answer3 = @answer3)))
+					OR ((@answer3 = 'FREETEXTNOTBLANKVALUE' AND pr.Answer3 IS NOT NULL AND LTRIM(RTRIM(pr.Answer3)) != '') OR (pr.Answer3 IS NOT NULL AND pr.Answer3 = @answer3)))
                 
                 AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%.__%'";
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3611

### Description
Delegate courses - query modified for blank and not-blank filter values.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/0fb2cbd9-7c72-4722-b8ca-8f9ba2b8a4c9)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/41de1034-fc2d-4cd7-a754-4320ac520de5)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1eb3e1c1-6977-4cfc-bff3-7624ec8390cf)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f259c4e6-7fc5-4f38-be80-36e515ae66ca)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/a07a31dc-b8e6-45c6-8346-8c79330dc87b)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8e7ab793-c631-4ac0-8d77-3dec02bbcf08)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
