### PR TITLE
TD-3173 Handling supervisor role when supervisor is not selected

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -262,7 +262,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault(x => x.ID == model.SelectedSupervisorRoleId).RoleName;
             }
             sessionEnrol.SelfAssessmentSupervisorRoleId = model.SelectedSupervisorRoleId;
-            if (roles.Count()==1)
+            if (roles.Count()==1 && !string.IsNullOrEmpty(sessionEnrol.SupervisorName))
             {
                 sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault().RoleName;
                 sessionEnrol.SelfAssessmentSupervisorRoleId = roles.FirstOrDefault().ID;


### PR DESCRIPTION
### JIRA link
[TD-3173](https://hee-tis.atlassian.net/browse/TD-3173)

### Description
If no supervisor is selected, a role will not be set. 

### Screenshots
**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/5c1aefc8-59a9-4a94-b304-0226bb6e83f0)
**
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/d8a12516-1f36-4a53-92b0-cfd79912c91d)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3173]: https://hee-tis.atlassian.net/browse/TD-3173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ