### PR TITLE
TD-3610-Show either "Submitted" or "Signed off" fields and filters.

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -116,6 +116,17 @@
                     existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableCourseFilters, existingFilterString);
                 }
             }
+            else
+            {
+                if (existingFilterString != null)
+                {
+                    var existingfilterList = selfAssessmentId == 1 ?
+                        existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("SignedOff")).ToList() :
+                        existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("SubmittedDate")).ToList();
+                    
+                    existingFilterString = existingfilterList.Any() ? string.Join(FilteringHelper.FilterSeparator, existingfilterList) : null;
+                }
+            }
 
             int offSet = ((page - 1) * itemsPerPage) ?? 0;
 
@@ -509,7 +520,7 @@
             }
 
             var delegateEntity = userService.GetUserById(delegateUserId)!;
-            string delegateName = delegateEntity != null ? delegateEntity.UserAccount.FirstName.ToString() + " " + delegateEntity.UserAccount.LastName.ToString() : ""; 
+            string delegateName = delegateEntity != null ? delegateEntity.UserAccount.FirstName.ToString() + " " + delegateEntity.UserAccount.LastName.ToString() : "";
 
             var model = new EditCompleteByDateViewModel(
                 assessment.Name,
@@ -552,8 +563,8 @@
             ReturnPageQuery? returnPageQuery = formData.ReturnPageQuery;
             var routeData = returnPageQuery!.Value.ToRouteDataDictionary();
             routeData.Add("selfAssessmentId", selfAssessmentId.ToString());
-            
-            if (accessedVia.Id==1 && accessedVia.Name == "ViewDelegate")
+
+            if (accessedVia.Id == 1 && accessedVia.Name == "ViewDelegate")
             {
                 var centreId = User.GetCentreIdKnownNotNull();
                 var delegateAccountId = selfAssessmentService.GetDelegateAccountId(centreId, delegateUserId);
@@ -563,7 +574,7 @@
             {
                 return RedirectToAction("Index", "ActivityDelegates", routeData, returnPageQuery.Value.ItemIdToReturnTo);
             }
-        }        
+        }
     }
 }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedDelegateDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedDelegateDetailsViewModel.cs
@@ -33,13 +33,19 @@
                 )
             );
 
-            Filters = SelfAssessmentDelegateViewModelFilterOptions.GetAllSelfAssessmentDelegatesFilterViewModels();
+            Filters = routeData["selfAssessmentId"]?.ToString() == "1" ?
+                SelfAssessmentDelegateViewModelFilterOptions.GetAllSelfAssessmentDelegatesFilterViewModels().Where(x => x.FilterProperty != "SignedOffStatus") :
+                SelfAssessmentDelegateViewModelFilterOptions.GetAllSelfAssessmentDelegatesFilterViewModels().Where(x => x.FilterProperty != "SubmittedStatus");
+
+            SortOptions = routeData["selfAssessmentId"]?.ToString() == "1" ?
+                Enumeration.GetAll<SelfAssessmentDelegatesSortByOption>().Where(x => x.PropertyName != "SignedOff").Select(o => (o.DisplayText, o.PropertyName)) :
+                Enumeration.GetAll<SelfAssessmentDelegatesSortByOption>().Where(x => x.PropertyName != "SubmittedDate").Select(o => (o.DisplayText, o.PropertyName));
+
         }
 
         public bool Active { get; set; }
         public IEnumerable<DelegateSelfAssessmentInfoViewModel> Delegates { get; set; }
-        public override IEnumerable<(string, string)> SortOptions { get; } =
-            Enumeration.GetAll<SelfAssessmentDelegatesSortByOption>().Select(o => (o.DisplayText, o.PropertyName));
+        public override IEnumerable<(string, string)> SortOptions { get; }
         public override bool NoDataFound => !Delegates.Any() && NoSearchOrFilter;
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -107,20 +107,26 @@
             </dd>
             <dd class="nhsuk-summary-list__actions"></dd>
         </div>
-        <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-                Signed off
-            </dt>
-            <partial name="_SummaryFieldValue" model="@Model.SignedOff" />
-            <dd class="nhsuk-summary-list__actions" />
-        </div>
-        <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-                Submitted
-            </dt>
-            <partial name="_SummaryFieldValue" model="@Model.SubmittedDate" />
-            <dd class="nhsuk-summary-list__actions" />
-        </div>
+        if (Model.SelfAssessmentId == 1)
+        {
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Submitted
+                </dt>
+                <partial name="_SummaryFieldValue" model="@Model.SubmittedDate" />
+                <dd class="nhsuk-summary-list__actions" />
+            </div>
+        }
+        else
+        {
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Signed off
+                </dt>
+                <partial name="_SummaryFieldValue" model="@Model.SignedOff" />
+                <dd class="nhsuk-summary-list__actions" />
+            </div>
+        }
         <div class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">
                 Removed


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3610

### Description
 'submitted' 'signed off' filter and sort options fields displays according to self assessments.
'Submitted' field/filter/sort option will be displayed only for 'Digital Capability Self Assessment' and 
'Signed Off' field/filter/sort option will be displayed for all self assessments other than 'Digital Capability Self Assessment'

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/7c84206d-54c3-44a2-a4f0-e54410b52929)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/198d4eac-71e2-4513-a6c7-42e8f2034edb)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/6919eefb-1dec-4acd-85b9-911f2b881059)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/5fd2d312-5a8b-4b19-afba-154856d232c6)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/6a40daf0-7c19-4fa1-8cb2-03c33b404725)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/07038abc-6ee6-473e-8bc1-aef0a3557eac)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/e9883a22-31de-4886-8d9a-66d2bd70fa3e)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/76a63098-7389-4d98-bb26-c73f20f2d782)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
