### PR TITLE
TD-3925-SystemNotificationsController - refactor 

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotificationControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/SystemNotificationControllerTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Models;    
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre;
@@ -23,18 +22,18 @@
         private HttpRequest httpRequest = null!;
         private HttpResponse httpResponse = null!;
         private ISearchSortFilterPaginateService searchSortFilterPaginateService = null!;
-        private ISystemNotificationsDataService systemNotificationsDataService = null!;
+        private ISystemNotificationsService systemNotificationsService = null!;
 
         [SetUp]
         public void Setup()
         {
             httpRequest = A.Fake<HttpRequest>();
             httpResponse = A.Fake<HttpResponse>();
-            systemNotificationsDataService = A.Fake<ISystemNotificationsDataService>();
+            systemNotificationsService = A.Fake<ISystemNotificationsService>();
             searchSortFilterPaginateService = A.Fake<ISearchSortFilterPaginateService>();
             controller =
                 new SystemNotificationsController(
-                        systemNotificationsDataService,
+                        systemNotificationsService,
                         clockUtility,
                         searchSortFilterPaginateService
                     )
@@ -51,7 +50,7 @@
             var testDate = new DateTime(2021, 8, 23);
             A.CallTo(() => clockUtility.UtcNow).Returns(testDate);
             var expectedExpiry = testDate.AddHours(24);
-            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+            A.CallTo(() => systemNotificationsService.GetUnacknowledgedSystemNotifications(A<int>._))
                 .Returns(new List<SystemNotification> { SystemNotificationTestHelper.GetDefaultSystemNotification() });
 
             // When
@@ -80,7 +79,7 @@
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => systemNotificationsDataService.AcknowledgeNotification(1, 7)).MustHaveHappened();
+                A.CallTo(() => systemNotificationsService.AcknowledgeNotification(1, 7)).MustHaveHappened();
                 result.Should().BeRedirectToActionResult().WithControllerName("SystemNotifications")
                     .WithActionName("Index");
             }
@@ -93,7 +92,7 @@
             A.CallTo(() => httpRequest.Cookies).Returns(
                 ControllerContextHelper.SetUpFakeRequestCookieCollection(SystemNotificationCookieHelper.CookieName, "7")
             );
-            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+            A.CallTo(() => systemNotificationsService.GetUnacknowledgedSystemNotifications(A<int>._))
                 .Returns(new List<SystemNotification>());
 
             // When
@@ -110,7 +109,7 @@
             A.CallTo(() => httpRequest.Cookies).Returns(
                 ControllerContextHelper.SetUpFakeRequestCookieCollection(SystemNotificationCookieHelper.CookieName, "8")
             );
-            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+            A.CallTo(() => systemNotificationsService.GetUnacknowledgedSystemNotifications(A<int>._))
                 .Returns(new List<SystemNotification>());
 
             // When
@@ -128,7 +127,7 @@
             A.CallTo(() => httpRequest.Cookies).Returns(
                 A.Fake<IRequestCookieCollection>()
             );
-            A.CallTo(() => systemNotificationsDataService.GetUnacknowledgedSystemNotifications(A<int>._))
+            A.CallTo(() => systemNotificationsService.GetUnacknowledgedSystemNotifications(A<int>._))
                 .Returns(new List<SystemNotification>());
 
             // When

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SystemNotificationsController.cs
@@ -1,7 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre
 {
     using System.Linq;
-    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Utilities;
@@ -23,15 +22,15 @@
     {
         private readonly IClockUtility clockUtility;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
-        private readonly ISystemNotificationsDataService systemNotificationsDataService;
+        private readonly ISystemNotificationsService systemNotificationsService;
 
         public SystemNotificationsController(
-            ISystemNotificationsDataService systemNotificationsDataService,
+            ISystemNotificationsService systemNotificationsService,
             IClockUtility clockUtility,
             ISearchSortFilterPaginateService searchSortFilterPaginateService
         )
         {
-            this.systemNotificationsDataService = systemNotificationsDataService;
+            this.systemNotificationsService = systemNotificationsService;
             this.clockUtility = clockUtility;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
         }
@@ -42,7 +41,7 @@
         {
             var adminId = User.GetAdminId()!.Value;
             var unacknowledgedNotifications =
-                systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId).ToList();
+                systemNotificationsService.GetUnacknowledgedSystemNotifications(adminId).ToList();
 
             if (unacknowledgedNotifications.Count > 0)
             {
@@ -74,7 +73,7 @@
         public IActionResult AcknowledgeNotification(int systemNotificationId, int page)
         {
             var adminId = User.GetAdminId()!.Value;
-            systemNotificationsDataService.AcknowledgeNotification(systemNotificationId, adminId);
+            systemNotificationsService.AcknowledgeNotification(systemNotificationId, adminId);
 
             return RedirectToAction("Index", "SystemNotifications", new { page });
         }

--- a/DigitalLearningSolutions.Web/Services/SystemNotificationsService.cs
+++ b/DigitalLearningSolutions.Web/Services/SystemNotificationsService.cs
@@ -1,0 +1,30 @@
+﻿using DigitalLearningSolutions.Data.DataServices;
+using DigitalLearningSolutions.Data.Models;
+using System.Collections.Generic;
+
+namespace DigitalLearningSolutions.Web.Services
+{
+    public interface ISystemNotificationsService
+    {
+        public IEnumerable<SystemNotification> GetUnacknowledgedSystemNotifications(int adminId);
+
+        public void AcknowledgeNotification(int notificationId, int adminId);
+    }
+    public class SystemNotificationsService : ISystemNotificationsService
+    {
+        private readonly ISystemNotificationsDataService systemNotificationsDataService;
+        public SystemNotificationsService(ISystemNotificationsDataService systemNotificationsDataService)
+        {
+            this.systemNotificationsDataService = systemNotificationsDataService;
+        }
+        public void AcknowledgeNotification(int notificationId, int adminId)
+        {
+            systemNotificationsDataService.AcknowledgeNotification(notificationId, adminId);
+        }
+
+        public IEnumerable<SystemNotification> GetUnacknowledgedSystemNotifications(int adminId)
+        {
+            return systemNotificationsDataService.GetUnacknowledgedSystemNotifications(adminId);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -452,6 +452,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IStoreAspService, StoreAspService>();
             services.AddScoped<ISupervisorDelegateService, SupervisorDelegateService>();
             services.AddScoped<ISupervisorService, SupervisorService>();
+            services.AddScoped<ISystemNotificationsService, SystemNotificationsService>();
             services.AddScoped<IDashboardInformationService, DashboardInformationService>();
             services.AddScoped<ITrackerService, TrackerService>();
             services.AddScoped<ITrackerActionService, TrackerActionService>();


### PR DESCRIPTION
### JIRA link
[_TD-3925_](https://hee-tis.atlassian.net/browse/TD-3925)

### Description
DataService reference removed from the controller.  Service class 'SystemNotificationsService' added
Code modified to use service class methods.

### Screenshots

Note: Dev testing has been done with dummy data by manipulating DB table data.

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c9e2b14c-cb63-48a9-b8de-aa80e38bb49c)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
