### PR TITLE
TD-3619 Includes other centres in centres self assessment report

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
@@ -66,6 +66,7 @@
                     	, CASE WHEN c.CustomField1PromptID = 10 THEN da.Answer1 WHEN c.CustomField2PromptID = 10 THEN da.Answer2 WHEN c.CustomField3PromptID = 10 THEN da.Answer3 WHEN c.CustomField4PromptID = 10 THEN da.Answer4 WHEN c.CustomField5PromptID = 10 THEN da.Answer5 WHEN c.CustomField6PromptID = 10 THEN da.Answer6 ELSE '' END AS 'ProgrammeCourse'
                         , CASE WHEN c.CustomField1PromptID = 4 THEN da.Answer1 WHEN c.CustomField2PromptID = 4 THEN da.Answer2 WHEN c.CustomField3PromptID = 4 THEN da.Answer3 WHEN c.CustomField4PromptID = 4 THEN da.Answer4 WHEN c.CustomField5PromptID = 4 THEN da.Answer5 WHEN c.CustomField6PromptID = 4 THEN da.Answer6 ELSE '' END AS 'Organisation'
                         , CASE WHEN c.CustomField1PromptID = 1 THEN da.Answer1 WHEN c.CustomField2PromptID = 1 THEN da.Answer2 WHEN c.CustomField3PromptID = 1 THEN da.Answer3 WHEN c.CustomField4PromptID = 1 THEN da.Answer4 WHEN c.CustomField5PromptID = 1 THEN da.Answer5 WHEN c.CustomField6PromptID = 1 THEN da.Answer6 ELSE '' END AS 'DepartmentTeam'
+                        , dbo.GetOtherCentresForSelfAssessment(da.UserID, @SelfAssessmentID, c.CentreID) AS OtherCentres
                         , CASE
                             WHEN aa.ID IS NULL THEN 'Learner'
                             WHEN aa.IsCentreManager = 1 THEN 'Centre Manager'
@@ -107,6 +108,7 @@
 	                    , c.CustomField4PromptID
 	                    , c.CustomField5PromptID
 	                    , c.CustomField6PromptID
+                        , c.CentreID
                         , jg.JobGroupName
                         , da.ID
 	                    , da.Answer1
@@ -116,6 +118,7 @@
 	                    , da.Answer5
 	                    , da.Answer6
 	                    , da.DateRegistered
+                        , da.UserID
                         , aa.ID
                         , aa.IsCentreManager
                         , aa.IsCentreAdmin

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Export/SelfAssessmentReportData.cs
@@ -11,6 +11,7 @@
         public string? ProgrammeCourse { get; set; }
         public string? Organisation { get; set; }
         public string? DepartmentTeam { get; set; }
+        public string? OtherCentres { get; set; }
         public string? DLSRole { get; set; }
         public DateTime? Registered { get; set; }
         public DateTime? Started { get; set; }

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
@@ -105,6 +105,7 @@
                           x.ProgrammeCourse,
                           x.Organisation,
                           x.DepartmentTeam,
+                          x.OtherCentres,
                           x.DLSRole,
                           x.Registered,
                           x.Started,


### PR DESCRIPTION
### JIRA link
[TD-3619](https://hee-tis.atlassian.net/browse/TD-3619)

### Description
Adds "OtherCentres" column to the Centres -> Reports -> Self assessment reports exported to Excel. This uses the existing SQL function to return a comma separated list of other centres.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/d2f0fa0e-c42c-4804-94a2-a76b29df37af)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3619]: https://hee-tis.atlassian.net/browse/TD-3619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ