### PR TITLE
TD-3652 fixed inactive account showing as not registered

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -233,7 +233,6 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 	                        ON ucd.UserID = u.ID
                             AND ucd.CentreID = da.CentreID
                             WHERE (ucd.Email = @delegateEmail OR u.PrimaryEmail = @delegateEmail)
-                            AND u.Active = 1 
                             AND da.CentreID = @centreId", new { delegateEmail, centreId });
             }
 


### PR DESCRIPTION
### JIRA link
[TD-3652](https://hee-tis.atlassian.net/browse/TD-3652)

### Description
Inactive account was showing as Not Registered when added as a staff member on the supervisor portal. It was because there is a condition on the view - @if (Model.SupervisorDelegateDetail.DelegateUserID == null) then show 'Not registered' tag. The details of Model.SupervisorDelegateDetail are populated from SupervisorDelegates table. 

While adding staff, we had a condition that checked only for active users and hence we were not populating SupervisorDelegates table with correct values. The solution is removing this condition.


### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/c0224eb5-2d2d-4bf5-b1d6-13c9ae6535d5)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/5aa568d6-1594-4f7f-8f55-41f049423a1c)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
