### PR TITLE
TD-4164-Feature flag the Login with Learning Hub button

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
@@ -13,5 +13,6 @@
         public const string RefactoredFindYourCentrePage = "RefactoredFindYourCentrePage";
         public const string UserFeedbackBar = "UserFeedbackBar";
         public const string ShowSelfAssessmentProgressButtons = "ShowSelfAssessmentProgressButtons";
+        public const string LoginWithLearningHub = "LoginWithLearningHub";
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Home/Welcome.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Home/Welcome.cshtml
@@ -1,46 +1,46 @@
+@using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.Home
 @model LandingPageViewModel
 
 @{
-  ViewData["Title"] = "Welcome";
+    ViewData["Title"] = "Welcome";
 }
 
 <link rel="stylesheet" href="@Url.Content("~/css/home/welcome.css")" asp-append-version="true" />
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <partial name="MiniHub/_MiniHubHeading" model="@Model.MiniHubNavigationModel" />
+    <div class="nhsuk-grid-column-full">
+        <partial name="MiniHub/_MiniHubHeading" model="@Model.MiniHubNavigationModel" />
 
-    <div class="welcome-page-button-container">
-      @if (Model.UserIsLoggedIn)
-      {
-        @if (Model.UserIsLoggedInCentre)
-        {
-          <a class="nhsuk-button auth-button auth-button--left" role="button" asp-controller="ApplicationSelector" asp-action="Index">
-            Switch application
-          </a>
-        }
-      }
-      else
-      {
-        <p class="nhsuk-body-m">If you have linked your account you can login through the Learning hub.</p>
-        <a class="nhsuk-button auth-button--blue" role="button" asp-controller="Login" asp-action="SharedAuth">
-          Log in with Learning hub
-        </a>
-        <p class="nhsuk-u-font-weight-bold">Or</p>
-        <a class="nhsuk-button auth-button auth-button--left" role="button" asp-controller="Login" asp-action="Index">
-          Log in
-        </a>
-        <a class="nhsuk-button nhsuk-button--secondary auth-button" role="button" asp-controller="Register" asp-action="Start">
-          Register
-        </a>
-      }
+        <div class="welcome-page-button-container">
+            @if (Model.UserIsLoggedIn)
+            {
+                @if (Model.UserIsLoggedInCentre)
+                {
+                    <a class="nhsuk-button auth-button auth-button--left" role="button" asp-controller="ApplicationSelector" asp-action="Index">
+                        Switch application
+                    </a>
+                }
+            }
+            else
+            {
+                <feature name="@(FeatureFlags.LoginWithLearningHub)">
+                    <p class="nhsuk-body-m">If you have linked your account you can login through the Learning hub.</p>
+                    <a class="nhsuk-button auth-button--blue" role="button" asp-controller="Login" asp-action="SharedAuth">
+                        Log in with Learning hub
+                    </a>
+                    <p class="nhsuk-u-font-weight-bold">Or</p>
+                </feature>
+                <a class="nhsuk-button auth-button auth-button--left" role="button" asp-controller="Login" asp-action="Index">
+                    Log in
+                </a>
+                <a class="nhsuk-button nhsuk-button--secondary auth-button" role="button" asp-controller="Register" asp-action="Start">
+                    Register
+                </a>
+            }
+        </div>
+        <partial name="MiniHub/_ContentsList" model="@Model.MiniHubNavigationModel" />
+        <p class="nhsuk-body-m">Our products and services can help you manage digital learning delivery for the benefit of the people in your organisation.</p>
+        <partial name="MiniHub/_Pagination" model="@Model.MiniHubNavigationModel" />
     </div>
-    @if (Model.UserIsLoggedIn)
-    {
-      <partial name="MiniHub/_ContentsList" model="@Model.MiniHubNavigationModel" />
-      <p class="nhsuk-body-m">Our products and services can help you manage digital learning delivery for the benefit of the people in your organisation.</p>
-      <partial name="MiniHub/_Pagination" model="@Model.MiniHubNavigationModel" />
-    }
-  </div>
 </div>

--- a/DigitalLearningSolutions.Web/appSettings.UAT.json
+++ b/DigitalLearningSolutions.Web/appSettings.UAT.json
@@ -21,7 +21,8 @@
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
     "ExportQueryRowLimit": 250,
-    "MaxBulkUploadRows": 200
+    "MaxBulkUploadRows": 200,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "FreshdeskAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -21,7 +21,8 @@
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
     "ExportQueryRowLimit": 250,
-    "MaxBulkUploadRows": 200
+    "MaxBulkUploadRows": 200,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.Production.json
+++ b/DigitalLearningSolutions.Web/appsettings.Production.json
@@ -21,7 +21,8 @@
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
     "ExportQueryRowLimit": 250,
-    "MaxBulkUploadRows": 200
+    "MaxBulkUploadRows": 200,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://learninghubnhsuk-openapi-prod.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.SIT.json
+++ b/DigitalLearningSolutions.Web/appsettings.SIT.json
@@ -18,7 +18,8 @@
     "PricingPage": true,
     "UserFeedbackBar": true,
     "ExportQueryRowLimit": 250,
-    "MaxBulkUploadRows": 200
+    "MaxBulkUploadRows": 200,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-dev.azurewebsites.net",
   "LearningHubReportAPIConfig": {

--- a/DigitalLearningSolutions.Web/appsettings.Test.json
+++ b/DigitalLearningSolutions.Web/appsettings.Test.json
@@ -20,7 +20,8 @@
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
     "ExportQueryRowLimit": 250,
-    "MaxBulkUploadRows": 200
+    "MaxBulkUploadRows": 200,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.UarTest.json
+++ b/DigitalLearningSolutions.Web/appsettings.UarTest.json
@@ -21,7 +21,8 @@
     "RefactoredFindYourCentrePage": true,
     "UserFeedbackBar": true,
     "ExportQueryRowLimit": 250,
-    "MaxBulkUploadRows": 200
+    "MaxBulkUploadRows": 200,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net"
 }

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -16,7 +16,8 @@
     "RefactoredSuperAdminInterface": false,
     "UseSignposting": true,
     "PricingPage": true,
-    "ShowSelfAssessmentProgressButtons": false
+    "ShowSelfAssessmentProgressButtons": false,
+    "LoginWithLearningHub": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "LearningHubOpenAPIKey": "",


### PR DESCRIPTION
### JIRA link
[_DLSV2-4164_](https://hee-tis.atlassian.net/browse/TD-4164)

### Description
'LoginWithLearningHub' feature flag added to hide 'Log in with Learning Hub' button on Home (log in) page.

Links issues (Products, Learning content) on the log in page has been resolved.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/66ac7225-9e93-4919-a3fb-de3dafcc2f9a)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/52852ed4-ef07-4c21-bec2-127c59b6bdaa)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/d5244b71-be74-4b77-b051-9f654658edc0)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
