### PR TITLE
TD-3174 Showing console '500' error on the screen when enrolling delegate on self assessments on Tracking system

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -484,7 +484,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                         SupervisorEmail,
                         AddedByDelegate)
                     OUTPUT INSERTED.Id
-                    SELECT
+                    SELECT DISTINCT
                         @supervisorId,
                         COALESCE(UCD.Email, U.PrimaryEmail),
                         DA.UserID,


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3174

### Description
I ensure that the query that return the delegate record, returns single record instead of multiple records it was returning before

### Screenshots
_Attach screenshots on mobile, tablet and desktop._
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/9bc712b2-ef57-40ab-8943-7f327dbef5e5)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/9d0cb42e-ea47-41e5-8c16-bd277f3d6491)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
