### PR TITLE
TD-149-Self assessment certificate - supervisor centre name issue fix

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -383,16 +383,17 @@
              Centres AS ce ON CE.CentreID = ca.CentreID INNER JOIN
 			 DelegateAccounts AS da ON da.UserID = Learner.ID AND da.CentreID = ca.CentreID 
              WHERE (ca.Id=@candidateAssessmentID) AND  (casv.SignedOff = 1) AND (NOT (casv.Verified IS NULL))) LearnerDetails INNER JOIN
-			 (select casv.ID ,Supervisor.FirstName + ' ' + Supervisor.LastName AS SupervisorName, 
-                    Supervisor.ProfessionalRegistrationNumber AS SupervisorPRN,
-              ce.CentreName AS SupervisorCentreName
+			 (select sd.SupervisorAdminID, casv.ID ,u.FirstName + ' ' + u.LastName AS SupervisorName, 
+                    u.ProfessionalRegistrationNumber AS SupervisorPRN,
+              c.CentreName AS SupervisorCentreName,ca.CentreID
               from CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
              CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
 			 SupervisorDelegates AS sd ON sd.ID = cas.SupervisorDelegateId INNER JOIN
-			 Users AS Supervisor ON Supervisor.PrimaryEmail = sd.SupervisorEmail   INNER JOIN
-			 CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-             Centres AS ce ON ca.CentreID = ce.CentreID
-			 where (ca.ID=@candidateAssessmentID)  AND  (casv.SignedOff = 1)
+			 AdminAccounts AS aa ON sd.SupervisorAdminID = aa.ID   INNER JOIN
+			 Users AS u ON aa.UserID = u.ID INNER JOIN
+			 Centres c ON aa.CentreID = c.CentreID INNER JOIN
+			 CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID 
+			 where (ca.ID = @candidateAssessmentID)  AND  (casv.SignedOff = 1)
                            AND (NOT (casv.Verified IS NULL))) Supervisor ON  LearnerDetails.Id =Supervisor.Id
              ORDER BY Verified DESC",
                 new { candidateAssessmentID }

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -16,6 +16,7 @@
         DashboardData? GetDashboardDataForAdminId(int adminId);
         IEnumerable<SupervisorDelegateDetail> GetSupervisorDelegateDetailsForAdminId(int adminId);
         SupervisorDelegateDetail GetSupervisorDelegateDetailsById(int supervisorDelegateId, int adminId, int delegateUserId);
+        SupervisorDelegate GetSupervisorDelegate(int adminId, int delegateUserId);
         int? ValidateDelegate(int centreId, string delegateEmail);
         IEnumerable<DelegateSelfAssessment> GetSelfAssessmentsForSupervisorDelegateId(int supervisorDelegateId, int adminId);
         DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId);
@@ -343,6 +344,18 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 supervisorDelegateDetail.CandidateEmail = delegateDetails.CandidateEmail;
                 supervisorDelegateDetail.CandidateNumber = delegateDetails.CandidateNumber;
             }
+
+            return supervisorDelegateDetail!;
+        }
+
+        public SupervisorDelegate GetSupervisorDelegate(int adminId, int delegateUserId)
+        {
+            var supervisorDelegateDetail = connection.Query<SupervisorDelegate>(
+                $@"SELECT ID,SupervisorAdminID,DelegateEmail,Added,NotificationSent,Removed,
+                    SupervisorEmail,AddedByDelegate,InviteHash,DelegateUserID
+                    FROM SupervisorDelegates
+                    WHERE DelegateUserID = @delegateUserId AND SupervisorAdminID = @adminId ", new { adminId, delegateUserId }
+            ).FirstOrDefault();
 
             return supervisorDelegateDetail!;
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -360,6 +360,7 @@
             }
 
             var delegateUserId = competencymaindata.LearnerId;
+            var supervisorDelegate = supervisorService.GetSupervisorDelegate(User.GetAdminIdKnownNotNull(), delegateUserId);
 
             var recentResults = selfAssessmentService.GetMostRecentResults(competencymaindata.SelfAssessmentID, competencymaindata.LearnerDelegateAccountId).ToList();
             var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(competencymaindata.SelfAssessmentID, delegateUserId);
@@ -410,8 +411,7 @@
             ViewBag.CompetencySummaries = competencySummaries;
             var activitySummaryCompetencySelfAssesment = selfAssessmentService.GetActivitySummaryCompetencySelfAssesment(competencymaindata.Id);
             var model = new CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, route, accessors, activitySummaryCompetencySelfAssesment, roleCount);
-            ViewBag.LoggedInSupervisorDelegatesId = TempData["CertificateSupervisorDelegateId"];
-            TempData.Remove("CertificateSupervisorDelegateId");
+            ViewBag.LoggedInSupervisorDelegatesId = supervisorDelegate.ID;
             return View("Current/CompetencySelfAssessmentCertificate", model);
         }
         [Route("DownloadCertificate")]

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -344,6 +344,7 @@
             return (resources.ToList(), apiIsAccessible);
         }
         [Route("/LearningPortal/Current/{candidateAssessmentId:int}/{route:int}/Certificate")]
+        [NoCaching]
         public IActionResult CompetencySelfAssessmentCertificate(int candidateAssessmentId, int route)
         {
 
@@ -360,11 +361,18 @@
 
             var delegateUserId = competencymaindata.LearnerId;
 
+            var recentResults = selfAssessmentService.GetMostRecentResults(competencymaindata.SelfAssessmentID, competencymaindata.LearnerDelegateAccountId).ToList();
+            var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(competencymaindata.SelfAssessmentID, delegateUserId);
+
+            if (!CertificateHelper.CanViewCertificate(recentResults, supervisorSignOffs))
+            {
+                return NotFound();
+            }
+
             var competencycount = selfAssessmentService.GetCompetencyCountSelfAssessmentCertificate(candidateAssessmentId);
             var roleCount = selfAssessmentService.GetRoleCount(candidateAssessmentId);
             var accessors = selfAssessmentService.GetAccessor(competencymaindata.SelfAssessmentID, competencymaindata.LearnerId);
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, competencymaindata.SelfAssessmentID);
-            var recentResults = selfAssessmentService.GetMostRecentResults(competencymaindata.SelfAssessmentID, competencymaindata.LearnerDelegateAccountId).ToList();
             var competencyIds = recentResults.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
             var competencies = CompetencyFilterHelper.FilterCompetencies(recentResults, competencyFlags, null);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -478,6 +478,8 @@
             {
                 searchModel.IsSupervisorResultsReviewed = assessment.IsSupervisorResultsReviewed;
             }
+
+            ViewBag.CanViewCertificate = CertificateHelper.CanViewCertificate(recentResults, model.SupervisorSignOffs);
             ViewBag.SupervisorSelfAssessmentReview = assessment.SupervisorSelfAssessmentReview;
             return View("SelfAssessments/SelfAssessmentOverview", model);
         }
@@ -1536,15 +1538,15 @@
             };
             return View("SelfAssessments/SignOffHistory", model);
         }
-        public IActionResult ExportCandidateAssessment(int candidateAssessmentId,string candidateAssessmentName, string delegateName)
+        public IActionResult ExportCandidateAssessment(int candidateAssessmentId, string candidateAssessmentName, string delegateName)
         {
             var content = candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(candidateAssessmentId, User.GetUserIdKnownNotNull(), true);
             var fileName = $"{((candidateAssessmentName.Length > 30) ? candidateAssessmentName.Substring(0, 30) : candidateAssessmentName)} - {delegateName} - {clockUtility.UtcNow:yyyy-MM-dd}.xlsx";
-             return File(
-                content,
-                FileHelper.GetContentTypeFromFileName(fileName),
-                fileName
-            );
+            return File(
+               content,
+               FileHelper.GetContentTypeFromFileName(fileName),
+               fileName
+           );
         }
 
         public IActionResult RemoveEnrolment(int selfAssessmentId)

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -368,7 +368,6 @@
             ViewBag.CanViewCertificate = CertificateHelper.CanViewCertificate(reviewedCompetencies, model.SupervisorSignOffs);
             ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
             ViewBag.navigatedFrom = selfAssessmentResultId == null;
-            TempData["CertificateSupervisorDelegateId"] = supervisorDelegateId;
             return View("ReviewSelfAssessment", model);
         }
         [HttpPost]

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -365,6 +365,7 @@
                 );
             }
 
+            ViewBag.CanViewCertificate = CertificateHelper.CanViewCertificate(reviewedCompetencies, model.SupervisorSignOffs);
             ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
             ViewBag.navigatedFrom = selfAssessmentResultId == null;
             TempData["CertificateSupervisorDelegateId"] = supervisorDelegateId;

--- a/DigitalLearningSolutions.Web/Helpers/CertificateHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CertificateHelper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DigitalLearningSolutions.Data.Enums;
+using DigitalLearningSolutions.Data.Models.SelfAssessments;
+using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
+using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments;
+
+namespace DigitalLearningSolutions.Web.Helpers
+{
+    public class CertificateHelper
+    {
+        public static bool CanViewCertificate(List<Competency> reviewedCompetencies, IEnumerable<SupervisorSignOff>? SupervisorSignOffs)
+        {
+
+            var CompetencyGroups = reviewedCompetencies.GroupBy(competency => competency.CompetencyGroup);
+
+            var competencySummaries = CompetencyGroups.Select(g =>
+            {
+                var questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
+                var verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required));
+                return new
+                {
+                    QuestionsCount = questions.Count(),
+                    VerifiedCount = verifiedCount
+                };
+            });
+
+            var latestSignoff = SupervisorSignOffs
+                    .Select(s => s.Verified)
+                    .DefaultIfEmpty(DateTime.MinValue)
+                    .Max();
+            var latestResult = CompetencyGroups
+                    .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
+                    .Select(q => q.ResultDateTime)
+                    .DefaultIfEmpty(DateTime.MinValue)
+                    .Max();
+
+            var allComptConfirmed = competencySummaries.Count() == 0 ? false : competencySummaries.Sum(c => c.VerifiedCount) == competencySummaries.Sum(c => c.QuestionsCount);
+
+            return SupervisorSignOffs?.FirstOrDefault()?.Verified != null &&
+                    SupervisorSignOffs.FirstOrDefault().SignedOff &&
+                    allComptConfirmed && latestResult <= latestSignoff;
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
@@ -125,7 +125,7 @@
                     </div>
                 </h1>
                 <p>
-                    Signed off at @Model.CompetencySelfAssessmentCertificates.CentreName <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">by @Model.CompetencySelfAssessmentCertificates.SupervisorName </span><span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">@Model.CompetencySelfAssessmentCertificates.SupervisorPRN</span>
+                    Signed off at @Model.CompetencySelfAssessmentCertificates.SupervisorCentreName <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">by @Model.CompetencySelfAssessmentCertificates.SupervisorName </span><span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">@Model.CompetencySelfAssessmentCertificates.SupervisorPRN</span>
                 </p>
 
                 <p>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
@@ -434,7 +434,7 @@
                         </div>
                     </h1>
                     <p>
-                        Signed off at @Model.CompetencySelfAssessmentCertificates.CentreName <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">by @Model.CompetencySelfAssessmentCertificates.SupervisorName </span><span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">@Model.CompetencySelfAssessmentCertificates.SupervisorPRN</span>
+                        Signed off at @Model.CompetencySelfAssessmentCertificates.SupervisorCentreName <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">by @Model.CompetencySelfAssessmentCertificates.SupervisorName </span><span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">@Model.CompetencySelfAssessmentCertificates.SupervisorPRN</span>
                     </p>
 
                     <p>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewActionButtons.cshtml
@@ -1,30 +1,6 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @using DigitalLearningSolutions.Web.Helpers
 @model SelfAssessmentOverviewViewModel
-@{
-    var latestSignoff = Model.SupervisorSignOffs
-          .Select(s => s.Verified)
-          .DefaultIfEmpty(DateTime.MinValue)
-          .Max();
-    var latestResult = Model.CompetencyGroups
-      .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
-      .Select(q => q.ResultDateTime)
-      .DefaultIfEmpty(DateTime.MinValue)
-      .Max();
-
-    var competencySummaries = from g in Model.CompetencyGroups
-                              let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
-                              let selfAssessedCount = questions.Count(q => q.Result.HasValue)
-                              let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
-                              select new ViewDataDictionary(ViewData)
-                              {
-
-        { "questionsCount", questions.Count() },
-        { "selfAssessedCount", selfAssessedCount },
-        { "verifiedCount", verifiedCount }
-      };
-    var allComptConfirmed = competencySummaries.Sum(c => (int)c["verifiedCount"]) == competencySummaries.Sum(c => (int)c["questionsCount"]);
-}
 
 @if (Model.NumberOfOptionalCompetencies > 0)
 {
@@ -55,8 +31,7 @@
         Export to Excel
     </a>
 </feature>
-@if (Model?.SupervisorSignOffs?.FirstOrDefault()?.Verified != null &&
-   Model.SupervisorSignOffs.FirstOrDefault().SignedOff && allComptConfirmed && latestResult <= latestSignoff)
+@if (ViewBag.CanViewCertificate)
 {
     <a class="nhsuk-button "
        asp-route-candidateAssessmentId="@Model.SelfAssessment.CandidateAssessmentId"

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -5,16 +5,6 @@
     ViewData["Application"] = "Supervisor";
     ViewData["HeaderPathName"] = "Supervisor";
 
-    var latestSignoff = Model.SupervisorSignOffs
-        .Select(s => s.Verified)
-        .DefaultIfEmpty(DateTime.MinValue)
-        .Max();
-    var latestResult = Model.CompetencyGroups
-      .SelectMany(g => g.SelectMany(c => c.AssessmentQuestions))
-      .Select(q => q.ResultDateTime)
-      .DefaultIfEmpty(DateTime.MinValue)
-      .Max();
-
     var competencySummaries = from g in Model.CompetencyGroups
                               let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
                               let selfAssessedCount = questions.Count(q => q.Result.HasValue)
@@ -26,7 +16,6 @@
                                 { "selfAssessedCount", selfAssessedCount },
                                 { "verifiedCount", verifiedCount }
                               };
-    var allComptConfirmed = competencySummaries.Sum(c => (int)c["verifiedCount"]) == competencySummaries.Sum(c => (int)c["questionsCount"]);
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
@@ -107,12 +96,8 @@
             </a>
         }
 
-        @if (Model?.SupervisorSignOffs?.FirstOrDefault()?.Verified != null &&
-        Model.SupervisorSignOffs.FirstOrDefault().SignedOff &&
-        Model?.DelegateSelfAssessment?.ResultsVerificationRequests == 0 && allComptConfirmed && latestResult <= latestSignoff
-        )
+        @if (ViewBag.CanViewCertificate)
         {
-
             <a class="nhsuk-button"
                asp-controller="LearningPortal"
                asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-149

### Description
1. View code moved to controller. Helper method created to check if a learner/supervisor can view certificate button.
2. Modified SQL query to return correct supervisor centre name.
3. Brower back button issue resolved on the certificate view.
4. Back link issue resolved on the certificate view.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
