### PR TITLE
TD-3876-SQL query modified to return valid assessment question responses count in the certificate

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -478,20 +478,25 @@
                 new { CandidateAssessmentSupervisorVerificationsId }
             );
         }
-        public int? GetRoleCount(int CandidateId)
+        public int? GetRoleCount(int candidateAssessmentId)
         {
             return connection.QueryFirstOrDefault<int?>(
-                @"SELECT COUNT(sas1.CompetencyID) AS RoleCount FROM    
-                              SelfAssessmentResults AS sar1 
-							  LEFT OUTER JOIN
-                              CompetencyAssessmentQuestionRoleRequirements AS caqrr1 ON sar1.Result = caqrr1.LevelValue AND sar1.CompetencyID = caqrr1.CompetencyID AND sar1.SelfAssessmentID = caqrr1.SelfAssessmentID AND 
-                              sar1.AssessmentQuestionID = caqrr1.AssessmentQuestionID RIGHT OUTER JOIN
-                              SelfAssessmentStructure AS sas1 INNER JOIN
-                              CandidateAssessments AS ca1 ON sas1.SelfAssessmentID = ca1.SelfAssessmentID INNER JOIN
-                              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.SelfAssessmentID =sas1.SelfAssessmentID and sar1.CompetencyID=sas1.CompetencyID AND sar1.AssessmentQuestionID = caq1.AssessmentQuestionID AND sar1.DelegateUserID = ca1.DelegateUserID LEFT OUTER JOIN
-                              CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
-                 WHERE  (ca1.ID = @CandidateId ) AND (CAOC1.IncludedInSelfAssessment = 1)",
-                new { CandidateId }
+                @"SELECT COUNT(sas1.CompetencyID) AS MeetingCount
+                    FROM   SelfAssessmentResultSupervisorVerifications AS sasrv INNER JOIN
+                             SelfAssessmentResults AS sar1 ON sasrv.SelfAssessmentResultId = sar1.ID AND sasrv.Superceded = 0 LEFT OUTER JOIN
+                             CompetencyAssessmentQuestionRoleRequirements AS caqrr1 ON sar1.Result = caqrr1.LevelValue AND 
+			                 sar1.CompetencyID = caqrr1.CompetencyID AND sar1.SelfAssessmentID = caqrr1.SelfAssessmentID AND 
+                             sar1.AssessmentQuestionID = caqrr1.AssessmentQuestionID RIGHT OUTER JOIN
+                             SelfAssessmentStructure AS sas1 INNER JOIN
+                             CandidateAssessments AS ca1 ON sas1.SelfAssessmentID = ca1.SelfAssessmentID INNER JOIN
+                             CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID ON sar1.SelfAssessmentID=sas1.SelfAssessmentID and 
+			                 sar1.CompetencyID=sas1.CompetencyID AND sar1.AssessmentQuestionID = caq1.AssessmentQuestionID AND sar1.DelegateUserID = ca1.DelegateUserID
+			                 LEFT OUTER JOIN   CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
+                    WHERE (ca1.ID = @CandidateAssessmentId) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) AND (sasrv.SignedOff = 1) AND (caqrr1.LevelRAG = 3) OR
+                             (ca1.ID = @candidateAssessmentId) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.Result IS NULL)) AND (sasrv.SignedOff = 1) AND (caqrr1.LevelRAG = 3) OR
+                             (ca1.ID = @candidateAssessmentId) AND (sas1.Optional = 0) AND (NOT (sar1.SupportingComments IS NULL)) AND (sasrv.SignedOff = 1) AND (caqrr1.LevelRAG = 3) OR
+                             (ca1.ID = @candidateAssessmentId) AND (caoc1.IncludedInSelfAssessment = 1) AND (NOT (sar1.SupportingComments IS NULL)) AND (sasrv.SignedOff = 1) AND (caqrr1.LevelRAG = 3)",
+                    new { candidateAssessmentId }
             );
         }
     }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -169,7 +169,7 @@
         CompetencySelfAssessmentCertificate GetCompetencySelfAssessmentCertificate(int candidateAssessmentID);
         IEnumerable<Accessor> GetAccessor(int selfAssessmentId, int delegateUserID);
         ActivitySummaryCompetencySelfAssesment GetActivitySummaryCompetencySelfAssesment(int CandidateAssessmentSupervisorVerificationsId);
-        int? GetRoleCount(int CandidateId);
+        int? GetRoleCount(int candidateAssessmentId);
         bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
     }
 

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -147,7 +147,7 @@
         CompetencySelfAssessmentCertificate GetCompetencySelfAssessmentCertificate(int candidateAssessmentID);
         IEnumerable<Accessor> GetAccessor(int selfAssessmentId, int delegateUserID);
         ActivitySummaryCompetencySelfAssesment GetActivitySummaryCompetencySelfAssesment(int CandidateAssessmentSupervisorVerificationsId);
-        int? GetRoleCount(int CandidateId);
+        int? GetRoleCount(int candidateAssessmentId);
         bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
     }
 
@@ -538,9 +538,9 @@
             return selfAssessmentDataService.GetActivitySummaryCompetencySelfAssesment(CandidateAssessmentSupervisorVerificationsId);
 
         }
-        public int? GetRoleCount(int CandidateId)
+        public int? GetRoleCount(int candidateAssessmentId)
         {
-            return selfAssessmentDataService.GetRoleCount(CandidateId);
+            return selfAssessmentDataService.GetRoleCount(candidateAssessmentId);
 
         }
         public bool IsUnsupervisedSelfAssessment(int selfAssessmentId)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
@@ -201,7 +201,7 @@
                 </p>
             </div>
             <div class="activity">
-                <p><b>Response meeting role requirements</b></p> <p>
+                <p><b>Responses meeting role requirements</b></p> <p>
                     @Model.RoleCount
                 </p>
             </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
@@ -513,7 +513,7 @@
                     </p>
                 </div>
                 <div class="activity">
-                    <p><b>Response meeting role requirements</b></p> <p>
+                    <p><b>Responses meeting role requirements</b></p> <p>
                         @Model.RoleCount
                     </p>
                 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3876

### Description
SQL query modified to return valid assessment question responses count in the certificate.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/edec7b4e-bc99-4745-8d6b-3241e4fb120d)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
