### PR TITLE
TD-3956 replace user research link for participant recruitment on dls

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/UserFeedbackControllerTest.cs
@@ -46,7 +46,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAchieved_ShouldReturnCorrectView()
         {
              // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAchieved(userFeedbackViewModel) as ViewResult;
@@ -61,7 +61,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAttempted_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAttempted(userFeedbackViewModel) as ViewResult;
@@ -76,7 +76,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskDifficulty_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskDifficulty(userFeedbackViewModel) as ViewResult;
@@ -91,7 +91,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackComplete_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackComplete(userFeedbackViewModel) as ViewResult;
@@ -106,7 +106,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackStart_ShouldReturnCorrectView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.GuestFeedbackStart(userFeedbackViewModel) as ViewResult;
@@ -161,7 +161,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAchievedSet_ShouldRedirectToUserFeedbackTaskAttempted()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAchievedSet(userFeedbackViewModel) as RedirectToActionResult;
@@ -175,7 +175,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAttemptedSet_ShouldRedirectToUserFeedbackTaskDifficulty()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAttemptedSet(userFeedbackViewModel) as RedirectToActionResult;
@@ -189,7 +189,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskDifficultySet_ShouldRedirectToUserFeedbackSave()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskDifficultySet(userFeedbackViewModel) as RedirectToActionResult;
@@ -203,7 +203,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackSave_ShouldCallSaveUserFeedbackAndRedirectToUserFeedbackComplete()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
             A.CallTo(() => _multiPageFormService.GetMultiPageFormData<UserFeedbackTempData>(
                     MultiPageFormDataFeature.AddUserFeedback, _tempData))
                 .Returns(new UserFeedbackTempData());
@@ -222,7 +222,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackComplete_ShouldCallSaveUserFeedbackAndRenderGuestFeedbackCompleteView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
             userFeedbackViewModel.FeedbackText = FeedbackText;
 
             // When
@@ -239,7 +239,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackComplete_ShouldNotCallSaveUserFeedbackIfNoFeedbackProvided()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.GuestFeedbackComplete(userFeedbackViewModel) as RedirectToActionResult;
@@ -269,7 +269,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void StartUserFeedbackSession_ShouldSetTempDataAndRedirectToUserFeedbackTaskAchieved()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
             
             // When
             var result = _userFeedbackController.StartUserFeedbackSession(userFeedbackViewModel) as RedirectToActionResult;
@@ -285,7 +285,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAchieved_ShouldRenderUserFeedbackTaskAchievedView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAchieved(userFeedbackViewModel) as ViewResult;
@@ -299,7 +299,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskAttempted_ShouldRenderUserFeedbackTaskAttemptedView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskAttempted(userFeedbackViewModel) as ViewResult;
@@ -313,7 +313,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackTaskDifficulty_ShouldRenderUserFeedbackTaskDifficultyView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackTaskDifficulty(userFeedbackViewModel) as ViewResult;
@@ -327,7 +327,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void GuestFeedbackStart_ShouldRenderGuestFeedbackStartView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.GuestFeedbackStart(userFeedbackViewModel) as ViewResult;
@@ -341,7 +341,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers
         public void UserFeedbackComplete_ShouldRenderUserFeedbackCompleteView()
         {
             // Given
-            var userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            var userFeedbackViewModel = new UserFeedbackViewModel();
 
             // When
             var result = _userFeedbackController.UserFeedbackComplete(userFeedbackViewModel) as ViewResult;

--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -29,7 +29,7 @@
         {
             this._userFeedbackDataService = userFeedbackDataService;
             this._multiPageFormService = multiPageFormService;
-            this._userFeedbackViewModel = new UserFeedbackViewModel(config.GetUserResearchUrl());
+            this._userFeedbackViewModel = new UserFeedbackViewModel();
             this.config = config; 
         }
 
@@ -40,7 +40,7 @@
 
             _multiPageFormService.ClearMultiPageFormData(MultiPageFormDataFeature.AddUserFeedback, TempData);
             
-            _userFeedbackViewModel = new(config.GetUserResearchUrl())
+            _userFeedbackViewModel = new()
             {
                 UserId = User.GetUserId(),
                 UserRoles = DeriveUserRoles(),

--- a/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/UserFeedback/UserFeedbackViewModel.cs
@@ -2,6 +2,7 @@
 {
     public class UserFeedbackViewModel
     {
+        public UserFeedbackViewModel() { }
         public UserFeedbackViewModel(string userResearchUrl)
         {
             UserId = null;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3956

### Description
I added the new user research URL to the  appsettings config
I replace the old user research URL with the new URL
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/933b232b-cec4-4b70-9876-a574a5b60465)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/1226983b-5351-4d17-8a2e-2928914c0afc)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c2cfe146-f2cd-4211-bae3-0720c029fdcd)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
