### PR TITLE
TD-3838 Reworks query to use coalesce to avoid throwing exception

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
@@ -269,13 +269,13 @@
         {
             try
             {
-                return connection.QueryFirst<int>(
+                return connection.QueryFirst<int?>(
                     @"SELECT COALESCE((SELECT ProgressID 
 					FROM Progress
                     WHERE CandidateID = @candidateId
                       AND CustomisationID = @customisationId
                       AND SystemRefreshed = 0
-                      AND RemovedDate IS NULL), 0) AS ProgressId",
+                      AND RemovedDate IS NULL), NULL) AS ProgressId",
                     new { candidateId, customisationId }
                 );
             }

--- a/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseContentService.cs
@@ -270,18 +270,18 @@
             try
             {
                 return connection.QueryFirst<int>(
-                    @"SELECT ProgressId
-                    FROM Progress
+                    @"SELECT COALESCE((SELECT ProgressID 
+					FROM Progress
                     WHERE CandidateID = @candidateId
                       AND CustomisationID = @customisationId
                       AND SystemRefreshed = 0
-                      AND RemovedDate IS NULL",
+                      AND RemovedDate IS NULL), 0) AS ProgressId",
                     new { candidateId, customisationId }
                 );
             }
             catch (InvalidOperationException)
             {
-                return null;
+                return 0;
             }
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
@@ -241,49 +241,50 @@
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
         }
+        //Deprecated in response to TD-3838 - a bug caused by this id manipulation detection functionality
 
-        [Test]
-        public void Index_detects_id_manipulation_no_progress_id()
-        {
-            // Given
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
-            A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId))
-             .Returns(expectedCourseContent);
-            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(10);
-            A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(null);
+        //[Test]
+        //public void Index_detects_id_manipulation_no_progress_id()
+        //{
+        //    // Given
+        //    var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
+        //    A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId))
+        //     .Returns(expectedCourseContent);
+        //    A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(10);
+        //    A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(null);
 
-            // When
-            var result = controller.Index(CustomisationId);
+        //    // When
+        //    var result = controller.Index(CustomisationId);
 
-            // Then
-            result.Should()
-                .BeRedirectToActionResult()
-                .WithControllerName("LearningSolutions")
-                .WithActionName("StatusCode")
-                .WithRouteValue("code", 404);
-        }
+        //    // Then
+        //    result.Should()
+        //        .BeRedirectToActionResult()
+        //        .WithControllerName("LearningSolutions")
+        //        .WithActionName("StatusCode")
+        //        .WithRouteValue("code", 404);
+        //}
 
-        [Test]
-        public void Index_detects_id_manipulation_self_register_false()
-        {
-            // Given
-            var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
-            A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId))
-             .Returns(expectedCourseContent);
-            A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(10);
-            A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(null);
-            A.CallTo(() => courseDataService.GetSelfRegister(CustomisationId)).Returns(false);
+        //[Test]
+        //public void Index_detects_id_manipulation_self_register_false()
+        //{
+        //    // Given
+        //    var expectedCourseContent = CourseContentHelper.CreateDefaultCourseContent(CustomisationId);
+        //    A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId))
+        //     .Returns(expectedCourseContent);
+        //    A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(10);
+        //    A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(null);
+        //    A.CallTo(() => courseDataService.GetSelfRegister(CustomisationId)).Returns(false);
 
-            // When
-            var result = controller.Index(CustomisationId);
+        //    // When
+        //    var result = controller.Index(CustomisationId);
 
-            // Then
-            result.Should()
-                .BeRedirectToActionResult()
-                .WithControllerName("LearningSolutions")
-                .WithActionName("StatusCode")
-                .WithRouteValue("code", 404);
-        }
+        //    // Then
+        //    result.Should()
+        //        .BeRedirectToActionResult()
+        //        .WithControllerName("LearningSolutions")
+        //        .WithActionName("StatusCode")
+        //        .WithRouteValue("code", 404);
+        //}
 
         [Test]
         public void Index_not_detects_id_manipulation_self_register_true()

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -85,10 +85,11 @@
                 var sectionId = courseContent.Sections.First().Id;
                 return RedirectToAction("Section", "LearningMenu", new { customisationId, sectionId });
             }
-            if (UniqueIdManipulationDetected(candidateId, customisationId))
-            {
-                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
-            }
+            // Unique Id Manipulation Detection is being disabled as part of work on TD-3838 - a bug created by its introduction
+            //if (UniqueIdManipulationDetected(candidateId, customisationId))
+            //{
+            //    return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
+            //}
             var progressId = courseContentService.GetOrCreateProgressId(candidateId, customisationId, centreId);
             if (progressId == null)
             {
@@ -97,6 +98,7 @@
                     $"Candidate id: {candidateId}, customisation id: {customisationId}, centre id: {centreId}");
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 404 });
             }
+
             if (sessionService.StartOrUpdateDelegateSession(candidateId, customisationId, HttpContext.Session) > 0)
             {
                 courseContentService.UpdateProgress(progressId.Value);


### PR DESCRIPTION
### JIRA link
[TD-3838](https://hee-tis.atlassian.net/browse/TD-3838)

### Description
This simple change uses a coalesce to ensure that the get progress ID query returns a 0 value rather than throwing an exception if progress does not exist. This fixes the problem in dev.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3838]: https://hee-tis.atlassian.net/browse/TD-3838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ