### PR TITLE
TD-3144 same email address is showing as Primary email for 2 users in super admin delegate page

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -231,7 +231,7 @@
                 @"SELECT COUNT(*) FROM AdminUsers WHERE CentreID = @centreId",
                 new { centreId }
             );
-            return Convert.ToInt32(count); ;
+            return Convert.ToInt32(count);
         }
 
         public void UpdateAdminUserPermissions(

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -227,10 +227,11 @@
 
         public int GetNumberOfAdminsAtCentre(int centreId)
         {
-            return (int)connection.ExecuteScalar(
+         var count =    connection.ExecuteScalar(
                 @"SELECT COUNT(*) FROM AdminUsers WHERE CentreID = @centreId",
                 new { centreId }
             );
+            return Convert.ToInt32(count); ;
         }
 
         public void UpdateAdminUserPermissions(

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -621,7 +621,7 @@
                 da.UserID,
                 da.RegistrationConfirmationHash,
                 u.ID as UserId,
-                COALESCE(ucd.Email, u.PrimaryEmail) AS EmailAddress,
+                COALESCE( u.PrimaryEmail,ucd.Email) AS EmailAddress,
                 u.FirstName,
                 u.LastName,
                 u.Active as UserActive,

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -294,7 +294,6 @@
 
     public partial class UserDataService : IUserDataService
     {
-        private readonly ILogger<UserDataService> logger;
         private const string BaseSelectUserQuery =
             @"SELECT
                 u.ID,
@@ -337,10 +336,12 @@
             INNER JOIN JobGroups AS jg ON jg.JobGroupID = u.JobGroupID";
 
         private readonly IDbConnection connection;
+        private readonly ILogger<UserDataService> logger;
 
-        public UserDataService(IDbConnection connection)
+        public UserDataService(IDbConnection connection, ILogger<UserDataService> logger)
         {
             this.connection = connection;
+            this.logger = logger;
         }
 
         public int? GetUserIdFromUsername(string username)

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -621,7 +621,7 @@
                 da.UserID,
                 da.RegistrationConfirmationHash,
                 u.ID as UserId,
-                COALESCE( u.PrimaryEmail,ucd.Email) AS EmailAddress,
+                 u.PrimaryEmail AS EmailAddress,
                 u.FirstName,
                 u.LastName,
                 u.Active as UserActive,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -100,7 +100,7 @@
             var result = controller.PersonalInformation(model);
 
             // Then
-            result.Should().BeRedirectToActionResult().WithActionName("LearnerInformation");
+            result.Should().BeViewResult().WithDefaultViewName();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -79,7 +79,6 @@
         public void PersonalInformationPost_with_duplicate_email_for_centre_fails_validation()
         {
             // Given
-            controller.TempData.Set(new DelegateRegistrationByCentreData());
             var duplicateUser = UserTestHelper.GetDefaultDelegateUser();
             var model = new RegisterDelegatePersonalInformationViewModel
             {
@@ -138,7 +137,6 @@
             const string firstName = "Test";
             const string lastName = "User";
             const string email = "test@email.com";
-            controller.TempData.Set(new DelegateRegistrationByCentreData());
             var model = new RegisterDelegatePersonalInformationViewModel
             {
                 FirstName = firstName,

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -63,7 +63,7 @@
             {
                 return;
             }
-            var emailIsHeldAtCentre = userService.CheckingIfPrimaryEmailExist(email, centreId);
+            var emailIsHeldAtCentre = userService.EmailIsHeldAtCentre(email, centreId);
             if (emailIsHeldAtCentre)
             {
                 modelState.AddModelError(nameOfFieldToValidate, CommonValidationErrorMessages.EmailInUseAtCentre);

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -115,7 +115,6 @@ namespace DigitalLearningSolutions.Web.Services
         UserEntity? GetDelegateUserFromLearningHubAuthId(int learningHubAuthId);
 
         int? GetUserLearningHubAuthId(int userId);
-        bool CheckingIfPrimaryEmailExist(string email, int centreId);
     }
 
     public class UserService : IUserService
@@ -628,20 +627,6 @@ namespace DigitalLearningSolutions.Web.Services
             var primaryEmailOwner = userDataService.GetUserAccountByPrimaryEmail(email);
             var primaryEmailOwnerIsAtCentre = primaryEmailOwner != null && userDataService
                 .GetDelegateAccountsByUserId(primaryEmailOwner.Id).Any(da => da.CentreId == centreId);
-            return primaryEmailOwnerIsAtCentre;
-        }
-        public bool CheckingIfPrimaryEmailExist(string email, int centreId)
-        {
-            var inUseAsCentreEmailAtCentre = userDataService.CentreSpecificEmailIsInUseAtCentre(email!, centreId);
-
-            var primaryEmailOwnerIsAtCentre = EmailIsHeldAsPrimaryEmailByUser(email);
-
-            return inUseAsCentreEmailAtCentre || primaryEmailOwnerIsAtCentre;
-        }
-        private bool EmailIsHeldAsPrimaryEmailByUser(string email)
-        {
-            var primaryEmailOwner = userDataService.GetUserAccountByPrimaryEmail(email);
-            var primaryEmailOwnerIsAtCentre = primaryEmailOwner != null;
             return primaryEmailOwnerIsAtCentre;
         }
         private bool NewUserRolesExceedAvailableSpots(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3144

### Description
Correcting the Centre email showing as primary email in the super admin delegate page

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/fa946603-30fd-4f32-ba9b-a6e42d47e818)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/98d370f8-85bf-4711-a992-9377e2339805)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
