### PR TITLE
TD-3938-EmailDelegatesController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EmailDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EmailDelegatesControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegates
 {
     using System.Collections.Generic;
-    //using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.User;
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EmailDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EmailDelegatesControllerTests.cs
@@ -1,10 +1,10 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegates
 {
     using System.Collections.Generic;
-    using DigitalLearningSolutions.Data.DataServices;
+    //using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.User;
-    
+
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
     using DigitalLearningSolutions.Web.Helpers;
@@ -24,7 +24,7 @@
         private EmailDelegatesController emailDelegatesController = null!;
         private HttpRequest httpRequest = null!;
         private HttpResponse httpResponse = null!;
-        private IJobGroupsDataService jobGroupsDataService = null!;
+        private IJobGroupsService jobGroupsService = null!;
         private IPasswordResetService passwordResetService = null!;
         private PromptsService promptsHelper = null!;
         private ISearchSortFilterPaginateService searchSortFilterPaginateService = null!;
@@ -38,7 +38,7 @@
             centreRegistrationPromptsService = A.Fake<ICentreRegistrationPromptsService>();
             promptsHelper = new PromptsService(centreRegistrationPromptsService);
             userService = A.Fake<IUserService>();
-            jobGroupsDataService = A.Fake<IJobGroupsDataService>();
+            jobGroupsService = A.Fake<IJobGroupsService>();
             passwordResetService = A.Fake<IPasswordResetService>();
             searchSortFilterPaginateService = A.Fake<ISearchSortFilterPaginateService>();
             config = A.Fake<IConfiguration>();
@@ -51,7 +51,7 @@
 
             emailDelegatesController = new EmailDelegatesController(
                     promptsHelper,
-                    jobGroupsDataService,
+                    jobGroupsService,
                     passwordResetService,
                     userService,
                     searchSortFilterPaginateService,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EmailDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EmailDelegatesController.cs
@@ -3,7 +3,6 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    //using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Helpers;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EmailDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EmailDelegatesController.cs
@@ -3,7 +3,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using DigitalLearningSolutions.Data.DataServices;
+    //using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Helpers;
@@ -29,7 +29,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
     {
         private const string EmailDelegateFilterCookieName = "EmailDelegateFilter";
         private readonly PromptsService promptsService;
-        private readonly IJobGroupsDataService jobGroupsDataService;
+        private readonly IJobGroupsService jobGroupsService;
         private readonly IPasswordResetService passwordResetService;
         private readonly IUserService userService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
@@ -38,7 +38,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 
         public EmailDelegatesController(
             PromptsService promptsService,
-            IJobGroupsDataService jobGroupsDataService,
+            IJobGroupsService jobGroupsService,
             IPasswordResetService passwordResetService,
             IUserService userService,
             ISearchSortFilterPaginateService searchSortFilterPaginateService,
@@ -47,7 +47,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         )
         {
             this.promptsService = promptsService;
-            this.jobGroupsDataService = jobGroupsDataService;
+            this.jobGroupsService = jobGroupsService;
             this.passwordResetService = passwordResetService;
             this.userService = userService;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
@@ -70,7 +70,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 Request,
                 EmailDelegateFilterCookieName
             );
-            var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
+            var jobGroups = jobGroupsService.GetJobGroupsAlphabetical();
             var customPrompts = promptsService.GetCentreRegistrationPrompts(User.GetCentreIdKnownNotNull());
             var delegateUsers = GetDelegateUserCards();
 
@@ -123,7 +123,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     Request,
                     EmailDelegateFilterCookieName
                 );
-                var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
+                var jobGroups = jobGroupsService.GetJobGroupsAlphabetical();
                 var customPrompts = promptsService.GetCentreRegistrationPrompts(User.GetCentreIdKnownNotNull());
 
                 var promptsWithOptions = customPrompts.Where(customPrompt => customPrompt.Options.Count > 0);
@@ -167,7 +167,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         [Route("AllEmailDelegateItems")]
         public IActionResult AllEmailDelegateItems(IEnumerable<int> selectedIds)
         {
-            var jobGroups = jobGroupsDataService.GetJobGroupsAlphabetical();
+            var jobGroups = jobGroupsService.GetJobGroupsAlphabetical();
             var customPrompts = promptsService.GetCentreRegistrationPrompts(User.GetCentreIdKnownNotNull());
             var delegateUsers = GetDelegateUserCards();
 


### PR DESCRIPTION
### JIRA link
[_TD-3938_](https://hee-tis.atlassian.net/browse/TD-3938)

### Description
DataService reference removed from the controller.
Code modified to use service class methods.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/439ec303-b71a-44d4-a79f-41dbf21c33e3)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/55798eec-e87f-450f-a36d-34f6deb94aa9)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8c4e8e99-11e0-4ac9-a5fd-64ae397708d5)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1a993142-a040-4434-a6b4-a81f8455d9ae)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/bc0fc8bf-a472-4093-a67f-ce62e78e8999)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
