### PR TITLE
TD-3640 - Added script to delete duplicate records and add unique constraint.

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202401301650_AddGroupDelegatesConstraints.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202401301650_AddGroupDelegatesConstraints.cs
@@ -1,0 +1,27 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202401301650)]
+    public class AddGroupDelegatesConstraints : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(
+                @"WITH duplicateRowNum AS (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY GroupId,DelegateId ORDER BY AddedDate) rownum
+                    FROM GroupDelegates
+                    )
+                DELETE FROM duplicateRowNum WHERE rownum > 1;"
+            );
+
+            Create.UniqueConstraint("UQ_GroupDelegates_GroupID_DelegateID").OnTable("GroupDelegates")
+                .Columns("GroupID","DelegateID");
+        }
+
+        public override void Down()
+        {
+            Delete.UniqueConstraint("UQ_GroupDelegates_GroupID_DelegateID").FromTable("GroupDelegates");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3640

### Description
Migration script added to delete duplicate records from GroupDelegates table and add unique constraint on GroupID and DelegateID.

### Screenshots
Duplicate records before migration on dev.:

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b5672a99-c5c0-4482-8f4d-6539dee6a173)

Constraints on table before migration:

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/bf8375c5-89c7-4ba6-b4a9-4e34bf4130d0)

----
Duplicate records after migration on dev.:

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/14eafe09-9d4b-4bd6-b7af-c643f2a562e0)

Constraints on table after migration:

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/e0f0854e-53ad-43a4-bed8-1ac4c32f5754)

-----
### Developer checks

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
