### PR TITLE
TD-3921-RegistrationPromptsController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Centre.Configuration
 {
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Models.MultiPageFormData.AddRegistrationPrompt;
     using DigitalLearningSolutions.Data.Models.MultiPageFormData.EditRegistrationPrompt;
     using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Configuration;
@@ -27,7 +26,7 @@
         private IMultiPageFormService multiPageFormService = null!;
         private RegistrationPromptsController registrationPromptsController = null!;
         private RegistrationPromptsController registrationPromptsControllerWithMockHttpContext = null!;
-        private IUserDataService userDataService = null!;
+        private IUserService userService = null!;
 
         private static IEnumerable<TestCaseData> AddAnswerModelErrorTestData
         {
@@ -57,13 +56,13 @@
         public void Setup()
         {
             centreRegistrationPromptsService = A.Fake<ICentreRegistrationPromptsService>();
-            userDataService = A.Fake<IUserDataService>();
+            userService = A.Fake<IUserService>();
             multiPageFormService = A.Fake<IMultiPageFormService>();
 
             registrationPromptsController =
                 new RegistrationPromptsController(
                         centreRegistrationPromptsService,
-                        userDataService,
+                        userService,
                         multiPageFormService
                     )
                     .WithDefaultContext()
@@ -77,7 +76,7 @@
             registrationPromptsControllerWithMockHttpContext =
                 new RegistrationPromptsController(
                         centreRegistrationPromptsService,
-                        userDataService,
+                        userService,
                         multiPageFormService
                     )
                     .WithMockHttpContext(httpRequest, cookieName, cookieValue)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Configuration/RegistrationPromptsController.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Centre.Configuration
 {
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.MultiPageFormData.AddRegistrationPrompt;
@@ -35,16 +34,16 @@
         public const string BulkAction = "bulk";
         private readonly ICentreRegistrationPromptsService centreRegistrationPromptsService;
         private readonly IMultiPageFormService multiPageFormService;
-        private readonly IUserDataService userDataService;
+        private readonly IUserService userService;
 
         public RegistrationPromptsController(
             ICentreRegistrationPromptsService centreRegistrationPromptsService,
-            IUserDataService userDataService,
+            IUserService userService,
             IMultiPageFormService multiPageFormService
         )
         {
             this.centreRegistrationPromptsService = centreRegistrationPromptsService;
-            this.userDataService = userDataService;
+            this.userService = userService;
             this.multiPageFormService = multiPageFormService;
         }
 
@@ -366,7 +365,7 @@
         public IActionResult RemoveRegistrationPrompt(int promptNumber)
         {
             var delegateWithAnswerCount =
-                userDataService.GetDelegateCountWithAnswerForPrompt(User.GetCentreIdKnownNotNull(), promptNumber);
+                userService.GetDelegateCountWithAnswerForPrompt(User.GetCentreIdKnownNotNull(), promptNumber);
 
             if (delegateWithAnswerCount == 0)
             {

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -143,6 +143,7 @@ namespace DigitalLearningSolutions.Web.Services
         AdminUser? GetAdminUserByEmailAddress(string emailAddress);
         DelegateAccount? GetDelegateAccountById(int id);
         int? GetUserIdFromUsername(string username);
+        int GetDelegateCountWithAnswerForPrompt(int centreId, int promptNumber);
     }
 
     public class UserService : IUserService
@@ -790,6 +791,11 @@ namespace DigitalLearningSolutions.Web.Services
         public int? GetUserIdFromUsername(string username)
         {
             return userDataService.GetUserIdFromUsername(username);
+        }
+
+        public int GetDelegateCountWithAnswerForPrompt(int centreId, int promptNumber)
+        {
+            return userDataService.GetDelegateCountWithAnswerForPrompt(centreId, promptNumber);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[_TD-3921_](https://hee-tis.atlassian.net/browse/TD-3921)

### Description

Controller refactor -DataService reference removed from the controller. New method added to UserService.cs
Code modified to use service class methods.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/d8f2be38-7434-4b1f-b382-bd489168ffd5)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/6c52705c-bdd4-41a7-8617-f538a2195a1f)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
