### PR TITLE
TD-4269 issue with the enrolmentmethod and lastaccessdate when admin enrolled the selfassessment on tracking system

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -122,7 +122,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             int customisationId, int centreId, bool? isDelegateActive, bool? isProgressLocked, bool? removed, bool? hasCompleted, string? answer1, string? answer2, string? answer3);
 
         int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail,
-            int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId);
+            int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId, int? enrolledByAdminId);
 
         bool IsCourseCompleted(int candidateId, int customisationId);
 
@@ -430,7 +430,7 @@ namespace DigitalLearningSolutions.Data.DataServices
         }
 
         public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail,
-            int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId)
+            int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId, int? enrolledByAdminId)
         {
             IClockUtility clockUtility = new ClockUtility();
             DateTime startedDate = clockUtility.UtcNow;
@@ -459,7 +459,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                            ,[LastAccessed]
                            ,[CompleteByDate]
                            ,[CentreID]
-                           ,[EnrolmentMethodId])
+                           ,[EnrolmentMethodId]
+                           ,EnrolledByAdminId)
                     OUTPUT INSERTED.Id
                      VALUES
                            (@DelegateUserID,
@@ -468,8 +469,9 @@ namespace DigitalLearningSolutions.Data.DataServices
                            @lastAccessed,
                            @completeByDateDynamic,
                            @centreId,
-                           @enrolmentMethodId);",
-                    new { delegateUserId, selfAssessmentId, startedDate, lastAccessed, completeByDateDynamic, centreId, enrolmentMethodId }
+                           @enrolmentMethodId,
+                           @enrolledByAdminId);",
+                    new { delegateUserId, selfAssessmentId, startedDate, lastAccessed, completeByDateDynamic, centreId, enrolmentMethodId, enrolledByAdminId }
                 );
             }
 

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -434,19 +434,20 @@ namespace DigitalLearningSolutions.Data.DataServices
         {
             IClockUtility clockUtility = new ClockUtility();
             DateTime startedDate = clockUtility.UtcNow;
-            DateTime lastAccessed = startedDate;
+            DateTime? lastAccessed = null;
             dynamic? completeByDateDynamic = null;
+            int enrolmentMethodId = 2;
             if (completeByDate == null || completeByDate.GetValueOrDefault().Year > 1753)
             {
                 completeByDateDynamic = completeByDate!;
             }
-            var candidateAssessmentId = (int)connection.ExecuteScalar(
+            var candidateAssessmentId = Convert.ToInt32(connection.ExecuteScalar(
                 @"SELECT COALESCE
                  ((SELECT ID
                   FROM    CandidateAssessments
                   WHERE (SelfAssessmentID = @selfAssessmentId) AND (DelegateUserID  = @delegateUserId) AND (CompletedDate IS NULL)), 0) AS ID",
                 new { selfAssessmentId, delegateUserId }
-            );
+            ));
 
             if (candidateAssessmentId == 0)
             {
@@ -457,7 +458,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                            ,[StartedDate]
                            ,[LastAccessed]
                            ,[CompleteByDate]
-                           ,[CentreID])
+                           ,[CentreID]
+                           ,[EnrolmentMethodId])
                     OUTPUT INSERTED.Id
                      VALUES
                            (@DelegateUserID,
@@ -465,16 +467,17 @@ namespace DigitalLearningSolutions.Data.DataServices
                            @startedDate,
                            @lastAccessed,
                            @completeByDateDynamic,
-                           @centreId);",
-                    new { delegateUserId, selfAssessmentId, startedDate, lastAccessed, completeByDateDynamic, centreId }
+                           @centreId,
+                           @enrolmentMethodId);",
+                    new { delegateUserId, selfAssessmentId, startedDate, lastAccessed, completeByDateDynamic, centreId, enrolmentMethodId }
                 );
             }
 
-            int supervisorDelegateId = (int)connection.ExecuteScalar(
+            int supervisorDelegateId = Convert.ToInt32(connection.ExecuteScalar(
                     @"SELECT COALESCE
                  ((SELECT TOP 1 ID FROM SupervisorDelegates WHERE SupervisorAdminID = @supervisorId AND DelegateUserId = @delegateUserId), 0) AS ID",
                     new { supervisorId, delegateUserId }
-                );
+                ));
             if (supervisorDelegateId == 0 && supervisorId > 0)
             {
                 supervisorDelegateId = connection.QuerySingle<int>(@"INSERT INTO SupervisorDelegates
@@ -501,11 +504,11 @@ namespace DigitalLearningSolutions.Data.DataServices
 
             if (candidateAssessmentId > 0 && supervisorDelegateId > 0 && selfAssessmentSupervisorRoleId > 0)
             {
-                int candidateAssessmentSupervisorsId = (int)connection.ExecuteScalar(
+                int candidateAssessmentSupervisorsId = Convert.ToInt32(connection.ExecuteScalar(
                     @"SELECT COALESCE
                              ((SELECT TOP 1 ID FROM CandidateAssessmentSupervisors WHERE CandidateAssessmentID = @candidateAssessmentID AND SupervisorDelegateId = @supervisorDelegateId), 0) AS ID",
                     new { candidateAssessmentId, supervisorDelegateId }
-                );
+                ));
 
                 if (candidateAssessmentSupervisorsId == 0)
                 {
@@ -547,13 +550,13 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public void EnrolOnSelfAssessment(int selfAssessmentId, int delegateUserId, int centreId)
         {
-            var enrolmentExists = (int)connection.ExecuteScalar(
+            var enrolmentExists = Convert.ToInt32(connection.ExecuteScalar(
                 @"SELECT COALESCE
                  ((SELECT ID
                   FROM    CandidateAssessments
                   WHERE (SelfAssessmentID = @selfAssessmentId) AND (DelegateUserID = @delegateUserId) AND (CompletedDate IS NULL)), 0) AS ID",
                 new { selfAssessmentId, delegateUserId }
-            );
+            ));
 
             if (enrolmentExists > 0)
             {
@@ -638,7 +641,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public int GetNumberOfActiveCoursesAtCentreFilteredByCategory(int centreId, int? adminCategoryId)
         {
-            return (int)connection.ExecuteScalar(
+            return Convert.ToInt32(connection.ExecuteScalar(
                 @"SELECT COUNT(*)
                         FROM dbo.Customisations AS cu
                         INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = cu.ApplicationID
@@ -649,7 +652,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                             AND ca.CentreID = @centreId
                             AND ap.DefaultContentTypeID <> 4",
                 new { centreId, adminCategoryId }
-            );
+            ));
         }
 
         public IEnumerable<CourseStatistics> GetCourseStatisticsAtCentreFilteredByCategory(

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -393,7 +393,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         public IEnumerable<SupervisorForEnrolDelegate> GetSupervisorForEnrolDelegate(int CustomisationID, int CentreID)
         {
             return connection.Query<SupervisorForEnrolDelegate>(
-                $@"SELECT AdminID, Forename + ' ' + Surname + ' (' + Email +'),' + ' ' + CentreNameAS Name, Email FROM AdminUsers AS au
+                $@"SELECT AdminID, Forename + ' ' + Surname + ' (' + Email +'),' + ' ' + CentreName AS Name, Email FROM AdminUsers AS au
                     WHERE (Supervisor = 1) AND (CentreID = @CentreID) AND (CategoryID = 0 OR
                          CategoryID = (SELECT au.CategoryID FROM Applications AS a INNER JOIN
                            Customisations AS c ON a.ApplicationID = c.ApplicationID

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -23,5 +23,6 @@
         public bool IsSameCentre { get; set; }
         public int? DelegateUserId { get; set; }
         public string? DelegateName { get; set; }
+        public string? EnrolledByFullName { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -325,7 +325,8 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     sessionEnrol.SelfAssessmentSupervisorRoleId.GetValueOrDefault(),
                     sessionEnrol.CompleteByDate,
                     (int)sessionEnrol.DelegateUserID,
-                    centreId
+                    centreId,
+                    GetAdminID()
                     );
 
             }

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -42,7 +42,8 @@ namespace DigitalLearningSolutions.Web.Services
             int selfAssessmentSupervisorRoleId,
             DateTime? completeByDate,
             int delegateUserId,
-            int centreId
+            int centreId,
+            int? enrolledByAdminId
             );
     }
     public class EnrolService : IEnrolService
@@ -185,9 +186,9 @@ namespace DigitalLearningSolutions.Web.Services
             return new Email(EnrolEmailSubject, body, emailAddress);
         }
 
-        public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail, int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId)
+        public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail, int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId, int? enrolledByAdminId)
         {
-           return courseDataService.EnrolOnActivitySelfAssessment(selfAssessmentId, candidateId, supervisorId, adminEmail, selfAssessmentSupervisorRoleId, completeByDate, delegateUserId, centreId);
+           return courseDataService.EnrolOnActivitySelfAssessment(selfAssessmentId, candidateId, supervisorId, adminEmail, selfAssessmentSupervisorRoleId, completeByDate, delegateUserId, centreId, enrolledByAdminId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
@@ -61,7 +61,7 @@
                 string enrolmentMethod = Model.EnrolmentMethodId switch
                 {
                     1 => "Self enrolled",
-                    2 => "Admin/supervisor enrolled",
+                    2 => Model.EnrolledByFullName != null ? "Enrolled by Admin - " + Model.EnrolledByFullName : "Admin/supervisor enrolled",
                     3 => "Group",
                     _ => "System",
                 };


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4269

### Description
I resolved some unboxing a possible null value warning in some method CourseDataService class
Making the Last access date null when the admin enrol self assessment
Adding right enrolment method 
ensuring the enrol by show the admin name 

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/e09cfa2d-855b-4f42-8a25-cba888aad467)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
