### PR TITLE
TD-3671 few courses which does not allow self enrolment

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -15,8 +15,7 @@
     {
         IEnumerable<Progress> GetDelegateProgressForCourse(int delegateId, int customisationId);
 
-        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate, int enrollmentMethodID);
-
+        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate, int enrollmentMethodID, DateTime? firstSubmittedTime);
         int CreateNewDelegateProgress(
             int delegateId,
             int customisationId,
@@ -144,16 +143,18 @@
             int progressId,
             int supervisorAdminId,
             DateTime? completeByDate,
-            int enrollmentMethodID
+            int enrollmentMethodID,
+            DateTime? firstSubmittedTime
         )
         {
             connection.Execute(
                 @"UPDATE Progress SET
                         SupervisorAdminID = @supervisorAdminId,
                         CompleteByDate = @completeByDate,
-                        EnrollmentMethodID = @enrollmentMethodID
+                        EnrollmentMethodID = @enrollmentMethodID,
+                        FirstSubmittedTime= @firstSubmittedTime
                     WHERE ProgressID = @progressId",
-                new { progressId, supervisorAdminId, completeByDate, enrollmentMethodID }
+                new { progressId, supervisorAdminId, completeByDate, enrollmentMethodID, @firstSubmittedTime }
             );
         }
 

--- a/DigitalLearningSolutions.Data/Utilities/ClockUtility.cs
+++ b/DigitalLearningSolutions.Data/Utilities/ClockUtility.cs
@@ -10,7 +10,7 @@ namespace DigitalLearningSolutions.Data.Utilities
 
     public class ClockUtility : IClockUtility
     {
-        public DateTime UtcNow => DateTime.UtcNow;
+        public DateTime UtcNow => DateTime.Now;
         public DateTime UtcToday => UtcNow.Date;
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -3,6 +3,7 @@
     using System;
     using Castle.Core.Internal;
     using DigitalLearningSolutions.Data.Models.Email;
+    using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using FakeItEasy;
     using FluentAssertions.Execution;
@@ -349,7 +350,8 @@
                         reusableProgressRecord.ProgressId,
                         A<int>._,
                         A<DateTime?>._,
-                         A<int>._
+                        A<int>._,
+                        A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }
@@ -386,7 +388,8 @@
                         reusableProgressRecord.ProgressId,
                         reusableProgressRecord.SupervisorAdminId,
                         A<DateTime?>._,
-                        A<int>._
+                        A<int>._,
+                         A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }
@@ -423,7 +426,8 @@
                         reusableProgressRecord.ProgressId,
                         supervisorId,
                         A<DateTime?>._,
-                        A<int>._
+                        A<int>._,
+                        A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }
@@ -460,7 +464,8 @@
                         reusableProgressRecord.ProgressId,
                         A<int>._,
                         null,
-                         A<int>._
+                         A<int>._,
+                          A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }
@@ -499,7 +504,8 @@
                         reusableProgressRecord.ProgressId,
                         A<int>._,
                         expectedFutureDate,
-                         A<int>._
+                         A<int>._,
+                          A<DateTime?>._
                     )
                 ).MustHaveHappened();
             }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -721,7 +721,7 @@
         private void DelegateProgressRecordMustNotHaveBeenUpdated()
         {
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
             ).MustNotHaveHappened();
         }
 
@@ -764,7 +764,7 @@
             A.CallTo(() => groupsDataService.AddDelegateToGroup(A<int>._, A<int>._, A<DateTime>._, A<int>._))
                 .DoesNothing();
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
             ).DoesNothing();
             A.CallTo(
                 () => progressDataService.CreateNewDelegateProgress(

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -58,7 +58,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)
@@ -84,7 +84,8 @@
                     progressId,
                     newSupervisorId,
                     A<DateTime?>._,
-                    A<int>._
+                    A<int>._,
+                     A<DateTime?>._
                 )
             ).MustHaveHappened();
             A.CallTo(
@@ -106,7 +107,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._, A<int>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._, A<int>._, A<DateTime?>._)
             ).MustHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(progressId)
@@ -123,7 +124,7 @@
             // Then
             Assert.Throws<ProgressNotFoundException>(() => progressService.UpdateSupervisor(progressId, null));
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -103,8 +103,9 @@ namespace DigitalLearningSolutions.Web.Services
                         progressRecord.ProgressId,
                         supervisorAdminId ?? 0,
                         completeByDate,
-                        2
-                    );
+                        2,
+                       clockUtility.UtcNow
+                        );
                 }
             }
             else
@@ -114,7 +115,7 @@ namespace DigitalLearningSolutions.Web.Services
                     customisationId,
                     customisationVersion,
                     clockUtility.UtcNow,
-                    3,
+                    2,
                     enrolledByAdminId,
                 completeByDate,
                 supervisorAdminId ?? 0

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -744,7 +744,8 @@
                         progressRecord.ProgressId,
                         updatedSupervisorAdminId,
                         completeByDate,
-                       3
+                       3,
+                      clockUtility.UtcNow
                     );
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -106,7 +106,8 @@
                 progressId,
                 supervisorId,
                 courseInfo.CompleteBy,
-                2
+                2,
+               clockUtility.UtcNow
             );
 
             progressDataService.ClearAspProgressVerificationRequest(progressId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3671

### Description
I alter the query that update the delegate information to update  FirstSubmittedTime whenever the admin enrol course for delegate

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/f5ec6487-2522-4f89-a48b-8b4dc88ad241)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
