### PR TITLE
TD-3919-AdministratorController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -2,8 +2,6 @@
 {
     using System.Linq;
     using System.Net;
-    using DigitalLearningSolutions.Data.DataServices;
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models;
@@ -30,16 +28,14 @@
     {
         private const string AdminFilterCookieName = "AdminFilter";
         private readonly ICentreContractAdminUsageService centreContractAdminUsageService;
-        private readonly ICourseCategoriesDataService courseCategoriesDataService;
+        private readonly ICourseCategoriesService courseCategoriesService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
-        private readonly IUserDataService userDataService;
         private readonly IUserService userService;
         private readonly IEmailService emailService;
         private readonly IEmailGenerationService emailGenerationService;
 
         public AdministratorController(
-            IUserDataService userDataService,
-            ICourseCategoriesDataService courseCategoriesDataService,
+            ICourseCategoriesService courseCategoriesService,
             ICentreContractAdminUsageService centreContractAdminUsageService,
             IUserService userService,
             ISearchSortFilterPaginateService searchSortFilterPaginateService,
@@ -47,8 +43,7 @@
             IEmailGenerationService emailGenerationService
         )
         {
-            this.userDataService = userDataService;
-            this.courseCategoriesDataService = courseCategoriesDataService;
+            this.courseCategoriesService = courseCategoriesService;
             this.centreContractAdminUsageService = centreContractAdminUsageService;
             this.userService = userService;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
@@ -75,9 +70,9 @@
             );
 
             var centreId = User.GetCentreIdKnownNotNull();
-            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId);
-            var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
-            var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
+            var adminsAtCentre = userService.GetAdminsByCentreId(centreId);
+            var categories = courseCategoriesService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
+            var loggedInAdmin = userService.GetAdminById(User.GetAdminId()!.Value);
 
             var availableFilters =
                 AdministratorsViewModelFilterOptions.GetAllAdministratorsFilterModels(categories);
@@ -111,10 +106,10 @@
         public IActionResult AllAdmins()
         {
             var centreId = User.GetCentreIdKnownNotNull();
-            var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.Value);
+            var loggedInAdmin = userService.GetAdminById(User.GetAdminId()!.Value);
 
-            var adminsAtCentre = userDataService.GetAdminsByCentreId(centreId);
-            var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
+            var adminsAtCentre = userService.GetAdminsByCentreId(centreId);
+            var categories = courseCategoriesService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
             var model = new AllAdminsViewModel(
                 adminsAtCentre,
                 categories,
@@ -129,9 +124,9 @@
         public IActionResult EditAdminRoles(int adminId, ReturnPageQuery returnPageQuery)
         {
             var centreId = User.GetCentreIdKnownNotNull();
-            var adminUser = userDataService.GetAdminUserById(adminId);
+            var adminUser = userService.GetAdminUserById(adminId);
 
-            var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
+            var categories = courseCategoriesService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
             categories = categories.Prepend(new Category { CategoryName = "All", CourseCategoryID = 0 });
             var numberOfAdmins = centreContractAdminUsageService.GetCentreAdministratorNumbers(centreId);
 
@@ -150,7 +145,7 @@
                 adminRoles.IsContentCreator || adminRoles.IsTrainer || adminRoles.IsCentreManager || adminRoles.IsContentManager))
             {
                 var centreId = User.GetCentreIdKnownNotNull();
-                var adminUser = userDataService.GetAdminUserById(adminId);
+                var adminUser = userService.GetAdminUserById(adminId);
 
                 adminUser.IsCentreAdmin = adminRoles.IsCentreAdmin;
                 adminUser.IsSupervisor = adminRoles.IsSupervisor;
@@ -162,7 +157,7 @@
                 adminUser.IsContentManager = model.ContentManagementRole.IsContentManager;
 
 
-                var categories = courseCategoriesDataService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
+                var categories = courseCategoriesService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
                 categories = categories.Prepend(new Category { CategoryName = "All", CourseCategoryID = 0 });
                 var numberOfAdmins = centreContractAdminUsageService.GetCentreAdministratorNumbers(centreId);
 
@@ -229,7 +224,7 @@
         [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
         public IActionResult UnlockAccount(int adminId)
         {
-            userService.ResetFailedLoginCountByUserId(userDataService.GetUserIdByAdminId(adminId)!.Value);
+            userService.ResetFailedLoginCountByUserId(userService.GetUserIdByAdminId(adminId)!.Value);
 
             return RedirectToAction("Index");
         }
@@ -239,7 +234,7 @@
         [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
         public IActionResult DeactivateOrDeleteAdmin(int adminId, ReturnPageQuery returnPageQuery)
         {
-            var admin = userDataService.GetAdminById(adminId);
+            var admin = userService.GetAdminById(adminId);
 
             if (!CurrentUserCanDeactivateAdmin(admin!.AdminAccount))
             {
@@ -255,7 +250,7 @@
         [ServiceFilter(typeof(VerifyAdminUserCanAccessAdminUser))]
         public IActionResult DeactivateOrDeleteAdmin(int adminId, DeactivateAdminViewModel model)
         {
-            var admin = userDataService.GetAdminById(adminId);
+            var admin = userService.GetAdminById(adminId);
 
             if (!CurrentUserCanDeactivateAdmin(admin!.AdminAccount))
             {
@@ -285,7 +280,7 @@
 
         private bool CurrentUserCanDeactivateAdmin(AdminAccount adminToDeactivate)
         {
-            var loggedInAdmin = userDataService.GetAdminById(User.GetAdminId()!.GetValueOrDefault());
+            var loggedInAdmin = userService.GetAdminById(User.GetAdminId()!.GetValueOrDefault());
 
             return UserPermissionsHelper.LoggedInAdminCanDeactivateUser(adminToDeactivate, loggedInAdmin!.AdminAccount);
         }

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -158,6 +158,8 @@ namespace DigitalLearningSolutions.Web.Services
 
         AdminUser? GetAdminUserById(int id);
         string GetUserDisplayName(int userId);
+        IEnumerable<AdminEntity> GetAdminsByCentreId(int centreId);
+        void DeactivateAdmin(int adminId);
 
     }
 
@@ -826,7 +828,7 @@ namespace DigitalLearningSolutions.Web.Services
         {
             return userDataService.GetDelegateCountWithAnswerForPrompt(centreId, promptNumber);
         }
-        
+
         public List<AdminUser> GetAdminUsersByCentreId(int centreId)
         {
             return userDataService.GetAdminUsersByCentreId(centreId);
@@ -842,6 +844,15 @@ namespace DigitalLearningSolutions.Web.Services
         public string GetUserDisplayName(int userId)
         {
             return userDataService.GetUserDisplayName(userId);
+        }
+        public IEnumerable<AdminEntity> GetAdminsByCentreId(int centreId)
+        {
+            return userDataService.GetAdminsByCentreId(centreId);
+        }
+
+        public void DeactivateAdmin(int adminId)
+        {
+            userDataService.DeactivateAdmin(adminId);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[_TD-3919_](https://hee-tis.atlassian.net/browse/TD-3919)

### Description

DataService reference removed from the controller. GetAdminsByCentreId(+), DeactivateAdmin(+) added to UserService
Code modified to use service class methods.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/36d239f2-7b6a-4a68-b9cc-f8f615a3bec8)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/817f27e9-b442-4aa3-9bfd-668d8e71245f)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/48f367f2-3066-4851-900a-a1b7bb1cdca1)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/73cd1abe-a288-4593-8e26-7b787c60c6b4)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/49d365bf-86a5-4b6b-b805-58e8a6a19e02)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/aeeed488-7682-4362-ac80-e3caa07ce447)



-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
