### PR TITLE
TD-3888- Self assessment certificate mobile view issue

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/learningPortal/selfassessmentcertificate.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningPortal/selfassessmentcertificate.scss
@@ -3,7 +3,6 @@
 }
 
 .certificate {
-  margin-left: 15px;
   padding: 0 0;
   width: 100%;
   justify-content: start;
@@ -78,7 +77,7 @@
 
 .footer-logo img {
   max-width: 18rem;
-  height: auto;
+  width: 100%;
 }
 
 .strips {
@@ -103,7 +102,7 @@
 .pg-2 {
   background-color: white;
   width: 100%;
-   position: relative;
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
@@ -19,7 +19,6 @@
 
     li:last-child, .nhsuk-list > li:last-child {
         margin-bottom: 0;
-        margin-left: -10px;
     }
 
     .nhsuk-grid-column-full {
@@ -92,159 +91,159 @@
                 Download certificate
             </a>
         </div>
-    </div>
-</div>
-<div class="certificate">
-    <div class="pg-1">
-        <div class="head">
-            <div class="logo">
-                <svg class="certificate__logo" width="150" height="60" viewBox="0 0 100 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <rect width="100" height="40" fill="#005EB8">
-                    </rect>
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0V40H100V0H0ZM22.4 36L15.7 13.9H15.6L11.1 36H3L9.9 4H20.7L27.3 26.2H27.4L31.9 4H40L33.2 36H22.4ZM55.7 36L58.5 22.3H48.4L45.6 36H37L43.7 4H52.3L49.8 16.2H60L62.4 4H71L64.3 36H55.7ZM93.9 10.8C92.2 10 89.9 9.3 86.7 9.3C83.2 9.3 80.4 9.8 80.4 12.4C80.4 16.9 93.1 15.2 93.1 24.9C93.1 33.7 84.7 36 77.1 36C73.7 36 69.8 35.2 67 34.3L69.1 27.8C70.8 28.9 74.3 29.6 77.2 29.6C79.9 29.6 84.2 29.1 84.2 25.8C84.2 20.7 71.5 22.6 71.5 13.6C71.4 5.5 78.8 3 86 3C90 3 93.8 3.4 96 4.4L93.9 10.8Z" fill="white">
-                    </path>
-                </svg>
-            </div>
-
-            <div class="text">
-                <h1 class="certificate__heading">
-                    <div class="nhsuk-u-margin-bottom-7">
-                        <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">
-                            This is to certify that
-                        </span>
-                        @Model.CompetencySelfAssessmentCertificates.LearnerName
-                        <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-top-1">
-                            @Model.CompetencySelfAssessmentCertificates.LearnerPRN
-                        </span>
+        <div class="certificate nhsuk-grid-column-full">
+            <div class="pg-1">
+                <div class="head">
+                    <div class="logo">
+                        <svg class="certificate__logo" width="150" height="60" viewBox="0 0 100 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <rect width="100" height="40" fill="#005EB8">
+                            </rect>
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0V40H100V0H0ZM22.4 36L15.7 13.9H15.6L11.1 36H3L9.9 4H20.7L27.3 26.2H27.4L31.9 4H40L33.2 36H22.4ZM55.7 36L58.5 22.3H48.4L45.6 36H37L43.7 4H52.3L49.8 16.2H60L62.4 4H71L64.3 36H55.7ZM93.9 10.8C92.2 10 89.9 9.3 86.7 9.3C83.2 9.3 80.4 9.8 80.4 12.4C80.4 16.9 93.1 15.2 93.1 24.9C93.1 33.7 84.7 36 77.1 36C73.7 36 69.8 35.2 67 34.3L69.1 27.8C70.8 28.9 74.3 29.6 77.2 29.6C79.9 29.6 84.2 29.1 84.2 25.8C84.2 20.7 71.5 22.6 71.5 13.6C71.4 5.5 78.8 3 86 3C90 3 93.8 3.4 96 4.4L93.9 10.8Z" fill="white">
+                            </path>
+                        </svg>
                     </div>
-                    <div>
-                        <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">
-                            has successfully completed the
-                        </span>
-                        @Model.CompetencySelfAssessmentCertificates.SelfAssessment
+
+                    <div class="text">
+                        <h1 class="certificate__heading">
+                            <div class="nhsuk-u-margin-bottom-7">
+                                <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">
+                                    This is to certify that
+                                </span>
+                                @Model.CompetencySelfAssessmentCertificates.LearnerName
+                                <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-top-1">
+                                    @Model.CompetencySelfAssessmentCertificates.LearnerPRN
+                                </span>
+                            </div>
+                            <div>
+                                <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">
+                                    has successfully completed the
+                                </span>
+                                @Model.CompetencySelfAssessmentCertificates.SelfAssessment
+                            </div>
+                        </h1>
+                        <p>
+                            Signed off at @Model.CompetencySelfAssessmentCertificates.SupervisorCentreName <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">by @Model.CompetencySelfAssessmentCertificates.SupervisorName </span><span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">@Model.CompetencySelfAssessmentCertificates.SupervisorPRN</span>
+                        </p>
+
+                        <p>
+                            on @Model.CompetencySelfAssessmentCertificates.FormattedDate
+                        </p>
                     </div>
-                </h1>
-                <p>
-                    Signed off at @Model.CompetencySelfAssessmentCertificates.SupervisorCentreName <span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">by @Model.CompetencySelfAssessmentCertificates.SupervisorName </span><span class="nhsuk-body-m nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0">@Model.CompetencySelfAssessmentCertificates.SupervisorPRN</span>
-                </p>
 
-                <p>
-                    on @Model.CompetencySelfAssessmentCertificates.FormattedDate
-                </p>
-            </div>
+                    <div class="fancy-box"></div>
+                </div>
 
-            <div class="fancy-box"></div>
-        </div>
-
-        <div class="body">
-            @if (Model.CompetencyCountSelfAssessmentCertificate.Any())
-            {
-                <h3 class=" nhsuk-u-margin-bottom-3">
-                    Including the following optional proficiencies:
-                </h3>
-                @foreach (var entry in Model.CompetencyCountSelfAssessmentCertificate)
-                {
-                    <p class="nhsuk-u-margin-bottom-2 nhsuk-body-s">
-                        @entry.CompetencyGroup - @entry.OptionalCompetencyCount
-                        @if (@entry.OptionalCompetencyCount == 1)
+                <div class="body">
+                    @if (Model.CompetencyCountSelfAssessmentCertificate.Any())
+                    {
+                        <h3 class=" nhsuk-u-margin-bottom-3">
+                            Including the following optional proficiencies:
+                        </h3>
+                        @foreach (var entry in Model.CompetencyCountSelfAssessmentCertificate)
                         {
-                            @Model.CompetencySelfAssessmentCertificates.Vocabulary
+                            <p class="nhsuk-u-margin-bottom-2 nhsuk-body-s">
+                                @entry.CompetencyGroup - @entry.OptionalCompetencyCount
+                                @if (@entry.OptionalCompetencyCount == 1)
+                                {
+                                    @Model.CompetencySelfAssessmentCertificates.Vocabulary
+                                }
+                                else
+                                {
+                                    @Model.VocabPlural
+                                }
+                            </p>
+                        }
+                    }
+                </div>
+
+                @if (Model.CompetencySelfAssessmentCertificates.NonReportable)
+                {
+                    <div class="footer">
+                        <p class="nhsuk-body-l nhsuk-u-font-weight-bold">
+                            THIS IS AN EXAMPLE ONLY, GENERATED FROM A TEST SELF ASSESSMENT
+                        </p>
+                    </div>
+                }
+
+                <div class="footer">
+                    <div class="text">
+                        <p class="blue">Certificate generated on @DateTime.Now.ToString("dd/MM/yyyy")</p>
+                        <p>By NHS England Digital Learning Solutions <br /> on behalf of @Model.CompetencySelfAssessmentCertificates.SupervisorCentreName</p>
+                    </div>
+                    <div class="footer-logo">
+                        @if (Model.CompetencySelfAssessmentCertificates.BrandImage != null)
+                        {
+                            <img id="Logo" src="data:image;base64,@Convert.ToBase64String(Model.CompetencySelfAssessmentCertificates.BrandImage)" alt="Brand Logo Image" />
                         }
                         else
                         {
-                            @Model.VocabPlural
+                            <img src="https://www.hee.nhs.uk/sites/default/files/styles/image_658_witdh/public/Capital-Nurse-Logo.jpg?itok=8hlRIj8r" alt="Brand Logo Image" />
                         }
-                    </p>
-                }
-            }
-        </div>
+                    </div>
+                </div>
 
-        @if (Model.CompetencySelfAssessmentCertificates.NonReportable)
-        {
-            <div class="footer">
-                <p class="nhsuk-body-l nhsuk-u-font-weight-bold">
-                    THIS IS AN EXAMPLE ONLY, GENERATED FROM A TEST SELF ASSESSMENT
-                </p>
+                <div class="strips">
+                    <div class="strip-green"></div>
+                    <div class="strip-blue"></div>
+                </div>
             </div>
-        }
-
-        <div class="footer">
-            <div class="text">
-                <p class="blue">Certificate generated on @DateTime.Now.ToString("dd/MM/yyyy")</p>
-                <p>By NHS England Digital Learning Solutions <br /> on behalf of @Model.CompetencySelfAssessmentCertificates.SupervisorCentreName</p>
-            </div>
-            <div class="footer-logo">
-                @if (Model.CompetencySelfAssessmentCertificates.BrandImage != null)
-                {
-                    <img id="Logo" src="data:image;base64,@Convert.ToBase64String(Model.CompetencySelfAssessmentCertificates.BrandImage)" alt="Brand Logo Image" />
-                }
-                else
-                {
-                    <img src="https://www.hee.nhs.uk/sites/default/files/styles/image_658_witdh/public/Capital-Nurse-Logo.jpg?itok=8hlRIj8r" alt="Brand Logo Image" />
-                }
-            </div>
-        </div>
-
-        <div class="strips">
-            <div class="strip-green"></div>
-            <div class="strip-blue"></div>
-        </div>
-    </div>
-    <br /><br />
-    <div class="pg-2">
-        <div class="body">
-            <h2>Activity summary report</h2>
-            <br />
-            @if (Model.CompetencySelfAssessmentCertificates.NonReportable)
-            {
-                <h3>THIS IS AN EXAMPLE ONLY, GENERATED FROM A TEST SELF ASSESSMENT</h3>
-            }
-            <div class="activity">
-                <p><b>Activity: </b>@Model.CompetencySelfAssessmentCertificates.SelfAssessment</p>
-            </div>
-            <div class="activity">
-                <p><b>Name: </b>@Model.CompetencySelfAssessmentCertificates.LearnerName</p>
-            </div>
-            <div class="activity">
-                <p><b>Professional Registration Number: </b>@Model.CompetencySelfAssessmentCertificates.LearnerPRN</p>
-            </div>
-            <div class="activity">
-                <p><b>Assessment question responses</b></p> <p>
-                    @sumQuestions
-                </p>
-            </div>
-            <div class="activity">
-                <p><b>Responses confirmed by assessor</b></p> <p>
-                    @sumVerifiedCount
-                </p>
-            </div>
-            <div class="activity">
-                <p><b>Assessors</b></p><ul>
-                    @foreach (var accessor in Model.Accessors)
+            <br /><br />
+            <div class="pg-2">
+                <div class="body">
+                    <h2>Activity summary report</h2>
+                    <br />
+                    @if (Model.CompetencySelfAssessmentCertificates.NonReportable)
                     {
-                        <p>
-                            @accessor.AccessorList
-                        </p>
-
+                        <h3>THIS IS AN EXAMPLE ONLY, GENERATED FROM A TEST SELF ASSESSMENT</h3>
                     }
-                </ul>
-            </div>
-            <div class="activityline">
-                <p><b>Signed Off By</b></p>
-                @if (string.IsNullOrEmpty(@Model.CompetencySelfAssessmentCertificates.SupervisorPRN))
-                {
-                    <p>
-                        @Model.CompetencySelfAssessmentCertificates.SupervisorName
-                    </p>
-                }
-                else
-                {
-                    <p>
-                        @Model.CompetencySelfAssessmentCertificates.SupervisorName, @Model.CompetencySelfAssessmentCertificates.SupervisorPRN
-                    </p>
-                }
+                    <div class="activity">
+                        <p><b>Activity: </b>@Model.CompetencySelfAssessmentCertificates.SelfAssessment</p>
+                    </div>
+                    <div class="activity">
+                        <p><b>Name: </b>@Model.CompetencySelfAssessmentCertificates.LearnerName</p>
+                    </div>
+                    <div class="activity">
+                        <p><b>Professional Registration Number: </b>@Model.CompetencySelfAssessmentCertificates.LearnerPRN</p>
+                    </div>
+                    <div class="activity">
+                        <p><b>Assessment question responses</b></p> <p>
+                            @sumQuestions
+                        </p>
+                    </div>
+                    <div class="activity">
+                        <p><b>Responses confirmed by assessor</b></p> <p>
+                            @sumVerifiedCount
+                        </p>
+                    </div>
+                    <div class="activity">
+                        <p><b>Assessors</b></p><ul>
+                            @foreach (var accessor in Model.Accessors)
+                            {
+                                <p>
+                                    @accessor.AccessorList
+                                </p>
+
+                            }
+                        </ul>
+                    </div>
+                    <div class="activityline">
+                        <p><b>Signed Off By</b></p>
+                        @if (string.IsNullOrEmpty(@Model.CompetencySelfAssessmentCertificates.SupervisorPRN))
+                        {
+                            <p>
+                                @Model.CompetencySelfAssessmentCertificates.SupervisorName
+                            </p>
+                        }
+                        else
+                        {
+                            <p>
+                                @Model.CompetencySelfAssessmentCertificates.SupervisorName, @Model.CompetencySelfAssessmentCertificates.SupervisorPRN
+                            </p>
+                        }
+                    </div>
+                </div>
+                <p class="foot-note">Certificate generated on @DateTime.Now.ToString("dd/MM/yyyy")</p>
             </div>
         </div>
-        <p class="foot-note">Certificate generated on @DateTime.Now.ToString("dd/MM/yyyy")</p>
     </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3888

### Description
CSS, cshtml modified to fix mobile view issue.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/86d6d87d-f98c-43ed-92c1-07c19a80e005)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/a6e6a1b9-394b-4926-a63f-5d8dcae44ea3)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/48083aa1-9403-4428-97b3-ec95abf7e766)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
