### PR TITLE
TD-3214 Taking care of other condition of supervisor

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -221,19 +221,20 @@
          ? new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.Removed)
          : new SearchableTagViewModel(SelfAssessmentDelegateRemovedFilterOptions.NotRemoved, true);
             tags.Add(removalTag);
-            if (selfAssessmentDelegate.SupervisorSelfAssessmentReview && selfAssessmentDelegate.SupervisorResultsReview)
-            {
-                var signedOffTag = selfAssessmentDelegate.SignedOff.HasValue
-             ? new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.SignedOff)
-             : new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.NotSignedOff);
-                tags.Add(signedOffTag);
-            }
-            else
+            if (!selfAssessmentDelegate.SupervisorSelfAssessmentReview && !selfAssessmentDelegate.SupervisorResultsReview)
             {
                 var submissionTag = selfAssessmentDelegate.SubmittedDate.HasValue
             ? new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.Submitted)
             : new SearchableTagViewModel(SelfAssessmentAssessmentSubmittedFilterOptions.NotSubmitted);
                 tags.Add(submissionTag);
+            }
+            else
+            {
+                var signedOffTag = selfAssessmentDelegate.SignedOff.HasValue
+             ? new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.SignedOff)
+             : new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.NotSignedOff);
+                tags.Add(signedOffTag);
+                
             }
 
             return tags;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3214

### Description
Ensure that all condition for supervisor is meant to show either the self assessment is signoff/not signoff or submitted/not submitted

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/00248ff7-488c-4770-bee0-bab96401588b)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
