### PR TITLE
TD-4238 launching few courses from 'current activities' or from 'course setup' seeing back link as completed activities'

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -125,7 +125,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId, int? enrolledByAdminId);
 
         bool IsCourseCompleted(int candidateId, int customisationId);
-
+        bool IsCourseCompleted(int candidateId, int customisationId, int progressID);
         public IEnumerable<Course> GetApplicationsAvailableToCentre(int centreId);
 
         public (IEnumerable<CourseStatistics>, int) GetCourseStatisticsAtCentre(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal,
@@ -137,7 +137,6 @@ namespace DigitalLearningSolutions.Data.DataServices
         public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
 
         public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive);
-        bool IsCourseCurrent(int candidateId, int customisationId);
     }
 
     public class CourseDataService : ICourseDataService
@@ -1820,15 +1819,14 @@ namespace DigitalLearningSolutions.Data.DataServices
                                 FROM  Progress AS p INNER JOIN
                                                 Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
                                                 Applications AS a ON cu.ApplicationID = a.ApplicationID
-                                WHERE  (p.CandidateID = @candidateId) AND p.CustomisationID = @customisationId
+                                WHERE  (p.CandidateID = @candidateId) AND p.CustomisationID = @customisationId 
                                 AND (NOT (p.Completed IS NULL)))
                             THEN CAST(1 AS BIT)
                             ELSE CAST(0 AS BIT) END",
                 new { candidateId, customisationId }
             );
         }
-
-        public bool IsCourseCurrent(int candidateId, int customisationId)
+        public bool IsCourseCompleted(int candidateId, int customisationId, int progressID)
         {
             return connection.ExecuteScalar<bool>(
                 @"SELECT CASE WHEN EXISTS (
@@ -1836,11 +1834,11 @@ namespace DigitalLearningSolutions.Data.DataServices
                                 FROM  Progress AS p INNER JOIN
                                                 Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
                                                 Applications AS a ON cu.ApplicationID = a.ApplicationID
-                                WHERE  (p.CandidateID = @candidateId) AND (p.CustomisationID = @customisationId)
-                                AND ((p.Completed IS NULL)))
+                                WHERE  (p.CandidateID = @candidateId) AND p.CustomisationID = @customisationId AND progressID =@progressID
+                                AND (NOT (p.Completed IS NULL)))
                             THEN CAST(1 AS BIT)
                             ELSE CAST(0 AS BIT) END",
-                new { candidateId, customisationId }
+                new { candidateId, customisationId, progressID }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -137,6 +137,7 @@ namespace DigitalLearningSolutions.Data.DataServices
         public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
 
         public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive);
+        bool IsCourseCurrent(int candidateId, int customisationId);
     }
 
     public class CourseDataService : ICourseDataService
@@ -1815,6 +1816,22 @@ namespace DigitalLearningSolutions.Data.DataServices
                                                 Applications AS a ON cu.ApplicationID = a.ApplicationID
                                 WHERE  (p.CandidateID = @candidateId) AND p.CustomisationID = @customisationId
                                 AND (NOT (p.Completed IS NULL)))
+                            THEN CAST(1 AS BIT)
+                            ELSE CAST(0 AS BIT) END",
+                new { candidateId, customisationId }
+            );
+        }
+
+        public bool IsCourseCurrent(int candidateId, int customisationId)
+        {
+            return connection.ExecuteScalar<bool>(
+                @"SELECT CASE WHEN EXISTS (
+                            SELECT p.Completed
+                                FROM  Progress AS p INNER JOIN
+                                                Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+                                                Applications AS a ON cu.ApplicationID = a.ApplicationID
+                                WHERE  (p.CandidateID = @candidateId) AND (p.CustomisationID = @customisationId)
+                                AND ((p.Completed IS NULL)))
                             THEN CAST(1 AS BIT)
                             ELSE CAST(0 AS BIT) END",
                 new { candidateId, customisationId }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/IndexTests.cs
@@ -21,7 +21,7 @@
             A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(10);
 
             // When
-            var result = controller.Index(CustomisationId);
+            var result = controller.Index(CustomisationId, progressID);
 
             // Then
             var expectedModel = new InitialMenuViewModel(expectedCourseContent);
@@ -44,7 +44,7 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, customisationId, CentreId)).Returns(10);
 
             // When
-            var result = controller.Index(customisationId);
+            var result = controller.Index(customisationId, progressID);
 
             // Then
             result.Should()
@@ -74,7 +74,7 @@
             A.CallTo(() => courseContentService.GetProgressId(CandidateId, customisationId)).Returns(10);
 
             // When
-            var result = controller.Index(customisationId);
+            var result = controller.Index(customisationId, progressID);
 
             // Then
             var expectedModel = new InitialMenuViewModel(expectedCourseContent);
@@ -91,7 +91,7 @@
                 .Returns(3);
 
             // When
-            var result = controller.Index(CustomisationId);
+            var result = controller.Index(CustomisationId, progressID);
 
             // Then
             result.Should()
@@ -112,7 +112,7 @@
                 .Returns(null);
 
             // When
-            var result = controller.Index(CustomisationId);
+            var result = controller.Index(CustomisationId, progressID);
 
             // Then
             result.Should()
@@ -129,7 +129,7 @@
             const int customisationId = 1;
 
             // When
-            controller.Index(1);
+            controller.Index(1,2);
 
             // Then
             A.CallTo(() => courseContentService.GetCourseContent(CandidateId, customisationId)).MustHaveHappened();
@@ -147,7 +147,7 @@
             A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(progressId);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(CandidateId, CustomisationId, A<ISession>._)).MustHaveHappened();
@@ -160,7 +160,7 @@
             A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId)).Returns(null);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => courseContentService.GetOrCreateProgressId(A<int>._, A<int>._, A<int>._)).MustNotHaveHappened();
@@ -173,7 +173,7 @@
             A.CallTo(() => courseContentService.GetCourseContent(CandidateId, CustomisationId)).Returns(null);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
@@ -186,7 +186,7 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(null);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => courseContentService.UpdateProgress(A<int>._)).MustNotHaveHappened();
@@ -203,7 +203,7 @@
             A.CallTo(() => courseContentService.GetProgressId(CandidateId, CustomisationId)).Returns(1);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(CandidateId, CustomisationId, httpContextSession)).MustHaveHappenedOnceExactly();
@@ -221,7 +221,7 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(1);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
@@ -236,7 +236,7 @@
             A.CallTo(() => courseContentService.GetOrCreateProgressId(CandidateId, CustomisationId, CentreId)).Returns(null);
 
             // When
-            controller.Index(CustomisationId);
+            controller.Index(CustomisationId, progressID);
 
             // Then
             A.CallTo(() => sessionService.StartOrUpdateDelegateSession(A<int>._, A<int>._, A<ISession>._)).MustNotHaveHappened();
@@ -298,7 +298,7 @@
             A.CallTo(() => courseService.GetSelfRegister(CustomisationId)).Returns(true);
 
             // When
-            var result = controller.Index(CustomisationId);
+            var result = controller.Index(CustomisationId, progressID);
 
             // Then
             result.Should()

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningMenu/LearningMenuControllerTests.cs
@@ -17,6 +17,7 @@
         private const int CandidateId = 11;
         private const int CentreId = 2;
         private const int CustomisationId = 12;
+        const int progressID = 34;
         private const int SectionId = 199;
         private const int TutorialId = 842;
         private ISession httpContextSession = null!;

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -58,7 +58,7 @@
         }
 
         [Route("/LearningMenu/{customisationId:int}")]
-        public IActionResult Index(int customisationId)
+        public IActionResult Index(int customisationId, int progressID)
         {
             var centreId = User.GetCentreIdKnownNotNull();
             var candidateId = User.GetCandidateIdKnownNotNull();
@@ -100,7 +100,7 @@
                 courseContentService.UpdateProgress(progressId.Value);
             };
 
-            SetTempData(candidateId, customisationId);
+            SetTempData(candidateId, customisationId, progressID);
 
             var model = new InitialMenuViewModel(courseContent);
             return View(model);
@@ -599,11 +599,19 @@
 
         private void SetTempData(int candidateId, int customisationId)
         {
-            var isCurrent = courseService.IsCourseCurrent(candidateId, customisationId);
-            if (isCurrent)
-                TempData["LearningActivity"] =  "Current";
-            else
+            var isCompleted = courseService.IsCourseCompleted(candidateId, customisationId);
+            if (isCompleted)
                 TempData["LearningActivity"] = "Completed";
+            else
+                TempData["LearningActivity"] = "Current";
+        }
+        private void SetTempData(int candidateId, int customisationId,int progressID)
+        {
+            var isCompleted = courseService.IsCourseCompleted(candidateId, customisationId, progressID);
+            if (isCompleted)
+                TempData["LearningActivity"] = "Completed";
+            else
+                TempData["LearningActivity"] = "Current";
         }
 
         private bool UniqueIdManipulationDetected(int candidateId, int customisationId)

--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -599,11 +599,11 @@
 
         private void SetTempData(int candidateId, int customisationId)
         {
-            var isCompleted = courseService.IsCourseCompleted(candidateId, customisationId);
-            if (isCompleted)
-                TempData["LearningActivity"] = "Completed";
+            var isCurrent = courseService.IsCourseCurrent(candidateId, customisationId);
+            if (isCurrent)
+                TempData["LearningActivity"] =  "Current";
             else
-                TempData["LearningActivity"] = "Current";
+                TempData["LearningActivity"] = "Completed";
         }
 
         private bool UniqueIdManipulationDetected(int candidateId, int customisationId)

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -132,6 +132,7 @@
         void EnrolOnSelfAssessment(int selfAssessmentId, int delegateUserId, int centreId);
         int GetNumberOfActiveCoursesAtCentreFilteredByCategory(int centreId, int? categoryId);
         public IEnumerable<Course> GetApplicationsAvailableToCentre(int centreId);
+        bool IsCourseCurrent(int candidateId, int customisationId);
     }
 
     public class CourseService : ICourseService
@@ -618,6 +619,11 @@
         public IEnumerable<Course> GetApplicationsAvailableToCentre(int centreId)
         {
             return courseDataService.GetApplicationsAvailableToCentre(centreId);
+        }
+
+        public bool IsCourseCurrent(int candidateId, int customisationId)
+        {
+            return courseDataService.IsCourseCurrent(candidateId,customisationId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -123,6 +123,7 @@
         public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive);
         IEnumerable<AvailableCourse> GetAvailableCourses(int delegateId, int? centreId, int categoryId);
         bool IsCourseCompleted(int candidateId, int customisationId);
+        bool IsCourseCompleted(int candidateId, int customisationId, int progressID);
         bool GetSelfRegister(int customisationId);
         IEnumerable<CurrentCourse> GetCurrentCourses(int candidateId);
         void SetCompleteByDate(int progressId, int candidateId, DateTime? completeByDate);
@@ -132,7 +133,6 @@
         void EnrolOnSelfAssessment(int selfAssessmentId, int delegateUserId, int centreId);
         int GetNumberOfActiveCoursesAtCentreFilteredByCategory(int centreId, int? categoryId);
         public IEnumerable<Course> GetApplicationsAvailableToCentre(int centreId);
-        bool IsCourseCurrent(int candidateId, int customisationId);
     }
 
     public class CourseService : ICourseService
@@ -571,9 +571,13 @@
             return courseDataService.GetAvailableCourses(delegateId, centreId, categoryId);
         }
 
-        public bool IsCourseCompleted(int candidateId, int customisationId)
+        public bool IsCourseCompleted(int candidateId, int customisationId )
         {
             return courseDataService.IsCourseCompleted(candidateId, customisationId);
+        }
+        public bool IsCourseCompleted(int candidateId, int customisationId, int progressID)
+        {
+            return courseDataService.IsCourseCompleted(candidateId, customisationId, progressID);
         }
 
         public bool GetSelfRegister(int customisationId)
@@ -619,11 +623,6 @@
         public IEnumerable<Course> GetApplicationsAvailableToCentre(int centreId)
         {
             return courseDataService.GetApplicationsAvailableToCentre(centreId);
-        }
-
-        public bool IsCourseCurrent(int candidateId, int customisationId)
-        {
-            return courseDataService.IsCourseCurrent(candidateId,customisationId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/CompletedCourseCard/_CompletedCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/CompletedCourseCard/_CompletedCourseCard.cshtml
@@ -38,6 +38,7 @@
                asp-controller="LearningMenu"
                asp-action="Index"
                asp-route-customisationId="@Model.Id"
+               asp-route-progressID="@Model.ProgressId"
                role="button">
                 Launch course <span class="nhsuk-u-visually-hidden">@Model.Name</span>
             </a>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CurrentCourseCard/_CurrentCourseCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/CurrentCourseCard/_CurrentCourseCard.cshtml
@@ -46,6 +46,7 @@
                asp-controller="LearningMenu"
                asp-action="Index"
                asp-route-customisationId="@Model.Id"
+               asp-route-progressID="@Model.ProgressId"
                role="button">
                 Launch course  <span class="nhsuk-u-visually-hidden">@Model.Name</span>
             </a>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4238

### Description
I added another parameter progressId  to the index action method in the LearningMenuController 
using method overloading to add SetTempData method also include progressId to the parameter
using method overloading to add IsCourseCompleted method also include progressId to the parameter, which enable the query to able to select the right course from the progress table, this fixed the issue of the  back link not showing the right activities 
I also refactor the test method to include the changes on the method
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/d7d7952e-bb03-4864-9c1a-6ae4c4b6d868)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/ea75231c-9dc8-4b57-9284-455169f8e055)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
