### PR TITLE
TD-3941-SetDelegatePasswordController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/SetDelegatePasswordControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/SetDelegatePasswordControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegates
 {
     using System.Threading.Tasks;
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
     using DigitalLearningSolutions.Web.Services;
     using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
@@ -20,14 +19,14 @@
 
         private IPasswordService passwordService = null!;
         private SetDelegatePasswordController setDelegatePasswordController = null!;
-        private IUserDataService userDataService = null!;
+        private IUserService userService = null!;
 
         [SetUp]
         public void Setup()
         {
-            userDataService = A.Fake<IUserDataService>();
+            userService = A.Fake<IUserService>();
             passwordService = A.Fake<IPasswordService>();
-            setDelegatePasswordController = new SetDelegatePasswordController(passwordService, userDataService)
+            setDelegatePasswordController = new SetDelegatePasswordController(passwordService, userService)
                 .WithDefaultContext()
                 .WithMockUser(true);
         }
@@ -36,7 +35,7 @@
         public void Index_should_return_view_result_with_IsFromViewDelegatePage_false_when_not_from_view_page()
         {
             // Given
-            A.CallTo(() => userDataService.GetDelegateUserById(DelegateId))
+            A.CallTo(() => userService.GetDelegateUserById(DelegateId))
                 .Returns(UserTestHelper.GetDefaultDelegateUser());
 
             // When
@@ -51,7 +50,7 @@
         public void Index_should_return_view_result_with_IsFromViewDelegatePage_true_when_from_view_page()
         {
             // Given
-            A.CallTo(() => userDataService.GetDelegateUserById(DelegateId))
+            A.CallTo(() => userService.GetDelegateUserById(DelegateId))
                 .Returns(UserTestHelper.GetDefaultDelegateUser());
 
             // When
@@ -85,7 +84,7 @@
             // Given
             var delegateAccount = UserTestHelper.GetDefaultDelegateAccount();
             var model = new SetDelegatePasswordViewModel { Password = Password };
-            A.CallTo(() => userDataService.GetDelegateAccountById(DelegateId))
+            A.CallTo(() => userService.GetDelegateAccountById(DelegateId))
                 .Returns(delegateAccount);
             A.CallTo(() => passwordService.ChangePasswordAsync(A<int>._, A<string>._)).Returns(Task.CompletedTask);
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/SetDelegatePasswordController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/SetDelegatePasswordController.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 {
     using System.Threading.Tasks;
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Web.Attributes;
@@ -23,12 +22,12 @@
     public class SetDelegatePasswordController : Controller
     {
         private readonly IPasswordService passwordService;
-        private readonly IUserDataService userDataService;
+        private readonly IUserService userService;
 
-        public SetDelegatePasswordController(IPasswordService passwordService, IUserDataService userDataService)
+        public SetDelegatePasswordController(IPasswordService passwordService, IUserService userDataService)
         {
             this.passwordService = passwordService;
-            this.userDataService = userDataService;
+            this.userService = userDataService;
         }
 
         [HttpGet]
@@ -38,7 +37,7 @@
             ReturnPageQuery? returnPageQuery = null
         )
         {
-            var delegateUser = userDataService.GetDelegateUserById(delegateId)!;
+            var delegateUser = userService.GetDelegateUserById(delegateId)!;
 
             var model = new SetDelegatePasswordViewModel(
                 DisplayStringHelper.GetNonSortableFullNameForDisplayOnly(delegateUser.FirstName, delegateUser.LastName),
@@ -64,7 +63,7 @@
                 return View(model);
             }
 
-            var delegateAccount = userDataService.GetDelegateAccountById(delegateId)!;
+            var delegateAccount = userService.GetDelegateAccountById(delegateId)!;
 
             await passwordService.ChangePasswordAsync(delegateAccount.UserId, model.Password!);
 

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -141,6 +141,7 @@ namespace DigitalLearningSolutions.Web.Services
         bool CentreSpecificEmailIsInUseAtCentre(string email, int centreId);
         int? GetUserIdByAdminId(int adminId);
         AdminUser? GetAdminUserByEmailAddress(string emailAddress);
+        DelegateAccount? GetDelegateAccountById(int id);
     }
 
     public class UserService : IUserService
@@ -762,7 +763,7 @@ namespace DigitalLearningSolutions.Web.Services
         }
         public bool PrimaryEmailInUseAtCentres(string email)
         {
-           return  userDataService.PrimaryEmailInUseAtCentres(email);
+            return userDataService.PrimaryEmailInUseAtCentres(email);
         }
 
         public bool CentreSpecificEmailIsInUseAtCentre(string email, int centreId)
@@ -778,6 +779,11 @@ namespace DigitalLearningSolutions.Web.Services
         public AdminUser? GetAdminUserByEmailAddress(string emailAddress)
         {
             return userDataService.GetAdminUserByEmailAddress(emailAddress);
+        }
+
+        public DelegateAccount? GetDelegateAccountById(int id)
+        {
+            return userDataService.GetDelegateAccountById(id);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[_TD-3941_](https://hee-tis.atlassian.net/browse/TD-3941)

### Description
DataService reference removed from the controller.
Code modified to use service class methods.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/58cc7cd8-d750-4ac7-8356-90bc6bd8bb77)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/59885991-789d-489c-a905-ebc0fe5a55e7)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
