### PR TITLE
TD-3671 Fixed enrolling from 'Tracking system-Manage Delegate' view doesn't appear on 'Current activities' 

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -101,6 +101,12 @@
             bool status,
             int progressId
         );
+        void UpdateProgressSupervisorSubmittedTimeAndCompleteByDate(
+            int progressId,
+            int supervisorAdminId,
+            DateTime? completeByDate,
+            DateTime? submittedTime
+        );
     }
 
     public class ProgressDataService : IProgressDataService
@@ -152,6 +158,23 @@
                         CompleteByDate = @completeByDate
                     WHERE ProgressID = @progressId",
                 new { progressId, supervisorAdminId, completeByDate }
+            );
+        }
+
+        public void UpdateProgressSupervisorSubmittedTimeAndCompleteByDate(
+            int progressId,
+            int supervisorAdminId,
+            DateTime? completeByDate,
+            DateTime? submittedTime
+        )
+        {
+            connection.Execute(
+                @"UPDATE Progress SET
+                        SupervisorAdminID = @supervisorAdminId,
+                        CompleteByDate = @completeByDate,
+                        SubmittedTime = @submittedTime
+                    WHERE ProgressID = @progressId",
+                new { progressId, supervisorAdminId, completeByDate, submittedTime }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -15,7 +15,7 @@
     {
         IEnumerable<Progress> GetDelegateProgressForCourse(int delegateId, int customisationId);
 
-        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate);
+        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate, DateTime? submittedTime);
 
         int CreateNewDelegateProgress(
             int delegateId,
@@ -101,12 +101,7 @@
             bool status,
             int progressId
         );
-        void UpdateProgressSupervisorSubmittedTimeAndCompleteByDate(
-            int progressId,
-            int supervisorAdminId,
-            DateTime? completeByDate,
-            DateTime? submittedTime
-        );
+       
     }
 
     public class ProgressDataService : IProgressDataService
@@ -147,21 +142,6 @@
         }
 
         public void UpdateProgressSupervisorAndCompleteByDate(
-            int progressId,
-            int supervisorAdminId,
-            DateTime? completeByDate
-        )
-        {
-            connection.Execute(
-                @"UPDATE Progress SET
-                        SupervisorAdminID = @supervisorAdminId,
-                        CompleteByDate = @completeByDate
-                    WHERE ProgressID = @progressId",
-                new { progressId, supervisorAdminId, completeByDate }
-            );
-        }
-
-        public void UpdateProgressSupervisorSubmittedTimeAndCompleteByDate(
             int progressId,
             int supervisorAdminId,
             DateTime? completeByDate,

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -348,6 +348,7 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         A<int>._,
+                        A<DateTime?>._,
                         A<DateTime?>._
                     )
                 ).MustHaveHappened();
@@ -384,6 +385,7 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         reusableProgressRecord.SupervisorAdminId,
+                        A<DateTime?>._,
                         A<DateTime?>._
                     )
                 ).MustHaveHappened();
@@ -420,6 +422,7 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         supervisorId,
+                        A<DateTime?>._,
                         A<DateTime?>._
                     )
                 ).MustHaveHappened();
@@ -456,7 +459,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         A<int>._,
-                        null
+                        null,
+                        A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }
@@ -494,7 +498,8 @@
                     () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         reusableProgressRecord.ProgressId,
                         A<int>._,
-                        expectedFutureDate
+                        expectedFutureDate,
+                        A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -721,7 +721,7 @@
         private void DelegateProgressRecordMustNotHaveBeenUpdated()
         {
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime?>._)
             ).MustNotHaveHappened();
         }
 
@@ -764,7 +764,7 @@
             A.CallTo(() => groupsDataService.AddDelegateToGroup(A<int>._, A<int>._, A<DateTime>._, A<int>._))
                 .DoesNothing();
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime?>._)
             ).DoesNothing();
             A.CallTo(
                 () => progressDataService.CreateNewDelegateProgress(

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -58,7 +58,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime?>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)
@@ -83,6 +83,7 @@
                 () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                     progressId,
                     newSupervisorId,
+                    A<DateTime?>._,
                     A<DateTime?>._
                 )
             ).MustHaveHappened();
@@ -105,7 +106,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._, A<DateTime?>._)
             ).MustHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(progressId)
@@ -122,7 +123,7 @@
             // Then
             Assert.Throws<ProgressNotFoundException>(() => progressService.UpdateSupervisor(progressId, null));
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<DateTime?>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -99,7 +99,7 @@ namespace DigitalLearningSolutions.Web.Services
             {
                 foreach (var progressRecord in existingRecordsToUpdate)
                 {
-                    progressDataService.UpdateProgressSupervisorSubmittedTimeAndCompleteByDate(
+                    progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         progressRecord.ProgressId,
                         supervisorAdminId ?? 0,
                         completeByDate,

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -99,10 +99,11 @@ namespace DigitalLearningSolutions.Web.Services
             {
                 foreach (var progressRecord in existingRecordsToUpdate)
                 {
-                    progressDataService.UpdateProgressSupervisorAndCompleteByDate(
+                    progressDataService.UpdateProgressSupervisorSubmittedTimeAndCompleteByDate(
                         progressRecord.ProgressId,
                         supervisorAdminId ?? 0,
-                        completeByDate
+                        completeByDate,
+                         clockUtility.UtcNow
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -743,7 +743,8 @@
                     progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                         progressRecord.ProgressId,
                         updatedSupervisorAdminId,
-                        completeByDate
+                        completeByDate,
+                         clockUtility.UtcNow
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -105,7 +105,8 @@
             progressDataService.UpdateProgressSupervisorAndCompleteByDate(
                 progressId,
                 supervisorId,
-                courseInfo.CompleteBy
+                courseInfo.CompleteBy,
+                clockUtility.UtcNow 
             );
 
             progressDataService.ClearAspProgressVerificationRequest(progressId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3671

### Description
Need to check the reason why the course is not appearing in the delegate current activity when expired course is enrol from tracking system, I saw the reason why  the the course is not showing on current activity and alter the query that update the delegate course when it re-enrol to correct the anomaly
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/28934265-88b6-4334-bc5f-cb8021d9b585)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
