### PR TITLE
TD-4130 Fix url matching in close window TypeScript code

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/learningMenu/diagnosticContentViewer.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningMenu/diagnosticContentViewer.ts
@@ -10,7 +10,7 @@ declare global {
 
 function diagnosticCloseMpe(): void {
   // Extract the current domain, customisationId and sectionId out of the URL
-  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/Diagnostic\/Content(\?checkedTutorials=\d+(&checkedTutorials=\d+)*)?#?$/);
+  const matches = window.location.href.match(/^(.*)\/LearningMenu\/(\d+)\/(\d+)\/Diagnostic\/Content\?(checkedTutorials=\d+(&checkedTutorials=\d+)*)?#?$/);
 
   if (!matches || matches.length < 4) {
     return;

--- a/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/diagnosticContentViewer.spec.ts
+++ b/DigitalLearningSolutions.Web/Scripts/spec/learningMenu/diagnosticContentViewer.spec.ts
@@ -19,7 +19,7 @@ describe('closeMpe', () => {
     'should redirect to diagnostic assessment with no checked tutorials',
     () => {
       // Given
-      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content';
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content?';
 
       // When
       window.closeMpe();
@@ -33,7 +33,7 @@ describe('closeMpe', () => {
     'should redirect to diagnostic assessment with no checked tutorials after entering fullscreen',
     () => {
       // Given
-      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content#';
+      window.location.href = 'https://localhost:44363/test/LearningMenu/123/456/Diagnostic/Content?#';
 
       // When
       window.closeMpe();


### PR DESCRIPTION
### JIRA link
[TD-4130](https://hee-tis.atlassian.net/browse/TD-4130)

### Description
Issue 2 in the above ticket related to diagnostic assessments failing to close. Investigation revealed that this was only the case when the course was set to not allow diagnostic objective selection (Course Setup option). We have some code in the diagnosticContentPlayer.ts that carries out URL matching when content is closed to work out where to take the learner after closing. This URL matching did not expect a trailing ? on the URL when no parameters were present. This change tweaks the code to anticipate the trailing ? which exists in the URL in this scenario.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4130]: https://hee-tis.atlassian.net/browse/TD-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ