### PR TITLE
TD-3173 Removing role selection from enrol on activity

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -215,7 +215,6 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             }
             else
             {
-                var roles = supervisorService.GetSupervisorRolesForSelfAssessment(sessionEnrol.AssessmentID.GetValueOrDefault()).ToArray();
                 var model = new EnrolSupervisorViewModel(
                     delegateId,
                     (int)sessionEnrol.DelegateUserID,
@@ -223,7 +222,6 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     sessionEnrol.IsSelfAssessment,
                    supervisorList,
                    sessionEnrol.SupervisorID.GetValueOrDefault(),
-                   roles,
                    sessionEnrol.SelfAssessmentSupervisorRoleId.GetValueOrDefault());
                 return View(model);
             }
@@ -235,7 +233,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             var centreId = GetCentreId();
             var sessionEnrol = multiPageFormService.GetMultiPageFormData<SessionEnrolDelegate>(MultiPageFormDataFeature.EnrolDelegateInActivity, TempData).GetAwaiter().GetResult();
             var supervisorList = supervisorService.GetSupervisorForEnrolDelegate(sessionEnrol.AssessmentID.Value, centreId.Value);
-            var roles = supervisorService.GetSupervisorRolesForSelfAssessment(sessionEnrol.AssessmentID.GetValueOrDefault()).ToArray();
+            var roles = supervisorService.GetSupervisorRolesBySelfAssessmentIdForSupervisor(sessionEnrol.AssessmentID.GetValueOrDefault()).ToArray();
 
             if (!ModelState.IsValid)
             {
@@ -246,7 +244,6 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     sessionEnrol.IsSelfAssessment,
                    supervisorList,
                    sessionEnrol.SupervisorID.GetValueOrDefault(),
-                   roles,
                    sessionEnrol.SelfAssessmentSupervisorRoleId.GetValueOrDefault());
                 errormodel.SelectedSupervisorRoleId = model.SelectedSupervisorRoleId.Value;
                 return View(errormodel);
@@ -257,11 +254,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 sessionEnrol.SupervisorName = supervisorList.FirstOrDefault(x => x.AdminId == model.SelectedSupervisor).Name;
                 sessionEnrol.SupervisorID = model.SelectedSupervisor;
             }
-            if (model.SelectedSupervisorRoleId.HasValue && model.SelectedSupervisorRoleId.Value > 0)
-            {
-                sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault(x => x.ID == model.SelectedSupervisorRoleId).RoleName;
-            }
-            sessionEnrol.SelfAssessmentSupervisorRoleId = model.SelectedSupervisorRoleId;
+            sessionEnrol.SelfAssessmentSupervisorRoleId = roles.FirstOrDefault().ID;
             multiPageFormService.SetMultiPageFormData(
                         sessionEnrol,
                         MultiPageFormDataFeature.EnrolDelegateInActivity,
@@ -285,6 +278,8 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 monthDiffrence = (((sessionEnrol.CompleteByDate.Value.Year - clockUtility.UtcNow.Year) * 12) + sessionEnrol.CompleteByDate.Value.Month - clockUtility.UtcNow.Month).ToString();
             }
 
+            var roles = supervisorService.GetSupervisorRolesBySelfAssessmentIdForSupervisor((int)sessionEnrol.AssessmentID);
+
             var model = new EnrolSummaryViewModel();
             model.SupervisorName = sessionEnrol.SupervisorName;
             model.ActivityName = sessionEnrol.AssessmentName;
@@ -294,7 +289,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             model.DelegateName = sessionEnrol.DelegateName;
             model.ValidFor = monthDiffrence;
             model.IsSelfAssessment = sessionEnrol.IsSelfAssessment;
-            model.SupervisorRoleName = sessionEnrol.SelfAssessmentSupervisorRoleName;
+            model.SupervisorRoleName = roles.FirstOrDefault().RoleName;
             return View(model);
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Enrol/EnrolSupervisorViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Enrol/EnrolSupervisorViewModel.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Enrol
 {
-    public class EnrolSupervisorViewModel : IValidatableObject
+    public class EnrolSupervisorViewModel
     {
         public EnrolSupervisorViewModel() { }
         public EnrolSupervisorViewModel(
@@ -33,7 +33,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Enrol
             bool isSelfAssessment,
             IEnumerable<SupervisorForEnrolDelegate> supervisorList,
             int selectedSupervisor,
-            IEnumerable<SelfAssessmentSupervisorRole>? supervisorRoleList,
             int selectedSupervisorRole
         )
         {
@@ -42,7 +41,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Enrol
             DelegateName = delegateName;
             IsSelfAssessment = isSelfAssessment;
             SupervisorList = PopulateItems(supervisorList, selectedSupervisor);
-            SupervisorRoleList = supervisorRoleList;
             SelectedSupervisorRoleId = selectedSupervisorRole;
         }
         public int DelegateId { get; set; }
@@ -50,7 +48,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Enrol
         public string? DelegateName { get; set; }
 
         public IEnumerable<SelectListItem>? SupervisorList { get; set; }
-        public IEnumerable<SelfAssessmentSupervisorRole>? SupervisorRoleList { get; set; }
         public IEnumerable<RadiosListItemViewModel>? SupervisorRoleList1 { get; set; }
 
         public int? SelectedSupervisor { get; set; }
@@ -65,16 +62,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Enrol
             return SelectListHelper.MapOptionsToSelectListItems(
                 LearningItemIdNames, selected
            );
-        }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            List<ValidationResult> errors = new List<ValidationResult>();
-            if (SelectedSupervisorRoleId.HasValue && !SelectedSupervisor.HasValue)
-            {
-                errors.Add(new ValidationResult("You must choose a supervisor in order to specify a supervisor role", new[] { nameof(SelectedSupervisor) }));
-            }
-            return errors;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Enrol/EnrolDelegateSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Enrol/EnrolDelegateSupervisor.cshtml
@@ -27,29 +27,6 @@
                             css-class="nhsuk-u-width-one-half"
                             default-option="--Select--"
                             select-list-options="@Model.SupervisorList" />
-            @if (Model.IsSelfAssessment && Model.SupervisorRoleList.Count() > 1)
-            {
-                <fieldset class="nhsuk-fieldset">
-                    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                        <h3 class="nhsuk-fieldset__heading">
-                            Choose your supervisor role
-                        </h3>
-                    </legend>
-                    <nhs-form-group nhs-validation-for="SelectedSupervisorRoleId">
-                        <div class="nhsuk-radios">
-                            @foreach (var role in Model.SupervisorRoleList)
-                            {
-                                <div class="nhsuk-radios__item">
-                                    <input class="nhsuk-radios__input" id="role-@role.ID" name="SelectedSupervisorRoleId" asp-for="SelectedSupervisorRoleId" type="radio" value="@role.ID">
-                                    <label class="nhsuk-label nhsuk-radios__label" for="role-@role.ID">
-                                        @role.RoleName
-                                    </label>
-                                </div>
-                            }
-                        </div>
-                    </nhs-form-group>
-                </fieldset>
-            }
             <div class=" nhsuk-u-margin-top-5">
                 <input class="nhsuk-button" type="submit" value="Next" />
                 <a class="nhsuk-button nhsuk-button--secondary" asp-action="EnrolDelegateSummary" asp-route-delegateId="@Model.DelegateId" asp-route-delegateName="@Model.DelegateName">


### PR DESCRIPTION
### JIRA link
[TD-3173](https://hee-tis.atlassian.net/browse/TD-3173)

### Description
Removing role selection from enrol on activity

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/6ca2cdea-ad73-42a7-9326-3557d50c9a6d)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/1fded22e-45a7-4dd0-8dec-44f331fe6f88)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3173]: https://hee-tis.atlassian.net/browse/TD-3173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ