### PR TITLE
TD-3672 - Delegate activities self assessment cards submitted signed off fields - issue fix

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -1923,8 +1923,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                         sa.Name AS Name,
                         cc.CategoryName AS Category,
                         CASE 
-                          WHEN sa.SupervisorSelfAssessmentReview = 1 OR sa.SupervisorResultsReview = 1 THEN 1
-                          ELSE 0
+                          WHEN sa.SupervisorSelfAssessmentReview = 0 AND sa.SupervisorResultsReview = 0 THEN 0
+                          ELSE 1
                         END AS Supervised,
                         (SELECT COUNT(can.ID)
                         FROM dbo.CandidateAssessments AS can WITH (NOLOCK)

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreAssessmentCardDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateCourses/_CentreAssessmentCardDetails.cshtml
@@ -2,37 +2,44 @@
 @model SearchableDelegateAssessmentStatisticsViewModel
 
 <dl class="nhsuk-summary-list">
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Category
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-        @Model.Category
-    </dd>
-  </div>
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Category
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.Category
+        </dd>
+    </div>
 
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Supervised
-    </dt>
-    <partial name="_SummaryBooleanField" model="Model.Supervised" />
-  </div>
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Supervised
+        </dt>
+        <partial name="_SummaryBooleanField" model="Model.Supervised" />
+    </div>
 
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Enrolled
-    </dt>
-    <dd class="nhsuk-summary-list__value">
-        @Model.DelegateCount
-    </dd>
-  </div>
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Enrolled
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.DelegateCount
+        </dd>
+    </div>
 
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Submitted/Signed off
-    </dt>
-    <dd class="nhsuk-summary-list__value" name="in-progress-count">
-        @Model.SubmittedSignedOffCount
-    </dd>
-  </div>
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            @if (Model.Supervised)
+            {
+                @:Signed off
+            }
+            else
+            {
+                @:Submitted
+            }
+        </dt>
+        <dd class="nhsuk-summary-list__value" name="in-progress-count">
+            @Model.SubmittedSignedOffCount
+        </dd>
+    </div>
 </dl>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3672

### Description
SQL query/view modified to show Signed of/Submitted on the delegate activities self assessment card based on supervised/unsupervised self assessment.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/d16662ae-1437-495e-8832-2d4657522b59)

_

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
