### PR TITLE
TD-3073-Filters applied in one centre affects the other centres

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -87,6 +87,15 @@
             string isActive, categoryName, courseTopic, hasAdminFields, isCourse, isSelfAssessment;
             isActive = categoryName = courseTopic = hasAdminFields = isCourse = isSelfAssessment = "Any";
 
+            var availableFilters = DelegateCourseStatisticsViewModelFilterOptions
+               .GetFilterOptions(categoryId.HasValue ? new string[] { } : Categories, Topics).ToList();
+
+            if (TempData["ActivityDelegatesCentreId"] != null && TempData["ActivityDelegatesCentreId"].ToString() != User.GetCentreId().ToString()
+                    && existingFilterString != null)
+            {
+                existingFilterString = FilterHelper.RemoveNonExistingFilterOptions(availableFilters, existingFilterString);
+            }
+
             if (!string.IsNullOrEmpty(existingFilterString))
             {
                 var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
@@ -163,9 +172,6 @@
 
             allItems = OrderActivities(allItems, sortBy, sortDirection);
 
-            var availableFilters = DelegateCourseStatisticsViewModelFilterOptions
-                .GetFilterOptions(categoryId.HasValue ? new string[] { } : Categories, Topics).ToList();
-
             var resultCount = allItems.Count();
 
             var result = paginateService.Paginate(
@@ -190,6 +196,7 @@
             model.TotalPages = (int)(resultCount / itemsPerPage) + ((resultCount % itemsPerPage) > 0 ? 1 : 0);
             model.MatchingSearchResults = resultCount;
             Response.UpdateFilterCookie(CourseFilterCookieName, result.FilterString);
+            TempData["ActivityDelegatesCentreId"] = centreId;
 
             return View(model);
         }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateGroupsController.cs
@@ -98,7 +98,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             if (TempData["DelegateGroupCentreId"] != null && TempData["DelegateGroupCentreId"].ToString() != User.GetCentreId().ToString()
                     && existingFilterString != null)
             {
-                existingFilterString = FilterHelper.RemoveNonExistingGroupFilters(availableFilters, existingFilterString);
+                existingFilterString = FilterHelper.RemoveNonExistingFilterOptions(availableFilters, existingFilterString);
             }
 
             int offSet = ((page - 1) * itemsPerPage) ?? 0;

--- a/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
@@ -61,10 +61,10 @@ namespace DigitalLearningSolutions.Web.Helpers
             return existingFilterString;
         }
 
-        public static string? RemoveNonExistingGroupFilters(List<FilterModel> availableFilters, string existingFilterString)
+        public static string? RemoveNonExistingFilterOptions(List<FilterModel> availableFilters, string existingFilterString)
         {
             var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
-            string[] filterGroups = { "AddedByAdminId", "LinkedToField" };
+            string[] filterGroups = { "LinkedToField", "AddedByAdminId", "CourseTopic", "CategoryName" };
             foreach (var filterGroup in filterGroups)
             {
                 var existingFilters = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => filter.Contains(filterGroup)).ToList();
@@ -78,14 +78,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                     var availableFilterOptions = availableFilters.Where(x => x.FilterProperty == filterGroup).Select(o => o.FilterOptions).ToList();
                     foreach (var availableFilterOption in availableFilterOptions)
                     {
-                        if (filterGroup == "AddedByAdminId")
-                        {
-                            if (availableFilterOption.Any(x => x.FilterValue.Contains(filterOptionText)))
-                            {
-                                isFound = true; break;
-                            }
-                        }
-                        else
+                        if (filterGroup == "LinkedToField")
                         {
                             if (availableFilterOption.Any(x => x.FilterValue.Contains(filterHeader)))
                             {
@@ -96,6 +89,13 @@ namespace DigitalLearningSolutions.Web.Helpers
                                     selectedFilters.Add(filter);
                                     existingFilterString = string.Join(FilteringHelper.FilterSeparator, selectedFilters);
                                 }
+                                isFound = true; break;
+                            }
+                        }
+                        else
+                        {
+                            if (availableFilterOption.Any(x => x.FilterValue.Contains(filterOptionText)))
+                            {
                                 isFound = true; break;
                             }
                         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3073

### Description
Mismatched filter options have been removed for Topic and Category filters when user change the logged in centre.

### Screenshots
Filter options selected at HEE Demo Centre
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/74bac033-4d6f-4569-9868-338a0d8776eb)

Filter options at other centre.

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1f3cc985-286e-4013-84bc-61e728aaca1f)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/231138cb-4db7-4952-b971-c68c8303a245)


-----
### Developer checks


I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
