### PR TITLE
TD-3530 Adding centre name to supervisor name

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -27,7 +27,6 @@
                     sv.Comments,
                     sv.SignedOff,
                     adu.Forename + ' ' + adu.Surname AS SupervisorName,
-                    adu.CentreName AS CentreName,
                     sv.CandidateAssessmentSupervisorID,
                     sv.EmailSent,
                     0 AS UserIsVerifier,

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -129,8 +129,7 @@
             LAR.SignedOff,
             LAR.UserIsVerifier,
             LAR.ResultRAG,
-            LAR.SupervisorName,
-            LAR.CentreName AS CentreName";
+            LAR.SupervisorName";
 
         private const string CompetencyTables =
             @"Competencies AS C
@@ -272,6 +271,7 @@
                 LAR.EmailSent,
                 LAR.Requested AS SupervisorVerificationRequested,
                 COALESCE(au.Forename + ' ' + au.Surname + (CASE WHEN au.Active = 1 THEN '' ELSE ' (Inactive)' END), sd.SupervisorEmail) AS SupervisorName,
+                au.CentreName,
                 SelfAssessmentResultSupervisorVerificationId AS SupervisorVerificationId,
                 CandidateAssessmentSupervisorID";
             const string supervisorTables = @"

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -27,6 +27,7 @@
                     sv.Comments,
                     sv.SignedOff,
                     adu.Forename + ' ' + adu.Surname AS SupervisorName,
+                    adu.CentreName AS CentreName,
                     sv.CandidateAssessmentSupervisorID,
                     sv.EmailSent,
                     0 AS UserIsVerifier,
@@ -128,7 +129,8 @@
             LAR.SignedOff,
             LAR.UserIsVerifier,
             LAR.ResultRAG,
-            LAR.SupervisorName";
+            LAR.SupervisorName,
+            LAR.CentreName AS CentreName";
 
         private const string CompetencyTables =
             @"Competencies AS C

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
@@ -20,7 +20,6 @@
         public bool IncludeComments { get; set; }
         public IEnumerable<LevelDescriptor> LevelDescriptors { get; set; } = new List<LevelDescriptor>();
         public string? SupervisorName { get; set; }
-        public string? CentreName { get; set; }
         public string? SupportingComments { get; set; }
         public int? SelfAssessmentResultSupervisorVerificationId { get; set; }
         public DateTime? Requested { get; set; }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/AssessmentQuestion.cs
@@ -20,6 +20,7 @@
         public bool IncludeComments { get; set; }
         public IEnumerable<LevelDescriptor> LevelDescriptors { get; set; } = new List<LevelDescriptor>();
         public string? SupervisorName { get; set; }
+        public string? CentreName { get; set; }
         public string? SupportingComments { get; set; }
         public int? SelfAssessmentResultSupervisorVerificationId { get; set; }
         public DateTime? Requested { get; set; }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
@@ -26,6 +26,7 @@
         public int? SupervisorVerificationId { get; set; }
         public int? CandidateAssessmentSupervisorId { get; set; }
         public string? SupervisorName { get; set; }
+        public string? CentreName { get; set; }
         public List<AssessmentQuestion> AssessmentQuestions { get; set; } = new List<AssessmentQuestion>();
         public IEnumerable<CompetencyFlag> CompetencyFlags { get; set; } = new List<CompetencyFlag>();
     }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1318,6 +1318,7 @@
                 User.GetUserIdKnownNotNull(),
                 sessionRequestVerification.SelfAssessmentID
             );
+            selfAssessment.CentreName = supervisor.CentreName;
             if (sessionRequestVerification.ResultIds == null)
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
@@ -77,7 +77,7 @@
                         </td>
                         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
                             <span class="nhsuk-table-responsive__heading">Request </span>
-                            @competency.SupervisorName<br />
+                            @competency.SupervisorName (@question.CentreName)<br />
                             @competency.SupervisorVerificationRequested?.ToString("dd/MM/yyyy")<br />
                             <div class="nhsuk-u-one-half-tablet" style="white-space: nowrap;">
                                 <div class="nhsuk-grid-row nhsuk-u-padding-0">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
@@ -77,7 +77,7 @@
                         </td>
                         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
                             <span class="nhsuk-table-responsive__heading">Request </span>
-                            @competency.SupervisorName (@question.CentreName)<br />
+                            @competency.SupervisorName (@competency.CentreName)<br />
                             @competency.SupervisorVerificationRequested?.ToString("dd/MM/yyyy")<br />
                             <div class="nhsuk-u-one-half-tablet" style="white-space: nowrap;">
                                 <div class="nhsuk-grid-row nhsuk-u-padding-0">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/VerificationSummary.cshtml
@@ -31,7 +31,7 @@
             @Model.SelfAssessment.VerificationRoleName
         </dt>
         <dd class="nhsuk-summary-list__value">
-            @Model.Supervisor
+            @Model.Supervisor (@Model.SelfAssessment.CentreName)
         </dd>
         <dd class="nhsuk-summary-list__actions">
             <a asp-action="VerificationPickSupervisor" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">


### PR DESCRIPTION
### JIRA link
[TD-3530](https://hee-tis.atlassian.net/browse/TD-3530)

### Description
Manage confirmation requests screen - adding a select statement to fetch the centre name and binding it to the newly added property in the view model and using that property in view to populate the centre name.

Request proficiency confirmation screen - using the existing value of the centre name in the supervisor variable and storing it in the selfAssessment variable so that it can be used to populate the model and hence used in the view.

### Screenshots
Manage confirmation requests screen -
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/db334d8c-9e27-4a90-bef2-c9cc1914181d)

Request proficiency confirmation screen -
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/81168f4c-cce4-4fe4-a100-02bbfd81c1b9)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3530]: https://hee-tis.atlassian.net/browse/TD-3530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ