### PR TITLE
TD-3217 Fixes super admin centre course add test fails - validation, routing and mobile alignment

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SuperAdmin/CentresControllerTests.cs
@@ -489,7 +489,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.SuperAdmin
             };
 
             // When
-            var result = controller.CourseAddCommit(model) as RedirectToActionResult;
+            var result = controller.CourseAddCommit(model, model.CentreId, "Core") as RedirectToActionResult;
 
             // Then
             result.Should().NotBeNull().And.BeOfType<RedirectToActionResult>().Which

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -700,7 +700,6 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                     break;
             }
             model.SearchTerm = searchTerm;
-            model.CentreName = centresDataService.GetCentreName(centreId);
             return View("CourseAdd", model);
         }
 
@@ -722,6 +721,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                         model.Courses = centreApplicationsService.GetPathwaysCoursesForPublish(centreId);
                         break;
                 }
+                model.CentreName = centresDataService.GetCentreName(centreId);
                 return View("CourseAdd", model);
             }
             foreach (var id in model.ApplicationIds)

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -700,6 +700,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
                     break;
             }
             model.SearchTerm = searchTerm;
+            model.CentreName = centresDataService.GetCentreName(centreId);
             return View("CourseAdd", model);
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -668,19 +668,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         [HttpPost]
         public IActionResult CourseAddChooseFlow(CourseAddChooseFlowViewModel model)
         {
-            switch (model.AddCourseOption)
-            {
-                case "Core":
-                    return RedirectToAction(nameof(CourseAddCore), new { centreId = model.CentreId });
-
-                case "Other":
-                    return RedirectToAction(nameof(CourseAddOther), new { centreId = model.CentreId, searchTerm = (model.SearchTerm != null ? model.SearchTerm.Replace(" ", "%") : "") });
-
-                case "Pathways":
-                    return RedirectToAction(nameof(CourseAddPathways), new { centreId = model.CentreId });
-            }
-
-            return RedirectToAction(nameof(Courses), new { centreId = model.CentreId });
+            return RedirectToAction(nameof(CourseAdd), new { centreId = model.CentreId, courseType = model.AddCourseOption, searchTerm = (model.SearchTerm != null ? model.SearchTerm.Replace(" ", "%") : "") });
         }
 
         private CourseAddViewModel SetupCommonModel(int centreId, string courseType, IEnumerable<CourseForPublish> courses)
@@ -694,29 +682,47 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
             };
         }
 
-        [Route("SuperAdmin/Centres/{centreId=0:int}/Courses/Add/Core")]
-        public IActionResult CourseAddCore(int centreId = 0)
+        [NoCaching]
+        [Route("SuperAdmin/Centres/{centreId}/Courses/Add/{courseType}")]
+        public IActionResult CourseAdd(int centreId, string courseType, string? searchTerm)
         {
-            var model = SetupCommonModel(centreId, "Core", centreApplicationsService.GetCentralCoursesForPublish(centreId));
-            return View("CourseAdd", model);
-        }
-        [Route("SuperAdmin/Centres/{centreId=0:int}/Courses/Add/Other")]
-        public IActionResult CourseAddOther(int centreId, string searchTerm)
-        {
-            var model = SetupCommonModel(centreId, "Other", centreApplicationsService.GetOtherCoursesForPublish(centreId, searchTerm));
+            CourseAddViewModel model;
+            switch (courseType)
+            {
+                case "Core":
+                    model = SetupCommonModel(centreId, "Core", centreApplicationsService.GetCentralCoursesForPublish(centreId));
+                    break;
+                case "Other":
+                    model = SetupCommonModel(centreId, "Other", centreApplicationsService.GetOtherCoursesForPublish(centreId, searchTerm));
+                    break;
+                default:
+                    model = SetupCommonModel(centreId, "Pathways", centreApplicationsService.GetPathwaysCoursesForPublish(centreId));
+                    break;
+            }
             model.SearchTerm = searchTerm;
             return View("CourseAdd", model);
         }
-        [NoCaching]
-        [Route("SuperAdmin/Centres/{centreId=0:int}/Courses/Add/Pathways")]
-        public IActionResult CourseAddPathways(int centreId = 0)
-        {
-            var model = SetupCommonModel(centreId, "Pathways", centreApplicationsService.GetPathwaysCoursesForPublish(centreId));
-            return View("CourseAdd", model);
-        }
+
         [HttpPost]
-        public IActionResult CourseAddCommit(CourseAddViewModel model)
+        [Route("SuperAdmin/Centres/{centreId}/Courses/Add/{courseType}")]
+        public IActionResult CourseAddCommit(CourseAddViewModel model, int centreId, string courseType)
         {
+            if (!ModelState.IsValid)
+            {
+                switch (courseType)
+                {
+                    case "Core":
+                        model.Courses = centreApplicationsService.GetCentralCoursesForPublish(centreId);
+                        break;
+                    case "Other":
+                        model.Courses = centreApplicationsService.GetOtherCoursesForPublish(centreId, model.SearchTerm);
+                        break;
+                    default:
+                        model.Courses = centreApplicationsService.GetPathwaysCoursesForPublish(centreId);
+                        break;
+                }
+                return View("CourseAdd", model);
+            }
             foreach (var id in model.ApplicationIds)
             {
                 centreApplicationsService.InsertCentreApplication(model.CentreId, id);

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CourseAddViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Centres/CourseAddViewModel.cs
@@ -3,14 +3,16 @@
     using DigitalLearningSolutions.Data.Models.Courses;
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
 
     public class CourseAddViewModel
     {
         public string? SearchTerm { get; set; }
         public int CentreId { get; set; }
         public string CourseType { get; set; }
-        public string CentreName { get; set; }
-        public IEnumerable<CourseForPublish> Courses { get; set; }
+        public string? CentreName { get; set; }
+        public IEnumerable<CourseForPublish>? Courses { get; set; }
+        [Required(ErrorMessage = "Please select at least one course")]
         public List<int>? ApplicationIds { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/CourseAdd.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/CourseAdd.cshtml
@@ -4,6 +4,7 @@
 @{
     ViewData["Title"] = "Add" + Model.CourseType + " courses";
     var cancelLinkData = Html.GetRouteValues();
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
 @section NavBreadcrumbs {
@@ -22,7 +23,7 @@
 }
 @if (Model.CourseType == "Other")
 {
-    <form method="post" asp-action="CourseAddChooseFlow">
+    <form method="post" asp-action="CourseAddChooseFlow" asp-route-centreID="@ViewContext.RouteData.Values["centreId"]" asp-route-courseType="@ViewContext.RouteData.Values["courseType"]">
         <input type="hidden" asp-for="CentreId" />
         <input type="hidden" name="AddCourseOption" value="@Model.CourseType" />
         <div class="search-container">
@@ -43,7 +44,12 @@
 }
 @if (Model.Courses.Any())
 {
-    <form method="post" asp-action="CourseAddCommit">
+    <form method="post" asp-action="CourseAddCommit" asp-route-centreID="@ViewContext.RouteData.Values["centreId"]" asp-route-courseType="@ViewContext.RouteData.Values["courseType"]">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new []{ nameof(CourseAddViewModel.ApplicationIds) })" />
+        }
+        <div class="@(errorHasOccurred ? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
         <fieldset class="nhsuk-fieldset">
             <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
                 <h1 class="nhsuk-fieldset__heading">
@@ -53,7 +59,12 @@
             <div class="nhsuk-hint">
                 Which courses would you like to add?
             </div>
-
+                @if (errorHasOccurred)
+                {
+                    <span class="nhsuk-error-message" id="dob-day-error-error">
+                        <span class="nhsuk-u-visually-hidden">Error:</span> Required
+                    </span>
+                }
             @if (Model.Courses.Count() > 1)
             {
                 <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
@@ -80,7 +91,6 @@
                         {
                             <tr role="row" class="nhsuk-table__row">
                                 <td class="nhsuk-table__cell nhsuk-u-font-size-16">
-                                    <span class="nhsuk-table-responsive__heading">Course </span>
                                     <div class="nhsuk-checkboxes__item">
                                         <input data-group="course-list" class="nhsuk-checkboxes__input select-all-checkbox" id="course-check-@course.Id" name="ApplicationIds" type="checkbox" value="@course.Id">
                                         <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="course-check-@course.Id">
@@ -98,7 +108,9 @@
                 </table>
             </div>
         </fieldset>
+        </div>
         <input type="hidden" asp-for="CentreId" />
+        <input type="hidden" asp-for="SearchTerm" />
         <button class="nhsuk-button" type="submit">
             Add selected courses to centre
         </button>
@@ -106,8 +118,25 @@
 }
 else
 {
-    <h1>No courses available</h1>
-    <p>There are no core courses available to add to the centre @ViewBag.CentreName.</p>
+    @if (Model.CourseType == "Other")
+    {
+        Model.SearchTerm = Model.SearchTerm ?? "";
+        if(Model.SearchTerm.Length == 0)
+        {
+            <h1>No search term</h1>
+            <p>Please enter a search term to locate a course.</p>
+        }
+        else
+        {
+            <h1>No courses match your search term</h1>
+            <p>There are no core courses available that match your search term. Please adjust it and try again.</p>
+        }
+    }
+    else
+    {
+        <h1>No courses available</h1>
+        <p>There are no core courses available to add to the centre @ViewBag.CentreName.</p>
+    }
 }
 
 <vc:cancel-link asp-controller="Centres" asp-action="Courses" asp-all-route-data="@cancelLinkData" />


### PR DESCRIPTION
### JIRA link
[TD-3217](https://hee-tis.atlassian.net/browse/TD-3217)

### Description
Fixes the fails identified by test analysts:
- Validates form inputs in the add course flow
- Fixes page routing
- Fixes mobile alignment of select checkboxes

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/137b3fb7-58f9-4954-93c9-fb31f0e8b546)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/9c56e123-3da4-4918-8740-297dcc130127)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3217]: https://hee-tis.atlassian.net/browse/TD-3217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ