### PR TITLE
TD-3885- All delegates view - groups filter added

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/GroupsDataService.cs
@@ -92,6 +92,7 @@
             int? jobGroupId
         );
         bool IsDelegateGroupExist(string groupLabel, int centreId);
+        IEnumerable<(int, string)> GetActiveGroups(int centreId);
     }
 
     public class GroupsDataService : IGroupsDataService
@@ -572,6 +573,15 @@
                 ELSE CAST(0 AS BIT) END",
                 new { groupLabel, centreId }
             );
+        }
+
+        public IEnumerable<(int, string)> GetActiveGroups(int centreId)
+        {
+            var groups = connection.Query<(int, string)>(
+                @"SELECT GroupID, GroupLabel FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL",
+                new { centreId }
+            );
+            return groups;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -103,7 +103,7 @@
 
         (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                    string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
+                                    int groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
 
         List<DelegateUserCard> GetDelegatesNotRegisteredForGroupByGroupId(int groupId, int centreId);
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
@@ -4,7 +4,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
-    using DigitalLearningSolutions.Data.Models.User;    
+    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
     using DigitalLearningSolutions.Web.Helpers;
@@ -29,6 +29,7 @@
         private PromptsService promptsHelper = null!;
         private IPaginateService paginateService = null!;
         private IUserDataService userDataService = null!;
+        private IGroupsService groupsService = null!;
 
         [SetUp]
         public void Setup()
@@ -39,6 +40,7 @@
             userDataService = A.Fake<IUserDataService>();
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
             paginateService = A.Fake<IPaginateService>();
+            groupsService = A.Fake<IGroupsService>();
 
             httpRequest = A.Fake<HttpRequest>();
             httpResponse = A.Fake<HttpResponse>();
@@ -50,7 +52,8 @@
                     userDataService,
                     promptsHelper,
                     jobGroupsDataService,
-                    paginateService
+                    paginateService,
+                    groupsService
                 )
                 .WithMockHttpContext(httpRequest, CookieName, cookieValue, httpResponse)
                 .WithMockUser(true)
@@ -73,7 +76,7 @@
             {
                 A.CallTo(() => userDataService.GetDelegateUserCards(A<string>._, A<int>._, A<int>._, A<string>._,
                     A<string>._, A<int>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._,
-                    A<string>._, A<int>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._)
+                    A<string>._, A<int>._, A<int>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._)
                 ).MustHaveHappened();
                 A.CallTo(() => jobGroupsDataService.GetJobGroupsAlphabetical())
                     .MustHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
@@ -3,7 +3,7 @@
     using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Models;
-    using DigitalLearningSolutions.Data.Models.User;    
+    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using FakeItEasy;
@@ -130,7 +130,7 @@
             .Returns(adminUser);
 
             A.CallTo(() => userDataService.GetDelegateUserCards("", 0, 10, "SearchableName", "Ascending", CentreId,
-            "Any", "Any", "Any", "Any", "Any", "Any", 0, "Any", "Any", "Any", "Any", "Any", "Any"))
+            "Any", "Any", "Any", "Any", "Any", "Any", 0, 0, "Any", "Any", "Any", "Any", "Any", "Any"))
                 .Returns((new List<DelegateUserCard>(), delegateCount)
                 );
 

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptionsTests.cs
@@ -22,7 +22,8 @@
             var result =
                 AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(
                     jobGroups,
-                    new List<CentreRegistrationPrompt>()
+                    new List<CentreRegistrationPrompt>(),
+                    new List<(int, string)>()
                 );
 
             // Then
@@ -38,7 +39,8 @@
             // When
             var result = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(
                 new List<(int, string)>(),
-                centreRegistrationPrompts
+                centreRegistrationPrompts,
+                new List<(int, string)>()
             );
 
             // Then
@@ -131,8 +133,8 @@
             };
             var customPromptFilters = new List<FilterModel>
             {
-                new FilterModel("CentreRegistrationPrompt1", "First prompt", prompt1Options,"prompts"),
-                new FilterModel("CentreRegistrationPrompt4", "Fourth prompt", prompt4Options,"prompts"),
+                new FilterModel("CentreRegistrationPrompt1", "Prompt: First prompt", prompt1Options,"prompts/groups"),
+                new FilterModel("CentreRegistrationPrompt4", "Prompt: Fourth prompt", prompt4Options,"prompts/groups"),
             };
 
             return (prompts, customPromptFilters);

--- a/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterHelper.cs
@@ -64,7 +64,7 @@ namespace DigitalLearningSolutions.Web.Helpers
         public static string? RemoveNonExistingFilterOptions(List<FilterModel> availableFilters, string existingFilterString)
         {
             var selectedFilters = existingFilterString.Split(FilteringHelper.FilterSeparator).ToList();
-            string[] filterGroups = { "LinkedToField", "AddedByAdminId", "CourseTopic", "CategoryName" };
+            string[] filterGroups = { "LinkedToField", "AddedByAdminId", "CourseTopic", "CategoryName", "DelegateGroup" };
             foreach (var filterGroup in filterGroups)
             {
                 var existingFilters = existingFilterString!.Split(FilteringHelper.FilterSeparator).Where(filter => filter.Contains(filterGroup)).ToList();

--- a/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
+++ b/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
@@ -42,7 +42,7 @@
             }
 
             (var delegates, var delegateCount) = userDataService.GetDelegateUserCards("", 0, 10, "SearchableName", "Ascending", centreId,
-            "Any", "Any", "Any", "Any", "Any", "Any", 0, "Any", "Any", "Any", "Any", "Any", "Any");
+            "Any", "Any", "Any", "Any", "Any", "Any", 0, 0, "Any", "Any", "Any", "Any", "Any", "Any");
             var courseCount =
                 courseDataService.GetNumberOfActiveCoursesAtCentreFilteredByCategory(
                     centreId,

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -137,6 +137,7 @@
 
         bool IsDelegateGroupExist(string groupLabel, int centreId);
         public IEnumerable<SelectListItem> GetUnlinkedGroupsSelectListForCentre(int centreId, int? selectedItemId);
+        IEnumerable<(int, string)> GetActiveGroups(int centreId);
     }
 
     public class GroupsService : IGroupsService
@@ -908,6 +909,10 @@
         public bool IsDelegateGroupExist(string groupLabel, int centreId)
         {
             return groupsDataService.IsDelegateGroupExist(groupLabel, centreId);
+        }
+        public IEnumerable<(int, string)> GetActiveGroups(int centreId)
+        {
+            return groupsDataService.GetActiveGroups(centreId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegateItemsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegateItemsViewModel.cs
@@ -15,7 +15,8 @@
         public AllDelegateItemsViewModel(
             IEnumerable<DelegateUserCard> delegateUserCards,
             IEnumerable<(int id, string name)> jobGroups,
-            IEnumerable<CentreRegistrationPrompt> centreRegistrationPrompts
+            IEnumerable<CentreRegistrationPrompt> centreRegistrationPrompts,
+            IEnumerable<(int id, string name)> groups = null
         )
         {
             var promptsWithOptions = centreRegistrationPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
@@ -33,7 +34,7 @@
                 }
             );
 
-            Filters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(jobGroups, promptsWithOptions)
+            Filters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(jobGroups, promptsWithOptions, groups)
                 .SelectAppliedFilterViewModels();
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModelFilterOptions.cs
@@ -49,7 +49,8 @@
 
         public static List<FilterModel> GetAllDelegatesFilterViewModels(
             IEnumerable<(int id, string name)> jobGroups,
-            IEnumerable<CentreRegistrationPrompt> promptsWithOptions
+            IEnumerable<CentreRegistrationPrompt> promptsWithOptions,
+            IEnumerable<(int id, string name)> groups
         )
         {
             var filters = new List<FilterModel>
@@ -57,11 +58,7 @@
                 new FilterModel("PasswordStatus", "Password status", PasswordStatusOptions,"status"),
                 new FilterModel("AdminStatus", "Admin status", AdminStatusOptions,"status"),
                 new FilterModel("ActiveStatus", "Active status", ActiveStatusOptions,"status"),
-                new FilterModel(
-                    "JobGroupId",
-                    "Job Group",
-                    DelegatesViewModelFilters.GetJobGroupOptions(jobGroups)
-                ),
+                new FilterModel("JobGroupId","Job Group",DelegatesViewModelFilters.GetJobGroupOptions(jobGroups)),
                 new FilterModel("RegistrationType", "Registration type", RegistrationTypeOptions,"status"),
                 new FilterModel("AccountStatus", "Account status", AccountStatusOptions,"status"),
                 new FilterModel("EmailStatus", "Email status", EmailStatusOptions,"status"),
@@ -70,11 +67,12 @@
                 promptsWithOptions.Select(
                     customPrompt => new FilterModel(
                         $"CentreRegistrationPrompt{customPrompt.RegistrationField.Id}",
-                        customPrompt.PromptText,
-                        FilteringHelper.GetPromptFilterOptions(customPrompt),"prompts"
+                        "Prompt: " + customPrompt.PromptText,
+                        FilteringHelper.GetPromptFilterOptions(customPrompt), "prompts/groups"
                     )
                 )
             );
+            filters.Add(new FilterModel("GroupId", "Groups", DelegatesViewModelFilters.GetGroupOptions(groups), "prompts/groups"));
             return filters;
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegatesViewModelFilters.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegatesViewModelFilters.cs
@@ -51,5 +51,22 @@
                     )
                 ).ToDictionary(x => x.Key, x => x.Value);
         }
+
+        public static IEnumerable<FilterOptionModel> GetGroupOptions(
+            IEnumerable<(int id, string name)> groups
+        )
+        {
+            return groups.Select(
+                group => new FilterOptionModel(
+                    group.name,
+                    FilteringHelper.BuildFilterValueString(
+                        "DelegateGroupId",
+                        "DelegateGroupId",
+                        group.id.ToString()
+                    ),
+                    FilterStatus.Default
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3885

### Description
All delegates view - groups filter added.

- New groups filter created
- Added groups filter within prompts filter
- Code modified to take care of applied filters when user changes centre.


### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/7a239e0b-c5c9-454f-8315-4d2d2010d10d)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/e6319c63-5332-4796-b143-cc5a4a3ad459)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
