### PR TITLE
TD-3214 Adding submitted / signed off status tags to Activity delegate cards 

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -210,27 +210,21 @@
 
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForSelfAssessmentDelegate(SelfAssessmentDelegate selfAssessmentDelegate)
         {
-            var tags = new List<SearchableTagViewModel>();
-
-            if (selfAssessmentDelegate.IsDelegateActive)
+            return new List<SearchableTagViewModel>
             {
-                tags.Add(new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Active));
-            }
-            else
-            {
-                tags.Add(new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Inactive));
-            }
-
-            if (selfAssessmentDelegate.RemovedDate.HasValue)
-            {
-                tags.Add(new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.Removed));
-            }
-            else
-            {
-                tags.Add(new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.NotRemoved, true));
-            }
-
-            return tags;
+                selfAssessmentDelegate.IsDelegateActive
+                ?new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Active)
+                :new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Inactive),
+                selfAssessmentDelegate.RemovedDate.HasValue
+                ?new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.Removed)
+                :new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.NotRemoved, true),
+                selfAssessmentDelegate.SignedOff.HasValue
+                ?new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.SignedOff)
+                :new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.NotSignedOff, true),
+                selfAssessmentDelegate.SubmittedDate.HasValue
+                ?new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.Submitted)
+                :new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.NotSubmitted, true)
+            };
         }
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForDelegateUser(
             DelegateUserCard delegateUser


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3214

### Description
I added submitted and signedoff to the filter tags helper page
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/6666a422-9d21-4981-a2c0-c032d9a87b66)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
