### PR TITLE
TD-3214 Adding Submitted / Signedoff Status tags

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -223,7 +223,9 @@
                 COALESCE(ucd.Email, u.PrimaryEmail) AS DelegateEmail,
                 da.Active AS IsDelegateActive,
                 sa.Name AS [Name],
-                MAX(casv.Verified) as SignedOff";
+                MAX(casv.Verified) as SignedOff,
+				sa.SupervisorSelfAssessmentReview,
+				sa.SupervisorResultsReview";
 
             var fromTableQuery = $@" FROM  dbo.SelfAssessments AS sa 
 				INNER JOIN dbo.CandidateAssessments AS ca WITH (NOLOCK) ON sa.ID = ca.SelfAssessmentID 
@@ -268,7 +270,9 @@
                 COALESCE(ucd.Email, u.PrimaryEmail),
                 da.Active,
                 sa.Name,
-                ca.Id";
+                ca.Id,
+				sa.SupervisorSelfAssessmentReview,
+				sa.SupervisorResultsReview";
 
             if (signedOff != null)
             {

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessmentDelegate.cs
@@ -46,7 +46,9 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
             RegistrationAnswer5 = delegateInfo.RegistrationAnswer5;
             RegistrationAnswer6 = delegateInfo.RegistrationAnswer6;
             CandidateAssessmentsId = delegateInfo.CandidateAssessmentsId;
-        }
+            SupervisorSelfAssessmentReview = delegateInfo.SupervisorSelfAssessmentReview;
+        SupervisorResultsReview = delegateInfo.SupervisorResultsReview;
+    }
         public int DelegateId { get; set; }
         public int CandidateAssessmentsId { get; set; }
         public string? DelegateFirstName { get; set; }
@@ -77,6 +79,8 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
         public string? RegistrationAnswer4 { get; set; }
         public string? RegistrationAnswer5 { get; set; }
         public string? RegistrationAnswer6 { get; set; }
+        public bool SupervisorSelfAssessmentReview { get; set; }
+        public bool SupervisorResultsReview { get; set; }
         public bool Removed => RemovedDate.HasValue;
         public string?[] DelegateRegistrationPrompts =>
             new[]

--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -210,21 +210,33 @@
 
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForSelfAssessmentDelegate(SelfAssessmentDelegate selfAssessmentDelegate)
         {
-            return new List<SearchableTagViewModel>
+            var tags = new List<SearchableTagViewModel>();
+
+            var statusTag = selfAssessmentDelegate.IsDelegateActive
+        ? new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Active)
+        : new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Inactive);
+            tags.Add(statusTag);
+
+            var removalTag = selfAssessmentDelegate.RemovedDate.HasValue
+         ? new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.Removed)
+         : new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.NotRemoved, true);
+            tags.Add(removalTag);
+            if (selfAssessmentDelegate.SupervisorSelfAssessmentReview && selfAssessmentDelegate.SupervisorResultsReview)
             {
-                selfAssessmentDelegate.IsDelegateActive
-                ?new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Active)
-                :new SearchableTagViewModel(SelfAssessmentDelegateAccountStatusFilterOptions.Inactive),
-                selfAssessmentDelegate.RemovedDate.HasValue
-                ?new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.Removed)
-                :new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.NotRemoved, true),
-                selfAssessmentDelegate.SignedOff.HasValue
-                ?new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.SignedOff)
-                :new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.NotSignedOff),
-                selfAssessmentDelegate.SubmittedDate.HasValue
-                ?new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.Submitted)
-                :new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.NotSubmitted)
-            };
+                var signedOffTag = selfAssessmentDelegate.SignedOff.HasValue
+             ? new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.SignedOff)
+             : new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.NotSignedOff);
+                tags.Add(signedOffTag);
+            }
+            else
+            {
+                var submissionTag = selfAssessmentDelegate.SubmittedDate.HasValue
+            ? new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.Submitted)
+            : new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.NotSubmitted);
+                tags.Add(submissionTag);
+            }
+
+            return tags;
         }
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForDelegateUser(
             DelegateUserCard delegateUser

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
@@ -57,7 +57,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
                 3 => "Group",
                 _ => "System",
             };
-        }
+            SupervisorSelfAssessmentReview = delegateInfo.SupervisorSelfAssessmentReview;
+            SupervisorResultsReview = delegateInfo.SupervisorResultsReview;
+    }
         public DelegateAccessRoute AccessedVia { get; set; }
         public ReturnPageQuery? ReturnPageQuery { get; set; }
         public int CandidateAssessmentsId { get; set; }
@@ -77,6 +79,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
         public string? SubmittedDate { get; set; }
         public string? RemovedDate { get; set; }
         public int DelegateUserId { get; set; }
+        public bool SupervisorSelfAssessmentReview { get; set; }
+        public bool SupervisorResultsReview { get; set; }
+
         public string SelfAssessmentDelegatesDisplayName { get; set; }
         public List<SelfAssessmentSupervisor> Supervisors { get; set; }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3214

### Description
I needed to make the self assessment tag to show according to the status of the self assessment
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/8d0ceffd-e7bb-4a90-b07b-cbf64db38afa)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
