### PR TITLE
TD-3610-Validated unsupervised self-assessment from database.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -170,6 +170,7 @@
         IEnumerable<Accessor> GetAccessor(int selfAssessmentId, int delegateUserID);
         ActivitySummaryCompetencySelfAssesment GetActivitySummaryCompetencySelfAssesment(int CandidateAssessmentSupervisorVerificationsId);
         int? GetRoleCount(int CandidateId);
+        bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
     }
 
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
@@ -705,6 +706,15 @@
                       WHERE (ID = @candidateAssessmentsId) AND ( RemovalMethodID =2)  AND (RemovedDate IS NOT NULL)",
                   new { candidateAssessmentsId }
               );
+        }
+
+        public bool IsUnsupervisedSelfAssessment(int selfAssessmentId)
+        {
+            var ResultCount = connection.ExecuteScalar<int>(
+                @"SELECT COUNT(*) FROM SelfAssessments WHERE ID = @selfAssessmentId AND SupervisorSelfAssessmentReview = 0 AND SupervisorResultsReview = 0",
+                new { selfAssessmentId }
+            );
+            return ResultCount > 0;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -92,6 +92,7 @@
             }
             searchString = searchString == null ? string.Empty : searchString.Trim();
             var isCourseDelegate = customisationId != null;
+            var isUnsupervisedSelfAssessment = false;
 
             var filterCookieName = isCourseDelegate ? courseDelegatesFilterCookieName : selfAssessmentDelegatesFilterCookieName;
 
@@ -118,12 +119,13 @@
             }
             else
             {
+                isUnsupervisedSelfAssessment = selfAssessmentService.IsUnsupervisedSelfAssessment((int)selfAssessmentId);
                 if (existingFilterString != null)
                 {
-                    var existingfilterList = selfAssessmentId == 1 ?
+                    var existingfilterList = isUnsupervisedSelfAssessment ?
                         existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("SignedOff")).ToList() :
                         existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => !filter.Contains("SubmittedDate")).ToList();
-                    
+
                     existingFilterString = existingfilterList.Any() ? string.Join(FilteringHelper.FilterSeparator, existingfilterList) : null;
                 }
             }
@@ -294,7 +296,7 @@
                     result.Page = page;
                     TempData["Page"] = result.Page;
                     Response.UpdateFilterCookie(filterCookieName, result.FilterString);
-                    var model = new ActivityDelegatesViewModel(selfAssessmentDelegatesData, result, availableFilters, "selfAssessmentId", selfAssessmentId, activityName, false);
+                    var model = new ActivityDelegatesViewModel(selfAssessmentDelegatesData, result, availableFilters, "selfAssessmentId", selfAssessmentId, activityName, false, isUnsupervisedSelfAssessment);
                     return View(model);
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -134,20 +134,21 @@
             int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
         public SelfAssessmentDelegatesData GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff);
-        public int GetSelfAssessmentActivityDelegatesExportCount(string searchString,  string sortBy, string sortDirection,
+        public int GetSelfAssessmentActivityDelegatesExportCount(string searchString, string sortBy, string sortDirection,
            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
         public string GetSelfAssessmentActivityDelegatesSupervisor(int selfAssessmentId, int delegateUserId);
         RemoveSelfAssessmentDelegate GetDelegateSelfAssessmentByCandidateAssessmentsId(int candidateAssessmentsId);
-       void RemoveDelegateSelfAssessment(int candidateAssessmentsId);
-       public int? GetSupervisorsCountFromCandidateAssessmentId(int candidateAssessmentsId);
-       public bool CheckForSameCentre(int centreId, int candidateAssessmentsId);        
-       public int? GetDelegateAccountId(int centreId, int delegateUserId);
+        void RemoveDelegateSelfAssessment(int candidateAssessmentsId);
+        public int? GetSupervisorsCountFromCandidateAssessmentId(int candidateAssessmentsId);
+        public bool CheckForSameCentre(int centreId, int candidateAssessmentsId);
+        public int? GetDelegateAccountId(int centreId, int delegateUserId);
         int CheckDelegateSelfAssessment(int candidateAssessmentsId);
         IEnumerable<CompetencyCountSelfAssessmentCertificate> GetCompetencyCountSelfAssessmentCertificate(int candidateAssessmentID);
         CompetencySelfAssessmentCertificate GetCompetencySelfAssessmentCertificate(int candidateAssessmentID);
         IEnumerable<Accessor> GetAccessor(int selfAssessmentId, int delegateUserID);
         ActivitySummaryCompetencySelfAssesment GetActivitySummaryCompetencySelfAssesment(int CandidateAssessmentSupervisorVerificationsId);
         int? GetRoleCount(int CandidateId);
+        bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -526,21 +527,25 @@
         }
         public CompetencySelfAssessmentCertificate GetCompetencySelfAssessmentCertificate(int candidateAssessmentID)
         {
-          return selfAssessmentDataService.GetCompetencySelfAssessmentCertificate(candidateAssessmentID);
+            return selfAssessmentDataService.GetCompetencySelfAssessmentCertificate(candidateAssessmentID);
         }
         public IEnumerable<Accessor> GetAccessor(int selfAssessmentId, int delegateUserID)
         {
-             return selfAssessmentDataService.GetAccessor(selfAssessmentId, delegateUserID);
+            return selfAssessmentDataService.GetAccessor(selfAssessmentId, delegateUserID);
         }
         public ActivitySummaryCompetencySelfAssesment GetActivitySummaryCompetencySelfAssesment(int CandidateAssessmentSupervisorVerificationsId)
         {
-           return selfAssessmentDataService.GetActivitySummaryCompetencySelfAssesment(CandidateAssessmentSupervisorVerificationsId);
+            return selfAssessmentDataService.GetActivitySummaryCompetencySelfAssesment(CandidateAssessmentSupervisorVerificationsId);
 
         }
         public int? GetRoleCount(int CandidateId)
         {
             return selfAssessmentDataService.GetRoleCount(CandidateId);
 
+        }
+        public bool IsUnsupervisedSelfAssessment(int selfAssessmentId)
+        {
+            return selfAssessmentDataService.IsUnsupervisedSelfAssessment(selfAssessmentId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/ActivityDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/ActivityDelegatesViewModel.cs
@@ -12,18 +12,20 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Cours
             IsCourseDelegate = isCourseDelegate;
             ActivityName = applicationName;
         }
-        public ActivityDelegatesViewModel(SelfAssessmentDelegatesData selfAssessmentDelegatesData, SearchSortFilterPaginationResult<SelfAssessmentDelegate> result, IEnumerable<FilterModel> availableFilters, string customisationIdQueryParameterName, int? selfAssessmentId, string selfAssessmentName, bool isCourseDelegate)
+        public ActivityDelegatesViewModel(SelfAssessmentDelegatesData selfAssessmentDelegatesData, SearchSortFilterPaginationResult<SelfAssessmentDelegate> result, IEnumerable<FilterModel> availableFilters, string customisationIdQueryParameterName, int? selfAssessmentId, string selfAssessmentName, bool isCourseDelegate, bool unSupervised)
         {
             SelfAssessmentId = selfAssessmentId;
             IsCourseDelegate = isCourseDelegate;
             ActivityName = selfAssessmentName;
+            Unsupervised = unSupervised;
             DelegatesDetails = selfAssessmentId != null
                 ? new SelectedDelegateDetailsViewModel(
                     result,
                     availableFilters,
                     selfAssessmentDelegatesData,
                     new Dictionary<string, string>
-                        { { customisationIdQueryParameterName, selfAssessmentId.ToString() } }
+                        { { customisationIdQueryParameterName, selfAssessmentId.ToString() } },
+                    Unsupervised
                 )
                 : null;
         }
@@ -31,6 +33,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Cours
         public int? SelfAssessmentId { get; set; }
         public string? ActivityName { get; set; }
         public bool IsCourseDelegate { get; set; }
+        public bool Unsupervised { get; set; }
         public SelectedDelegateDetailsViewModel? DelegatesDetails { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedDelegateDetailsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelectedDelegateDetailsViewModel.cs
@@ -16,7 +16,8 @@
             SearchSortFilterPaginationResult<SelfAssessmentDelegate> result,
             IEnumerable<FilterModel> availableFilters,
             SelfAssessmentDelegatesData selfAssessmentDelegatesData,
-            Dictionary<string, string> routeData
+            Dictionary<string, string> routeData,
+            bool unSupervised
         ) : base(
             result,
             true,
@@ -29,15 +30,16 @@
                 d => new DelegateSelfAssessmentInfoViewModel(
                     d,
                     DelegateAccessRoute.ActivityDelegates,
-                    result.GetReturnPageQuery($"{d.DelegateId}-card")
+                    result.GetReturnPageQuery($"{d.DelegateId}-card"),
+                    unSupervised
                 )
             );
 
-            Filters = routeData["selfAssessmentId"]?.ToString() == "1" ?
+            Filters = unSupervised ?
                 SelfAssessmentDelegateViewModelFilterOptions.GetAllSelfAssessmentDelegatesFilterViewModels().Where(x => x.FilterProperty != "SignedOffStatus") :
                 SelfAssessmentDelegateViewModelFilterOptions.GetAllSelfAssessmentDelegatesFilterViewModels().Where(x => x.FilterProperty != "SubmittedStatus");
 
-            SortOptions = routeData["selfAssessmentId"]?.ToString() == "1" ?
+            SortOptions = unSupervised ?
                 Enumeration.GetAll<SelfAssessmentDelegatesSortByOption>().Where(x => x.PropertyName != "SignedOff").Select(o => (o.DisplayText, o.PropertyName)) :
                 Enumeration.GetAll<SelfAssessmentDelegatesSortByOption>().Where(x => x.PropertyName != "SubmittedDate").Select(o => (o.DisplayText, o.PropertyName));
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
@@ -15,12 +15,14 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
         public DelegateSelfAssessmentInfoViewModel(
             SelfAssessmentDelegate selfAssessmentDelegate,
             DelegateAccessRoute accessedVia,
-            ReturnPageQuery returnPageQuery
+            ReturnPageQuery returnPageQuery,
+            bool unSupervised
         ) : this(selfAssessmentDelegate)
         {
             AccessedVia = accessedVia;
             ReturnPageQuery = returnPageQuery;
             Tags = FilterableTagHelper.GetCurrentTagsForSelfAssessmentDelegate(selfAssessmentDelegate);
+            Unsupervised = unSupervised;
         }
 
         private DelegateSelfAssessmentInfoViewModel(SelfAssessmentDelegate delegateInfo)
@@ -79,6 +81,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
         public int DelegateUserId { get; set; }
         public string SelfAssessmentDelegatesDisplayName { get; set; }
         public List<SelfAssessmentSupervisor> Supervisors { get; set; }
+        public bool Unsupervised { get; set; }
 
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -107,7 +107,7 @@
             </dd>
             <dd class="nhsuk-summary-list__actions"></dd>
         </div>
-        if (Model.SelfAssessmentId == 1)
+        if (Model.Unsupervised)
         {
             <div class="nhsuk-summary-list__row">
                 <dt class="nhsuk-summary-list__key">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3610

### Description
Validated unsupervised self-assessment from database.
Screen shot below displays 'submitted' filter for unsupervised self assessment.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/01089180-3564-454a-9995-ac8b6fac7188)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/49fa55e9-a4a2-4c49-80e1-c2c91410f0c5)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
