### PR TITLE
TD-3978 Delegates are not being enrolled on courses related to registration fields when they register

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202404091703_UpdateGroups_SetLinkedToFieldToTrue.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202404091703_UpdateGroups_SetLinkedToFieldToTrue.cs
@@ -1,0 +1,25 @@
+﻿using FluentMigrator;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    [Migration(202404091703)]
+    public class UpdateGroups_SetLinkedToFieldToTrue : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(
+                @$"UPDATE Groups SET
+                    LinkedToField =1,
+                    SyncFieldChanges=1,
+                    AddNewRegistrants=1,
+                    PopulateExisting=1
+                    WHERE  GroupLabel IN ('BH Pharmacist','BH Anaesthetist');"
+            );
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}
+


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3978

### Description
Need to write a query that update table Groups set linkfeilds and others to true

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/f7f3d811-21ea-4e91-a424-767b2cb8898b)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/418787f6-ef47-4a36-a5bf-a70bd937728f)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
