### PR TITLE
TD-2310- Delegate email added in the Update statement.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -256,7 +256,8 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 
             if (existingId > 0)
             {
-                var numberOfAffectedRows = connection.Execute(@"UPDATE SupervisorDelegates SET Removed = NULL, DelegateUserId = @delegateUserId WHERE ID = @existingId", new { delegateUserId, existingId });
+                var numberOfAffectedRows = connection.Execute(@"UPDATE SupervisorDelegates SET Removed = NULL, DelegateUserId = @delegateUserId, 
+                                                                DelegateEmail = @delegateEmail WHERE ID = @existingId", new { delegateUserId, delegateEmail, existingId });
                 return existingId;
             }
             else


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2310

### Description
Delegate email added in the Update statement. 
If a learner's centre email exists in the MyStaff and the user adds a learner's primary email to MyStaff, the centre email will be replaced with the entered primary email.

### Screenshots
eg. 'auldrinpossa@testmail.com' primary email at HEE centre and 'Bedford@Bedfordshire.com' is a centre email at Bedfordshire centre.

Staff with centre email.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f780c393-b181-4072-8a66-1337fb2e8bc6)

Staff after adding learners primary email.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2b59940d-0377-44a7-92df-f94c5f4c98e3)

Staff with centre email now updated with primary email
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2ac6cce0-3225-44df-8c2a-2cd2f5c53385)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
