### PR TITLE
TD-4093 Fix for 404 certificate error

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -350,54 +350,34 @@
                   LearnerDetails.SupervisorDelegateId,
                   LearnerDetails.FormattedDate,
                   LearnerDetails.NonReportable
-                  FROM(SELECT casv.ID,
-                    ca.NonReportable,
-                    sa.Name AS SelfAssessment, 
-                    Learner.FirstName + ' ' + Learner.LastName AS LearnerName,
-                    Learner.ProfessionalRegistrationNumber AS LearnerPRN,
-                    Learner.ID  AS LearnerId,da.Id AS LearnerDelegateAccountId,
-                    casv.Verified, 
-                    ce.CentreName, 
-                    Supervisor.FirstName + ' ' + Supervisor.LastName AS SupervisorName, 
-                    Supervisor.ProfessionalRegistrationNumber AS SupervisorPRN,
-                    b.BrandName, 
-                    b.BrandImage,
-                    ca.ID  CandidateAssessmentID,
-                    ca.SelfAssessmentID,  COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
-					cas.SupervisorDelegateId,CONVERT(VARCHAR(2), DAY(Verified)) +
-                     CASE 
-                        WHEN DAY(Verified) % 100 IN (11, 12, 13) THEN 'th'
-                        WHEN DAY(Verified) % 10 = 1 THEN 'st'
-                        WHEN DAY(Verified) % 10 = 2 THEN 'nd'
-                         WHEN DAY(Verified) % 10 = 3 THEN 'rd'
-                        ELSE 'th'
-                       END +
-                        ' ' +
-                      FORMAT(Verified, 'MMMM yyyy') AS FormattedDate
-             FROM   CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
-             CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
-             AdminAccounts AS aa ON casv.ID = aa.ID INNER JOIN
-             Users AS Supervisor ON aa.UserID = Supervisor.ID INNER JOIN
-             CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-             Users AS Learner ON ca.DelegateUserID = Learner.ID INNER JOIN
-             SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
-             Brands AS b ON sa.BrandID = b.BrandID INNER JOIN
-             Centres AS ce ON CE.CentreID = ca.CentreID INNER JOIN
-			 DelegateAccounts AS da ON da.UserID = Learner.ID AND da.CentreID = ca.CentreID 
-             WHERE (ca.Id=@candidateAssessmentID) AND  (casv.SignedOff = 1) AND (NOT (casv.Verified IS NULL))) LearnerDetails INNER JOIN
-			 (select sd.SupervisorAdminID, casv.ID ,u.FirstName + ' ' + u.LastName AS SupervisorName, 
-                    u.ProfessionalRegistrationNumber AS SupervisorPRN,
-              c.CentreName AS SupervisorCentreName,ca.CentreID
-              from CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
-             CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
-			 SupervisorDelegates AS sd ON sd.ID = cas.SupervisorDelegateId INNER JOIN
-			 AdminAccounts AS aa ON sd.SupervisorAdminID = aa.ID   INNER JOIN
-			 Users AS u ON aa.UserID = u.ID INNER JOIN
-			 Centres c ON aa.CentreID = c.CentreID INNER JOIN
-			 CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID 
-			 where (ca.ID = @candidateAssessmentID)  AND  (casv.SignedOff = 1)
-                           AND (NOT (casv.Verified IS NULL))) Supervisor ON  LearnerDetails.Id =Supervisor.Id
-             ORDER BY Verified DESC",
+                  FROM(SELECT casv.ID, ca.NonReportable, sa.Name AS SelfAssessment, Learner.FirstName + ' ' + Learner.LastName AS LearnerName, Learner.ProfessionalRegistrationNumber AS LearnerPRN, Learner.ID AS LearnerId, da.ID AS LearnerDelegateAccountId, casv.Verified, ce.CentreName, 
+                                 Supervisor.FirstName + ' ' + Supervisor.LastName AS SupervisorName, Supervisor.ProfessionalRegistrationNumber AS SupervisorPRN, b.BrandName, b.BrandImage, ca.ID AS CandidateAssessmentID, ca.SelfAssessmentID, COALESCE (sa.Vocabulary, 'Capability') AS Vocabulary, 
+                                 cas.SupervisorDelegateId, CONVERT(VARCHAR(2), DAY(casv.Verified)) + CASE WHEN DAY(Verified) % 100 IN (11, 12, 13) THEN 'th' WHEN DAY(Verified) % 10 = 1 THEN 'st' WHEN DAY(Verified) % 10 = 2 THEN 'nd' WHEN DAY(Verified) 
+                                 % 10 = 3 THEN 'rd' ELSE 'th' END + ' ' + FORMAT(casv.Verified, 'MMMM yyyy') AS FormattedDate
+                    FROM   dbo.CandidateAssessments AS ca LEFT OUTER JOIN
+                                 dbo.DelegateAccounts AS da RIGHT OUTER JOIN
+                                 dbo.Users AS Learner ON da.UserID = Learner.ID ON ca.CentreID = da.CentreID AND ca.DelegateUserID = Learner.ID LEFT OUTER JOIN
+                                 dbo.Centres AS ce ON ca.CentreID = ce.CentreID LEFT OUTER JOIN
+                                 dbo.Brands AS b RIGHT OUTER JOIN
+                                 dbo.SelfAssessments AS sa ON b.BrandID = sa.BrandID ON ca.SelfAssessmentID = sa.ID LEFT OUTER JOIN
+                                 dbo.CandidateAssessmentSupervisors AS cas ON ca.ID = cas.CandidateAssessmentID LEFT OUTER JOIN
+                                 dbo.Users AS Supervisor RIGHT OUTER JOIN
+                                 dbo.AdminAccounts AS aa ON Supervisor.ID = aa.UserID RIGHT OUTER JOIN
+                                dbo.CandidateAssessmentSupervisorVerifications AS casv ON aa.ID = casv.ID ON cas.ID = casv.CandidateAssessmentSupervisorID
+                    WHERE (ca.ID = @candidateAssessmentID) AND (casv.SignedOff = 1) AND (NOT (casv.Verified IS NULL))) LearnerDetails INNER JOIN
+                    			 (select sd.SupervisorAdminID, casv.ID ,u.FirstName + ' ' + u.LastName AS SupervisorName, 
+                                        u.ProfessionalRegistrationNumber AS SupervisorPRN,
+                                  c.CentreName AS SupervisorCentreName,ca.CentreID
+                                  from CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
+                                 CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
+                    			 SupervisorDelegates AS sd ON sd.ID = cas.SupervisorDelegateId INNER JOIN
+                    			 AdminAccounts AS aa ON sd.SupervisorAdminID = aa.ID   INNER JOIN
+                    			 Users AS u ON aa.UserID = u.ID INNER JOIN
+                    			 Centres c ON aa.CentreID = c.CentreID INNER JOIN
+                    			 CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID 
+                    			 where (ca.ID = @candidateAssessmentID)  AND  (casv.SignedOff = 1)
+                                               AND (NOT (casv.Verified IS NULL))) Supervisor ON  LearnerDetails.Id =Supervisor.Id
+                                 ORDER BY Verified DESC",
                 new { candidateAssessmentID }
             );
         }


### PR DESCRIPTION
### JIRA link
[TD-4093](https://hee-tis.atlassian.net/browse/TD-4093)

### Description
Fixes the query joins in the SQL returning data for self assessment certificates to ensure that data is returned even if some non-essential related data does not exist.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4093]: https://hee-tis.atlassian.net/browse/TD-4093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ