### PR TITLE
TD-3645-Removed message, made non-JavaScript search count equal to JavaScript search.

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -55,7 +55,26 @@
             var centreRegistrationPrompts = centreRegistrationPromptsService.GetCentreRegistrationPromptsByCentreId(centreId);
             var supervisorDelegateDetails = supervisorService.GetSupervisorDelegateDetailsForAdminId(adminId);
             var isSupervisor = User.GetCustomClaimAsBool(CustomClaimTypes.IsSupervisor) ?? false;
-            var supervisorDelegateDetailViewModels = supervisorDelegateDetails.Select(
+            var allSupervisorDelegateDetailViewModels = supervisorDelegateDetails.Select(
+                supervisor =>
+                {
+                    return new SupervisorDelegateDetailViewModel(
+                        supervisor,
+                        new ReturnPageQuery(
+                            page,
+                            $"{supervisor.ID}-card",
+                            PaginationOptions.DefaultItemsPerPage,
+                            searchString,
+                            sortBy,
+                            sortDirection
+                        ),
+                        isSupervisor,
+                        loggedInUserId
+                    );
+                }
+            );
+
+            var supervisorDelegateDetailViewModels = supervisorDelegateDetails.Where(x => x.DelegateUserID != loggedInUserId).Select(
                 supervisor =>
                 {
                     return new SupervisorDelegateDetailViewModel(
@@ -92,7 +111,7 @@
                 centreRegistrationPrompts
             );
             model.IsActiveSupervisorDelegateExist = IsSupervisorDelegateExistAndActive(adminId, supervisorEmail, centreId) > 0;
-            model.SelfSuperviseDelegateDetailViewModels = supervisorDelegateDetailViewModels.Where(x => x.SupervisorDelegateDetail.DelegateUserID == loggedInUserId).FirstOrDefault();
+            model.SelfSuperviseDelegateDetailViewModels = allSupervisorDelegateDetailViewModels.Where(x => x.SupervisorDelegateDetail.DelegateUserID == loggedInUserId).FirstOrDefault();
             ModelState.ClearErrorsForAllFieldsExcept("DelegateEmailAddress");
             return View("MyStaffList", model);
         }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/MyStaffList.cshtml
@@ -45,7 +45,7 @@
     <h1>My Staff</h1>
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
-            @if (Model.SuperviseDelegateDetailViewModels.Any() | (Model.SearchString != null)|Model.SelfSuperviseDelegateDetailViewModels!=null )
+            @if (Model.SuperviseDelegateDetailViewModels.Any() | (Model.SearchString != null) | Model.SelfSuperviseDelegateDetailViewModels != null)
             {
                 <form method="get" role="search" asp-action="Index" asp-route-page="@Model.Page">
                     <div class="nhsuk-grid-row">
@@ -75,10 +75,6 @@
                                 </div>
                                 <partial name="SearchablePage/_BottomPagination" model="Model" />
                             }
-                            else
-                            {
-                                <p>Please change your search criteria and try again.</p>
-                            }
                         </div>
                     </div>
                 </form>
@@ -100,14 +96,14 @@
                     <div class="nhsuk-form-group">
                         <div class=" sort-select-container">
                             <vc:text-input asp-for="DelegateEmailAddress"
-                                       label="User email address"
-                                       populate-with-current-value="false"
-                                       type="text"
-                                       spell-check="false"
-                                       hint-text="Provide the work email address of a member of staff to add to your supervision list.<br/>If the email address already exists in your staff list, it will be ignored."
-                                       autocomplete="email"
-                                       css-class="nhsuk-input"
-                                       required="true" />
+                                           label="User email address"
+                                           populate-with-current-value="false"
+                                           type="text"
+                                           spell-check="false"
+                                           hint-text="Provide the work email address of a member of staff to add to your supervision list.<br/>If the email address already exists in your staff list, it will be ignored."
+                                           autocomplete="email"
+                                           css-class="nhsuk-input"
+                                           required="true" />
                         </div>
                     </div>
                     <button class="nhsuk-button" type="submit" asp-action="AddSuperviseDelegate">
@@ -140,5 +136,5 @@
 {
     @section scripts {
     <script src="@Url.Content("~/js/supervisor/staffList.js")" asp-append-version="true"></script>
-}
+    }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3645

### Description
Removed 'Please change your search criteria and try again' message for consistency with other searches.
Made non-JavaScript search count equal to JavaScript search.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1fba443f-694e-4d0b-b7e3-5f3b1bf9ebb1)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/feba3d36-b569-4bab-8dcf-40352dd1d678)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/d6ff3483-0864-4b77-8592-84f4c85adc41)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
