### PR TITLE
TD-3956 Replace user research link for participant recruitment on DLS

### DIFF
--- a/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
@@ -48,6 +48,8 @@
         private const string LearningHubAuthenticationClientSecret = "LearningHubAuthentication:ClientSecret";
 
         private const string LearningHubUserAPIUserAPIUrl = "LearningHubUserApi:UserApiUrl";
+        private const string UserResearchUrlName = "UserResearchUrl";
+
         public static string GetAppRootPath(this IConfiguration config)
         {
             return config[AppRootPathName];
@@ -200,6 +202,10 @@
         public static string GetLearningHubUserApiUrl(this IConfiguration config)
         {
             return config[LearningHubUserAPIUserAPIUrl];
+        }
+        public static string GetUserResearchUrl(this IConfiguration config)
+        {
+            return config[UserResearchUrlName];
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
@@ -50,49 +50,49 @@
         private const string LearningHubUserAPIUserAPIUrl = "LearningHubUserApi:UserApiUrl";
         private const string UserResearchUrlName = "UserResearchUrl";
 
-        public static string? GetAppRootPath(this IConfiguration config)
+        public static string GetAppRootPath(this IConfiguration config)
         {
-            return config[AppRootPathName];
+            return config[AppRootPathName]!;
         }
 
-        public static string? GetCurrentSystemBaseUrl(this IConfiguration config)
+        public static string GetCurrentSystemBaseUrl(this IConfiguration config)
         {
-            return config[CurrentSystemBaseUrlName];
+            return config[CurrentSystemBaseUrlName]!;
         }
 
-        public static string? GetLearningHubOpenApiKey(this IConfiguration config)
+        public static string GetLearningHubOpenApiKey(this IConfiguration config)
         {
-            return config[LearningHubOpenApiKey];
+            return config[LearningHubOpenApiKey]!;
         }
 
-        public static string? GetLearningHubOpenApiBaseUrl(this IConfiguration config)
+        public static string GetLearningHubOpenApiBaseUrl(this IConfiguration config)
         {
-            return config[LearningHubOpenApiBaseUrl];
+            return config[LearningHubOpenApiBaseUrl]!;
         }
 
-        public static string? GetLearningHubAuthApiBaseUrl(this IConfiguration config)
+        public static string GetLearningHubAuthApiBaseUrl(this IConfiguration config)
         {
-            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthBaseUrl}"];
+            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthBaseUrl}"]!;
         }
 
-        public static string? GetLearningHubAuthApiClientCode(this IConfiguration config)
+        public static string GetLearningHubAuthApiClientCode(this IConfiguration config)
         {
-            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthClientCode}"];
+            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthClientCode}"]!;
         }
 
-        public static string? GetLearningHubAuthApiSsoClientCode(this IConfiguration config)
+        public static string GetLearningHubAuthApiSsoClientCode(this IConfiguration config)
         {
-            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthSsoClientCode}"];
+            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthSsoClientCode}"]!;
         }
 
-        public static string? GetLearningHubAuthApiLoginEndpoint(this IConfiguration config)
+        public static string GetLearningHubAuthApiLoginEndpoint(this IConfiguration config)
         {
-            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthLoginEndpoint}"];
+            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthLoginEndpoint}"]!;
         }
 
-        public static string? GetLearningHubAuthApiLinkingEndpoint(this IConfiguration config)
+        public static string GetLearningHubAuthApiLinkingEndpoint(this IConfiguration config)
         {
-            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthLinkingEndpoint}"];
+            return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthLinkingEndpoint}"]!;
         }
 
         public static bool IsSignpostingUsed(this IConfiguration config)
@@ -125,14 +125,14 @@
             return ssoByteLength;
         }
 
-        public static string? GetLearningHubSsoSecretKey(this IConfiguration config)
+        public static string GetLearningHubSsoSecretKey(this IConfiguration config)
         {
-            return config[$"{LearningHubSsoSectionKey}:{LearningHubSsoSecretKey}"];
+            return config[$"{LearningHubSsoSectionKey}:{LearningHubSsoSecretKey}"]!;
         }
 
-        public static string? GetMapsApiKey(this IConfiguration config)
+        public static string GetMapsApiKey(this IConfiguration config)
         {
-            return config[MapsApiKey];
+            return config[MapsApiKey]!;
         }
 
         public static int GetJavascriptSearchSortFilterPaginateItemLimit(this IConfiguration config)
@@ -147,25 +147,25 @@
             return userDetailsCheckKey;
         }
 
-        public static string? GetExcelPassword(this IConfiguration config)
+        public static string GetExcelPassword(this IConfiguration config)
         {
-            return config[ExcelPassword];
+            return config[ExcelPassword]!;
         }
-        public static string? GetLearningHubReportApiBaseUrl(this IConfiguration config)
+        public static string GetLearningHubReportApiBaseUrl(this IConfiguration config)
         {
-            return config[LearningHubReportAPIBaseUrl];
+            return config[LearningHubReportAPIBaseUrl]!;
         }
-        public static string? GetLearningHubReportApiClientId(this IConfiguration config)
+        public static string GetLearningHubReportApiClientId(this IConfiguration config)
         {
-            return config[LearningHubReportAPIClientId];
+            return config[LearningHubReportAPIClientId]!;
         }
-        public static string? GetLearningHubReportApiClientIdentityKey(this IConfiguration config)
+        public static string GetLearningHubReportApiClientIdentityKey(this IConfiguration config)
         {
-            return config[LearningHubReportAPIClientIdentityKey];
+            return config[LearningHubReportAPIClientIdentityKey]!;
         }
-        public static string? GetCookieBannerConsentCookieName(this IConfiguration config)
+        public static string GetCookieBannerConsentCookieName(this IConfiguration config)
         {
-            return config[CookieBannerConsentCookieName];
+            return config[CookieBannerConsentCookieName]!;
         }
 
         public static int GetCookieBannerConsentExpiryDays(this IConfiguration config)
@@ -184,19 +184,19 @@
             return limitKey;
         }
 
-        public static string? GetLearningHubAuthenticationAuthority(this IConfiguration config)
+        public static string GetLearningHubAuthenticationAuthority(this IConfiguration config)
         {
-            return config[LearningHubAuthenticationAuthority];
+            return config[LearningHubAuthenticationAuthority]!;
         }
 
-        public static string? GetLearningHubAuthenticationClientId(this IConfiguration config)
+        public static string GetLearningHubAuthenticationClientId(this IConfiguration config)
         {
-            return config[LearningHubAuthenticationClientId];
+            return config[LearningHubAuthenticationClientId]!;
         }
 
-        public static string? GetLearningHubAuthenticationClientSecret(this IConfiguration config)
+        public static string GetLearningHubAuthenticationClientSecret(this IConfiguration config)
         {
-            return config[LearningHubAuthenticationClientSecret];
+            return config[LearningHubAuthenticationClientSecret]!;
         }
 
         public static long GetFreshdeskCreateTicketGroupId(this IConfiguration config)
@@ -210,13 +210,13 @@
             return ticketProductId;
         }
 
-        public static string? GetLearningHubUserApiUrl(this IConfiguration config)
+        public static string GetLearningHubUserApiUrl(this IConfiguration config)
         {
-            return config[LearningHubUserAPIUserAPIUrl];
+            return config[LearningHubUserAPIUserAPIUrl]!;
         }
-        public static string? GetUserResearchUrl(this IConfiguration config)
+        public static string GetUserResearchUrl(this IConfiguration config)
         {
-            return config[UserResearchUrlName];
+            return config[UserResearchUrlName]!;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
@@ -50,113 +50,120 @@
         private const string LearningHubUserAPIUserAPIUrl = "LearningHubUserApi:UserApiUrl";
         private const string UserResearchUrlName = "UserResearchUrl";
 
-        public static string GetAppRootPath(this IConfiguration config)
+        public static string? GetAppRootPath(this IConfiguration config)
         {
             return config[AppRootPathName];
         }
 
-        public static string GetCurrentSystemBaseUrl(this IConfiguration config)
+        public static string? GetCurrentSystemBaseUrl(this IConfiguration config)
         {
             return config[CurrentSystemBaseUrlName];
         }
 
-        public static string GetLearningHubOpenApiKey(this IConfiguration config)
+        public static string? GetLearningHubOpenApiKey(this IConfiguration config)
         {
             return config[LearningHubOpenApiKey];
         }
 
-        public static string GetLearningHubOpenApiBaseUrl(this IConfiguration config)
+        public static string? GetLearningHubOpenApiBaseUrl(this IConfiguration config)
         {
             return config[LearningHubOpenApiBaseUrl];
         }
 
-        public static string GetLearningHubAuthApiBaseUrl(this IConfiguration config)
+        public static string? GetLearningHubAuthApiBaseUrl(this IConfiguration config)
         {
             return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthBaseUrl}"];
         }
 
-        public static string GetLearningHubAuthApiClientCode(this IConfiguration config)
+        public static string? GetLearningHubAuthApiClientCode(this IConfiguration config)
         {
             return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthClientCode}"];
         }
 
-        public static string GetLearningHubAuthApiSsoClientCode(this IConfiguration config)
+        public static string? GetLearningHubAuthApiSsoClientCode(this IConfiguration config)
         {
             return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthSsoClientCode}"];
         }
 
-        public static string GetLearningHubAuthApiLoginEndpoint(this IConfiguration config)
+        public static string? GetLearningHubAuthApiLoginEndpoint(this IConfiguration config)
         {
             return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthLoginEndpoint}"];
         }
 
-        public static string GetLearningHubAuthApiLinkingEndpoint(this IConfiguration config)
+        public static string? GetLearningHubAuthApiLinkingEndpoint(this IConfiguration config)
         {
             return config[$"{LearningHubSsoSectionKey}:{LearningHubAuthLinkingEndpoint}"];
         }
 
         public static bool IsSignpostingUsed(this IConfiguration config)
         {
-            return bool.Parse(config[UseSignposting]);
+            bool.TryParse(config[UseSignposting], out bool isEnabled);
+            return isEnabled;
         }
 
         public static bool IsPricingPageEnabled(this IConfiguration config)
         {
-            return bool.Parse(config[PricingPageEnabled]);
+            bool.TryParse(config[PricingPageEnabled], out bool isEnabled);
+            return isEnabled;
         }
 
         public static int GetLearningHubSsoHashTolerance(this IConfiguration config)
         {
-            return int.Parse(config[$"{LearningHubSsoSectionKey}:{LearningHubSsoToleranceKey}"]);
+            int.TryParse(config[$"{LearningHubSsoSectionKey}:{LearningHubSsoToleranceKey}"], out int ssoHashTolerance);
+            return ssoHashTolerance;
         }
 
         public static int GetLearningHubSsoHashIterations(this IConfiguration config)
         {
-            return int.Parse(config[$"{LearningHubSsoSectionKey}:{LearningHubSsoIterationsKey}"]);
+            int.TryParse(config[$"{LearningHubSsoSectionKey}:{LearningHubSsoIterationsKey}"], out int ssoIterationsKey);
+            return ssoIterationsKey;
         }
 
         public static int GetLearningHubSsoByteLength(this IConfiguration config)
         {
-            return int.Parse(config[$"{LearningHubSsoSectionKey}:{LearningHubSsoByteLengthKey}"]);
+            int.TryParse(config[$"{LearningHubSsoSectionKey}:{LearningHubSsoByteLengthKey}"], out int ssoByteLength);
+            return ssoByteLength;
         }
 
-        public static string GetLearningHubSsoSecretKey(this IConfiguration config)
+        public static string? GetLearningHubSsoSecretKey(this IConfiguration config)
         {
             return config[$"{LearningHubSsoSectionKey}:{LearningHubSsoSecretKey}"];
         }
 
-        public static string GetMapsApiKey(this IConfiguration config)
+        public static string? GetMapsApiKey(this IConfiguration config)
         {
             return config[MapsApiKey];
         }
 
         public static int GetJavascriptSearchSortFilterPaginateItemLimit(this IConfiguration config)
         {
-            return int.Parse(config[JavascriptSearchSortFilterPaginateItemLimitKey]);
+            int.TryParse(config[JavascriptSearchSortFilterPaginateItemLimitKey], out int filterPaginateItemLimitKey);
+            return filterPaginateItemLimitKey;
         }
 
         public static int GetMonthsToPromptUserDetailsCheck(this IConfiguration config)
         {
-            return int.Parse(config[MonthsToPromptUserDetailsCheckKey]);
+            int.TryParse(config[MonthsToPromptUserDetailsCheckKey], out int userDetailsCheckKey);
+            return userDetailsCheckKey;
         }
 
-        public static string GetExcelPassword(this IConfiguration config)
+        public static string? GetExcelPassword(this IConfiguration config)
         {
             return config[ExcelPassword];
         }
-        public static string GetLearningHubReportApiBaseUrl(this IConfiguration config)
+        public static string? GetLearningHubReportApiBaseUrl(this IConfiguration config)
         {
             return config[LearningHubReportAPIBaseUrl];
         }
-        public static string GetLearningHubReportApiClientId(this IConfiguration config)
+        public static string? GetLearningHubReportApiClientId(this IConfiguration config)
         {
             return config[LearningHubReportAPIClientId];
         }
-        public static string GetLearningHubReportApiClientIdentityKey(this IConfiguration config)
+        public static string? GetLearningHubReportApiClientIdentityKey(this IConfiguration config)
         {
             return config[LearningHubReportAPIClientIdentityKey];
         }
-        public static string GetCookieBannerConsentCookieName(this IConfiguration config)
+        public static string? GetCookieBannerConsentCookieName(this IConfiguration config)
         {
             return config[CookieBannerConsentCookieName];
         }
@@ -168,42 +175,46 @@
         }
         public static int GetExportQueryRowLimit(this IConfiguration config)
         {
-            return int.Parse(config[ExportQueryRowLimitKey]);
+            int.TryParse(config[ExportQueryRowLimitKey], out int limitKey);
+            return limitKey;
         }
         public static int GetMaxBulkUploadRowsLimit(this IConfiguration config)
         {
-            return int.Parse(config[MaxBulkUploadRowsLimitKey]);
+             int.TryParse(config[MaxBulkUploadRowsLimitKey],out int limitKey);
+            return limitKey;
         }
 
-        public static string GetLearningHubAuthenticationAuthority(this IConfiguration config)
+        public static string? GetLearningHubAuthenticationAuthority(this IConfiguration config)
         {
             return config[LearningHubAuthenticationAuthority];
         }
 
-        public static string GetLearningHubAuthenticationClientId(this IConfiguration config)
+        public static string? GetLearningHubAuthenticationClientId(this IConfiguration config)
         {
             return config[LearningHubAuthenticationClientId];
         }
 
-        public static string GetLearningHubAuthenticationClientSecret(this IConfiguration config)
+        public static string? GetLearningHubAuthenticationClientSecret(this IConfiguration config)
         {
             return config[LearningHubAuthenticationClientSecret];
         }
 
         public static long GetFreshdeskCreateTicketGroupId(this IConfiguration config)
         {
-            return long.Parse(config[FreshdeskCreateTicketGroupId]);
+           long.TryParse(config[FreshdeskCreateTicketGroupId], out long ticketGroupId);
+            return ticketGroupId;
         }
         public static long GetFreshdeskCreateTicketProductId(this IConfiguration config)
         {
-            return long.Parse(config[FreshdeskCreateTicketProductId]);
+            long.TryParse(config[FreshdeskCreateTicketProductId], out long ticketProductId);
+            return ticketProductId;
         }
 
-        public static string GetLearningHubUserApiUrl(this IConfiguration config)
+        public static string? GetLearningHubUserApiUrl(this IConfiguration config)
         {
             return config[LearningHubUserAPIUserAPIUrl];
         }
-        public static string GetUserResearchUrl(this IConfiguration config)
+        public static string? GetUserResearchUrl(this IConfiguration config)
         {
             return config[UserResearchUrlName];
         }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
@@ -12,6 +12,7 @@ using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
 using GDS.MultiPageFormData.Enums;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Configuration;
+using static Org.BouncyCastle.Math.EC.ECCurve;
 
 namespace DigitalLearningSolutions.Web.Tests.Controllers
 {
@@ -26,13 +27,14 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         private IUserFeedbackDataService _userFeedbackDataService = null!;
         private IMultiPageFormService _multiPageFormService = null!;
         private ITempDataDictionary _tempData = null!;
-        private readonly IConfiguration config = null!;
+        private IConfiguration config = null!;
 
         [SetUp]
         public void SetUp()
         {
             _userFeedbackDataService = A.Fake<IUserFeedbackDataService>();
             _multiPageFormService = A.Fake<IMultiPageFormService>();
+            config = A.Fake<IConfiguration>();
             _userFeedbackController = new UserFeedbackController(_userFeedbackDataService, _multiPageFormService, config)
                 .WithDefaultContext()
                 .WithMockUser(true, userId: LoggedInUserId);

--- a/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
@@ -11,6 +11,7 @@ using DigitalLearningSolutions.Data.Models.UserFeedback;
 using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
 using GDS.MultiPageFormData.Enums;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Configuration;
 
 namespace DigitalLearningSolutions.Web.Tests.Controllers
 {
@@ -25,13 +26,14 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         private IUserFeedbackDataService _userFeedbackDataService = null!;
         private IMultiPageFormService _multiPageFormService = null!;
         private ITempDataDictionary _tempData = null!;
+        private readonly IConfiguration config = null!;
 
         [SetUp]
         public void SetUp()
         {
             _userFeedbackDataService = A.Fake<IUserFeedbackDataService>();
             _multiPageFormService = A.Fake<IMultiPageFormService>();
-            _userFeedbackController = new UserFeedbackController(_userFeedbackDataService, _multiPageFormService)
+            _userFeedbackController = new UserFeedbackController(_userFeedbackDataService, _multiPageFormService, config)
                 .WithDefaultContext()
                 .WithMockUser(true, userId: LoggedInUserId);
             _tempData = A.Fake<ITempDataDictionary>();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
@@ -12,7 +12,7 @@ using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
 using GDS.MultiPageFormData.Enums;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Configuration;
-using static Org.BouncyCastle.Math.EC.ECCurve;
+using DigitalLearningSolutions.Data.Extensions;
 
 namespace DigitalLearningSolutions.Web.Tests.Controllers
 {
@@ -45,8 +45,8 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         [Test]
         public void UserFeedbackTaskAchieved_ShouldReturnCorrectView()
         {
-            // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+             // Given
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAchieved(userFeedbackViewModel) as ViewResult;
@@ -61,7 +61,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAttempted_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAttempted(userFeedbackViewModel) as ViewResult;
@@ -76,7 +76,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskDifficulty_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskDifficulty(userFeedbackViewModel) as ViewResult;
@@ -91,7 +91,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackComplete_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackComplete(userFeedbackViewModel) as ViewResult;
@@ -106,7 +106,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackStart_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.GuestFeedbackStart(userFeedbackViewModel) as ViewResult;
@@ -161,7 +161,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAchievedSet_ShouldRedirectToUserFeedbackTaskAttempted()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAchievedSet(userFeedbackViewModel) as RedirectToActionResult;
@@ -175,7 +175,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAttemptedSet_ShouldRedirectToUserFeedbackTaskDifficulty()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAttemptedSet(userFeedbackViewModel) as RedirectToActionResult;
@@ -189,7 +189,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskDifficultySet_ShouldRedirectToUserFeedbackSave()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskDifficultySet(userFeedbackViewModel) as RedirectToActionResult;
@@ -203,7 +203,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackSave_ShouldCallSaveUserFeedbackAndRedirectToUserFeedbackComplete()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
             A.CallTo(() => _multiPageFormService.GetMultiPageFormData<UserFeedbackTempData>(
                     MultiPageFormDataFeature.AddUserFeedback, _tempData))
                 .Returns(new UserFeedbackTempData());
@@ -222,7 +222,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackComplete_ShouldCallSaveUserFeedbackAndRenderGuestFeedbackCompleteView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
             userFeedbackViewModel.FeedbackText = FeedbackText;
 
             // When
@@ -239,7 +239,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackComplete_ShouldNotCallSaveUserFeedbackIfNoFeedbackProvided()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.GuestFeedbackComplete(userFeedbackViewModel) as RedirectToActionResult;
@@ -269,7 +269,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void StartUserFeedbackSession_ShouldSetTempDataAndRedirectToUserFeedbackTaskAchieved()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
             
             // When
             var result = _userFeedbackController.StartUserFeedbackSession(userFeedbackViewModel) as RedirectToActionResult;
@@ -285,7 +285,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAchieved_ShouldRenderUserFeedbackTaskAchievedView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAchieved(userFeedbackViewModel) as ViewResult;
@@ -299,7 +299,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAttempted_ShouldRenderUserFeedbackTaskAttemptedView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAttempted(userFeedbackViewModel) as ViewResult;
@@ -313,7 +313,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskDifficulty_ShouldRenderUserFeedbackTaskDifficultyView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskDifficulty(userFeedbackViewModel) as ViewResult;
@@ -327,7 +327,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackStart_ShouldRenderGuestFeedbackStartView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.GuestFeedbackStart(userFeedbackViewModel) as ViewResult;
@@ -341,7 +341,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackComplete_ShouldRenderUserFeedbackCompleteView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel();
+            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
 
             // When
             var result = _userFeedbackController.UserFeedbackComplete(userFeedbackViewModel) as ViewResult;

--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -11,21 +11,26 @@
     using GDS.MultiPageFormData.Enums;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.FeatureManagement.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using DigitalLearningSolutions.Data.Extensions;
 
     public class UserFeedbackController : Controller
     {
         private readonly IUserFeedbackDataService _userFeedbackDataService;
         private readonly IMultiPageFormService _multiPageFormService;
         private UserFeedbackViewModel _userFeedbackViewModel;
+        private readonly IConfiguration config;
 
         public UserFeedbackController(
             IUserFeedbackDataService userFeedbackDataService,
             IMultiPageFormService multiPageFormService
+            , IConfiguration config
         )
         {
             this._userFeedbackDataService = userFeedbackDataService;
             this._multiPageFormService = multiPageFormService;
             this._userFeedbackViewModel = new UserFeedbackViewModel();
+            this.config = config; 
         }
 
         [Route("/Index")]
@@ -277,7 +282,8 @@
         public IActionResult UserFeedbackComplete(UserFeedbackViewModel userFeedbackViewModel)
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
-
+            var userResearchUrl = config.GetUserResearchUrl();
+            userFeedbackViewModel.UserResearchUrl = userResearchUrl;
             return View("UserFeedbackComplete", userFeedbackViewModel);
         }
 
@@ -302,7 +308,8 @@
         [ResponseCache(CacheProfileName = "Never")]
         public IActionResult GuestFeedbackComplete()
         {
-            var userFeedbackModel = new UserFeedbackViewModel();
+            var userResearchUrl = config.GetUserResearchUrl();
+            var userFeedbackModel = new UserFeedbackViewModel(userResearchUrl);
 
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
 

--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -29,7 +29,7 @@
         {
             this._userFeedbackDataService = userFeedbackDataService;
             this._multiPageFormService = multiPageFormService;
-            this._userFeedbackViewModel = new UserFeedbackViewModel();
+            this._userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
             this.config = config; 
         }
 
@@ -40,7 +40,7 @@
 
             _multiPageFormService.ClearMultiPageFormData(MultiPageFormDataFeature.AddUserFeedback, TempData);
             
-            _userFeedbackViewModel = new()
+            _userFeedbackViewModel = new(config.GetUserResearchUrl())
             {
                 UserId = User.GetUserId(),
                 UserRoles = DeriveUserRoles(),

--- a/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
@@ -2,11 +2,6 @@
 {
     public class UserFeedbackViewModel
     {
-        public UserFeedbackViewModel()
-        {
-
-        }
-
         public UserFeedbackViewModel(string userResearchUrl)
         {
             UserId = null;

--- a/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
@@ -4,6 +4,11 @@
     {
         public UserFeedbackViewModel()
         {
+
+        }
+
+        public UserFeedbackViewModel(string userResearchUrl)
+        {
             UserId = null;
             UserRoles = null;
             SourceUrl = null;
@@ -12,6 +17,7 @@
             TaskAttempted = null;
             FeedbackText = null;
             TaskRating = null;
+            UserResearchUrl = userResearchUrl;
         }
 
         public int? UserId { get; set; }
@@ -22,5 +28,8 @@
         public string? TaskAttempted { get; set; }
         public string? FeedbackText { get; set; }
         public int? TaskRating { get; set; }
+        public string UserResearchUrl { get; set; }
+
+        
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -3,7 +3,10 @@
 @using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @inject IClockUtility ClockUtility
-
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
+@{
+    var userResearchUrl = Configuration["UserResearchUrl"];
+}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -67,7 +70,7 @@
                 </div>
             </div>
             <feature name="@(FeatureFlags.UserFeedbackBar)">
-                <partial name="_UserFeedbackBarPartial" />
+                <partial name="_UserFeedbackBarPartial" model=@(userResearchUrl) />
             </feature>
         </header>
         <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -21,6 +21,7 @@
     }
     var headerExtension = (string)ViewData[LayoutViewDataKeys.Application];
     var shouldDisplayHelpMenuItem = dlsSubApplication?.DisplayHelpMenuItem ?? headerExtension != DlsSubApplication.TrackingSystem.HeaderExtension;
+    var userResearchUrl = Configuration["UserResearchUrl"];
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -155,7 +156,7 @@
                 <div class="visual-separator @visualSeparatorNoNavBar"></div>
 
                 <feature name="@(FeatureFlags.UserFeedbackBar)">
-                    <partial name="_UserFeedbackBarPartial" />
+                    <partial name="_UserFeedbackBarPartial" model=@(userResearchUrl) />
                 </feature>
             </div>
 

--- a/DigitalLearningSolutions.Web/Views/Shared/_UserFeedbackBarPartial.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_UserFeedbackBarPartial.cshtml
@@ -1,7 +1,8 @@
 ﻿@using DigitalLearningSolutions.Web.Helpers
+@using DigitalLearningSolutions.Web.ViewModels.UserFeedback;
 @using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.Mvc.TagHelpers
-
+@model string 
 @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] != true)
 {
     @if (User.Identity.IsAuthenticated)
@@ -15,7 +16,7 @@
                     </div>
                     <a asp-controller="UserFeedback" asp-action="Index" asp-route-sourceurl="@Context.Request.GetDisplayUrl()"
                asp-route-sourcePageTitle="@(ViewData.ContainsKey("Title") ? ViewData["Title"].ToString() : string.Empty)">Give page feedback</a>
-                    or <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=K5Gn_5ewMUGcD9DoB1Wyqy_N2dia4StEr8rvzDM1MnlUNEhQUDk4UVpHUDc2N0g4OTZGNFRBNktLOC4u" target="_blank">join our research panel</a> - this website is in
+                    or <a href="@Model" target="_blank">join our research panel</a> - this website is in
                     <a href="https://www.gov.uk/help/beta" target="_blank">Beta</a>, your feedback will help us improve this platform.
                 </div>
             </div>

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackComplete.cshtml
@@ -9,7 +9,7 @@
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 
-<p><a href="https://forms.office.com/Pages/ResponsePage.aspx?id=K5Gn_5ewMUGcD9DoB1Wyqy_N2dia4StEr8rvzDM1MnlUNEhQUDk4UVpHUDc2N0g4OTZGNFRBNktLOC4u" target="_blank">Join our user research panel</a></p>
+<p><a href="@Model.UserResearchUrl" target="_blank">Join our user research panel</a></p>
 
 <h1>Thank you for your feedback</h1>
 

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackComplete.cshtml
@@ -39,7 +39,7 @@
 
         <h3>Help us improve our website</h3>
 
-        <p>Would you like to <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=K5Gn_5ewMUGcD9DoB1Wyqy_N2dia4StEr8rvzDM1MnlUNEhQUDk4UVpHUDc2N0g4OTZGNFRBNktLOC4u" target="_blank">join our research panel</a> and help us improve the experience of our website?</p>
+        <p>Would you like to <a href="@Model.UserResearchUrl" target="_blank">join our research panel</a> and help us improve the experience of our website?</p>
 
         <p>We will not use your details for any purpose other than to get feedback about our services to help us make improvements in the future. You can opt out at any time.</p>
 

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -76,5 +76,6 @@
   },
   "LearningHubUserApi": {
     "UserApiUrl": "https://userapi.learninghub.nhs.uk/api/"
-  }
+  },
+  "UserResearchUrl": "https://forms.office.com/e/nKcK8AdHRX"
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3956

### Description
I added the new user research URL to the  appsettings config
I replace the old user research URL with the new URL
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/933b232b-cec4-4b70-9876-a574a5b60465)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/1226983b-5351-4d17-8a2e-2928914c0afc)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c2cfe146-f2cd-4211-bae3-0720c029fdcd)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
