### PR TITLE
TD-4254 Groups Filter Added To View Model

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/GroupDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/GroupDelegatesController.cs
@@ -158,12 +158,13 @@
             var jobGroups = jobGroupsService.GetJobGroupsAlphabetical();
             var customPrompts = promptsService.GetCentreRegistrationPrompts(centreId);
             var delegateUsers = userService.GetDelegatesNotRegisteredForGroupByGroupId(groupId, centreId);
-
+            var groups = groupsService.GetActiveGroups(centreId);
             var model = new SelectDelegateAllItemsViewModel(
                 delegateUsers,
                 jobGroups,
                 customPrompts,
-                groupId
+                groupId,
+                groups
             );
 
             return View(model);

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/GroupDelegates/SelectDelegateAllItemsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/GroupDelegates/SelectDelegateAllItemsViewModel.cs
@@ -11,9 +11,10 @@
             IEnumerable<DelegateUserCard> delegateUserCards,
             IEnumerable<(int id, string name)> jobGroups,
             IEnumerable<CentreRegistrationPrompt> customPrompts,
-            int groupId
+            int groupId,
+            IEnumerable<(int id, string name)> groups
         )
-            : base(delegateUserCards, jobGroups, customPrompts)
+            : base(delegateUserCards, jobGroups, customPrompts, groups)
         {
             GroupId = groupId;
         }


### PR DESCRIPTION
### JIRA link
[TD-4254](https://hee-tis.atlassian.net/browse/TD-4254)

### Description
The groups filter values where missing in the 'AllDelegateItemsViewModel'. From the SelectDelegateAllItems in GroupDelegatesController, we are Getting Active Groups and sending it to SelectDelegateAllItemsViewModel which in turn sets the groups property of the base class.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/913dab17-6c94-499d-9cea-42cbaed9ac1d)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4254]: https://hee-tis.atlassian.net/browse/TD-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ