### PR TITLE
TD-3885 Handling Deleted Group Filter Issue

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -163,7 +163,14 @@
                             jobGroupId = Convert.ToInt32(filterValue);
 
                         if (filter.Contains("DelegateGroupId"))
+                        {
                             groupId = Convert.ToInt32(filterValue);
+                            if (!(groups.Any(g => g.Item1 == groupId)))
+                            {
+                                groupId = null;
+                                existingFilterString = FilterHelper.RemoveNonExistingFilterOptions(availableFilters, existingFilterString);
+                            }                            
+                        }                            
 
                         if (filter.Contains("Answer1"))
                             answer1 = filterValue;
@@ -217,7 +224,7 @@
                 customPrompts,
                 availableFilters
             );
-
+            
             model.TotalPages = (int)(resultCount / itemsPerPage) + ((resultCount % itemsPerPage) > 0 ? 1 : 0);
             model.MatchingSearchResults = resultCount;
 


### PR DESCRIPTION
### JIRA link
[TD-3885](https://hee-tis.atlassian.net/browse/TD-3885)

### Description
We have placed a check for a scenario where we have a filter with groupID that is now deleted. We already had groups that were fetched in the code above. Comparing the currently applied filter to check whether that group is still existent. If NO (that means the group is deleted), we are making groupId null so that we get the correct delegates and delegates count. We are also flushing out the value of the existing filter if it is the case.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3885]: https://hee-tis.atlassian.net/browse/TD-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ