### PR TITLE
TD-4218 'Last access' date and time shouldn't show on the learner record when admin registers the delegate from the 'Tracking system'

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -24,7 +24,8 @@
             int enrollmentMethodId,
             int? enrolledByAdminId,
             DateTime? completeByDate,
-            int supervisorAdminId
+            int supervisorAdminId,
+            DateTime firstSubmittedTime
         );
 
         void CreateNewAspProgress(int tutorialId, int progressId);
@@ -166,7 +167,8 @@
             int enrollmentMethodId,
             int? enrolledByAdminId,
             DateTime? completeByDate,
-            int supervisorAdminId
+            int supervisorAdminId,
+            DateTime firstSubmittedTime
         )
         {
             var progressId = connection.QuerySingle<int>(
@@ -178,7 +180,8 @@
                         EnrollmentMethodID,
                         EnrolledByAdminID,
                         CompleteByDate,
-                        SupervisorAdminID)
+                        SupervisorAdminID,
+                        FirstSubmittedTime)
                     OUTPUT Inserted.ProgressID
                     VALUES (
                         @delegateId,
@@ -188,7 +191,8 @@
                         @enrollmentMethodId,
                         @enrolledByAdminId,
                         @completeByDate,
-                        @supervisorAdminId)",
+                        @supervisorAdminId,
+                        @firstSubmittedTime)",
                 new
                 {
                     delegateId,
@@ -199,6 +203,7 @@
                     enrolledByAdminId,
                     completeByDate,
                     supervisorAdminId,
+                    firstSubmittedTime
                 }
             );
 

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -58,7 +58,8 @@
                         3,
                         null,
                         A<DateTime?>._,
-                        A<int>._
+                        A<int>._,
+                          testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
@@ -100,7 +101,8 @@
                         3,
                         null,
                         A<DateTime?>._,
-                        A<int>._
+                        A<int>._,
+                          testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
@@ -142,7 +144,8 @@
                         3,
                         null,
                         A<DateTime?>._,
-                        A<int>._
+                        A<int>._,
+                        testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
@@ -184,7 +187,8 @@
                         3,
                         null,
                         A<DateTime?>._,
-                        0
+                        0 ,
+                        testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
@@ -227,7 +231,8 @@
                         3,
                         null,
                         testDate.AddMonths(12),
-                        supervisorId
+                        supervisorId,
+                          testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
@@ -269,7 +274,8 @@
                         3,
                         null,
                         null,
-                        A<int>._
+                        A<int>._,
+                          testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
@@ -313,7 +319,8 @@
                         3,
                         null,
                         expectedFutureDate,
-                        A<int>._
+                        A<int>._,
+                          testDate
                     )
                 ).MustHaveHappened();
                 A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -736,7 +736,8 @@
                     A<int>._,
                     A<int?>._,
                     A<DateTime?>._,
-                    A<int>._
+                    A<int>._,
+                      A<DateTime>._
                 )
             ).MustNotHaveHappened();
             A.CallTo(
@@ -775,7 +776,8 @@
                     A<int>._,
                     A<int?>._,
                     A<DateTime?>._,
-                    A<int>._
+                    A<int>._,
+                      A<DateTime>._
                 )
             ).Returns(0);
             A.CallTo(() => progressDataService.CreateNewAspProgress(A<int>._, A<int>._)).DoesNothing();
@@ -804,7 +806,8 @@
                     A<int>._,
                     A<int?>._,
                     A<DateTime?>._,
-                    A<int>._
+                    A<int>._,
+                    A<DateTime>._
                 )
             ).Returns(newProgressId);
             A.CallTo(() => tutorialContentDataService.GetTutorialIdsForCourse(A<int>._))

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/DelegateCourseInfoViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/AllDelegates/DelegateCourseInfoViewModelTests.cs
@@ -56,7 +56,7 @@
         }
 
         [TestCase(1, "Self enrolled")]
-        [TestCase(2, "Enrolled by Test Admin")]
+        [TestCase(2, "Enrolled by Admin - Test Admin")]
         [TestCase(3, "Group")]
         [TestCase(4, "System")]
         public void DelegateCourseInfoViewModel_sets_enrollment_method_correctly(

--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgress/DelegateProgressViewModelTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateProgress/DelegateProgressViewModelTests.cs
@@ -107,7 +107,7 @@
 
         [Test]
         [TestCase(1, "Self enrolled")]
-        [TestCase(2, "Enrolled by Ronnie Dio")]
+        [TestCase(2, "Enrolled by Admin - Ronnie Dio")]
         [TestCase(3, "Group")]
         [TestCase(4, "System")]
         public void ViewModel_sets_Enrolment_method_text_correctly(int enrolmentMethodId, string expectedText)

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -118,7 +118,8 @@ namespace DigitalLearningSolutions.Web.Services
                     2,
                     enrolledByAdminId,
                 completeByDate,
-                supervisorAdminId ?? 0
+                supervisorAdminId ?? 0,
+                clockUtility.UtcNow
                 );
                 var tutorialsForCourse =
                     tutorialContentDataService.GetTutorialIdsForCourse(customisationId);

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -759,7 +759,8 @@
                     3,
                     addedByAdminId,
                     completeByDate,
-                    groupCourse.SupervisorAdminId ?? 0
+                    groupCourse.SupervisorAdminId ?? 0,
+                    clockUtility.UtcNow
                 );
 
                 var tutorialsForCourse =

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
@@ -77,7 +77,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
             EnrolmentMethod = info.EnrolmentMethodId switch
             {
                 1 => "Self enrolled",
-                2 => "Enrolled by " + (enrolledByFullName ?? "Admin"),
+                2 => "Enrolled by Admin",
                 3 => "Group",
                 _ => "System",
             };

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
@@ -77,7 +77,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
             EnrolmentMethod = info.EnrolmentMethodId switch
             {
                 1 => "Self enrolled",
-                2 => "Enrolled by Admin - " + (enrolledByFullName),
+                2 => enrolledByFullName != null ? "Enrolled by Admin - " + enrolledByFullName : "Enrolled by Admin",
                 3 => "Group",
                 _ => "System",
             };

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
@@ -77,7 +77,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
             EnrolmentMethod = info.EnrolmentMethodId switch
             {
                 1 => "Self enrolled",
-                2 => "Enrolled by Admin",
+                2 => "Enrolled by Admin - " + (enrolledByFullName),
                 3 => "Group",
                 _ => "System",
             };


### PR DESCRIPTION


### JIRA link
https://hee-tis.atlassian.net/browse/TD-4218

### Description
Ensuring the enrol date is local time instead of using 

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c49648b9-d7b2-4909-bfae-dc081915317d)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
