### PR TITLE
TD-3835 Handling hyperlinks in excel and fixing a typo

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -108,7 +108,7 @@
 
                 return RedirectToAction("UploadComplete");
             }
-            catch (Exception)
+            catch (DocumentFormat.OpenXml.Packaging.OpenXmlPackageException)
             {
                 ModelState.AddModelError("DelegatesFile", "The Excel file has at least one cell containing an invalid hyperlink or email address.");
                 return View("Index", model);

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddToGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddToGroup.cshtml
@@ -22,7 +22,7 @@
                 @if (Model.RegisteringInactiveDelegates > 0 | Model.UpdatingInactiveDelegates > 0)
                 {
                     <div class="nhsuk-inset-text">
-                        <p>Only active delegates can be groupe. You can use this option to group:
+                        <p>Only active delegates can be grouped. You can use this option to group:
                           <ul>
                             @if(Model.RegisteringActiveDelegates > 0)
                                 {


### PR DESCRIPTION
### JIRA link
[TD-3835](https://hee-tis.atlassian.net/browse/TD-3835)

### Description
The 500 error that we saw while uploading a file was because of malformed URIs when we entered an email like 'sample@'. A well-formed URI does not cause issues. The code was breaking at the point where the code was trying to open a stream to read the contents of the uploaded Excel file and construct a new XLWorkbook object. So I put it inside a try-catch block to handle it.

### Screenshots
Issue 2 - Showing an error message when malformed hyperlinks are found.

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/24b3c4c5-5aed-46d1-8621-8ff33e5b15fe)


Issue 3 - Typo corrected.

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/000aa252-4029-47ad-9ee2-011e330da1b1)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3835]: https://hee-tis.atlassian.net/browse/TD-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ