### PR TITLE
TD-3885 Fixing issue with prompts filter

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -98,7 +98,7 @@
             var CurrentSiteBaseUrl = configuration.GetCurrentSystemBaseUrl();
 
             if (((TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString())
-                     || (TempData["LastBaseUrl"].ToString() != CurrentSiteBaseUrl)) && existingFilterString != null)
+                     || (TempData["LastBaseUrl"] != null && (TempData["LastBaseUrl"].ToString() != CurrentSiteBaseUrl))) && existingFilterString != null)
             {
                 if (existingFilterString.Contains("Answer"))
                     existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableFilters, existingFilterString);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -97,12 +97,12 @@
 
             var CurrentSiteBaseUrl = configuration.GetCurrentSystemBaseUrl();
 
-            if (TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString()
-                    && existingFilterString != null &&(TempData["LastBaseUrl"].ToString() != CurrentSiteBaseUrl))
+            if (((TempData["allDelegatesCentreId"] != null && TempData["allDelegatesCentreId"].ToString() != User.GetCentreId().ToString())
+                     || (TempData["LastBaseUrl"].ToString() != CurrentSiteBaseUrl)) && existingFilterString != null)
             {
                 if (existingFilterString.Contains("Answer"))
                     existingFilterString = FilterHelper.RemoveNonExistingPromptFilters(availableFilters, existingFilterString);
-                if (existingFilterString.Contains("DelegateGroup"))
+                if (existingFilterString != null && existingFilterString.Contains("DelegateGroup"))
                     existingFilterString = FilterHelper.RemoveNonExistingFilterOptions(availableFilters, existingFilterString);
             }
 


### PR DESCRIPTION
### JIRA link
[TD-3885](https://hee-tis.atlassian.net/browse/TD-3885)

### Description
Changed the if condition - The error we got was because we had an AND condition that prevented the code from stepping inside the if block.
Now it should check for two different scenarios - 
[ { (If centre is changed) OR (If UAT-Live is toggled) } AND (If existingFilterString has value) ]

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3885]: https://hee-tis.atlassian.net/browse/TD-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ