### PR TITLE
TD-3835 Introduces new add who to group option and logic to bulk upload flow

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateUploadFileServiceTests.cs
@@ -307,7 +307,7 @@
             A.CallTo(() => userDataService.GetDelegateByCandidateNumber(delegateId)).Returns(null);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             AssertBulkUploadResultHasOnlyOneError(result);
@@ -323,7 +323,7 @@
             A.CallTo(() => userService.EmailIsHeldAtCentre("email@centre.com", CentreId)).Returns(true);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             using (var _ = new AssertionScope())
@@ -358,7 +358,7 @@
                 .Returns(true);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             AssertBulkUploadResultHasOnlyOneError(result);
@@ -386,7 +386,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -421,7 +421,7 @@
                 .Returns(candidateNumberDelegate);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             AssertCreateOrUpdateDelegateWereNotCalled();
@@ -450,7 +450,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             result.ProcessedCount.Should().Be(1);
@@ -474,7 +474,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -521,7 +521,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -557,7 +557,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -592,7 +592,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -623,7 +623,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -683,7 +683,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -718,7 +718,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -754,7 +754,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -789,7 +789,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -827,7 +827,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -893,7 +893,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -954,7 +954,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, welcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, welcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -1013,7 +1013,7 @@
             ).DoesNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -1066,7 +1066,7 @@
             ).DoesNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -1111,7 +1111,7 @@
             ).DoesNothing();
 
             // When
-            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             A.CallTo(
@@ -1144,7 +1144,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             result.ProcessedCount.Should().Be(5);
@@ -1172,7 +1172,7 @@
                 .Returns(candidateNumberDelegate);
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             result.ProcessedCount.Should().Be(5);
@@ -1201,7 +1201,7 @@
             ).DoesNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             result.ProcessedCount.Should().Be(5);
@@ -1255,7 +1255,7 @@
             CallsToUserDataServiceUpdatesDoNothing();
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             using (new AssertionScope())
@@ -1294,7 +1294,7 @@
             var table = CreateTableFromData(new[] { row });
 
             // When
-            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, 1, null);
+            var result = delegateUploadFileService.ProcessDelegatesTable(table, CentreId, WelcomeEmailDate, 1, 250, true, true, 1, null);
 
             // Then
             AssertBulkUploadResultHasOnlyOneError(result);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/BulkUploadController.cs
@@ -213,7 +213,7 @@
                 data.NewGroupDescription = model.NewGroupDescription;
             }
 
-            if (data.ToRegisterActiveCount > 0 && data.ToUpdateActiveCount > 0)
+            if (data.ToUpdateActiveCount > 0)
             {
                 setBulkUploadData(data);
                 return RedirectToAction("AddWhoToGroup");
@@ -247,7 +247,7 @@
             {
                 return RedirectToAction("UploadSummary");
             }
-            var model = new AddWhoToGroupViewModel(groupName!, data.IncludeUpdatedDelegates, data.ToUpdateActiveCount, data.ToRegisterActiveCount);
+            var model = new AddWhoToGroupViewModel(groupName!, data.IncludeUpdatedDelegates, data.IncludeSkippedDelegates, data.ToUpdateActiveCount, data.ToRegisterActiveCount);
             return View(model);
         }
 
@@ -256,7 +256,8 @@
         public IActionResult SubmitAddWhoToGroup(AddWhoToGroupViewModel model)
         {
             var data = GetBulkUploadData();
-            data.IncludeUpdatedDelegates = model.IncludeUpdatedDelegates;
+            data.IncludeUpdatedDelegates = model.AddWhoToGroupOption>=2;
+            data.IncludeSkippedDelegates = model.AddWhoToGroupOption == 3;
             setBulkUploadData(data);
             return RedirectToAction("UploadSummary");
         }
@@ -321,6 +322,7 @@
                   data.LastRowProcessed,
                   data.MaxRowsToProcess,
                   data.IncludeUpdatedDelegates,
+                  data.IncludeSkippedDelegates,
                   adminId,
                   data.ExistingGroupId
                   );
@@ -354,7 +356,7 @@
                 {
                     return RedirectToAction("BulkUploadResults");
                 }
-                return RedirectToAction("ProcessBulkDelegates", new { step = step, totalSteps = processSteps });
+                return RedirectToAction("ProcessBulkDelegates", new { step, totalSteps = processSteps });
             }
         }
 

--- a/DigitalLearningSolutions.Web/Models/BulkUploadData.cs
+++ b/DigitalLearningSolutions.Web/Models/BulkUploadData.cs
@@ -20,6 +20,7 @@
             ToRegisterInactiveCount = 0;
             ToUpdateActiveCount = 0;
             ToUpdateInactiveCount = 0;
+            IncludeSkippedDelegates = false;
             IncludeUpdatedDelegates = false;
             Day = today.Day;
             Month = today.Month;
@@ -42,6 +43,7 @@
         public int ToUpdateActiveCount { get; set; }
         public int ToUpdateInactiveCount { get; set; }
         public int MaxRowsToProcess { get; set; }
+        public bool IncludeSkippedDelegates { get; set; }
         public bool IncludeUpdatedDelegates { get; set; }
         public int LastRowProcessed { get; set; }
         public int SubtotalDelegatesRegistered { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/AddWhoToGroupViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/BulkUpload/AddWhoToGroupViewModel.cs
@@ -6,17 +6,18 @@
         public AddWhoToGroupViewModel(
             string groupName,
             bool includeUpdatedDelegates,
+            bool includeSkippedDelegates,
             int toUpdateActiveCount,
             int toRegisterActiveCount
             )
         {
             GroupName = groupName;
-            IncludeUpdatedDelegates = includeUpdatedDelegates;
+            AddWhoToGroupOption = (includeUpdatedDelegates&&includeSkippedDelegates? 3 : (includeUpdatedDelegates ? 2 : 1));
             ToUpdateActiveCount = toUpdateActiveCount;
             ToRegisterActiveCount = toRegisterActiveCount;
         }
         public string? GroupName { get; set; }
-        public bool IncludeUpdatedDelegates { get; set; }
+        public int AddWhoToGroupOption { get; set; }
         public int ToUpdateActiveCount { get; set; }
         public int ToRegisterActiveCount { get; set; }
     }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddWhoToGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/BulkUpload/AddWhoToGroup.cshtml
@@ -25,22 +25,34 @@
                 </div>
                 <div class="nhsuk-form-group">
                     <div class="nhsuk-radios">
+                        @if (Model.ToRegisterActiveCount > 0)
+                        {
+                            <div class="nhsuk-radios__item">
+                                <input class="nhsuk-radios__input" id="option-1" asp-for="AddWhoToGroupOption" type="radio" value="1" aria-describedby="option-1-hint">
+                                <label class="nhsuk-label nhsuk-radios__label" for="option-1">
+                                    Only add active newly registered delegates to this group
+                                </label>
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="option-1-hint">
+                                    @Model.ToRegisterActiveCount active new delegates will be added to the group @Model.GroupName
+                                </div>
+                            </div>
+                        }
                         <div class="nhsuk-radios__item">
-                            <input class="nhsuk-radios__input" id="option-2" asp-for="IncludeUpdatedDelegates" type="radio" value="false" aria-describedby="option-1-hint">
+                            <input class="nhsuk-radios__input" id="option-2" asp-for="AddWhoToGroupOption" type="radio" value="2" aria-describedby="option-2-hint">
                             <label class="nhsuk-label nhsuk-radios__label" for="option-2">
-                                Only add active newly registered delegates to this group
+                                Only add @(Model.ToRegisterActiveCount > 0 ? Model.ToRegisterActiveCount + " active, newly registered and " : "") active, modified delegates to this group
                             </label>
                             <div class="nhsuk-hint nhsuk-radios__hint" id="option-2-hint">
-                                @Model.ToRegisterActiveCount active new delegates will be added to the group @Model.GroupName
+                                @(Model.ToRegisterActiveCount > 0 ? Model.ToRegisterActiveCount + " active new delegates and only those of the " : "Only those of the ") @Model.ToUpdateActiveCount existing delegates that have been modified in the sheet will be added to the group @Model.GroupName
                             </div>
                         </div>
                         <div class="nhsuk-radios__item">
-                            <input class="nhsuk-radios__input" id="option-1" asp-for="IncludeUpdatedDelegates" type="radio" value="true" aria-describedby="option-1-hint">
-                            <label class="nhsuk-label nhsuk-radios__label" for="option-1">
+                            <input class="nhsuk-radios__input" id="option-3" asp-for="AddWhoToGroupOption" type="radio" value="3" aria-describedby="option-3-hint">
+                            <label class="nhsuk-label nhsuk-radios__label" for="option-3">
                                 Add all active delegates in my uploaded sheet to this group
                             </label>
-                            <div class="nhsuk-hint nhsuk-radios__hint" id="option-1-hint">
-                                @Model.ToRegisterActiveCount active new delegates and @Model.ToUpdateActiveCount active existing delegates will be added to the group @Model.GroupName
+                            <div class="nhsuk-hint nhsuk-radios__hint" id="option-3-hint">
+                                All @(Model.ToRegisterActiveCount + Model.ToUpdateActiveCount) delegates in the sheet that are active and valid will be added to the group @Model.GroupName
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### JIRA link
[TD-3835](https://hee-tis.atlassian.net/browse/TD-3835)

### Description
During testing it was identified that it was not always clear whether delegates skipped because they were in the uploaded sheet but had no changes would be added to the group selected during bulk upload. This change introduces a new option to allow the user to choose whether they should be included and directs all users with sheets containing updated (or possibly updated delegates) through that flow.

There is conditional logic in the page to adjust the options presented depending on whether delegates are also being registered.

### Screenshots
With registered delegates and updated delegates in sheet:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/ea978917-3bb0-4c56-93db-4fc361e39d8e)

With only updated (or existing unchanged) delegates in sheet:
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/67740339/b0408746-ca03-4425-9fee-85dce26d1caa)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3835]: https://hee-tis.atlassian.net/browse/TD-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ