### PR TITLE
TD-3939-EnrolController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EnrolControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EnrolControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿using DigitalLearningSolutions.Web.Services;
 using DigitalLearningSolutions.Data.Models.SessionData.Tracking.Delegate.Enrol;
-using DigitalLearningSolutions.Data.DataServices;
 using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
 using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
 using FakeItEasy;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -1,5 +1,4 @@
-﻿using DigitalLearningSolutions.Data.DataServices;
-using DigitalLearningSolutions.Data.Models.Courses;
+﻿using DigitalLearningSolutions.Data.Models.Courses;
 using DigitalLearningSolutions.Data.Models.SessionData.Tracking.Delegate.Enrol;
 using DigitalLearningSolutions.Web.Attributes;
 using DigitalLearningSolutions.Web.Helpers;
@@ -262,7 +261,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault(x => x.ID == model.SelectedSupervisorRoleId).RoleName;
             }
             sessionEnrol.SelfAssessmentSupervisorRoleId = model.SelectedSupervisorRoleId;
-            if (roles.Count()==1 && !string.IsNullOrEmpty(sessionEnrol.SupervisorName))
+            if (roles.Count() == 1 && !string.IsNullOrEmpty(sessionEnrol.SupervisorName))
             {
                 sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault().RoleName;
                 sessionEnrol.SelfAssessmentSupervisorRoleId = roles.FirstOrDefault().ID;


### PR DESCRIPTION
### JIRA link
[_TD-3939_](https://hee-tis.atlassian.net/browse/TD-3939)

### Description
DataService reference removed from the controller.
No other relative change is required in the controller code as it is solved by the implementation of ISupervisorService interface in the other ticket.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/5ae1cd88-65cf-4245-b05f-280c856ed5aa)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b4801459-e6ac-49e8-b5c6-24c295f37b7e)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/974adb59-d62a-4e25-be14-cd567a3dc72e)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/713a7b9a-5ba7-4a69-97a9-3be8b4cede86)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/84ba9834-28eb-4a95-959b-d5d7a69919a0)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
