### PR TITLE
TD-3880- GTM script moved to js file.

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/gtm-script.ts
+++ b/DigitalLearningSolutions.Web/Scripts/gtm-script.ts
@@ -1,0 +1,20 @@
+﻿export { };
+declare global {
+  interface Window {
+    push: any;
+  }
+  interface HTMLElement {
+    src: any;
+    async: any;
+  }
+}
+(function (w: Window, d: Document, s: string, l: any, i: string) {
+  w[l] = w[l] || [];
+  w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s),
+    dl = l !== 'dataLayer' ? '&l=' + l : '';
+  j.async = true;
+  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+  f.parentNode!.insertBefore(j, f);
+})(window, document, 'script', 'dataLayer', 'GTM-KJPJHGW');

--- a/DigitalLearningSolutions.Web/Scripts/gtm-script.ts
+++ b/DigitalLearningSolutions.Web/Scripts/gtm-script.ts
@@ -9,8 +9,9 @@ declare global {
   }
 }
 (function (w: Window, d: Document, s: string, l: any, i: string) {
-  w[l] = w[l] || [];
-  w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+  const windowObj = w || window;
+  windowObj[l] = windowObj[l] || [];
+  windowObj[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
   var f = d.getElementsByTagName(s)[0],
     j = d.createElement(s),
     dl = l !== 'dataLayer' ? '&l=' + l : '';

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -41,21 +41,7 @@
     }
     @if (cookieConsent == "true")
     {
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-YVQ5NMPX7P"></script>
-        <script>window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', 'G-YVQ5NMPX7P');</script>
-        <!-- End Google Tag -->
-        <!-- Google Tag Manager -->
-        <script>
-            (function (w, d, s, l, i) {
-                w[l] = w[l] || []; w[l].push({
-                    'gtm.start':
-                        new Date().getTime(), event: 'gtm.js'
-                }); var f = d.getElementsByTagName(s)[0],
-                    j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-            })(window, document, 'script', 'dataLayer', 'GTM-5SKPRFQ');</script>
-        <!-- End Google Tag Manager -->
+        <script src="@Url.Content("~/js/gtm-script.js")" asp-append-version="true"></script>
     }
 </head>
 

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -54,26 +54,11 @@
     <meta name="twitter:title" content="@(ViewData["twitter:title"] ?? ViewData[LayoutViewDataKeys.Title] ?? "Digital Learning Solutions")">
     <meta name="twitter:description" content="@(ViewData["twitter:description"] ?? "")">
     @{
-        var validateCookieBannerCookieViaTempData = (string)TempData["userConsentCookieOption"]; // Need to capture cookie status before page load to avoid inconsistencies.
+        Context.Request.Cookies.TryGetValue("Dls-cookie-consent", out string cookieConsent);
     }
-
-    @if (validateCookieBannerCookieViaTempData == "true")  // [BY] When the user consent for first time load the follolwing JS. To avoid inconsistencies a temp varaible has been set when the user consent cookie choice
+    @if (cookieConsent == "true")
     {
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-YVQ5NMPX7P"></script>
-        <script>window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', 'G-YVQ5NMPX7P');</script>
-        <!-- End Google Tag -->
-        <!-- Google Tag Manager -->
-        <script>
-            (function (w, d, s, l, i) {
-                w[l] = w[l] || []; w[l].push({
-                    'gtm.start':
-                        new Date().getTime(), event: 'gtm.js'
-                }); var f = d.getElementsByTagName(s)[0],
-                    j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-            })(window, document, 'script', 'dataLayer', 'GTM-KJPJHGW');</script>
-        <!-- End Google Tag Manager -->
+        <script src="@Url.Content("~/js/gtm-script.js")" asp-append-version="true"></script>
     }
 </head>
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3880

### Description
GTM script code moved to js file.
GTM code updated.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8ecf4134-11ac-4b2a-a674-9f93a4affc33)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/4193f491-cf40-4c01-8ed4-d66764d59d23)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/87ad0256-80cb-4c4d-a515-a8f66c543c5b)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
