### PR TITLE
TD-2272 DLS feedback bar, view in logged out is inconsistent with the view in logged in

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
@@ -2,6 +2,7 @@
 {
     public class UserFeedbackViewModel
     {
+        public UserFeedbackViewModel() { }
         public UserFeedbackViewModel(string userResearchUrl)
         {
             UserId = null;

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackComplete.cshtml
@@ -9,10 +9,25 @@
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 
-<p><a href="@Model.UserResearchUrl" target="_blank">Join our user research panel</a></p>
 
-<h1>Thank you for your feedback</h1>
 
-<a class="nhsuk-button" role="button" asp-controller="Home" asp-action="Index">
-  Back to Welcome page
-</a>
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+        <h2 class="nhsuk-caption-l">Join our user research panel</h2>
+        <h1 id="page-heading" class="nhsuk-heading-xl">Thank you for your feedback</h1>
+    </div>
+    <div class="nhsuk-grid-column-two-thirds">
+
+
+        <h3>Help us improve our website</h3>
+
+        <p>Would you like to <a href="@Model.UserResearchUrl" target="_blank">join our research panel</a> and help us improve the experience of our website?</p>
+
+        <p>We will not use your details for any purpose other than to get feedback about our services to help us make improvements in the future. You can opt out at any time.</p>
+
+        <a class="nhsuk-button" role="button" asp-controller="Home" asp-action="Index">
+            Back to Welcome page
+        </a>
+
+    </div>
+</div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-2272

### Description
I change the guest feedback page content  to user feedback page content

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/f7bbf267-d2d5-46e0-932b-bb1af29e7fcf)


I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
