### PR TITLE
TD-149-Show/hide certificate button

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -393,7 +393,8 @@
 			 CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
              Centres AS ce ON ca.CentreID = ce.CentreID
 			 where (ca.ID=@candidateAssessmentID)  AND  (casv.SignedOff = 1)
-                           AND (NOT (casv.Verified IS NULL))) Supervisor ON  LearnerDetails.Id =Supervisor.Id",
+                           AND (NOT (casv.Verified IS NULL))) Supervisor ON  LearnerDetails.Id =Supervisor.Id
+             ORDER BY Verified DESC",
                 new { candidateAssessmentID }
             );
         }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
@@ -161,7 +161,7 @@
 
         <div class="footer">
             <div class="text">
-                <p class="blue">Certificate generated on @Model.CompetencySelfAssessmentCertificates.Verified.ToString("dd/MM/yyyy")</p>
+                <p class="blue">Certificate generated on @DateTime.Now.ToString("dd/MM/yyyy")</p>
                 <p>By NHS England Digital Learning Solutions <br /> on behalf of @Model.CompetencySelfAssessmentCertificates.CentreName</p>
             </div>
             <div class="footer-logo">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
@@ -470,7 +470,7 @@
 
             <div class="footer">
                 <div class="text">
-                    <p class="blue">Certificate generated on @Model.CompetencySelfAssessmentCertificates.Verified.ToString("dd/MM/yyyy")</p>
+                    <p class="blue">Certificate generated on @DateTime.Now.ToString("dd/MM/yyyy")</p>
                     <p>By NHS England Digital Learning Solutions <br /> on behalf of @Model.CompetencySelfAssessmentCertificates.CentreName</p>
                 </div>
                 <div class="footer-logo">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
@@ -1,42 +1,68 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @using DigitalLearningSolutions.Web.Helpers
 @model SelfAssessmentOverviewViewModel
+@{
+    var latestSignoff = Model.SupervisorSignOffs
+          .Select(s => s.Verified)
+          .DefaultIfEmpty(DateTime.MinValue)
+          .Max();
+    var latestResult = Model.CompetencyGroups
+      .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
+      .Select(q => q.ResultDateTime)
+      .DefaultIfEmpty(DateTime.MinValue)
+      .Max();
+
+    var competencySummaries = from g in Model.CompetencyGroups
+                              let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
+                              let selfAssessedCount = questions.Count(q => q.Result.HasValue)
+                              let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
+                              select new ViewDataDictionary(ViewData)
+                              {
+
+        { "questionsCount", questions.Count() },
+        { "selfAssessedCount", selfAssessedCount },
+        { "verifiedCount", verifiedCount }
+      };
+    var allComptConfirmed = competencySummaries.Sum(c => (int)c["verifiedCount"]) == competencySummaries.Sum(c => (int)c["questionsCount"]);
+}
+
 @if (Model.NumberOfOptionalCompetencies > 0)
 {
-  <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
-   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-   asp-route-vocabulary="@Model.VocabPlural()"
-   asp-action="ManageOptionalCompetencies"
-   role="button">
-    Manage optional @Model.VocabPlural().ToLower()
-  </a>
+    <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+       asp-route-vocabulary="@Model.VocabPlural()"
+       asp-action="ManageOptionalCompetencies"
+       role="button">
+        Manage optional @Model.VocabPlural().ToLower()
+    </a>
 }
 @if (Model.SelfAssessment.IsSupervisorResultsReviewed)
 {
-  <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
-   asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
-   asp-action="ReviewConfirmationRequests"
-   role="button">
-    Manage confirmation requests
-  </a>
+    <a class="nhsuk-button nhsuk-button--secondary trigger-loader"
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id"
+       asp-action="ReviewConfirmationRequests"
+       role="button">
+        Manage confirmation requests
+    </a>
 }
 <feature name="@(FeatureFlags.CandidateAssessmentExcelExport)">
-  <a class="nhsuk-button nhsuk-button--secondary"
-     asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
-     asp-route-candidateAssessmentName="@Model.SelfAssessment.Name"
+    <a class="nhsuk-button nhsuk-button--secondary"
+       asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
+       asp-route-candidateAssessmentName="@Model.SelfAssessment.Name"
        asp-route-delegateName="@Model.SelfAssessment.DelegateName"
-     asp-action="ExportCandidateAssessment"
-     role="button">
-    Export to Excel
-  </a>
+       asp-action="ExportCandidateAssessment"
+       role="button">
+        Export to Excel
+    </a>
 </feature>
-  @if (Model.SupervisorSignOffs.Where(x=> x.Verified != null && x.SignedOff).Any())
- {
-<a class="nhsuk-button "
-   asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
-   asp-route-route="2"
-   asp-action="CompetencySelfAssessmentCertificate"
-   role="button">
-    Certificate
-</a>
- }
+@if (Model?.SupervisorSignOffs?.FirstOrDefault()?.Verified != null &&
+   Model.SupervisorSignOffs.FirstOrDefault().SignedOff && allComptConfirmed && latestResult <= latestSignoff)
+{
+    <a class="nhsuk-button "
+       asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"
+       asp-route-route="2"
+       asp-action="CompetencySelfAssessmentCertificate"
+       role="button">
+        Certificate
+    </a>
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SelfAssessmentCard.cshtml
@@ -52,17 +52,17 @@
                     Remove
                 </a>
             }
-            @if (Model.Verified != null && Model.SignedOff)
+            @*  @if (Model.Verified != null && Model.SignedOff)
             {
-                <a class="nhsuk-button nhsuk-button--secondary"
-               aria-describedby="@Model.CandidateAssessmentId-name-sa"
-               asp-action="CompetencySelfAssessmentCertificate"
-               asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
-               asp-route-route="1"
-               role="button">
-                Certificate
+            <a class="nhsuk-button nhsuk-button--secondary"
+            aria-describedby="@Model.CandidateAssessmentId-name-sa"
+            asp-action="CompetencySelfAssessmentCertificate"
+            asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
+            asp-route-route="1"
+            role="button">
+            Certificate
             </a>
-            }
+            } *@
         </div>
     </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -4,17 +4,29 @@
     ViewData["Title"] = "Review Profile Assessment";
     ViewData["Application"] = "Supervisor";
     ViewData["HeaderPathName"] = "Supervisor";
+
+    var latestSignoff = Model.SupervisorSignOffs
+        .Select(s => s.Verified)
+        .DefaultIfEmpty(DateTime.MinValue)
+        .Max();
+    var latestResult = Model.CompetencyGroups
+      .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
+      .Select(q => q.ResultDateTime)
+      .DefaultIfEmpty(DateTime.MinValue)
+      .Max();
+
     var competencySummaries = from g in Model.CompetencyGroups
                               let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
                               let selfAssessedCount = questions.Count(q => q.Result.HasValue)
                               let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
                               select new ViewDataDictionary(ViewData)
-{
+                              {
 
-        { "questionsCount", questions.Count() },
-        { "selfAssessedCount", selfAssessedCount },
-        { "verifiedCount", verifiedCount }
-      };
+                                { "questionsCount", questions.Count() },
+                                { "selfAssessedCount", selfAssessedCount },
+                                { "verifiedCount", verifiedCount }
+                              };
+    var allComptConfirmed = competencySummaries.Sum(c => (int)c["verifiedCount"]) == competencySummaries.Sum(c => (int)c["questionsCount"]);
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
@@ -95,17 +107,20 @@
             </a>
         }
 
-        @if (Model.SupervisorSignOffs.Where(x => x.Verified != null && x.SignedOff).Any() && Model.DelegateSelfAssessment.ResultsVerificationRequests ==0)
-        { 
-          
-                <a class="nhsuk-button"
-           asp-controller="LearningPortal"
-           asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
-           asp-action="CompetencySelfAssessmentCertificate"
-           asp-route-route="3"
-           role="button">
-                    Certificate
-                </a>
+        @if (Model?.SupervisorSignOffs?.FirstOrDefault()?.Verified != null &&
+        Model.SupervisorSignOffs.FirstOrDefault().SignedOff &&
+        Model?.DelegateSelfAssessment?.ResultsVerificationRequests == 0 && allComptConfirmed && latestResult <= latestSignoff
+        )
+        {
+
+            <a class="nhsuk-button"
+               asp-controller="LearningPortal"
+               asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
+               asp-action="CompetencySelfAssessmentCertificate"
+               asp-route-route="3"
+               role="button">
+                Certificate
+            </a>
         }
         @if (
         Model.DelegateSelfAssessment.SignOffRequested > 0 &&


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-149

### Description
1. Latest Signoff by supervisor and date issue fixed.
2. Fixed 'Certificate generated on' date issue on first page
3. Show/hide certificate button activity based on sign off status.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/e9077421-b335-4175-a39d-4918ab18d29e)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/51aa033b-8394-4363-8048-727f1ef69719)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
