### PR TITLE
TD-3915-DelegatesController - refactor

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Delegates/DelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Delegates/DelegatesController.cs
@@ -1,8 +1,6 @@
 ﻿
 namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
 {
-    using DigitalLearningSolutions.Data.DataServices;
-    using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
@@ -27,18 +25,16 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
     [SetSelectedTab(nameof(NavMenuTab.Admins))]
     public class DelegatesController : Controller
     {
-        private readonly IUserDataService userDataService;
         private readonly ISearchSortFilterPaginateService searchSortFilterPaginateService;
-        private readonly ICentresDataService centresDataService;
+        private readonly ICentresService centresService;
         private readonly IUserService userService;
-        public DelegatesController(IUserDataService userDataService,
-            ICentresDataService centresDataService,
+        public DelegatesController(
+            ICentresService centresService,
             ISearchSortFilterPaginateService searchSortFilterPaginateService,
             IUserService userService
             )
         {
-            this.userDataService = userDataService;
-            this.centresDataService = centresDataService;
+            this.centresService = centresService;
             this.searchSortFilterPaginateService = searchSortFilterPaginateService;
             this.userService = userService;
         }
@@ -107,9 +103,9 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
                     }
                 }
             }
-            (var Delegates, var ResultCount) = this.userDataService.GetAllDelegates(Search ?? string.Empty, offSet, itemsPerPage ?? 0, DelegateId, AccountStatus, LHLinkStatus, CentreId, AuthHelper.FailedLoginThreshold);
+            (var Delegates, var ResultCount) = this.userService.GetAllDelegates(Search ?? string.Empty, offSet, itemsPerPage ?? 0, DelegateId, AccountStatus, LHLinkStatus, CentreId, AuthHelper.FailedLoginThreshold);
 
-            var centres = centresDataService.GetAllCentres().ToList();
+            var centres = centresService.GetAllCentres().ToList();
             centres.Insert(0, (0, "Any"));
 
             var searchSortPaginationOptions = new SearchSortFilterAndPaginateOptions(
@@ -183,7 +179,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
         [Route("SuperAdmin/Delegates/{delegateId=0:int}/InactivateDelegateConfirmation")]
         public IActionResult InactivateDelegateConfirmation(int delegateId = 0)
         {
-            var delegateEntity = userDataService.GetDelegateById(delegateId);
+            var delegateEntity = userService.GetDelegateById(delegateId);
             if (!delegateEntity.DelegateAccount.Active)
             {
                 return StatusCode((int)HttpStatusCode.Gone);
@@ -219,7 +215,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
             TempData["DelegateId"] = delegateId;
             if (confirmationViewModel.IsChecked)
             {
-                this.userDataService.DeactivateDelegateUser(delegateId);
+                this.userService.DeactivateDelegateUser(delegateId);
                 return RedirectToAction("Index", "Delegates", new { DelegateId = delegateId });
             }
             else
@@ -234,7 +230,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
         [Route("SuperAdmin/Delegates/{delegateId=0:int}/ActivateDelegate")]
         public IActionResult ActivateDelegate(int delegateId = 0)
         {
-            userDataService.ActivateDelegateUser(delegateId);
+            userService.ActivateDelegateUser(delegateId);
             TempData["DelegateId"] = delegateId;
             return RedirectToAction("Index", "Delegates", new { DelegateId = delegateId });
         }
@@ -243,11 +239,11 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
         [Route("SuperAdmin/Delegates/{delegateId=0:int}/RemoveCentreEmailConfirmation")]
         public IActionResult RemoveCentreEmailConfirmation(int delegateId = 0)
         {
-            var delegateEntity = userDataService.GetDelegateById(delegateId);
+            var delegateEntity = userService.GetDelegateById(delegateId);
 
             if (delegateEntity != null)
             {
-                var userCenterEmail = userDataService.GetCentreEmail(delegateEntity.DelegateAccount.UserId, delegateEntity.DelegateAccount.CentreId);
+                var userCenterEmail = userService.GetCentreEmail(delegateEntity.DelegateAccount.UserId, delegateEntity.DelegateAccount.CentreId);
                 if (userCenterEmail == null) 
                     return StatusCode((int)HttpStatusCode.Gone);
             }
@@ -282,10 +278,10 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
             TempData["DelegateId"] = delegateId;
             if (confirmationViewModel.IsChecked)
             {
-                var delegateEntity = userDataService.GetDelegateById(delegateId);
+                var delegateEntity = userService.GetDelegateById(delegateId);
                 if (delegateEntity != null)
                 {
-                    userDataService.DeleteUserCentreDetail(delegateEntity.DelegateAccount.UserId, delegateEntity.DelegateAccount.CentreId);
+                    userService.DeleteUserCentreDetail(delegateEntity.DelegateAccount.UserId, delegateEntity.DelegateAccount.CentreId);
                 }
                 return RedirectToAction("Index", "Delegates", new { DelegateId = delegateId });
             }
@@ -303,7 +299,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
         [Route("SuperAdmin/Delegates/{delegateId=0:int}/ApproveDelegate")]
         public IActionResult ApproveDelegate(int delegateId = 0)
         {
-            userDataService.ApproveDelegateUsers(delegateId);
+            userService.ApproveDelegateUsers(delegateId);
             TempData["DelegateId"] = delegateId;
             return RedirectToAction("Index", "Delegates", new { DelegateId = delegateId });
         }

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -9,6 +9,7 @@ namespace DigitalLearningSolutions.Web.Services
     using DigitalLearningSolutions.Data.DataServices.UserDataService;
     using DigitalLearningSolutions.Data.Exceptions;
     using DigitalLearningSolutions.Data.Models;
+    using DigitalLearningSolutions.Data.Models.SuperAdmin;
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Data.Utilities;
     using DocumentFormat.OpenXml.Office2010.Excel;
@@ -158,6 +159,11 @@ namespace DigitalLearningSolutions.Web.Services
 
         AdminUser? GetAdminUserById(int id);
         string GetUserDisplayName(int userId);
+        (IEnumerable<SuperAdminDelegateAccount>, int) GetAllDelegates(
+      string search, int offset, int rows, int? delegateId, string accountStatus, string lhlinkStatus, int? centreId, int failedLoginThreshold
+      );
+        void DeleteUserCentreDetail(int userId, int centreId);
+        void ApproveDelegateUsers(params int[] ids);
 
     }
 
@@ -826,7 +832,7 @@ namespace DigitalLearningSolutions.Web.Services
         {
             return userDataService.GetDelegateCountWithAnswerForPrompt(centreId, promptNumber);
         }
-        
+
         public List<AdminUser> GetAdminUsersByCentreId(int centreId)
         {
             return userDataService.GetAdminUsersByCentreId(centreId);
@@ -842,6 +848,21 @@ namespace DigitalLearningSolutions.Web.Services
         public string GetUserDisplayName(int userId)
         {
             return userDataService.GetUserDisplayName(userId);
+        }
+
+        public (IEnumerable<SuperAdminDelegateAccount>, int) GetAllDelegates(string search, int offset, int rows, int? delegateId, string accountStatus, string lhlinkStatus, int? centreId, int failedLoginThreshold)
+        {
+            return userDataService.GetAllDelegates(search, offset, rows, delegateId, accountStatus, lhlinkStatus, centreId, failedLoginThreshold);
+        }
+
+        public void DeleteUserCentreDetail(int userId, int centreId)
+        {
+            userDataService.DeleteUserCentreDetail(userId, centreId);
+        }
+
+        public void ApproveDelegateUsers(params int[] ids)
+        {
+            userDataService.ApproveDelegateUsers(ids);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[_TD-3915_](https://hee-tis.atlassian.net/browse/TD-3915)

### Description

DataService reference removed from the controller.  
New methods added to UserService :
    GetAllDelegates(+)
    DeleteUserCentreDetail(+)
    ApproveDelegateUsers(+)

Code modified to use service class methods.


### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/8927edbe-2456-4d86-ab2b-d6640baf5180)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b0616b78-fc16-47b0-a71f-0dffebee9c20)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/03319f17-493d-4b8a-822b-af5f56206fa0)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/3c55fafc-31a2-474b-9dea-1dbff35e0a09)


-----
### Developer checks


I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
