### PR TITLE
TD-3890- Certificate controller - refactor

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Certificate/CertificateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Certificate/CertificateController.cs
@@ -1,5 +1,4 @@
-﻿using DigitalLearningSolutions.Data.DataServices;
-using DigitalLearningSolutions.Data.Models.Centres;
+﻿using DigitalLearningSolutions.Data.Models.Centres;
 using DigitalLearningSolutions.Data.Models.Certificates;
 using DigitalLearningSolutions.Data.Models.Common;
 using DigitalLearningSolutions.Data.Utilities;
@@ -23,21 +22,18 @@ namespace DigitalLearningSolutions.Web.Controllers.Certificate
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     public class CertificateController : Controller
     {
-        private readonly ICentresDataService centresDataService;
         private readonly ILogger<ConfigurationController> logger;
         private readonly IMapsApiHelper mapsApiHelper;
         private readonly IImageResizeService imageResizeService;
         private ICertificateService certificateService;
 
         public CertificateController(
-           ICentresDataService centresDataService,
            IMapsApiHelper mapsApiHelper,
            ILogger<ConfigurationController> logger,
            IImageResizeService imageResizeService,
            ICertificateService certificateService
        )
         {
-            this.centresDataService = centresDataService;
             this.mapsApiHelper = mapsApiHelper;
             this.logger = logger;
             this.imageResizeService = imageResizeService;


### PR DESCRIPTION
### JIRA link
[_DLSV2-3890_](https://hee-tis.atlassian.net/browse/TD-3890)

### Description
DataServices reference of centreDataService has been removed from the controller code.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/06377e64-303b-468b-a851-11436fb7bd28)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
