### PR TITLE
TD-3885 Correcting groups filter in TS dashboard and all delegates page

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -309,7 +309,7 @@
         }
         public (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                    int groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
+                                    int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
         {
             if (!string.IsNullOrEmpty(searchString))
             {
@@ -342,10 +342,9 @@
             var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
 											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
 											)";
-            if (groupId == 0)
-                whereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " )";
-            else
+            if (groupId.HasValue)
                 whereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+                
 
             string orderBy;
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -164,7 +164,7 @@
 			INNER JOIN Users AS u WITH (NOLOCK) ON u.ID = da.UserID
 			LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
 			INNER JOIN JobGroups AS jg WITH (NOLOCK) ON jg.JobGroupID = u.JobGroupID ";
-        private const string DelegatewhereConditon = $@" Where ((CentreID = @centreId) OR (@centreId= 0))
+        private string DelegatewhereConditon = $@" Where ((CentreID = @centreId) OR (@centreId= 0))
                             AND ( FirstName + ' ' + LastName + ' ' + PrimaryEmail + ' ' + COALESCE(Email, '') + ' ' + COALESCE(CandidateNumber, '') LIKE N'%' + @searchString + N'%')
 					        AND ((@isActive = 'Any') OR (@isActive = 'true' AND DelegateActive = 1) OR (@isActive = 'false' AND DelegateActive = 0))
 					        AND ((@isPasswordSet = 'Any') OR (@isPasswordSet = 'true' AND (Password <>'')) OR (@isPasswordSet = 'false' AND (Password ='')))
@@ -218,13 +218,21 @@
         }
         public int GetCountDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
                                      string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                     string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
+                                     int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
         {
             if (!string.IsNullOrEmpty(searchString))
             {
                 searchString = searchString.Trim();
             }
-
+            
+            if (groupId.HasValue)
+            {
+                var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
+											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
+											)";
+                DelegatewhereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+            }
+                
 
             var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches FROM ( " + DelegateUserExportSelectQuery + " ) D " + DelegatewhereConditon;
 
@@ -243,6 +251,7 @@
                     isEmailVerified,
                     registrationType,
                     jobGroupId,
+                    groupId,
                     answer1,
                     answer2,
                     answer3,
@@ -257,11 +266,18 @@
 
         public List<DelegateUserCard> GetDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
                                      string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                     string answer1, string answer2, string answer3, string answer4, string answer5, string answer6, int exportQueryRowLimit, int currentRun)
+                                     int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6, int exportQueryRowLimit, int currentRun)
         {
             if (!string.IsNullOrEmpty(searchString))
             {
                 searchString = searchString.Trim();
+            }
+            if (groupId.HasValue)
+            {
+                var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
+											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
+											)";
+                DelegatewhereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
             }
 
             string orderBy;
@@ -294,6 +310,7 @@
                     isEmailVerified,
                     registrationType,
                     jobGroupId,
+                    groupId,
                     answer1,
                     answer2,
                     answer3,
@@ -316,34 +333,12 @@
                 searchString = searchString.Trim();
             }
 
-            string whereConditon = $@" Where ((CentreID = @centreId) OR (@centreId= 0))
-                            AND ( FirstName + ' ' + LastName + ' ' + PrimaryEmail + ' ' + COALESCE(Email, '') + ' ' + COALESCE(CandidateNumber, '') LIKE N'%' + @searchString + N'%')
-					        AND ((@isActive = 'Any') OR (@isActive = 'true' AND DelegateActive = 1) OR (@isActive = 'false' AND DelegateActive = 0))
-					        AND ((@isPasswordSet = 'Any') OR (@isPasswordSet = 'true' AND (Password <>'')) OR (@isPasswordSet = 'false' AND (Password ='')))
-					        AND ((@isAdmin = 'Any') OR (@isAdmin = 'true' AND (AdminID is not null)) OR (@isAdmin = 'false' AND (AdminID is null)))
-					        AND ((@isUnclaimed = 'Any') OR (@isUnclaimed = 'true' AND (RegistrationConfirmationHash is not null)) OR (@isUnclaimed = 'false' AND (RegistrationConfirmationHash is null)))
-					        AND ((@isEmailVerified = 'Any') OR (@isEmailVerified = 'true' AND EmailVerified IS NOT NULL) OR (@isEmailVerified = 'false' AND EmailVerified IS NULL))
-
-					        AND ((@registrationType = 'Any') OR (@registrationType = 'SelfRegistered' AND SelfReg = 1 AND ExternalReg = 0) OR 
-					        (@registrationType = 'SelfRegisteredExternal' AND SelfReg = 1 AND ExternalReg = 1) OR 
-					        (@registrationType = 'RegisteredByCentre' AND SelfReg = 0 AND (ExternalReg = 0 OR ExternalReg = 1)))
-
-                            AND ((@jobGroupId = 0) OR (JobGroupID = @jobGroupId ))
-
-                            AND ((@answer1 = 'Any') OR (@answer1 = 'No option selected' AND (Answer1 IS NULL)) OR(Answer1 = @answer1))
-                            AND ((@answer2 = 'Any') OR (@answer2 = 'No option selected' AND (Answer2 IS NULL)) OR (Answer2 = @answer2))
-                            AND ((@answer3 = 'Any') OR (@answer3 = 'No option selected' AND (Answer3 IS NULL)) OR (Answer3 = @answer3))
-                            AND ((@answer4 = 'Any') OR (@answer4 = 'No option selected' AND (Answer4 IS NULL)) OR (Answer4 = @answer4))
-                            AND ((@answer5 = 'Any') OR (@answer5 = 'No option selected' AND (Answer5 IS NULL)) OR (Answer5 = @answer5))
-                            AND ((@answer6 = 'Any') OR (@answer6 = 'No option selected' AND (Answer6 IS NULL)) OR (Answer6 = @answer6))
-                            AND Approved = 1
-                            AND EmailAddress LIKE '%_@_%.__%'";
 
             var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
 											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
 											)";
             if (groupId.HasValue)
-                whereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+                DelegatewhereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
                 
 
             string orderBy;
@@ -360,7 +355,7 @@
 
             orderBy += " OFFSET " + offSet + " ROWS FETCH NEXT " + itemsPerPage + " ROWS ONLY ";
 
-            var mainSql = "SELECT * FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + whereConditon + orderBy;
+            var mainSql = "SELECT * FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + DelegatewhereConditon + orderBy;
 
             IEnumerable<DelegateUserCard> delegateUserCard = connection.Query<DelegateUserCard>(
                 mainSql,
@@ -390,7 +385,7 @@
                 commandTimeout: 3000
             );
 
-            var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + whereConditon;
+            var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + DelegatewhereConditon;
 
             int ResultCount = connection.ExecuteScalar<int>(
                 delegateCountQuery,

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -103,7 +103,7 @@
 
         (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                    int groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
+                                    int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
 
         List<DelegateUserCard> GetDelegatesNotRegisteredForGroupByGroupId(int groupId, int centreId);
 

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/UserDataService.cs
@@ -96,10 +96,10 @@
         List<DelegateUserCard> GetDelegateUserCardsByCentreId(int centreId);
         List<DelegateUserCard> GetDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                    string answer1, string answer2, string answer3, string answer4, string answer5, string answer6, int exportQueryRowLimit, int currentRun);
+                                    int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6, int exportQueryRowLimit, int currentRun);
         int GetCountDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
                                      string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                     string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
+                                     int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6);
 
         (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
@@ -76,7 +76,7 @@
             {
                 A.CallTo(() => userDataService.GetDelegateUserCards(A<string>._, A<int>._, A<int>._, A<string>._,
                     A<string>._, A<int>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._,
-                    A<string>._, A<int>._, A<int>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._)
+                    A<string>._, A<int>._, A<int?>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._, A<string>._)
                 ).MustHaveHappened();
                 A.CallTo(() => jobGroupsDataService.GetJobGroupsAlphabetical())
                     .MustHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
@@ -16,6 +16,7 @@
     using FluentAssertions.Execution;
     using Microsoft.AspNetCore.Http;
     using NUnit.Framework;
+    using Microsoft.Extensions.Configuration;
 
     public class AllDelegatesControllerTests
     {
@@ -30,6 +31,7 @@
         private IPaginateService paginateService = null!;
         private IUserDataService userDataService = null!;
         private IGroupsService groupsService = null!;
+        private IConfiguration? configuration;
 
         [SetUp]
         public void Setup()
@@ -41,7 +43,7 @@
             jobGroupsDataService = A.Fake<IJobGroupsDataService>();
             paginateService = A.Fake<IPaginateService>();
             groupsService = A.Fake<IGroupsService>();
-
+            configuration = A.Fake<IConfiguration>();
             httpRequest = A.Fake<HttpRequest>();
             httpResponse = A.Fake<HttpResponse>();
 
@@ -53,7 +55,8 @@
                     promptsHelper,
                     jobGroupsDataService,
                     paginateService,
-                    groupsService
+                    groupsService,
+                    configuration
                 )
                 .WithMockHttpContext(httpRequest, CookieName, cookieValue, httpResponse)
                 .WithMockUser(true)

--- a/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DashboardInformationServiceTests.cs
@@ -130,7 +130,7 @@
             .Returns(adminUser);
 
             A.CallTo(() => userDataService.GetDelegateUserCards("", 0, 10, "SearchableName", "Ascending", CentreId,
-            "Any", "Any", "Any", "Any", "Any", "Any", 0, 0, "Any", "Any", "Any", "Any", "Any", "Any"))
+            "Any", "Any", "Any", "Any", "Any", "Any", 0, null, "Any", "Any", "Any", "Any", "Any", "Any"))
                 .Returns((new List<DelegateUserCard>(), delegateCount)
                 );
 

--- a/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/DelegateDownloadFileServiceTests.cs
@@ -146,8 +146,8 @@
                 .Returns(new CentreRegistrationPrompts(centreId, centreRegistrationPrompts));
 
             A.CallTo(() => userDataService.GetDelegateUserCardsByCentreId(2)).Returns(delegateUserCards);
-            A.CallTo(() => userDataService.GetCountDelegateUserCardsForExportByCentreId("", "", "", 2, "", "", "", "", "", "", 0, "", "", "", "", "", "")).Returns(17);
-            A.CallTo(() => userDataService.GetDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending",2,"Any", "Any", "Any", "Any", "Any", "Any",2, "Any", "Any", "Any", "Any", "Any", "Any", 10, 1)).Returns(delegateUserCards);
+            A.CallTo(() => userDataService.GetCountDelegateUserCardsForExportByCentreId("", "", "", 2, "", "", "", "", "", "", 0, null,"", "", "", "", "", "")).Returns(17);
+            A.CallTo(() => userDataService.GetDelegateUserCardsForExportByCentreId("Test", "SearchableName", "Ascending",2,"Any", "Any", "Any", "Any", "Any", "Any",2, null,"Any", "Any", "Any", "Any", "Any", "Any", 10, 1)).Returns(delegateUserCards);
             // When
             var resultBytes = delegateDownloadFileService.GetAllDelegatesFileForCentre(2, null, "", GenericSortingHelper.Ascending, null);
             using var resultsStream = new MemoryStream(resultBytes);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -102,7 +102,7 @@
             string isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, answer1, answer2, answer3, answer4, answer5, answer6;
             isActive = isPasswordSet = isAdmin = isUnclaimed = isEmailVerified = registrationType = answer1 = answer2 = answer3 = answer4 = answer5 = answer6 = "Any";
             int jobGroupId = 0;
-            int groupId = 0;
+            int? groupId = null;
 
             if (!string.IsNullOrEmpty(existingFilterString))
             {

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -16,6 +16,8 @@
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.FeatureManagement.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using DigitalLearningSolutions.Data.Extensions;
 
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
@@ -31,6 +33,7 @@
         private readonly IPaginateService paginateService;
         private readonly IUserDataService userDataService;
         private readonly IGroupsService groupsService;
+        private readonly IConfiguration configuration;
 
         public AllDelegatesController(
             IDelegateDownloadFileService delegateDownloadFileService,
@@ -38,7 +41,8 @@
             PromptsService promptsService,
             IJobGroupsDataService jobGroupsDataService,
             IPaginateService paginateService,
-            IGroupsService groupsService
+            IGroupsService groupsService,
+            IConfiguration configuration
         )
         {
             this.delegateDownloadFileService = delegateDownloadFileService;
@@ -47,6 +51,7 @@
             this.jobGroupsDataService = jobGroupsDataService;
             this.paginateService = paginateService;
             this.groupsService = groupsService;
+            this.configuration = configuration;
         }
 
         [NoCaching]
@@ -90,8 +95,10 @@
             var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
             var availableFilters = AllDelegatesViewModelFilterOptions.GetAllDelegatesFilterViewModels(jobGroups, promptsWithOptions, groups);
 
+            var CurrentSiteBaseUrl = configuration.GetCurrentSystemBaseUrl();
+
             if (TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString()
-                    && existingFilterString != null)
+                    && existingFilterString != null &&(TempData["LastBaseUrl"].ToString() != CurrentSiteBaseUrl))
             {
                 if (existingFilterString.Contains("Answer"))
                     existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableFilters, existingFilterString);
@@ -203,6 +210,7 @@
 
             result.Page = page;
             TempData["Page"] = result.Page;
+            TempData["LastBaseUrl"] = configuration.GetCurrentSystemBaseUrl();
 
             var model = new AllDelegatesViewModel(
                 result,

--- a/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
+++ b/DigitalLearningSolutions.Web/Services/DashboardInformationService.cs
@@ -42,7 +42,7 @@
             }
 
             (var delegates, var delegateCount) = userDataService.GetDelegateUserCards("", 0, 10, "SearchableName", "Ascending", centreId,
-            "Any", "Any", "Any", "Any", "Any", "Any", 0, 0, "Any", "Any", "Any", "Any", "Any", "Any");
+            "Any", "Any", "Any", "Any", "Any", "Any", 0, null, "Any", "Any", "Any", "Any", "Any", "Any");
             var courseCount =
                 courseDataService.GetNumberOfActiveCoursesAtCentreFilteredByCategory(
                     centreId,

--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -205,6 +205,7 @@
             string isEmailVerified = "Any";
             string registrationType = "Any";
             int jobGroupId = 0;
+            int? groupId = null;
             string answer1 = "Any";
             string answer2 = "Any";
             string answer3 = "Any";
@@ -244,6 +245,9 @@
                         if (filter.Contains("JobGroupId"))
                             jobGroupId = Convert.ToInt32(filterValue);
 
+                        if (filter.Contains("DelegateGroupId"))
+                            groupId = Convert.ToInt32(filterValue);
+
                         if (filter.Contains("Answer1"))
                             answer1 = filterValue;
 
@@ -266,7 +270,7 @@
             }
             var delegatesToExport = Task.Run(() => GetDelegatesToExport(searchString ?? string.Empty, sortBy, sortDirection, centreId,
                                                isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
-                                               answer1, answer2, answer3, answer4, answer5, answer6)).Result;
+                                               groupId, answer1, answer2, answer3, answer4, answer5, answer6)).Result;
             var dataTable = new DataTable();
             SetUpDataTableColumnsForAllDelegates(registrationPrompts, dataTable);
 
@@ -293,12 +297,12 @@
 
         private async Task<IEnumerable<DelegateUserCard>> GetDelegatesToExport(String searchString, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
-                                    string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
+                                    int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
         {
             var exportQueryRowLimit = Data.Extensions.ConfigurationExtensions.GetExportQueryRowLimit(configuration);
             int resultCount = userDataService.GetCountDelegateUserCardsForExportByCentreId(searchString ?? string.Empty, sortBy, sortDirection, centreId,
                                                 isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
-                                                answer1, answer2, answer3, answer4, answer5, answer6);
+                                                groupId, answer1, answer2, answer3, answer4, answer5, answer6);
 
             int totalRun = (int)(resultCount / exportQueryRowLimit) + ((resultCount % exportQueryRowLimit) > 0 ? 1 : 0);
             int currentRun = 1;
@@ -307,7 +311,7 @@
             {
                 delegates.AddRange(userDataService.GetDelegateUserCardsForExportByCentreId(searchString ?? string.Empty, sortBy, sortDirection, centreId,
                                                 isActive, isPasswordSet, isAdmin, isUnclaimed, isEmailVerified, registrationType, jobGroupId,
-                                                answer1, answer2, answer3, answer4, answer5, answer6, exportQueryRowLimit, currentRun));
+                                                groupId, answer1, answer2, answer3, answer4, answer5, answer6, exportQueryRowLimit, currentRun));
                 currentRun++;
             }
 


### PR DESCRIPTION
### JIRA link
[TD-3885](https://hee-tis.atlassian.net/browse/TD-3885)

### Description
Changed the type of groupId to a nullable integer. In the query formation for getting delegate count for the dashboard and delegates for all delegates page, changed condition which deals with filtering based on groupId.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3885]: https://hee-tis.atlassian.net/browse/TD-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ