### PR TITLE
TD-3904-RegisterAtNewCentreController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAtNewCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterAtNewCentreControllerTests.cs
@@ -3,12 +3,10 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using DigitalLearningSolutions.Data.DataServices;
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models.Register;
-    using DigitalLearningSolutions.Data.Models.User;    
+    using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Web.Controllers.Register;
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
@@ -33,7 +31,7 @@
     {
         private const string IpAddress = "1.1.1.1";
         private const int UserId = 2;
-        private ICentresDataService centresDataService = null!;
+        private ICentresService centresService = null!;
         private IConfiguration config = null!;
         private RegisterAtNewCentreController controller = null!;
         private IEmailVerificationService emailVerificationService = null!;
@@ -42,17 +40,15 @@
         private IRegistrationService registrationService = null!;
         private HttpRequest request = null!;
         private ISupervisorDelegateService supervisorDelegateService = null!;
-        private IUserDataService userDataService = null!;
         private IUserService userService = null!;
         private ISupervisorService supervisorService = null!;
 
         [SetUp]
         public void Setup()
         {
-            centresDataService = A.Fake<ICentresDataService>();
+            centresService = A.Fake<ICentresService>();
             registrationService = A.Fake<IRegistrationService>();
             userService = A.Fake<IUserService>();
-            userDataService = A.Fake<IUserDataService>();
             supervisorService = A.Fake<ISupervisorService>();
             promptsService = A.Fake<PromptsService>();
             featureManager = A.Fake<IFeatureManager>();
@@ -62,7 +58,7 @@
             request = A.Fake<HttpRequest>();
 
             controller = new RegisterAtNewCentreController(
-                    centresDataService,
+                    centresService,
                     config,
                     emailVerificationService,
                     featureManager,
@@ -70,7 +66,6 @@
                     registrationService,
                     supervisorDelegateService,
                     userService,
-                    userDataService,
                     supervisorService
                 )
                 .WithDefaultContext()
@@ -85,13 +80,13 @@
         {
             // Given
             const int centreId = 7;
-            A.CallTo(() => centresDataService.GetCentreName(centreId)).Returns(null);
+            A.CallTo(() => centresService.GetCentreName(centreId)).Returns(null);
 
             // When
             var result = controller.Index(centreId);
 
             // Then
-            A.CallTo(() => centresDataService.GetCentreName(centreId)).MustHaveHappened(1, Times.Exactly);
+            A.CallTo(() => centresService.GetCentreName(centreId)).MustHaveHappened(1, Times.Exactly);
             result.Should().BeNotFoundResult();
         }
 
@@ -100,13 +95,13 @@
         {
             // Given
             const int centreId = 7;
-            A.CallTo(() => centresDataService.GetCentreName(centreId)).Returns("Some centre");
+            A.CallTo(() => centresService.GetCentreName(centreId)).Returns("Some centre");
 
             // When
             var result = controller.Index(centreId);
 
             // Then
-            A.CallTo(() => centresDataService.GetCentreName(centreId)).MustHaveHappened(1, Times.Exactly);
+            A.CallTo(() => centresService.GetCentreName(centreId)).MustHaveHappened(1, Times.Exactly);
             var data = controller.TempData.Peek<InternalDelegateRegistrationData>()!;
             data.Centre.Should().Be(centreId);
             data.IsCentreSpecificRegistration.Should().BeTrue();
@@ -120,7 +115,7 @@
             var result = controller.Index();
 
             // Then
-            A.CallTo(() => centresDataService.GetCentreName(A<int>._)).MustNotHaveHappened();
+            A.CallTo(() => centresService.GetCentreName(A<int>._)).MustNotHaveHappened();
             var data = controller.TempData.Peek<InternalDelegateRegistrationData>()!;
             data.Centre.Should().BeNull();
             data.IsCentreSpecificRegistration.Should().BeFalse();
@@ -140,7 +135,7 @@
                 CentreSpecificEmail = "centre email",
             };
             A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    () => userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
                         model.CentreSpecificEmail!,
                         centreId,
                         userAccount.Id
@@ -156,7 +151,7 @@
 
             // Then
             A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    () => userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
                         model.CentreSpecificEmail!,
                         centreId,
                         userAccount.Id
@@ -187,7 +182,7 @@
 
             // Then
             A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                () => userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
                     A<string>._,
                     A<int>._,
                     A<int>._
@@ -207,7 +202,7 @@
                 CentreSpecificEmail = "centre email",
             };
             A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    () => userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
                         model.CentreSpecificEmail!,
                         model.Centre!.Value,
                         UserId
@@ -220,7 +215,7 @@
 
             // Then
             A.CallTo(
-                    () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                    () => userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
                         model.CentreSpecificEmail!,
                         model.Centre!.Value,
                         UserId

--- a/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/RegistrationEmailValidatorTests.cs
@@ -224,7 +224,7 @@
         {
             // Given
             A.CallTo(
-                () => userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
+                () => userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(
                     DefaultCentreSpecificEmail,
                     DefaultCentreId,
                     DefaultUserId
@@ -238,7 +238,7 @@
                 DefaultUserId,
                 DefaultFieldName,
                 modelState,
-                userDataService
+                userService
             );
 
             // Then
@@ -265,7 +265,7 @@
                 DefaultUserId,
                 DefaultFieldName,
                 modelState,
-                userDataService
+                userService
             );
 
             // Then
@@ -282,7 +282,7 @@
                 DefaultUserId,
                 DefaultFieldName,
                 modelState,
-                userDataService
+                userService
             );
 
             // Then
@@ -311,7 +311,7 @@
                 DefaultUserId,
                 DefaultFieldName,
                 modelState,
-                userDataService
+                userService
             );
 
             // Then
@@ -332,7 +332,7 @@
                 DefaultUserId,
                 DefaultFieldName,
                 modelState,
-                userDataService
+                userService
             );
 
             // Then

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterAtNewCentreController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterAtNewCentreController.cs
@@ -4,8 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using DigitalLearningSolutions.Data.DataServices;
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Extensions;
@@ -28,19 +26,18 @@
     [ServiceFilter(typeof(VerifyUserHasVerifiedPrimaryEmail))]
     public class RegisterAtNewCentreController : Controller
     {
-        private readonly ICentresDataService centresDataService;
+        private readonly ICentresService centresService;
         private readonly IConfiguration config;
         private readonly IEmailVerificationService emailVerificationService;
         private readonly IFeatureManager featureManager;
         private readonly PromptsService promptsService;
         private readonly IRegistrationService registrationService;
         private readonly ISupervisorDelegateService supervisorDelegateService;
-        private readonly IUserDataService userDataService;
         private readonly IUserService userService;
         private readonly ISupervisorService supervisorService;
 
         public RegisterAtNewCentreController(
-            ICentresDataService centresDataService,
+            ICentresService centresService,
             IConfiguration config,
             IEmailVerificationService emailVerificationService,
             IFeatureManager featureManager,
@@ -48,11 +45,10 @@
             IRegistrationService registrationService,
             ISupervisorDelegateService supervisorDelegateService,
             IUserService userService,
-            IUserDataService userDataService,
             ISupervisorService supervisorService
         )
         {
-            this.centresDataService = centresDataService;
+            this.centresService = centresService;
             this.config = config;
             this.emailVerificationService = emailVerificationService;
             this.featureManager = featureManager;
@@ -60,7 +56,6 @@
             this.registrationService = registrationService;
             this.supervisorDelegateService = supervisorDelegateService;
             this.userService = userService;
-            this.userDataService = userDataService;
             this.supervisorService = supervisorService;
         }
 
@@ -220,7 +215,7 @@
             var viewModel = new InternalSummaryViewModel
             {
                 CentreSpecificEmail = data.CentreSpecificEmail,
-                Centre = centresDataService.GetCentreName((int)data.Centre!),
+                Centre = centresService.GetCentreName((int)data.Centre!),
                 DelegateRegistrationPrompts = promptsService.GetDelegateRegistrationPromptsForCentre(
                     data.Centre!.Value,
                     data.Answer1,
@@ -348,7 +343,7 @@
 
         private bool CheckCentreIdValid(int? centreId)
         {
-            return centreId == null || centresDataService.GetCentreName(centreId.Value) != null;
+            return centreId == null || centresService.GetCentreName(centreId.Value) != null;
         }
 
         private void ValidateEmailAddress(InternalPersonalInformationViewModel model)
@@ -361,16 +356,16 @@
                     User.GetUserIdKnownNotNull(),
                     nameof(PersonalInformationViewModel.CentreSpecificEmail),
                     ModelState,
-                    userDataService
+                    userService
                 );
             }
         }
 
         private void PopulatePersonalInformationExtraFields(InternalPersonalInformationViewModel model)
         {
-            model.CentreName = model.Centre.HasValue ? centresDataService.GetCentreName(model.Centre.Value) : null;
+            model.CentreName = model.Centre.HasValue ? centresService.GetCentreName(model.Centre.Value) : null;
             model.CentreOptions = SelectListHelper.MapOptionsToSelectListItems(
-                centresDataService.GetCentresForDelegateSelfRegistrationAlphabetical(),
+                centresService.GetCentresForDelegateSelfRegistrationAlphabetical(),
                 model.Centre
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Register/RegisterInternalAdminController.cs
@@ -103,7 +103,7 @@
                 userId,
                 nameof(InternalAdminInformationViewModel.CentreSpecificEmail),
                 ModelState,
-                userDataService
+                userService
             );
 
             RegistrationEmailValidator.ValidateEmailsForCentreManagerIfNecessary(

--- a/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
+++ b/DigitalLearningSolutions.Web/Helpers/RegistrationEmailValidator.cs
@@ -76,13 +76,13 @@
             int userId,
             string nameOfFieldToValidate,
             ModelStateDictionary modelState,
-            IUserDataService userDataService
+            IUserService userService
         )
         {
             if (
                 centreId.HasValue &&
                 IsValidationNecessary(centreEmail, nameOfFieldToValidate, modelState) &&
-                userDataService.CentreSpecificEmailIsInUseAtCentreByOtherUser(centreEmail!, centreId.Value, userId)
+                userService.CentreSpecificEmailIsInUseAtCentreByOtherUser(centreEmail!, centreId.Value, userId)
             )
             {
                 modelState.AddModelError(nameOfFieldToValidate, CommonValidationErrorMessages.EmailInUseAtCentre);

--- a/DigitalLearningSolutions.Web/Services/CentresService.cs
+++ b/DigitalLearningSolutions.Web/Services/CentresService.cs
@@ -41,6 +41,8 @@
             string? telephone
         );
         string? GetBannerText(int centreId);
+        string? GetCentreName(int centreId);
+        IEnumerable<(int, string)> GetCentresForDelegateSelfRegistrationAlphabetical();
     }
 
     public class CentresService : ICentresService
@@ -71,12 +73,12 @@
             return centreRanking?.Ranking;
         }
 
-        public (IEnumerable<CentreEntity>, int) GetAllCentreSummariesForSuperAdmin(string search, int offset, int rows,int region,
+        public (IEnumerable<CentreEntity>, int) GetAllCentreSummariesForSuperAdmin(string search, int offset, int rows, int region,
           int centreType,
           int contractType,
           string centreStatus)
         {
-            return centresDataService.GetAllCentreSummariesForSuperAdmin(search,offset,rows,region,centreType,contractType,centreStatus);
+            return centresDataService.GetAllCentreSummariesForSuperAdmin(search, offset, rows, region, centreType, contractType, centreStatus);
         }
 
         public IEnumerable<CentreSummaryForFindYourCentre> GetAllCentreSummariesForFindCentre()
@@ -123,15 +125,25 @@
             return centresDataService.GetCentreManagerDetailsByCentreId(centreId);
         }
 
-        public void UpdateCentreManagerDetails(int centreId,string firstName,string lastName,string email,string? telephone
+        public void UpdateCentreManagerDetails(int centreId, string firstName, string lastName, string email, string? telephone
         )
         {
-            centresDataService.UpdateCentreManagerDetails(centreId,firstName,lastName,email,telephone);
+            centresDataService.UpdateCentreManagerDetails(centreId, firstName, lastName, email, telephone);
         }
 
         public string? GetBannerText(int centreId)
         {
             return centresDataService.GetBannerText(centreId);
+        }
+
+        public string? GetCentreName(int centreId)
+        {
+            return centresDataService.GetCentreName(centreId);
+        }
+
+        public IEnumerable<(int, string)> GetCentresForDelegateSelfRegistrationAlphabetical()
+        {
+            return centresDataService.GetCentresForDelegateSelfRegistrationAlphabetical();
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[_DLSV2-3904_](https://hee-tis.atlassian.net/browse/TD-3904)

### Description
DataService reference removed from the controller.
Note: RegisterInternalAdminController, RegistrationEmailValidator and RegistrationEmailValidatorTests data service references to be handled in their respective tickets.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/a2c8d021-c741-4e8e-9c04-36fc2d40533b)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/86996567-e88a-4fe9-b924-a66512a41179)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/422df817-b7f5-42f3-baec-638e1f558da4)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8715c776-3029-41b1-aaec-b6e7ce2c65f8)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
