### PR TITLE
TD-3639 Returns pre release .23 code to fix DSAT report

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -10,6 +10,8 @@
     {
         IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatus();
         IEnumerable<DCSAOutcomeSummary> GetOutcomeSummary();
+        IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId);
+        IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId);
     }
     public partial class DCSAReportDataService : IDCSAReportDataService
     {
@@ -122,5 +124,111 @@
                 WHERE (ca.Active = 1) AND (caa.SelfAssessmentID = 1) AND  caa.NonReportable = 0
                 ORDER BY EnrolledYear DESC, EnrolledMonth DESC, ca.LastName, ca.FirstName");
         }
+        public IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId)
+        {
+            return connection.Query<DCSADelegateCompletionStatus>(
+                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, ca.FirstName, ca.LastName, ca.EmailAddress AS Email, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
+                     THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status
+        FROM   Candidates AS ca INNER JOIN
+                     CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN
+                     JobGroups AS jg ON ca.JobGroupID = jg.JobGroupID
+        WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1) AND caa.NonReportable = 0
+        ORDER BY EnrolledYear DESC, EnrolledMonth DESC, ca.LastName, ca.FirstName",
+                new { centreId }
+            );
+        }
+
+        public IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId)
+        {
+            return connection.Query<DCSAOutcomeSummary>(
+                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
+                     THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
+                         (SELECT COUNT(*) AS Expr1
+                         FROM    FilteredLearningActivity AS fla
+                         WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
+                         (SELECT COUNT(*) AS Expr1
+                         FROM    FilteredLearningActivity AS fla
+                         WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                        WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationConfidence,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
+                         (SELECT AVG(sar.Result) AS AvgConfidence
+                         FROM    SelfAssessmentResults AS sar INNER JOIN
+                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                        (SELECT AVG(sar.Result) AS AvgConfidence
+                        FROM    SelfAssessmentResults AS sar INNER JOIN
+                                     Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                     SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
+                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
+                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
+        FROM   Candidates AS ca INNER JOIN
+                     CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
+                     JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
+        WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
+        ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
+                new { centreId }
+            );
+        }
+
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
@@ -42,8 +42,8 @@
         public IActionResult DownloadDigitalCapabilityToExcel()
         {
             var centreId = User.GetCentreIdKnownNotNull();
-            var dataFile = selfAssessmentReportService.GetDigitalCapabilityExcelExport();
-            var fileName = $"DLS DSAT Report - downloaded {clockUtility.UtcToday:yyyy-MM-dd}.xlsx";
+            var dataFile = selfAssessmentReportService.GetDigitalCapabilityExcelExportForCentre(centreId);
+            var fileName = $"DLS DSAT Report - Centre {centreId} - downloaded {clockUtility.UtcToday:yyyy-MM-dd}.xlsx";
             return File(
                 dataFile,
                 FileHelper.GetContentTypeFromFileName(fileName),

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
@@ -13,6 +13,7 @@
     {
         byte[] GetDigitalCapabilityExcelExport();
         byte[] GetSelfAssessmentExcelExportForCentre(int centreId, int selfAssessmentId);
+        byte[] GetDigitalCapabilityExcelExportForCentre(int centreId);
         IEnumerable<SelfAssessmentSelect> GetSelfAssessmentsForReportList(int centreId, int? categoryId);
     }
     public class SelfAssessmentReportService : ISelfAssessmentReportService
@@ -122,5 +123,57 @@
             workbook.SaveAs(stream);
             return stream.ToArray();
         }
+        public byte[] GetDigitalCapabilityExcelExportForCentre(int centreId)
+        {
+            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatusForCentre(centreId);
+            var outcomeSummary = dcsaReportDataService.GetOutcomeSummaryForCentre(centreId);
+            var summary = delegateCompletionStatus.Select(
+                x => new
+                {
+                    x.EnrolledMonth,
+                    x.EnrolledYear,
+                    x.FirstName,
+                    x.LastName,
+                    Email = (Guid.TryParse(x.Email, out _) ? string.Empty : x.Email),
+                    x.CentreField1,
+                    x.CentreField2,
+                    x.CentreField3,
+                    x.Status
+                }
+                );
+            var details = outcomeSummary.Select(
+                x => new
+                {
+                    x.EnrolledMonth,
+                    x.EnrolledYear,
+                    x.JobGroup,
+                    x.CentreField1,
+                    x.CentreField2,
+                    x.CentreField3,
+                    x.Status,
+                    x.LearningLaunched,
+                    x.LearningCompleted,
+                    x.DataInformationAndContentConfidence,
+                    x.DataInformationAndContentRelevance,
+                    x.TeachinglearningAndSelfDevelopmentConfidence,
+                    x.TeachinglearningAndSelfDevelopmentRelevance,
+                    x.CommunicationCollaborationAndParticipationConfidence,
+                    x.CommunicationCollaborationAndParticipationRelevance,
+                    x.TechnicalProficiencyConfidence,
+                    x.TechnicalProficiencyRelevance,
+                    x.CreationInnovationAndResearchConfidence,
+                    x.CreationInnovationAndResearchRelevance,
+                    x.DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                    x.DigitalIdentityWellbeingSafetyAndSecurityRelevance
+                }
+                );
+            using var workbook = new XLWorkbook();
+            AddSheetToWorkbook(workbook, "Delegate Completion Status", summary);
+            AddSheetToWorkbook(workbook, "Assessment Outcome Summary", outcomeSummary);
+            using var stream = new MemoryStream();
+            workbook.SaveAs(stream);
+            return stream.ToArray();
+        }
     }
+
 }


### PR DESCRIPTION


### JIRA link
TD-3639

### Description
Quick reversion of code for Tracking System -> Centre Reports -> Self assessment reports -> DSAT report to prevent it from returning learners that have no account at the user's centre. Faulty code was introduced in TD-1988.

New code was left in place (though no longer used) to make a correct fix to TD-1988 easier.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
