### PR TITLE
TD-3835 Fixes to grouping - only group active delegates and group all delegates in upload

### DIFF
--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/BulkUploadResult.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/BulkUploadResult.cs
@@ -42,16 +42,20 @@
         )
         {
             ProcessedCount = delegateRows.Count;
-            RegisteredCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.Registered);
-            UpdatedCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.Updated);
+            RegisteredActiveCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.RegisteredActive);
+            RegisteredInactiveCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.RegsiteredInactive);
+            UpdatedActiveCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.UpdatedActive);
+            UpdatedInactiveCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.UpdatedInactive);
             SkippedCount = delegateRows.Count(dr => dr.RowStatus == RowStatus.Skipped);
             Errors = delegateRows.Where(dr => dr.Error.HasValue).Select(dr => (dr.RowNumber, dr.Error!.Value));
         }
 
         public IEnumerable<(int RowNumber, ErrorReason Reason)>? Errors { get; set; }
         public int ProcessedCount { get; set; }
-        public int RegisteredCount { get; set; }
-        public int UpdatedCount { get; set; }
+        public int RegisteredActiveCount { get; set; }
+        public int RegisteredInactiveCount { get; set; }
+        public int UpdatedActiveCount { get; set; }
+        public int UpdatedInactiveCount { get; set; }
         public int SkippedCount { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
@@ -13,8 +13,10 @@
     {
         NotYetProcessed,
         Skipped,
-        Registered,
-        Updated,
+        RegisteredActive,
+        RegsiteredInactive,
+        UpdatedActive,
+        UpdatedInactive
     }
 
     public class DelegateTableRow

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -395,7 +395,7 @@
                 .MustNotHaveHappened();
 
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(1);
+            result.UpdatedActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -454,7 +454,7 @@
 
             // Then
             result.ProcessedCount.Should().Be(1);
-            result.RegisteredCount.Should().Be(1);
+            result.RegisteredActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -501,7 +501,7 @@
             ).MustNotHaveHappened();
 
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(1);
+            result.UpdatedActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -695,7 +695,7 @@
                     )
             ).MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(1);
+            result.UpdatedActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -730,7 +730,7 @@
                     )
             ).MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(1);
+            result.UpdatedActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -766,7 +766,7 @@
                     )
             ).MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(1);
+            result.UpdatedActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -801,7 +801,7 @@
                     )
             ).MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(1);
+            result.UpdatedActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -867,7 +867,7 @@
                 )
             ).MustHaveHappenedOnceExactly();
             result.ProcessedCount.Should().Be(1);
-            result.RegisteredCount.Should().Be(1);
+            result.RegisteredActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -920,7 +920,7 @@
                 )
                 .MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
-            result.RegisteredCount.Should().Be(1);
+            result.RegisteredActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -967,7 +967,7 @@
                 )
                 .MustHaveHappened();
             result.ProcessedCount.Should().Be(1);
-            result.RegisteredCount.Should().Be(1);
+            result.RegisteredActiveCount.Should().Be(1);
         }
 
         [Test]
@@ -1148,7 +1148,7 @@
 
             // Then
             result.ProcessedCount.Should().Be(5);
-            result.UpdatedCount.Should().Be(5);
+            result.UpdatedActiveCount.Should().Be(5);
         }
 
         [Test]
@@ -1205,7 +1205,7 @@
 
             // Then
             result.ProcessedCount.Should().Be(5);
-            result.RegisteredCount.Should().Be(5);
+            result.RegisteredActiveCount.Should().Be(5);
         }
 
         [Test]
@@ -1261,9 +1261,9 @@
             using (new AssertionScope())
             {
                 result.ProcessedCount.Should().Be(10);
-                result.UpdatedCount.Should().Be(4);
+                result.UpdatedActiveCount.Should().Be(4);
                 result.SkippedCount.Should().Be(3);
-                result.RegisteredCount.Should().Be(2);
+                result.RegisteredActiveCount.Should().Be(2);
                 result.Errors.Should().HaveCount(1);
             }
         }
@@ -1419,8 +1419,8 @@
         private void AssertBulkUploadResultHasOnlyOneError(BulkUploadResult result)
         {
             result.ProcessedCount.Should().Be(1);
-            result.UpdatedCount.Should().Be(0);
-            result.RegisteredCount.Should().Be(0);
+            result.UpdatedActiveCount.Should().Be(0);
+            result.RegisteredActiveCount.Should().Be(0);
             result.SkippedCount.Should().Be(0);
             result.Errors.Should().HaveCount(1);
         }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterDelegateByCentreController.cs
@@ -169,7 +169,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             var data = GetDelegateRegistrationByCentreData();
             var centreId = User.GetCentreIdKnownNotNull();
             var groupSelect = groupsService.GetUnlinkedGroupsSelectListForCentre(centreId, data.ExistingGroupId);
-            var model = new AddToGroupViewModel(data.AddToGroupOption, existingGroups: groupSelect, data.ExistingGroupId, data.NewGroupName, data.NewGroupDescription, true, false);
+            var model = new AddToGroupViewModel(data.AddToGroupOption, existingGroups: groupSelect, data.ExistingGroupId, data.NewGroupName, data.NewGroupDescription, 1, 0, 0, 0);
             return View(model);
         }
 
@@ -193,8 +193,10 @@ namespace DigitalLearningSolutions.Web.Controllers.Register
             {
                 var groupSelect = groupsService.GetUnlinkedGroupsSelectListForCentre(centreId, data.ExistingGroupId);
                 model.ExistingGroups = groupSelect;
-                model.RegisteringDelegates = true;
-                model.UpdatingDelegates = false;
+                model.RegisteringActiveDelegates = 1;
+                model.UpdatingActiveDelegates = 0;
+                model.RegisteringInactiveDelegates = 0;
+                model.UpdatingInactiveDelegates = 0;
                 return View("AddToGroup", model);
             }
             data.AddToGroupOption = model.AddToGroupOption;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -239,7 +239,7 @@
             {
                 return RedirectToAction("UploadSummary");
             }
-            var model = new AddWhoToGroupViewModel(groupName!, data.IncludeUpdatedDelegates, data.ToProcessCount, data.ToRegisterActiveCount);
+            var model = new AddWhoToGroupViewModel(groupName!, data.IncludeUpdatedDelegates, data.ToUpdateActiveCount, data.ToRegisterActiveCount);
             return View(model);
         }
 

--- a/DigitalLearningSolutions.Web/Models/BulkUploadData.cs
+++ b/DigitalLearningSolutions.Web/Models/BulkUploadData.cs
@@ -16,8 +16,10 @@
             DelegatesFileName = delegatesFileName;
             MaxRowsToProcess = maxRowsToProcess;
             ToProcessCount = 0;
-            ToRegisterCount = 0;
-            ToUpdateCount = 0;
+            ToRegisterActiveCount = 0;
+            ToRegisterInactiveCount = 0;
+            ToUpdateActiveCount = 0;
+            ToUpdateInactiveCount = 0;
             IncludeUpdatedDelegates = false;
             Day = today.Day;
             Month = today.Month;
@@ -35,8 +37,10 @@
         public string? NewGroupDescription { get; set; }
         public int? ExistingGroupId { get; set; }
         public int ToProcessCount { get; set; }
-        public int ToRegisterCount { get; set; }
-        public int ToUpdateCount { get; set; }
+        public int ToRegisterActiveCount { get; set; }
+        public int ToRegisterInactiveCount { get; set; }
+        public int ToUpdateActiveCount { get; set; }
+        public int ToUpdateInactiveCount { get; set; }
         public int MaxRowsToProcess { get; set; }
         public bool IncludeUpdatedDelegates { get; set; }
         public int LastRowProcessed { get; set; }

--- a/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
@@ -195,6 +195,11 @@ namespace DigitalLearningSolutions.Web.Services
                 if (delegateRow.MatchesDelegateEntity(delegateEntity))
                 {
                     delegateRow.RowStatus = RowStatus.Skipped;
+                    if (delegateRow.Error == null && (bool)delegateRow.Active && includeUpdatedDelegatesInGroup && delegateGroupId != null)
+                    {
+                        //Add delegate to group
+                        groupsService.AddDelegateToGroup((int)delegateGroupId, delegateEntity.DelegateAccount.Id, adminId);
+                    }
                     return;
                 }
 
@@ -208,7 +213,7 @@ namespace DigitalLearningSolutions.Web.Services
                 }
 
                 UpdateDelegate(delegateRow, delegateEntity);
-                if (delegateRow.Error == null && includeUpdatedDelegatesInGroup && delegateGroupId != null)
+                if (delegateRow.Error == null && (bool)delegateRow.Active && includeUpdatedDelegatesInGroup && delegateGroupId != null)
                 {
                     //Add delegate to group
                     groupsService.AddDelegateToGroup((int)delegateGroupId, delegateEntity.DelegateAccount.Id, adminId);
@@ -314,7 +319,7 @@ namespace DigitalLearningSolutions.Web.Services
                 welcomeEmailDate,
                 "DelegateBulkUpload_Refactor"
             );
-            if (delegateGroupId != null)
+            if (delegateGroupId != null && (bool)delegateTableRow.Active)
             {
                 //Add delegate to group
                 groupsService.AddDelegateToGroup((int)delegateGroupId, delegateId, adminId);

--- a/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateUploadFileService.cs
@@ -156,11 +156,11 @@ namespace DigitalLearningSolutions.Web.Services
             }
             if (string.IsNullOrEmpty(delegateRow.CandidateNumber))
             {
-                delegateRow.RowStatus = RowStatus.Registered;
+                delegateRow.RowStatus = (bool)delegateRow.Active ? RowStatus.RegisteredActive : RowStatus.RegsiteredInactive;
             }
             else
             {
-                delegateRow.RowStatus = RowStatus.Updated;
+                delegateRow.RowStatus = (bool)delegateRow.Active ? RowStatus.UpdatedActive : RowStatus.UpdatedInactive;
             }
         }
 
@@ -285,7 +285,7 @@ namespace DigitalLearningSolutions.Web.Services
                     delegateRow.Email
                 );
 
-                delegateRow.RowStatus = RowStatus.Updated;
+                delegateRow.RowStatus = (bool)delegateRow.Active ? RowStatus.UpdatedActive : RowStatus.UpdatedInactive;
             }
             catch
             {
@@ -319,7 +319,7 @@ namespace DigitalLearningSolutions.Web.Services
                 //Add delegate to group
                 groupsService.AddDelegateToGroup((int)delegateGroupId, delegateId, adminId);
             }
-            delegateTableRow.RowStatus = RowStatus.Registered;
+            delegateTableRow.RowStatus = (bool)delegateTableRow.Active ? RowStatus.RegisteredActive : RowStatus.RegsiteredInactive;
         }
 
         private void UpdateUserProfessionalRegistrationNumberIfNecessary(

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/AddToGroupViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/AddToGroupViewModel.cs
@@ -13,8 +13,10 @@
             int? existingGroupId,
             string? newGroupName,
             string? newGroupDescription,
-            bool registeringDelegates,
-            bool updatingDelegates
+            int registeringActiveDelegates,
+            int updatingActiveDelegates,
+            int registeringInactiveDelegates,
+            int updatingInactiveDelegates
             )
         {
             AddToGroupOption = addToGroupOption;
@@ -22,8 +24,10 @@
             ExistingGroupId = existingGroupId;
             NewGroupName = newGroupName;
             NewGroupDescription = newGroupDescription;
-            RegisteringDelegates = registeringDelegates;
-            UpdatingDelegates = updatingDelegates;
+            RegisteringActiveDelegates = registeringActiveDelegates;
+            UpdatingActiveDelegates = updatingActiveDelegates;
+            RegisteringInactiveDelegates = registeringInactiveDelegates;
+            UpdatingInactiveDelegates = updatingInactiveDelegates;
         }
         [Required(ErrorMessage = "Please select an option.")]
         public int? AddToGroupOption { get; set; }
@@ -31,8 +35,10 @@
         public int? ExistingGroupId { get; set; }
         public string? NewGroupName { get; set; }
         public string? NewGroupDescription { get; set; }
-        public bool RegisteringDelegates { get; set; }
-        public bool UpdatingDelegates { get; set; }
+        public int RegisteringActiveDelegates { get; set; }
+        public int UpdatingActiveDelegates { get; set; }
+        public int RegisteringInactiveDelegates { get; set; }
+        public int UpdatingInactiveDelegates { get; set; }
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if (AddToGroupOption == 1 && (ExistingGroupId == null || ExistingGroupId <= 0))

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/AddWhoToGroupViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/AddWhoToGroupViewModel.cs
@@ -6,18 +6,18 @@
         public AddWhoToGroupViewModel(
             string groupName,
             bool includeUpdatedDelegates,
-            int toProcessCount,
-            int toRegisterCount
+            int toUpdateActiveCount,
+            int toRegisterActiveCount
             )
         {
             GroupName = groupName;
             IncludeUpdatedDelegates = includeUpdatedDelegates;
-            ToProcessCount = toProcessCount;
-            ToRegisterCount = toRegisterCount;
+            ToUpdateActiveCount = toUpdateActiveCount;
+            ToRegisterActiveCount = toRegisterActiveCount;
         }
         public string? GroupName { get; set; }
         public bool IncludeUpdatedDelegates { get; set; }
-        public int ToProcessCount { get; set; }
-        public int ToRegisterCount { get; set; }
+        public int ToUpdateActiveCount { get; set; }
+        public int ToRegisterActiveCount { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadPreProcessViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadPreProcessViewModel.cs
@@ -3,19 +3,19 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using ClosedXML.Excel;
-    using DigitalLearningSolutions.Data.Models.Centres;
     using DigitalLearningSolutions.Data.Models.DelegateUpload;
-    using DigitalLearningSolutions.Web.Services;
-    using Microsoft.AspNetCore.Http;
 
     public class BulkUploadPreProcessViewModel : UploadDelegatesViewModel
     {
         public BulkUploadPreProcessViewModel(BulkUploadResult bulkUploadResult)
         {
             ToProcessCount = bulkUploadResult.ProcessedCount;
-            ToRegisterCount = bulkUploadResult.RegisteredCount;
-            ToUpdateOrSkipCount = bulkUploadResult.UpdatedCount;
+            ToRegisterCount = bulkUploadResult.RegisteredActiveCount + bulkUploadResult.RegisteredInactiveCount;
+            ToUpdateOrSkipCount = bulkUploadResult.UpdatedActiveCount + bulkUploadResult.UpdatedInactiveCount;
+            ToRegisterActiveCount = bulkUploadResult.RegisteredActiveCount;
+            ToUpdateOrSkipActiveCount = bulkUploadResult.UpdatedActiveCount;
+            ToRegisterInactiveCount = bulkUploadResult.RegisteredInactiveCount;
+            ToUpdateOrSkipInactiveCount = bulkUploadResult.UpdatedInactiveCount;
             Errors = bulkUploadResult.Errors.Select(x => (x.RowNumber, MapReasonToErrorMessage(x.Reason)));
         }
 
@@ -24,6 +24,10 @@
         public int ToProcessCount { get; set; }
         public int ToRegisterCount { get; set; }
         public int ToUpdateOrSkipCount { get; set; }
+        public int ToRegisterActiveCount { get; set; }
+        public int ToUpdateOrSkipActiveCount { get; set; }
+        public int ToRegisterInactiveCount { get; set; }
+        public int ToUpdateOrSkipInactiveCount { get; set; }
 
         private static string MapReasonToErrorMessage(BulkUploadResult.ErrorReason reason)
         {

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadResultsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/BulkUploadResultsViewModel.cs
@@ -10,12 +10,12 @@
         public BulkUploadResultsViewModel(BulkUploadResult bulkUploadResult)
         {
             ProcessedCount = bulkUploadResult.ProcessedCount;
-            RegisteredCount = bulkUploadResult.RegisteredCount;
-            UpdatedCount = bulkUploadResult.UpdatedCount;
+            RegisteredCount = bulkUploadResult.RegisteredActiveCount + bulkUploadResult.RegisteredInactiveCount;
+            UpdatedCount = bulkUploadResult.UpdatedActiveCount + bulkUploadResult.UpdatedInactiveCount;
             SkippedCount = bulkUploadResult.SkippedCount;
             Errors = bulkUploadResult.Errors.Select(x => (x.RowNumber, MapReasonToErrorMessage(x.Reason)));
         }
-        public BulkUploadResultsViewModel(int processedCount, int registeredCount, int updatedCount, int skippedCount, IEnumerable<(int, string)> errors, int day, int month, int year, int totalSteps)
+        public BulkUploadResultsViewModel(int processedCount, int registeredCount,int updatedCount, int skippedCount, IEnumerable<(int, string)> errors, int day, int month, int year, int totalSteps)
         {
             ProcessedCount = processedCount;
             TotalSteps = totalSteps;

--- a/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/AddToGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/RegisterDelegateByCentre/AddToGroup.cshtml
@@ -90,12 +90,9 @@
                     </div>
                 </div>
             </fieldset>
-            <input type="hidden" asp-for="RegisteringDelegates" />
-            <input type="hidden" asp-for="UpdatingDelegates" />
-            @if (Model.RegisteringDelegates)
-            {
-                <a asp-controller="RegisterDelegateByCentre" asp-action="LearnerInformation" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
-            }
+            <input type="hidden" asp-for="RegisteringActiveDelegates" />
+            <input type="hidden" asp-for="UpdatingActiveDelegates" />
+            <a asp-controller="RegisterDelegateByCentre" asp-action="LearnerInformation" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
             <button class="nhsuk-button" type="submit">Next</button>
         </form>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddToGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddToGroup.cshtml
@@ -19,11 +19,9 @@
                         @ViewData["Title"]
                     </h1>
                 </legend>
-                @if (Model.RegisteringInactiveDelegates > 0 | Model.UpdatingInactiveDelegates > 0 | (Model.RegisteringActiveDelegates > 0 && Model.UpdatingActiveDelegates > 0))
+                @if (Model.RegisteringInactiveDelegates > 0 | Model.UpdatingInactiveDelegates > 0)
                 {
                     <div class="nhsuk-inset-text">
-                        @if (Model.RegisteringInactiveDelegates > 0 | Model.UpdatingInactiveDelegates > 0)
-                        {
                         <p>Only active delegates can be groupe. You can use this option to group:
                           <ul>
                             @if(Model.RegisteringActiveDelegates > 0)
@@ -43,12 +41,6 @@
                         @if (Model.UpdatingInactiveDelegates > 0)
                         {
                         <p>@Model.UpdatingInactiveDelegates inactive delegates to be updated will not be grouped.</p>
-                        }
-                        }
-                        @if(Model.RegisteringActiveDelegates > 0 && Model.UpdatingActiveDelegates > 0)
-                        {
-                            <p>@Model.RegisteringActiveDelegates delegates being registered during this process will be added to the group.</p>
-                             <p>You will be able to choose whether @Model.UpdatingActiveDelegates delegates being updated should also be added to the group.</p>
                         }
                     </div>
                 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddToGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddToGroup.cshtml
@@ -3,7 +3,7 @@
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     var radioListErrorClass = !ViewData.ModelState.IsValid && Model.AddToGroupOption == null ? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group";
-    ViewData["Title"] = "Add" + (!Model.RegisteringDelegates ? " updated " : !Model.UpdatingDelegates ? " registered " : " ") + "delegates to a group";
+    ViewData["Title"] = "Add delegates to a group";
 }
 
 <div class="nhsuk-grid-row">
@@ -19,21 +19,52 @@
                         @ViewData["Title"]
                     </h1>
                 </legend>
-                <div class="nhsuk-hint nhsuk-u-margin-bottom-2">
-                    Make a new group or add delegates to an existing group
-                </div>
-
+                @if (Model.RegisteringInactiveDelegates > 0 | Model.UpdatingInactiveDelegates > 0 | (Model.RegisteringActiveDelegates > 0 && Model.UpdatingActiveDelegates > 0))
+                {
+                    <div class="nhsuk-inset-text">
+                        @if (Model.RegisteringInactiveDelegates > 0 | Model.UpdatingInactiveDelegates > 0)
+                        {
+                        <p>Only active delegates can be groupe. You can use this option to group:
+                          <ul>
+                            @if(Model.RegisteringActiveDelegates > 0)
+                                {
+                                    <li>@Model.RegisteringActiveDelegates active delegates to be registered.</li>
+                                }
+                                @if (Model.UpdatingActiveDelegates > 0)
+                                {
+                                    <li>@Model.UpdatingActiveDelegates existing active delegates to be updated.</li>
+                                }
+                          </ul>
+                        </p>
+                        @if (Model.RegisteringInactiveDelegates > 0)
+                        {
+                        <p>@Model.RegisteringInactiveDelegates inactive delegates to be registered will not be grouped.</p>
+                        }
+                        @if (Model.UpdatingInactiveDelegates > 0)
+                        {
+                        <p>@Model.UpdatingInactiveDelegates inactive delegates to be updated will not be grouped.</p>
+                        }
+                        }
+                        @if(Model.RegisteringActiveDelegates > 0 && Model.UpdatingActiveDelegates > 0)
+                        {
+                            <p>@Model.RegisteringActiveDelegates delegates being registered during this process will be added to the group.</p>
+                             <p>You will be able to choose whether @Model.UpdatingActiveDelegates delegates being updated should also be added to the group.</p>
+                        }
+                    </div>
+                }
+                
                 <div class="nhsuk-hint">
-                    Select one option
+                    <p>Make a new group or add delegates to an existing group</p>
+                    <p>Select one option</p>
                 </div>
                 <div class="@radioListErrorClass">
                     <div class="nhsuk-radios nhsuk-radios--conditional">
-                        @if (!ViewData.ModelState.IsValid && Model.AddToGroupOption == null)
-                        {
+                @if (!ViewData.ModelState.IsValid && Model.AddToGroupOption == null)
+                {
                             <span class="nhsuk-error-message" id="radio-list-error">
                                 <span class="nhsuk-u-visually-hidden">Error:</span> Please select an option
                             </span>
-                        }
+                }
                         <div class="nhsuk-radios__item">
                             <input class="nhsuk-radios__input" id="group-option-1" asp-for="AddToGroupOption" type="radio" value="1" aria-controls="conditional-option-1" aria-expanded="false">
                             <label class="nhsuk-label nhsuk-radios__label" for="group-option-1">
@@ -46,7 +77,7 @@
                             <vc:select-list asp-for="@nameof(Model.ExistingGroupId)"
                                             label="Select a group"
                                             value="@Model.ExistingGroupId.ToString()"
-                                            hint-text="Groups that are linked to centre registration prompts are not included in this list. Delegates will automatically be added to groups linked to prompts based on their regiatration details."
+                                            hint-text="Groups that are linked to centre registration prompts are not included in this list. Delegates will automatically be added to groups linked to prompts based on their registration details."
                                             required="true"
                                             css-class="nhsuk-u-width-one-half"
                                             default-option="Select a group"
@@ -90,12 +121,12 @@
                     </div>
                 </div>
             </fieldset>
-            <input type="hidden" asp-for="RegisteringDelegates" />
-            <input type="hidden" asp-for="UpdatingDelegates" />
-            @if (Model.RegisteringDelegates)
-            {
+            <input type="hidden" asp-for="RegisteringActiveDelegates" />
+            <input type="hidden" asp-for="UpdatingActiveDelegates" />
+                @if (Model.RegisteringActiveDelegates > 0)
+                {
                 <a asp-controller="BulkUpload" asp-action="WelcomeEmail" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
-            }
+                }
             <button class="nhsuk-button" type="submit">Next</button>
         </form>
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddWhoToGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddWhoToGroup.cshtml
@@ -28,19 +28,19 @@
                         <div class="nhsuk-radios__item">
                             <input class="nhsuk-radios__input" id="option-2" asp-for="IncludeUpdatedDelegates" type="radio" value="false" aria-describedby="option-1-hint">
                             <label class="nhsuk-label nhsuk-radios__label" for="option-2">
-                                Only add newly registered delegates to this group
+                                Only add active newly registered delegates to this group
                             </label>
                             <div class="nhsuk-hint nhsuk-radios__hint" id="option-2-hint">
-                                @Model.ToRegisterCount delegates will be added to the group @Model.GroupName
+                                @Model.ToRegisterActiveCount active new delegates will be added to the group @Model.GroupName
                             </div>
                         </div>
                         <div class="nhsuk-radios__item">
                             <input class="nhsuk-radios__input" id="option-1" asp-for="IncludeUpdatedDelegates" type="radio" value="true" aria-describedby="option-1-hint">
                             <label class="nhsuk-label nhsuk-radios__label" for="option-1">
-                                Add all delegates in my uploaded sheet to this group
+                                Add all active delegates in my uploaded sheet to this group
                             </label>
                             <div class="nhsuk-hint nhsuk-radios__hint" id="option-1-hint">
-                                @Model.ToProcessCount delegates will be added to the group @Model.GroupName
+                                @Model.ToRegisterActiveCount active new delegates and @Model.ToUpdateActiveCount active existing delegates will be added to the group @Model.GroupName
                             </div>
                         </div>
                     </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/BulkUploadResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/BulkUploadResults.cshtml
@@ -20,7 +20,7 @@
                     Delegate rows processed
                 </dt>
                 <dd class="nhsuk-summary-list__value">
-                    @(Model.ProcessedCount)
+                    @Model.ProcessedCount
                 </dd>
             </div>
             <div class="nhsuk-summary-list__row">

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/UploadSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/UploadSummary.cshtml
@@ -3,7 +3,7 @@
 @{
     ViewData["Title"] = "Summary";
     var process = Model.ToRegisterCount > 0 && Model.ToUpdateCount > 0 ? "register and update" : Model.ToRegisterCount > 0 ? "register" : "update";
-    var groupWho = Model.IncludeUpdatedDelegates && Model.ToRegisterCount > 0 && Model.ToUpdateCount > 0 ? "registered and updated delegates" : Model.ToRegisterCount > 0 ? "registered delegates" : "updated delegates";
+    var groupWho = Model.IncludeUpdatedDelegates && Model.ToRegisterCount > 0 && Model.ToUpdateCount > 0 ? "registered and active updated delegates" : Model.ToRegisterCount > 0 ? "registered delegates" : "updated delegates";
     int processSteps = Model.ToProcessCount / Model.MaxRowsToProcess + 1;
 }
 <div class="nhsuk-grid-row">
@@ -47,7 +47,7 @@
 
             <div class="nhsuk-summary-list__row">
                 <dt class="nhsuk-summary-list__key">
-                    Add @groupWho to group
+                    Add active @groupWho to group
                 </dt>
                 <dd class="nhsuk-summary-list__value">
                     @(Model.AddToGroupOption < 3 ? @Model.GroupName : "No group selected")


### PR DESCRIPTION
### JIRA link
[TD-3835](https://hee-tis.atlassian.net/browse/TD-3835)

### Description
Separates to register and update counts in the model into inactive and active counts. Uses these new counts to indicate how many delegates will be grouped and display appropriate warnings. Change service to only group active delegates. Changes service to group delegates included in the upload even if they are skipped with no updates.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/8de7ace3-9575-4f4a-b041-97461b63d137)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3835]: https://hee-tis.atlassian.net/browse/TD-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ