### PR TITLE
TD-3671 fixed enrolling from 'Tracking system-Manage Delegate' view doesn't appear on 'Current activities'

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -15,7 +15,7 @@
     {
         IEnumerable<Progress> GetDelegateProgressForCourse(int delegateId, int customisationId);
 
-        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate);
+        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate,DateTime submittedTime);
 
         int CreateNewDelegateProgress(
             int delegateId,
@@ -143,15 +143,16 @@
         public void UpdateProgressSupervisorAndCompleteByDate(
             int progressId,
             int supervisorAdminId,
-            DateTime? completeByDate
+            DateTime? completeByDate, DateTime submittedTime
         )
         {
             connection.Execute(
                 @"UPDATE Progress SET
                         SupervisorAdminID = @supervisorAdminId,
-                        CompleteByDate = @completeByDate
+                        CompleteByDate = @completeByDate,
+                        SubmittedTime = @submittedTime
                     WHERE ProgressID = @progressId",
-                new { progressId, supervisorAdminId, completeByDate }
+                new { progressId, supervisorAdminId, completeByDate, submittedTime }
             );
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -348,7 +348,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         A<int>._,
-                        A<DateTime?>._
+                        A<DateTime?>._,
+                         A<DateTime>._
                     )
                 ).MustHaveHappened();
             }
@@ -384,7 +385,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         reusableProgressRecord.SupervisorAdminId,
-                        A<DateTime?>._
+                        A<DateTime?>._,
+                          A<DateTime>._
                     )
                 ).MustHaveHappened();
             }
@@ -420,7 +422,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         supervisorId,
-                        A<DateTime?>._
+                        A<DateTime?>._,
+                          A<DateTime>._
                     )
                 ).MustHaveHappened();
             }
@@ -456,7 +459,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         A<int>._,
-                        null
+                        null,
+                          A<DateTime>._
                     )
                 ).MustHaveHappened();
             }
@@ -494,7 +498,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         A<int>._,
-                        expectedFutureDate
+                        expectedFutureDate,
+                          A<DateTime>._
                     )
                 ).MustHaveHappened();
             }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -721,7 +721,7 @@
         private void DelegateProgressRecordMustNotHaveBeenUpdated()
         {
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime>._)
             ).MustNotHaveHappened();
         }
 
@@ -764,7 +764,7 @@
             A.CallTo(() => groupsDataService.AddDelegateToGroup(A<int>._, A<int>._, A<DateTime>._, A<int>._))
                 .DoesNothing();
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime>._)
             ).DoesNothing();
             A.CallTo(
                 () => progressDataService.CreateNewDelegateProgress(

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -58,7 +58,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)
@@ -83,7 +83,8 @@
                 () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                     progressId,
                     newSupervisorId,
-                    A<DateTime?>._
+                    A<DateTime?>._,
+                    A<DateTime>._
                 )
             ).MustHaveHappened();
             A.CallTo(
@@ -105,7 +106,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._, A<DateTime>._)
             ).MustHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(progressId)
@@ -122,7 +123,7 @@
             // Then
             Assert.Throws<ProgressNotFoundException>(() => progressService.UpdateSupervisor(progressId, null));
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -102,7 +102,8 @@ namespace DigitalLearningSolutions.Web.Services
                     progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         progressRecord.ProgressId,
                         supervisorAdminId ?? 0,
-                        completeByDate
+                        completeByDate,
+                        clockUtility.UtcNow
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -730,7 +730,9 @@
                     progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         progressRecord.ProgressId,
                         updatedSupervisorAdminId,
-                        completeByDate
+                        completeByDate,
+                    clockUtility.UtcNow
+
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -105,7 +105,9 @@
             progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                 progressId,
                 supervisorId,
-                courseInfo.CompleteBy
+                courseInfo.CompleteBy,
+                    clockUtility.UtcNow
+
             );
 
             progressDataService.ClearAspProgressVerificationRequest(progressId);


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-3671

### Description
Need to check the reason why the course is not appearing in the delegate current activity when enrol from tracking system when the course is expired, saw the reason and alter the query that update the delegate course when it re-enrol

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/cfac5903-0f6e-4b6f-b636-ac835798ba41)




I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
