### PR TITLE
Fixed issue where LogIntoCentreAsync was called. Fixed Logout issue

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/LoginServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/LoginServiceTests.cs
@@ -910,7 +910,8 @@
                 ticketReceivedContext,
                 "",
                 sessionService,
-                userService);
+                userService,
+                "");
 
             // Then
             result

--- a/DigitalLearningSolutions.Web/Controllers/LogoutController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LogoutController.cs
@@ -35,7 +35,8 @@
 
             if (string.IsNullOrEmpty(authScheme))
             {
-                return this.Redirect("/home");
+                var appRootPath = config.GetAppRootPath();
+                return this.Redirect(appRootPath + "/home");
             }
 
             await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme);
@@ -54,8 +55,8 @@
                 "id_token",
                 out idToken);
             var auth = config.GetLearningHubAuthenticationAuthority();
-            var baseUrl = config.GetCurrentSystemBaseUrl();
-            var uri = Uri.EscapeDataString($"{baseUrl}/signout-callback-oidc");
+            var appRootPath = config.GetAppRootPath();
+            var uri = Uri.EscapeDataString($"{appRootPath}/signout-callback-oidc");
             var logoutUrl = $"{auth}/connect/endsession" +
                 $"?post_logout_redirect_uri={uri}" +
                 $"&id_token_hint={idToken}";

--- a/DigitalLearningSolutions.Web/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Web/Services/LoginService.cs
@@ -32,7 +32,8 @@
             TicketReceivedContext context,
             string returnUrl,
             ISessionService sessionService,
-            IUserService userService);
+            IUserService userService,
+            string appRootPath);
     }
 
     public class LoginService : ILoginService
@@ -142,20 +143,21 @@
             TicketReceivedContext context,
             string returnUrl,
             ISessionService sessionService,
-            IUserService userService)
+            IUserService userService,
+            string appRootPath)
         {
             switch (loginResult.LoginAttemptResult)
             {
                 case LoginAttemptResult.AccountLocked:
-                    return "/login/AccountLocked";
+                    return appRootPath + "/login/AccountLocked";
                 case LoginAttemptResult.InactiveAccount:
-                    return "/login/AccountInactive";
+                    return appRootPath + "/login/AccountInactive";
                 case LoginAttemptResult.UnverifiedEmail:
                     await LoginHelper.CentrelessLogInAsync(
                         context,
                         loginResult.UserEntity!.UserAccount,
                         false);
-                    return "/VerifyYourEmail/" + EmailVerificationReason.EmailNotVerified;
+                    return appRootPath + "/VerifyYourEmail/" + EmailVerificationReason.EmailNotVerified;
                 case LoginAttemptResult.LogIntoSingleCentre:
                     return await LoginHelper.LogIntoCentreAsync(
                         loginResult.UserEntity,
@@ -198,7 +200,7 @@
                         context,
                         loginResult.UserEntity!.UserAccount,
                         false);
-                    return "/Login/ChooseACentre";
+                    return appRootPath + "/Login/ChooseACentre";
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -298,13 +298,15 @@ namespace DigitalLearningSolutions.Web
                 .Principal
                 .Identity;
 
+            var appRootPath = ConfigHelper.GetAppConfig().GetAppRootPath();
+
             var authIdClaim = claimsIdentity
             .Claims
                 .Where(c => c.Type == claimsType)
                 .FirstOrDefault();
             if (authIdClaim == null)
             {
-                context.ReturnUri = "/Login/RemoteFailure";
+                context.ReturnUri = appRootPath + "/Login/RemoteFailure";
             }
             else
             {
@@ -319,7 +321,7 @@ namespace DigitalLearningSolutions.Web
                 }
                 else
                 {
-                    context.ReturnUri = "/login/NotLinked";
+                    context.ReturnUri = appRootPath + "/login/NotLinked";
                 }
             }
             
@@ -365,15 +367,17 @@ namespace DigitalLearningSolutions.Web
                 context,
                 returnUrl,
                 sessionService,
-                userService);
-            context.ReturnUri = appRootPath + redirectString;
+                userService,
+                appRootPath);
+            context.ReturnUri = redirectString;
         }
 
         private static async Task OnAuthenticationFailed(AuthenticationFailedContext context)
         {
+            var appRootPath = ConfigHelper.GetAppConfig().GetAppRootPath();
             context
                 .Response
-                .Redirect("/Login/RemoteFailure");
+                .Redirect(appRootPath + "/Login/RemoteFailure");
             await context
                 .HttpContext
                 .Response


### PR DESCRIPTION
### JIRA link
[TD-2454](https://hee-tis.atlassian.net/browse/TD-2454)

### Description
Fixed the issue where LogIntoCentreAsync was called. Fixed issue when user logs out.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [X] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2454]: https://hee-tis.atlassian.net/browse/TD-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ