### PR TITLE
TD-3835 Fixes testing fails for bulk upload improvements

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202404120935_InactivateDelegateAccountsWithNoEmail.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202404120935_InactivateDelegateAccountsWithNoEmail.cs
@@ -1,0 +1,19 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202404120935)]
+    public class InactivateDelegateAccountsWithNoEmail : ForwardOnlyMigration
+    {
+        public override void Up()
+        {
+            Execute.Sql(
+                @$"UPDATE DelegateAccounts
+                    SET       Active = 1
+                    FROM   Users AS u INNER JOIN
+                                 DelegateAccounts ON u.ID = DelegateAccounts.UserID
+                    WHERE (NOT (u.PrimaryEmail LIKE N'%@%')) AND (DelegateAccounts.Active = 1)"
+                );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202404120935_InactivateDelegateAccountsWithNoEmail.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202404120935_InactivateDelegateAccountsWithNoEmail.cs
@@ -9,7 +9,7 @@
         {
             Execute.Sql(
                 @$"UPDATE DelegateAccounts
-                    SET       Active = 1
+                    SET       Active = 0
                     FROM   Users AS u INNER JOIN
                                  DelegateAccounts ON u.ID = DelegateAccounts.UserID
                     WHERE (NOT (u.PrimaryEmail LIKE N'%@%')) AND (DelegateAccounts.Active = 1)"

--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
@@ -92,7 +92,11 @@
             {
                 Error = BulkUploadResult.ErrorReason.InvalidActive;
             }
-            else if (string.IsNullOrEmpty(Email))
+            else if (string.IsNullOrEmpty(Email) && Active == true && !string.IsNullOrEmpty(CandidateNumber))
+            {
+                Error = BulkUploadResult.ErrorReason.MissingEmail;
+            }
+            else if (string.IsNullOrEmpty(Email) && string.IsNullOrEmpty(CandidateNumber))
             {
                 Error = BulkUploadResult.ErrorReason.MissingEmail;
             }
@@ -103,18 +107,6 @@
             else if (LastName.Length > 250)
             {
                 Error = BulkUploadResult.ErrorReason.TooLongLastName;
-            }
-            else if (Email.Length > 250)
-            {
-                Error = BulkUploadResult.ErrorReason.TooLongEmail;
-            }
-            else if (!new EmailAddressAttribute().IsValid(Email))
-            {
-                Error = BulkUploadResult.ErrorReason.BadFormatEmail;
-            }
-            else if (Email.Any(char.IsWhiteSpace))
-            {
-                Error = BulkUploadResult.ErrorReason.WhitespaceInEmail;
             }
             else if (Answer1 != null && Answer1.Length > 100)
             {
@@ -160,7 +152,21 @@
             {
                 Error = BulkUploadResult.ErrorReason.InvalidPrnCharacters;
             }
-
+            else if (!string.IsNullOrEmpty(Email))
+            {
+                if (!new EmailAddressAttribute().IsValid(Email))
+                {
+                    Error = BulkUploadResult.ErrorReason.BadFormatEmail;
+                }
+                else if (Email.Length > 250)
+                {
+                    Error = BulkUploadResult.ErrorReason.TooLongEmail;
+                }
+                else if (Email.Any(char.IsWhiteSpace))
+                {
+                    Error = BulkUploadResult.ErrorReason.WhitespaceInEmail;
+                }
+            }
             return !Error.HasValue;
         }
 
@@ -216,7 +222,7 @@
                 return false;
             }
 
-            if (delegateEntity.EmailForCentreNotifications != Email)
+            if (!string.IsNullOrEmpty(Email) && !new EmailAddressAttribute().IsValid(delegateEntity.EmailForCentreNotifications) | delegateEntity.EmailForCentreNotifications != Email)
             {
                 return false;
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -355,7 +355,7 @@
             var model = new ProcessBulkDelegatesViewModel(
                 stepNumber: step,
                 totalSteps: totalSteps,
-                rowsProcessed: data.LastRowProcessed,
+                rowsProcessed: data.LastRowProcessed-1,
                 totalRows: data.ToProcessCount,
                 maxRowsPerStep: data.MaxRowsToProcess,
                 delegatesRegistered: data.SubtotalDelegatesRegistered,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -355,7 +355,7 @@
             var model = new ProcessBulkDelegatesViewModel(
                 stepNumber: step,
                 totalSteps: totalSteps,
-                rowsProcessed: data.LastRowProcessed-1,
+                rowsProcessed: data.LastRowProcessed-1, //Adjusted because last row processed includes header row
                 totalRows: data.ToProcessCount,
                 maxRowsPerStep: data.MaxRowsToProcess,
                 delegatesRegistered: data.SubtotalDelegatesRegistered,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -324,7 +324,7 @@
                 var centreId = User.GetCentreIdKnownNotNull();
                 var data = GetBulkUploadData();
                 var adminId = User.GetAdminIdKnownNotNull();
-                int processSteps = data.ToProcessCount / data.MaxRowsToProcess + 1;
+                int processSteps = (int)Math.Ceiling((double)data.ToProcessCount / data.MaxRowsToProcess);
                 int step = data.LastRowProcessed / data.MaxRowsToProcess + 1;
                 var results = ProcessRowsAndReturnResults();
                 data.SubtotalDelegatesRegistered += results.RegisteredCount;
@@ -371,6 +371,7 @@
         {
             var data = GetBulkUploadData();
             FileHelper.DeleteFile(webHostEnvironment, data.DelegatesFileName);
+            int processSteps = (int)Math.Ceiling((double)data.ToProcessCount / data.MaxRowsToProcess);
             var model = new BulkUploadResultsViewModel(
                 processedCount: data.ToProcessCount,
                 registeredCount: data.SubtotalDelegatesRegistered,
@@ -379,7 +380,8 @@
                 errors: data.Errors,
                 day: (int)data.Day,
                 month: (int)data.Month,
-                year: (int)data.Year
+                year: (int)data.Year,
+                totalSteps: processSteps
                 );
             TempData.Clear();
             return View(model);

--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -167,7 +167,7 @@
                     x.Answer4,
                     x.Answer5,
                     x.Answer6,
-                    x.Active,
+                    Active = blank ? null : (bool?)x.Active,
                     EmailAddress = (Guid.TryParse(x.EmailAddress, out _) ? string.Empty : x.EmailAddress),
                     HasPRN = PrnHelper.GetHasPrnForDelegate(x.HasBeenPromptedForPrn, x.ProfessionalRegistrationNumber),
                     PRN = x.HasBeenPromptedForPrn ? x.ProfessionalRegistrationNumber : null,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadPreProcessViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadPreProcessViewModel.cs
@@ -36,7 +36,7 @@
                 BulkUploadResult.ErrorReason.MissingFirstName =>
                     "FirstName is blank. First name is a required field and cannot be left blank",
                 BulkUploadResult.ErrorReason.MissingEmail =>
-                    "EmailAddress is blank. Email address is a required field and cannot be left blank",
+                    "EmailAddress is blank. Email address is a required field and cannot be left blank for new or active delegates",
                 BulkUploadResult.ErrorReason.InvalidActive =>
                     "Active field is invalid. The Active field must contain 'TRUE' or 'FALSE'",
                 BulkUploadResult.ErrorReason.TooLongFirstName => "FirstName must be 250 characters or fewer",

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadResultsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadResultsViewModel.cs
@@ -15,9 +15,10 @@
             SkippedCount = bulkUploadResult.SkippedCount;
             Errors = bulkUploadResult.Errors.Select(x => (x.RowNumber, MapReasonToErrorMessage(x.Reason)));
         }
-        public BulkUploadResultsViewModel(int processedCount, int registeredCount, int updatedCount, int skippedCount, IEnumerable<(int, string)> errors, int day, int month, int year)
+        public BulkUploadResultsViewModel(int processedCount, int registeredCount, int updatedCount, int skippedCount, IEnumerable<(int, string)> errors, int day, int month, int year, int totalSteps)
         {
             ProcessedCount = processedCount;
+            TotalSteps = totalSteps;
             RegisteredCount = registeredCount;
             UpdatedCount = updatedCount;
             SkippedCount = skippedCount;
@@ -29,6 +30,7 @@
 
         public IEnumerable<(int RowNumber, string ErrorMessage)> Errors { get; set; }
         public int ErrorCount => Errors.Count();
+        public int TotalSteps { get; set; }
         public int ProcessedCount { get; set; }
         public int RegisteredCount { get; set; }
         public int UpdatedCount { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/BulkUploadResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/BulkUploadResults.cshtml
@@ -8,24 +8,54 @@
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
         <h1 class="nhsuk-heading-xl">Delegate processing complete</h1>
-        <details class="nhsuk-details">
-            <summary class="nhsuk-details__summary">
-                <span class="nhsuk-details__summary-text">
-                    Summary of results
-                </span>
-            </summary>
-            <div class="nhsuk-details__text">
-                <p>Processing your uploaded spreadsheet resulted in the following:</p>
-                <ul>
-                    <li>@Model.ProcessedCount @(Model.ProcessedCount == 1 ? "row" : "rows") processed</li>
-                    <li>@Model.RegisteredCount new @(Model.RegisteredCount == 1 ? "delegate" : "delegates") registered</li>
-                    <li>@Model.UpdatedCount existing delegate  @(Model.UpdatedCount == 1 ? "record" : "records") updated</li>
-                    <li>@Model.SkippedCount existing delegate  @(Model.SkippedCount == 1 ? "record" : "records") skipped (no changes)</li>
-                    <li>@Model.ErrorCount @(Model.ErrorCount == 1 ? "row" : "rows") skipped due to errors</li>
-                </ul>
+        <h2>Results summary</h2>
+        @if (Model.TotalSteps > 1)
+        {
+            <h3>Step @Model.TotalSteps of @Model.TotalSteps </h3>
+        }
+        <dl class="nhsuk-summary-list">
 
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Delegate rows processed
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @(Model.ProcessedCount)
+                </dd>
             </div>
-        </details>
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    New delegates registered
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @Model.RegisteredCount
+                </dd>
+            </div>
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Existing delegates updated
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @Model.UpdatedCount
+                </dd>
+            </div>
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Rows skipped with no changes
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @Model.SkippedCount
+                </dd>
+            </div>
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Rows skipped with errors
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @Model.ErrorCount
+                </dd>
+            </div>
+        </dl>
         <h2>What to do next</h2>
         <ul>
             @if (Model.ErrorCount > 0)

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/BulkUploadResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/BulkUploadResults.cshtml
@@ -35,7 +35,7 @@
             @if (Model.RegisteredCount > 0)
             {
                 <li>Registered delegates (@Model.RegisteredCount) will be sent a welcome email on @Model.Day/@Model.Month/@Model.Year.</li>
-                <li>You can resend re-send the welcome email by using the <a asp-controller="AllDelegates" asp-action="Email" asp-all-route-data="@null">Email</a> button on the <a asp-controller="AllDelegates" asp-action="Index" asp-all-route-data="@null">Delegates</a> screen.</li>
+                <li>You can resend re-send the welcome email by using the <a asp-controller="EmailDelegates" asp-action="Index" asp-all-route-data="@null">Email</a> button on the <a asp-controller="AllDelegates" asp-action="Index" asp-all-route-data="@null">Delegates</a> screen.</li>
             }
             <li>If you need to promote any of the users to an administrator role, you can do this from the <a asp-controller="AllDelegates" asp-action="Index" asp-all-route-data="@null">Delegates</a> screen. Search for the user and click "Manage delegate".</li>
         </ul>
@@ -56,7 +56,6 @@
                             <dd class="nhsuk-summary-list__value">
                                 @errorMessage
                             </dd>
-
                         </div>
                     }
                 </dl>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/ProcessBulkDelegates.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/ProcessBulkDelegates.cshtml
@@ -16,7 +16,7 @@
                     Delegate rows processed
                 </dt>
                 <dd class="nhsuk-summary-list__value">
-                    @(Model.RowsProcessed - 1)
+                    @(Model.RowsProcessed)
                 </dd>
             </div>
             <div class="nhsuk-summary-list__row">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/UploadSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/UploadSummary.cshtml
@@ -38,7 +38,7 @@
                     Delegates to update
                 </dt>
                 <dd class="nhsuk-summary-list__value">
-                    @Model.ToRegisterCount
+                    @Model.ToUpdateCount
                 </dd>
             </div>
         </dl>


### PR DESCRIPTION
### JIRA link
[TD-3835](https://hee-tis.atlassian.net/browse/TD-3835)

### Description
Changes made in response to test analyst feedback, including:
- Clears the "TRUE" value for the "Active" column in the first data row when downloading a blank template by allowing Active bool in anonymous class to be nullable.
- Corrects the controller and action for the Email link on the upload results page (fixing link)
- Adds a migration to inactivate all delegate accounts with no email address
- Fixes validation of upload to allow blank email only for updated delegates if they are inactive
- Fixes count of rows to process in summary page
- Make results page work as final step in multi-step slow by showing step number 

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3835]: https://hee-tis.atlassian.net/browse/TD-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ