### PR TITLE
TD-3080 Remove duplicates from group delegates table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202404231652_RemoveDuplicateDelegatesFromDelegateGroups.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202404231652_RemoveDuplicateDelegatesFromDelegateGroups.cs
@@ -1,0 +1,20 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202404231652)]
+    public class RemoveDuplicateDelegatesFromDelegateGroups : ForwardOnlyMigration
+    {
+        public override void Up()
+        {
+            Execute.Sql(
+                @$"WITH GroupDelegatesCTE AS (
+                        SELECT *,
+                               ROW_NUMBER() OVER (PARTITION BY GroupID, DelegateID ORDER BY GroupDelegateID) AS rn
+                        FROM GroupDelegates
+                    )
+                    DELETE FROM GroupDelegatesCTE WHERE rn > 1;"
+                );
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-3080](https://hee-tis.atlassian.net/browse/TD-3080)

### Description
Migration to remove duplicate records from the GroupDelegates table to support work in preventing duplicates.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3080]: https://hee-tis.atlassian.net/browse/TD-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ