### PR TITLE
TD 3885 correcting issue related to prompt filter and UAT live filter

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/AllDelegatesControllerTests.cs
@@ -17,6 +17,7 @@
     using Microsoft.AspNetCore.Http;
     using NUnit.Framework;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.AspNetCore.Hosting;
 
     public class AllDelegatesControllerTests
     {
@@ -32,6 +33,7 @@
         private IUserDataService userDataService = null!;
         private IGroupsService groupsService = null!;
         private IConfiguration? configuration;
+        private IWebHostEnvironment? env;
 
         [SetUp]
         public void Setup()
@@ -46,6 +48,7 @@
             configuration = A.Fake<IConfiguration>();
             httpRequest = A.Fake<HttpRequest>();
             httpResponse = A.Fake<HttpResponse>();
+            env = A.Fake<IWebHostEnvironment>();
 
             const string cookieValue = "ActiveStatus|Active|false";
 
@@ -56,7 +59,8 @@
                     jobGroupsDataService,
                     paginateService,
                     groupsService,
-                    configuration
+                    configuration,
+                    env
                 )
                 .WithMockHttpContext(httpRequest, CookieName, cookieValue, httpResponse)
                 .WithMockUser(true)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -81,10 +81,7 @@
             sortBy ??= DefaultSortByOptions.Name.PropertyName;
             sortDirection ??= GenericSortingHelper.Ascending;
 
-            if (string.Equals(env.EnvironmentName, "UAT", StringComparison.OrdinalIgnoreCase))
-            {
-                DelegateFilterCookieName = "DelegateFilterUat";
-            }
+            DelegateFilterCookieName += env.EnvironmentName;
             existingFilterString = FilteringHelper.GetFilterString(
                 existingFilterString,
                 newFilterToAdd,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -77,7 +77,7 @@
 
             sortBy ??= DefaultSortByOptions.Name.PropertyName;
             sortDirection ??= GenericSortingHelper.Ascending;
-            if (HttpContext.Request.GetDisplayUrl().ToString().Contains("uat"))
+            if (HttpContext.Request.GetDisplayUrl().ToString().ToLower().Contains("uat"))
             {
                 DelegateFilterCookieName = "DelegateFilterUat";
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/AllDelegatesController.cs
@@ -18,7 +18,7 @@
     using Microsoft.FeatureManagement.Mvc;
     using Microsoft.Extensions.Configuration;
     using DigitalLearningSolutions.Data.Extensions;
-    using Microsoft.AspNetCore.Http.Extensions;
+    using Microsoft.AspNetCore.Hosting;
 
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
@@ -35,6 +35,7 @@
         private readonly IUserDataService userDataService;
         private readonly IGroupsService groupsService;
         private readonly IConfiguration configuration;
+        private readonly IWebHostEnvironment env;
 
         public AllDelegatesController(
             IDelegateDownloadFileService delegateDownloadFileService,
@@ -43,7 +44,8 @@
             IJobGroupsDataService jobGroupsDataService,
             IPaginateService paginateService,
             IGroupsService groupsService,
-            IConfiguration configuration
+            IConfiguration configuration,
+            IWebHostEnvironment env
         )
         {
             this.delegateDownloadFileService = delegateDownloadFileService;
@@ -53,6 +55,7 @@
             this.paginateService = paginateService;
             this.groupsService = groupsService;
             this.configuration = configuration;
+            this.env = env;
         }
 
         [NoCaching]
@@ -77,7 +80,8 @@
 
             sortBy ??= DefaultSortByOptions.Name.PropertyName;
             sortDirection ??= GenericSortingHelper.Ascending;
-            if (HttpContext.Request.GetDisplayUrl().ToString().ToLower().Contains("uat"))
+
+            if (string.Equals(env.EnvironmentName, "UAT", StringComparison.OrdinalIgnoreCase))
             {
                 DelegateFilterCookieName = "DelegateFilterUat";
             }


### PR DESCRIPTION
### JIRA link
[TD-3885](https://hee-tis.atlassian.net/browse/TD-3885)

### Description
**Issue 1.** Issue still can be seen when prompt filter applied in one centre affects the another centre
This has been corrected by correcting the if statement. Now it correctly checks that if the centreId is changed, the prompts filters are cleared out.

**Issue 2.** Applied Delegate group filter in UAT and accessing DLS Live Delegate page results in 500 error
For this, we are using a different name for the cookie variable for UAT and for Live. We are fetching the full current URL from HttpContext.Request.GetDisplayUrl() and checking if it contains the term 'uat' in it. If it contains, we change the cookie variable name.
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/d787101f-1d2d-492e-a737-e6a6c9862f8a)




We will be able to test if this is working or not only when it is deployed to live. @kevwhitt-hee are we willing to take this risk?

Just for testing purposes, I changed the cookie name for the localhost and we see a new cookie name being shown in the dev console - 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/d1ee5231-5ea4-4316-a12d-cb6d5c6d5a50)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/ba3d21aa-1be4-4994-b3ef-226cf90d8bc0)

This same localhost cookie name was seen to be used throughout the localhost dev testing.
### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3885]: https://hee-tis.atlassian.net/browse/TD-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ