### PR TITLE
TD-1988 Updates DSAT report to show learners at centre who enrolled on DSAT at another centre

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -8,8 +8,6 @@
 
     public interface IDCSAReportDataService
     {
-        IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatus();
-        IEnumerable<DCSAOutcomeSummary> GetOutcomeSummary();
         IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId);
         IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId);
     }
@@ -23,117 +21,17 @@
             this.connection = connection;
             this.logger = logger;
         }
-        public IEnumerable<DCSAOutcomeSummary> GetOutcomeSummary()
-        {
-            return connection.Query<DCSAOutcomeSummary>(
-                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
-                             THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
-                                 (SELECT COUNT(*) AS Expr1
-                                 FROM    FilteredLearningActivity AS fla
-                                 WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
-                                 (SELECT COUNT(*) AS Expr1
-                                 FROM    FilteredLearningActivity AS fla
-                                 WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
-                                 (SELECT AVG(sar.Result) AS AvgConfidence
-                                 FROM    SelfAssessmentResults AS sar INNER JOIN
-                                              Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                              SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
-                                (SELECT AVG(sar.Result) AS AvgConfidence
-                                FROM    SelfAssessmentResults AS sar INNER JOIN
-                                             Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                             SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                              DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                                 WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
-                FROM   Candidates AS ca INNER JOIN
-                             CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
-                             JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
-                WHERE (ca.Active = 1) AND (caa.SelfAssessmentID = 1)
-                ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status");
-        }
-
-        public IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatus()
-        {
-            return connection.Query<DCSADelegateCompletionStatus>(
-                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, ca.FirstName, ca.LastName, ca.EmailAddress AS Email, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
-                             THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status
-                FROM   Candidates AS ca INNER JOIN
-                             CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN
-                             JobGroups AS jg ON ca.JobGroupID = jg.JobGroupID
-                WHERE (ca.Active = 1) AND (caa.SelfAssessmentID = 1) AND  caa.NonReportable = 0
-                ORDER BY EnrolledYear DESC, EnrolledMonth DESC, ca.LastName, ca.FirstName");
-        }
+        
         public IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId)
         {
             return connection.Query<DCSADelegateCompletionStatus>(
-                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, ca.FirstName, ca.LastName, ca.EmailAddress AS Email, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
-                     THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status
-        FROM   Candidates AS ca INNER JOIN
-                     CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN
-                     JobGroups AS jg ON ca.JobGroupID = jg.JobGroupID
-        WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1) AND caa.NonReportable = 0
-        ORDER BY EnrolledYear DESC, EnrolledMonth DESC, ca.LastName, ca.FirstName",
+                @"SELECT DATEPART(month, ca.StartedDate) AS EnrolledMonth, DATEPART(yyyy, ca.StartedDate) AS EnrolledYear, u.FirstName, u.LastName, COALESCE (ucd.Email, u.PrimaryEmail) AS Email, da.Answer1 AS CentreField1, da.Answer2 AS CentreField2, da.Answer3 AS CentreField3, 
+                        CASE WHEN (ca.SubmittedDate IS NOT NULL) THEN 'Submitted' WHEN (ca.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND ca.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status
+                    FROM   CandidateAssessments AS ca INNER JOIN
+                        DelegateAccounts AS da ON ca.DelegateUserID = da.UserID INNER JOIN
+                        Users AS u ON da.UserID = u.ID LEFT OUTER JOIN
+                        UserCentreDetails AS ucd ON da.CentreID = ucd.CentreID AND u.ID = ucd.UserID
+                    WHERE (ca.SelfAssessmentID = 1) AND (da.CentreID = @centreId) AND (u.Active = 1) AND (da.Active = 1)",
                 new { centreId }
             );
         }
@@ -141,91 +39,87 @@
         public IEnumerable<DCSAOutcomeSummary> GetOutcomeSummaryForCentre(int centreId)
         {
             return connection.Query<DCSAOutcomeSummary>(
-                @"SELECT DATEPART(month, caa.StartedDate) AS EnrolledMonth, DATEPART(yyyy, caa.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, ca.Answer1 AS CentreField1, ca.Answer2 AS CentreField2, ca.Answer3 AS CentreField3, CASE WHEN (caa.SubmittedDate IS NOT NULL) 
-                     THEN 'Submitted' WHEN (caa.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND caa.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
-                         (SELECT COUNT(*) AS Expr1
-                         FROM    FilteredLearningActivity AS fla
-                         WHERE (CandidateId = ca.CandidateID)) AS LearningLaunched,
-                         (SELECT COUNT(*) AS Expr1
-                         FROM    FilteredLearningActivity AS fla
-                         WHERE (CandidateId = ca.CandidateID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                        WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationConfidence,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
-                         (SELECT AVG(sar.Result) AS AvgConfidence
-                         FROM    SelfAssessmentResults AS sar INNER JOIN
-                                      Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                      SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
-                        (SELECT AVG(sar.Result) AS AvgConfidence
-                        FROM    SelfAssessmentResults AS sar INNER JOIN
-                                     Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
-                                     SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID INNER JOIN
-                                      DelegateAccounts as da ON sar.DelegateUserID = da.UserID AND ca.CandidateID = da.ID
-                         WHERE (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
-        FROM   Candidates AS ca INNER JOIN
-                     CandidateAssessments AS caa ON ca.UserID = caa.DelegateUserID AND ca.CentreID = caa.CentreID INNER JOIN Users AS u ON caa.DelegateUserID = u.ID INNER JOIN
+                @"SELECT DATEPART(month, ca.StartedDate) AS EnrolledMonth, DATEPART(yyyy, ca.StartedDate) AS EnrolledYear, jg.JobGroupName AS JobGroup, da.Answer1 AS CentreField1, da.Answer2 AS CentreField2, da.Answer3 AS CentreField3, CASE WHEN (ca.SubmittedDate IS NOT NULL) 
+                   THEN 'Submitted' WHEN (ca.UserBookmark LIKE N'/LearningPortal/SelfAssessment/1/Review' AND ca.SubmittedDate IS NULL) THEN 'Reviewing' ELSE 'Incomplete' END AS Status,
+                     (SELECT COUNT(*) AS LearningLaunched
+                     FROM    CandidateAssessmentLearningLogItems AS calli INNER JOIN
+                                  LearningLogItems AS lli ON calli.LearningLogItemID = lli.LearningLogItemID
+                     WHERE (NOT (lli.LearningResourceReferenceID IS NULL)) AND (calli.CandidateAssessmentID = ca.ID)) +
+                     (SELECT COUNT(*) AS FilteredLearning
+                     FROM    FilteredLearningActivity AS fla
+                     WHERE (CandidateId = da.ID)) AS LearningCompleted,
+                         (SELECT COUNT(*) AS LearningLaunched
+                     FROM    CandidateAssessmentLearningLogItems AS calli INNER JOIN
+                                  LearningLogItems AS lli ON calli.LearningLogItemID = lli.LearningLogItemID
+                     WHERE (NOT (lli.LearningResourceReferenceID IS NULL)) AND (calli.CandidateAssessmentID = ca.ID) AND (NOT (lli.CompletedDate IS NULL))) +
+                     (SELECT COUNT(*) AS FilteredCompleted
+                     FROM    FilteredLearningActivity AS fla
+                     WHERE (CandidateId = da.ID) AND (CompletedDate IS NOT NULL)) AS LearningCompleted,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                  Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                  SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentConfidence,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                  Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                  SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 1)) AS DataInformationAndContentRelevance,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentConfidence,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 2)) AS TeachingLearningAndSelfDevelopmentRelevance,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationConfidence,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                  SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                     WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 3)) AS CommunicationCollaborationAndParticipationRelevance,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyConfidence,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 4)) AS TechnicalProficiencyRelevance,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchConfidence,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 5)) AS CreationInnovationAndResearchRelevance,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 1) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityConfidence,
+                    (SELECT AVG(sar.Result) AS AvgConfidence
+                    FROM    SelfAssessmentResults AS sar INNER JOIN
+                                Competencies AS co ON sar.CompetencyID = co.ID INNER JOIN
+                                SelfAssessmentStructure AS sas ON co.ID = sas.CompetencyID
+                    WHERE (sar.DelegateUserID = da.UserID) AND (sar.AssessmentQuestionID = 2) AND (sas.CompetencyGroupID = 6)) AS DigitalIdentityWellbeingSafetyAndSecurityRelevance
+                    FROM   CandidateAssessments AS ca INNER JOIN
+                    DelegateAccounts AS da ON ca.DelegateUserID = da.UserID INNER JOIN
+                    Users AS u ON da.UserID = u.ID INNER JOIN
                      JobGroups AS jg ON u.JobGroupID = jg.JobGroupID
-        WHERE (ca.Active = 1) AND (ca.CentreID = @centreId) AND (caa.SelfAssessmentID = 1)
-        ORDER BY EnrolledYear DESC, EnrolledMonth DESC, JobGroup, CentreField1, CentreField2, CentreField3, Status",
+                    WHERE (ca.SelfAssessmentID = 1) AND (da.CentreID = @centreId) AND (u.Active = 1) AND (da.Active = 1)",
                 new { centreId }
             );
         }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -21,7 +21,7 @@
             this.connection = connection;
             this.logger = logger;
         }
-        
+
         public IEnumerable<DCSADelegateCompletionStatus> GetDelegateCompletionStatusForCentre(int centreId)
         {
             return connection.Query<DCSADelegateCompletionStatus>(

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
@@ -34,7 +34,7 @@
             table.Theme = XLTableTheme.TableStyleLight9;
             sheet.Columns().AdjustToContents();
         }
-        
+
         public IEnumerable<SelfAssessmentSelect> GetSelfAssessmentsForReportList(int centreId, int? categoryId)
         {
             return selfAssessmentReportDataService.GetSelfAssessmentsForReportList(centreId, categoryId);

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentReportService.cs
@@ -11,7 +11,6 @@
 
     public interface ISelfAssessmentReportService
     {
-        byte[] GetDigitalCapabilityExcelExport();
         byte[] GetSelfAssessmentExcelExportForCentre(int centreId, int selfAssessmentId);
         byte[] GetDigitalCapabilityExcelExportForCentre(int centreId);
         IEnumerable<SelfAssessmentSelect> GetSelfAssessmentsForReportList(int centreId, int? categoryId);
@@ -35,57 +34,7 @@
             table.Theme = XLTableTheme.TableStyleLight9;
             sheet.Columns().AdjustToContents();
         }
-        public byte[] GetDigitalCapabilityExcelExport()
-        {
-            var delegateCompletionStatus = dcsaReportDataService.GetDelegateCompletionStatus();
-            var outcomeSummary = dcsaReportDataService.GetOutcomeSummary();
-            var summary = delegateCompletionStatus.Select(
-                x => new
-                {
-                    x.EnrolledMonth,
-                    x.EnrolledYear,
-                    x.FirstName,
-                    x.LastName,
-                    Email = (Guid.TryParse(x.Email, out _) ? string.Empty : x.Email),
-                    x.CentreField1,
-                    x.CentreField2,
-                    x.CentreField3,
-                    x.Status
-                }
-                );
-            var details = outcomeSummary.Select(
-                x => new
-                {
-                    x.EnrolledMonth,
-                    x.EnrolledYear,
-                    x.JobGroup,
-                    x.CentreField1,
-                    x.CentreField2,
-                    x.CentreField3,
-                    x.Status,
-                    x.LearningLaunched,
-                    x.LearningCompleted,
-                    x.DataInformationAndContentConfidence,
-                    x.DataInformationAndContentRelevance,
-                    x.TeachinglearningAndSelfDevelopmentConfidence,
-                    x.TeachinglearningAndSelfDevelopmentRelevance,
-                    x.CommunicationCollaborationAndParticipationConfidence,
-                    x.CommunicationCollaborationAndParticipationRelevance,
-                    x.TechnicalProficiencyConfidence,
-                    x.TechnicalProficiencyRelevance,
-                    x.CreationInnovationAndResearchConfidence,
-                    x.CreationInnovationAndResearchRelevance,
-                    x.DigitalIdentityWellbeingSafetyAndSecurityConfidence,
-                    x.DigitalIdentityWellbeingSafetyAndSecurityRelevance
-                }
-                );
-            using var workbook = new XLWorkbook();
-            AddSheetToWorkbook(workbook, "Delegate Completion Status", summary);
-            AddSheetToWorkbook(workbook, "Assessment Outcome Summary", outcomeSummary);
-            using var stream = new MemoryStream();
-            workbook.SaveAs(stream);
-            return stream.ToArray();
-        }
+        
         public IEnumerable<SelfAssessmentSelect> GetSelfAssessmentsForReportList(int centreId, int? categoryId)
         {
             return selfAssessmentReportDataService.GetSelfAssessmentsForReportList(centreId, categoryId);


### PR DESCRIPTION
### JIRA link
[TD-1988](https://hee-tis.atlassian.net/browse/TD-1988)

### Description
Updates queries returning centre DSAT report data to:
- include centre learners who enrolled on DSAT at a different centre 
- count learning accessed and completed through the new Learning Hub signposting mechanism (as well as the old Filtered one)

Also removes redundant services that don't take centreId parameter and return all data.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1988]: https://hee-tis.atlassian.net/browse/TD-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ