### PR TITLE
Corrected Issue with the default authentication scheme. oidc is only …

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -258,7 +258,8 @@
                     "Index",
                     "Home");
             }
-            return new ChallengeResult(new AuthenticationProperties() { RedirectUri = "/" });
+            return new ChallengeResult(OpenIdConnectDefaults.AuthenticationScheme,
+              new AuthenticationProperties() { RedirectUri = "/" });
         }
 
         public IActionResult AccountLocked()

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -220,7 +220,7 @@ namespace DigitalLearningSolutions.Web
             services.AddAuthentication(options =>
                 {
                     options.DefaultScheme = "Identity.Application";
-                    options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
                 }
             )
             .AddCookie(


### PR DESCRIPTION
…used for LH/elfh login now.

### JIRA link
[TD-2454](https://hee-tis.atlassian.net/browse/TD-2454)

### Description
 Corrected Issue with the default authentication scheme. oidc is only used for LH/elfh login now.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2454]: https://hee-tis.atlassian.net/browse/TD-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ