### PR TITLE
TD-3888 mobile view issue on the certificate screen for all the self assessments issue fix

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/learningPortal/selfassessmentcertificate.scss
+++ b/DigitalLearningSolutions.Web/Styles/learningPortal/selfassessmentcertificate.scss
@@ -378,4 +378,18 @@
   .certificate .nhsuk-u-margin-bottom-2 {
     margin-bottom: 8px !important;
   }
+ }
+@media screen and (max-width: 767px) {
+  .certificate {
+    width: 95%;
+    justify-content: space-around;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    -webkit-print-color-adjust: exact;
+  }
+  .certificate .pg-1 {
+    width: 95%;
+  }
+  .pg-2 {
+    width: 95%;
+  }
 }


### PR DESCRIPTION


### JIRA link
https://hee-tis.atlassian.net/browse/TD-3888

### Description
I handle the mobile view for the self assessments  certificate on the css

### Screenshots
![localhost_44363_LearningPortal_Current_9495_2_Certificate(Samsung Galaxy S20 Ultra) (1)](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/4e4e99aa-01f5-4106-9291-7b7a0fc8471d)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
