### PR TITLE
TD-3144 A learner shouldn't be able to change their primary email to …

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -100,7 +100,7 @@
             var result = controller.PersonalInformation(model);
 
             // Then
-            result.Should().BeViewResult().WithDefaultViewName();
+            result.Should().BeRedirectToActionResult().WithActionName("LearnerInformation");
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -79,6 +79,7 @@
         public void PersonalInformationPost_with_duplicate_email_for_centre_fails_validation()
         {
             // Given
+            controller.TempData.Set(new DelegateRegistrationByCentreData());
             var duplicateUser = UserTestHelper.GetDefaultDelegateUser();
             var model = new RegisterDelegatePersonalInformationViewModel
             {
@@ -137,7 +138,7 @@
             const string firstName = "Test";
             const string lastName = "User";
             const string email = "test@email.com";
-
+            controller.TempData.Set(new DelegateRegistrationByCentreData());
             var model = new RegisterDelegatePersonalInformationViewModel
             {
                 FirstName = firstName,

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -63,9 +63,7 @@
             {
                 return;
             }
-
-            var emailIsHeldAtCentre = userService.EmailIsHeldAtCentre(email, centreId);
-
+            var emailIsHeldAtCentre = userService.CheckingIfPrimaryEmailExist(email, centreId);
             if (emailIsHeldAtCentre)
             {
                 modelState.AddModelError(nameOfFieldToValidate, CommonValidationErrorMessages.EmailInUseAtCentre);

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -115,6 +115,7 @@ namespace DigitalLearningSolutions.Web.Services
         UserEntity? GetDelegateUserFromLearningHubAuthId(int learningHubAuthId);
 
         int? GetUserLearningHubAuthId(int userId);
+        bool CheckingIfPrimaryEmailExist(string email, int centreId);
     }
 
     public class UserService : IUserService
@@ -629,7 +630,20 @@ namespace DigitalLearningSolutions.Web.Services
                 .GetDelegateAccountsByUserId(primaryEmailOwner.Id).Any(da => da.CentreId == centreId);
             return primaryEmailOwnerIsAtCentre;
         }
+        public bool CheckingIfPrimaryEmailExist(string email, int centreId)
+        {
+            var inUseAsCentreEmailAtCentre = userDataService.CentreSpecificEmailIsInUseAtCentre(email!, centreId);
 
+            var primaryEmailOwnerIsAtCentre = EmailIsHeldAsPrimaryEmailByUser(email);
+
+            return inUseAsCentreEmailAtCentre || primaryEmailOwnerIsAtCentre;
+        }
+        private bool EmailIsHeldAsPrimaryEmailByUser(string email)
+        {
+            var primaryEmailOwner = userDataService.GetUserAccountByPrimaryEmail(email);
+            var primaryEmailOwnerIsAtCentre = primaryEmailOwner != null;
+            return primaryEmailOwnerIsAtCentre;
+        }
         private bool NewUserRolesExceedAvailableSpots(
             int adminId,
             AdminRoles adminRoles


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3144

### Description
I remove the centre validation  join with the primary email validation that make the validation not to see user existing that is in different centre
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c0cacb62-b1ae-4d2a-93b3-f5c18587ac0a)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c4549670-6f0c-494b-ba84-762526dbda19)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/62e9d0d1-3bcb-4ffb-8978-c7b3d6c9b9d5)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.