### PR TITLE
TD-3784 Making manage course button available for inactive courses

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -46,7 +46,7 @@
                     Launch course
                 </a>
             }
-            else if (!Model.Archived)
+            @if (!Model.Archived)
             {
                 <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
                    role="button"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/_CentreCourseCard.cshtml
@@ -33,10 +33,10 @@
         </div>
     </details>
 
-    @if (Model.Active && !Model.Archived)
-    {
-        <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-full nhsuk-u-margin-left-4">
+    <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full nhsuk-u-margin-left-4">
+            @if (Model.Active && !Model.Archived)
+            {
                 <a class="nhsuk-button nhsuk-u-margin-right-2 nhsuk-u-margin-bottom-2"
                    role="button"
                    id="launch-course-@Model.CustomisationId"
@@ -45,6 +45,9 @@
                    asp-route-customisationId="@Model.CustomisationId">
                     Launch course
                 </a>
+            }
+            else if (!Model.Archived)
+            {
                 <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
                    role="button"
                    asp-controller="ManageCourse"
@@ -52,7 +55,7 @@
                    asp-route-customisationId="@Model.CustomisationId">
                     Manage course
                 </a>
-            </div>
+            }
         </div>
-    }
+    </div>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-3784](https://hee-tis.atlassian.net/browse/TD-3784)

### Description
Changing the conditions to show/hide the 'manage course' button. 
If a course is active and not archived, we show the 'manage course' and 'launch course' buttons. 
If The course is inactive and not archived, we show only the 'manage course' button

### Screenshots
Active courses - 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/e0ddff71-6a92-4a6f-bd9a-fba121b387f9)

Inactive/Archived courses (Inactive courses have manage course button, but archived courses does not) -
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/c9b090e5-1933-4ff4-9999-3faf0fb7ebaf)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
