### PR TITLE
TD-3835 Fixes issue with delegate records being falsely marked for update

### DIFF
--- a/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/DelegateUpload/DelegateTableRow.cs
@@ -174,12 +174,12 @@
 
         public bool MatchesDelegateEntity(DelegateEntity delegateEntity)
         {
-            if (delegateEntity.UserAccount.FirstName != FirstName)
+            if (delegateEntity.UserAccount.FirstName.Trim() != (FirstName ?? string.Empty).Trim())
             {
                 return false;
             }
 
-            if (delegateEntity.UserAccount.LastName != LastName)
+            if (delegateEntity.UserAccount.LastName.Trim() != (LastName ?? string.Empty).Trim())
             {
                 return false;
             }
@@ -194,32 +194,32 @@
                 return false;
             }
 
-            if ((delegateEntity.DelegateAccount.Answer1 ?? string.Empty) != Answer1)
+            if ((delegateEntity.DelegateAccount.Answer1 ?? string.Empty).Trim() != (Answer1 ?? string.Empty).Trim())
             {
                 return false;
             }
 
-            if ((delegateEntity.DelegateAccount.Answer2 ?? string.Empty) != Answer2)
+            if ((delegateEntity.DelegateAccount.Answer2 ?? string.Empty).Trim() != (Answer2 ?? string.Empty).Trim())
             {
                 return false;
             }
 
-            if ((delegateEntity.DelegateAccount.Answer3 ?? string.Empty) != Answer3)
+            if ((delegateEntity.DelegateAccount.Answer3 ?? string.Empty).Trim() != (Answer3 ?? string.Empty).Trim())
             {
                 return false;
             }
 
-            if ((delegateEntity.DelegateAccount.Answer4 ?? string.Empty) != Answer4)
+            if ((delegateEntity.DelegateAccount.Answer4 ?? string.Empty).Trim() != (Answer4 ?? string.Empty).Trim())
             {
                 return false;
             }
 
-            if ((delegateEntity.DelegateAccount.Answer5 ?? string.Empty) != Answer5)
+            if ((delegateEntity.DelegateAccount.Answer5 ?? string.Empty).Trim() != (Answer5 ?? string.Empty).Trim())
             {
                 return false;
             }
 
-            if ((delegateEntity.DelegateAccount.Answer6 ?? string.Empty) != Answer6)
+            if ((delegateEntity.DelegateAccount.Answer6 ?? string.Empty).Trim() != (Answer6 ?? string.Empty).Trim())
             {
                 return false;
             }
@@ -229,7 +229,7 @@
                 return false;
             }
 
-            if (delegateEntity.UserAccount.ProfessionalRegistrationNumber != Prn)
+            if ((delegateEntity.UserAccount.ProfessionalRegistrationNumber ?? string.Empty).Trim() != (Prn ?? string.Empty).Trim())
             {
                 return false;
             }


### PR DESCRIPTION
### JIRA link
[TD-3835](https://hee-tis.atlassian.net/browse/TD-3835)

### Description
Fixes a problem where some records were being marked as updated even when they were unchanged in the uploaded spreadsheet. On investigation, this was revealed to be because some string fields included trailing spaces (particularly in the custom field responses). This change trims trailing spaces from the input string and the existing value before comparing to avoid falsely marking records for update.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3835]: https://hee-tis.atlassian.net/browse/TD-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ