### PR TITLE
TD-3604-Centre email not verified is showing as 'Verified' on 'Delegates' section

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -629,7 +629,7 @@
                 ucd.UserID,
                 ucd.CentreID,
                 ucd.Email as CentreEmail,
-                ucd.EmailVerified,
+                ucd.EmailVerified as CentreEmailVerified,
                 (SELECT ID
                     FROM AdminAccounts aa
                         WHERE aa.UserID = da.UserID

--- a/DigitalLearningSolutions.Data/Models/SuperAdmin/SuperAdminDelegateAccount.cs
+++ b/DigitalLearningSolutions.Data/Models/SuperAdmin/SuperAdminDelegateAccount.cs
@@ -1,11 +1,13 @@
 ﻿using DigitalLearningSolutions.Data.Models.User;
+using System;
 
 namespace DigitalLearningSolutions.Data.Models.SuperAdmin
 {
-    public class SuperAdminDelegateAccount:DelegateUser
+    public class SuperAdminDelegateAccount : DelegateUser
     {
         public SuperAdminDelegateAccount() { }
-        public SuperAdminDelegateAccount(DelegateEntity delegateEntity) {
+        public SuperAdminDelegateAccount(DelegateEntity delegateEntity)
+        {
             Id = delegateEntity.DelegateAccount.Id;
             FirstName = delegateEntity.UserAccount.FirstName;
             LastName = delegateEntity.UserAccount.LastName;
@@ -26,6 +28,7 @@ namespace DigitalLearningSolutions.Data.Models.SuperAdmin
         }
         public bool SelfReg { get; set; }
         public string? CentreEmail { get; set; }
+        public DateTime? CentreEmailVerified { get; set; }
         public int? LearningHubAuthId { get; set; }
         public bool UserActive { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Delegates/SearchableDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Delegates/SearchableDelegatesViewModel.cs
@@ -30,7 +30,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.SuperAdmin.Delegates
             DateRegistered = delegates.DateRegistered?.ToString(Data.Helpers.DateHelper.StandardDateFormat);
             SelRegistered = delegates.SelfReg;
             IsDelegateActive = delegates.Active;
-            IsCentreEmailVerified = delegates.EmailVerified == null ? false : true;
+            IsCentreEmailVerified = delegates.CentreEmailVerified == null ? false : true;
             CanShowInactivateDelegateButton = IsDelegateActive;
             IsUserActive = delegates.UserActive;
             IsApproved = delegates.Approved;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3604

### Description
Added the CentreEmailVerified property and referenced the same in the view to display the centre email status.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1c1165d8-5644-4ec5-b1a4-08c6fcc1bc48)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c9bf641d-3877-4399-b464-26018605fc48)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
