### PR TITLE
TD-4222-Enrolled Supervisor has different email address

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorService.cs
@@ -393,7 +393,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         public IEnumerable<SupervisorForEnrolDelegate> GetSupervisorForEnrolDelegate(int CustomisationID, int CentreID)
         {
             return connection.Query<SupervisorForEnrolDelegate>(
-                $@"SELECT AdminID, Forename + ' ' + Surname + ' (' + CentreName +')' AS Name, Email FROM AdminUsers AS au
+                $@"SELECT AdminID, Forename + ' ' + Surname + ' (' + Email +')' + ' (' + CentreName +')' AS Name, Email FROM AdminUsers AS au
                     WHERE (Supervisor = 1) AND (CentreID = @CentreID) AND (CategoryID = 0 OR
                          CategoryID = (SELECT au.CategoryID FROM Applications AS a INNER JOIN
                            Customisations AS c ON a.ApplicationID = c.ApplicationID

--- a/DigitalLearningSolutions.Data/Models/SessionData/Tracking/Delegate/Enrol/SessionEnrolDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SessionData/Tracking/Delegate/Enrol/SessionEnrolDelegate.cs
@@ -13,6 +13,7 @@
         public string? SelfAssessmentSupervisorRoleName { get; set; }
         public int? SupervisorID { get; set; }
         public string? SupervisorName { get; set; }
+        public string? SupervisorEmail { get; set; }
         public bool IsSelfAssessment { get; set; }
         public int AssessmentVersion { get; set; }
     }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -256,13 +256,14 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             {
                 sessionEnrol.SupervisorName = supervisorList.FirstOrDefault(x => x.AdminId == model.SelectedSupervisor).Name;
                 sessionEnrol.SupervisorID = model.SelectedSupervisor;
+                sessionEnrol.SupervisorEmail = supervisorList.FirstOrDefault(x => x.AdminId == model.SelectedSupervisor).Email;
             }
             if (model.SelectedSupervisorRoleId.HasValue && model.SelectedSupervisorRoleId.Value > 0)
             {
                 sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault(x => x.ID == model.SelectedSupervisorRoleId).RoleName;
             }
             sessionEnrol.SelfAssessmentSupervisorRoleId = model.SelectedSupervisorRoleId;
-            if (roles.Count()==1 && !string.IsNullOrEmpty(sessionEnrol.SupervisorName))
+            if (roles.Count() == 1 && !string.IsNullOrEmpty(sessionEnrol.SupervisorName))
             {
                 sessionEnrol.SelfAssessmentSupervisorRoleName = roles.FirstOrDefault().RoleName;
                 sessionEnrol.SelfAssessmentSupervisorRoleId = roles.FirstOrDefault().ID;
@@ -292,6 +293,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 
             var model = new EnrolSummaryViewModel();
             model.SupervisorName = sessionEnrol.SupervisorName;
+            model.SupervisorEmail = sessionEnrol.SupervisorEmail;
             model.ActivityName = sessionEnrol.AssessmentName;
             model.CompleteByDate = sessionEnrol.CompleteByDate;
             model.DelegateId = delegateId;
@@ -316,12 +318,11 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             }
             else
             {
-                var adminEmail = User.GetUserPrimaryEmailKnownNotNull();
                 var selfAssessmentId = enrolService.EnrolOnActivitySelfAssessment(
                     sessionEnrol.AssessmentID.GetValueOrDefault(),
                     delegateId,
                     sessionEnrol.SupervisorID.GetValueOrDefault(),
-                    adminEmail,
+                    sessionEnrol.SupervisorEmail,
                     sessionEnrol.SelfAssessmentSupervisorRoleId.GetValueOrDefault(),
                     sessionEnrol.CompleteByDate,
                     (int)sessionEnrol.DelegateUserID,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Enrol/EnrolDelegateSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Enrol/EnrolDelegateSummaryViewModel.cs
@@ -9,6 +9,7 @@
         public string? ActivityName { get; set; }
         public DateTime? CompleteByDate { get; set; }
         public string? SupervisorName { get; set; }
+        public string? SupervisorEmail { get; set; }
         public string? SupervisorRoleName { get; set; }
         public bool? IsMandatory { get; set; }
         public string? ValidFor { get; set; }


### PR DESCRIPTION
### JIRA link
[_TD-4222_](https://hee-tis.atlassian.net/browse/TD-4222)

### Description
SupervisorEmail property added to hold supervisor email address.
Supervisor email address appended to drop down list, enrolment details view as shown in the screen shot below.


### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8d8b935f-2fdb-472e-951b-3d006df87468)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/f6feb098-f79f-408d-9e39-d88d7bf5d71a)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/fb3a9b22-3bec-4aec-b14f-66fc8e3f04d6)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/23b22a17-9ce3-4560-9ce5-01fe3e2c9584)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2645417b-894e-4458-977c-b404f861bf85)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
