### PR TITLE
TD-4048 Fix for super admin delegates issue

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -410,10 +410,10 @@
                                           Questions = questions.Count()
                                       };
 
-            ViewBag.CompetencySummaries = competencySummaries;
+            int sumVerifiedCount = competencySummaries.Sum(item => item.VerifiedCount);
+            int sumQuestions = competencySummaries.Sum(item => item.Questions);
             var activitySummaryCompetencySelfAssesment = selfAssessmentService.GetActivitySummaryCompetencySelfAssesment(competencymaindata.Id);
-            var model = new CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, route, accessors, activitySummaryCompetencySelfAssesment);
-            ViewBag.LoggedInSupervisorDelegatesId = supervisorDelegateId;
+            var model = new CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, route, accessors, activitySummaryCompetencySelfAssesment, sumQuestions, sumVerifiedCount, supervisorDelegateId);
             return View("Current/CompetencySelfAssessmentCertificate", model);
         }
         [Route("DownloadCertificate")]
@@ -471,8 +471,9 @@
                                           Questions = questions.Count()
                                       };
 
-            ViewBag.CompetencySummaries = competencySummaries;
-            var model = new CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, 1, accessors, activitySummaryCompetencySelfAssesment);
+            int sumVerifiedCount = competencySummaries.Sum(item => item.VerifiedCount);
+            int sumQuestions = competencySummaries.Sum(item => item.Questions);
+            var model = new CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, 1, accessors, activitySummaryCompetencySelfAssesment, sumQuestions, sumVerifiedCount, null);
             var renderedViewHTML = RenderRazorViewToString(this, "Current/DownloadCompetencySelfAssessmentCertificate", model);
 
             var pdfReportResponse = await pdfService.PdfReport(candidateAssessmentId.ToString(), renderedViewHTML, delegateId);

--- a/DigitalLearningSolutions.Web/Models/Enums/DelegateAccountCard.cs
+++ b/DigitalLearningSolutions.Web/Models/Enums/DelegateAccountCard.cs
@@ -1,6 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Models.Enums
 {
-    enum DelegateAccountCard
+    public enum DelegateAccountCard
     {
         Active,
         Inactive,

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Current/CompetencySelfAssessmentCertificateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/Current/CompetencySelfAssessmentCertificateViewModel.cs
@@ -14,7 +14,10 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
         public CompetencySelfAssessmentCertificateViewModel(CompetencySelfAssessmentCertificate competency,
             IEnumerable<CompetencyCountSelfAssessmentCertificate> competencies,
             int route, IEnumerable<Accessor> accessors,
-           ActivitySummaryCompetencySelfAssesment activitySummaryCompetencySelfAssesment
+           ActivitySummaryCompetencySelfAssesment activitySummaryCompetencySelfAssesment,
+           int questionResponses,
+           int confirmedResponses,
+           int? loggedInSupervisorDelegateId
          )
         {
             Route = route;
@@ -23,6 +26,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
             VocabPlural = FrameworkVocabularyHelper.VocabularyPlural(competency.Vocabulary);
             Accessors = accessors;
             ActivitySummaryCompetencySelfAssesment = activitySummaryCompetencySelfAssesment;
+            QuestionResponses = questionResponses;
+            ConfirmedResponses = confirmedResponses;
+            LoggedInSupervisorDelegateId = loggedInSupervisorDelegateId;
         }
 
         public int Route { get; set; }
@@ -31,5 +37,9 @@ namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.Current
         public CompetencySelfAssessmentCertificate CompetencySelfAssessmentCertificates { get; set; }
         public IEnumerable<CompetencyCountSelfAssessmentCertificate> CompetencyCountSelfAssessmentCertificate { get; set; }
         public IEnumerable<Accessor> Accessors { get; set; }
+        public int QuestionResponses { get; set; }
+        public int ConfirmedResponses { get; set; }
+        public int? LoggedInSupervisorDelegateId { get; set; }
+        
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CompetencySelfAssessmentCertificate.cshtml
@@ -3,8 +3,6 @@
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = "Competency Self Assessment Certificate";
-    var sumVerifiedCount = ((IEnumerable<dynamic>)ViewBag.CompetencySummaries).Sum(item => item.VerifiedCount);
-    var sumQuestions = ((IEnumerable<dynamic>)ViewBag.CompetencySummaries).Sum(item => item.Questions);
 }
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfassessmentcertificate.css")" asp-append-version="true">
 <style>
@@ -66,7 +64,7 @@
                 <li class="nhsuk-breadcrumb__item">
                     <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
                        asp-action="ReviewDelegateSelfAssessment"
-                       asp-route-supervisorDelegateId="@ViewBag.LoggedInSupervisorDelegatesId"
+                       asp-route-supervisorDelegateId="@Model.LoggedInSupervisorDelegateId"
                        asp-route-candidateAssessmentId="@Model.CompetencySelfAssessmentCertificates.CandidateAssessmentID">
                         &lt; Back
                     </a>
@@ -207,12 +205,12 @@
                     </div>
                     <div class="activity">
                         <p><b>Assessment question responses</b></p> <p>
-                            @sumQuestions
+                            @Model.QuestionResponses
                         </p>
                     </div>
                     <div class="activity">
                         <p><b>Responses confirmed by assessor</b></p> <p>
-                            @sumVerifiedCount
+                            @Model.ConfirmedResponses
                         </p>
                     </div>
                     <div class="activity">

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/DownloadCompetencySelfAssessmentCertificate.cshtml
@@ -3,8 +3,6 @@
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = "Competency Self Assessment Certificate";
-    var sumVerifiedCount = ((IEnumerable<dynamic>)ViewBag.CompetencySummaries).Sum(item => item.VerifiedCount);
-    var sumQuestions = ((IEnumerable<dynamic>)ViewBag.CompetencySummaries).Sum(item => item.Questions);
 }
 
 <!DOCTYPE html>
@@ -521,13 +519,12 @@
                 </div>
                 <div class="activity">
                     <p><b>Assessment question responses</b></p> <p>
-
-                        @sumQuestions
+                        @Model.QuestionResponses
                     </p>
                 </div>
                 <div class="activity">
                     <p><b>Responses confirmed by assessor</b></p> <p>
-                        @sumVerifiedCount
+                        @Model.ConfirmedResponses
                     </p>
                 </div>
                 <div class="activity">


### PR DESCRIPTION
### JIRA link
[TD-4048](https://hee-tis.atlassian.net/browse/TD-4048)

### Description
The problem loading the Delegates page in Super Admin was caused by another enumerator class with a missing access modifier. This change adds the "public" access modifier to the class. I have also checked that no other enums have a missing access modifier in Web.Models.Enums.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4048]: https://hee-tis.atlassian.net/browse/TD-4048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ