### PR TITLE
TD-4269 Issue with the 'Enrolment method' and 'Last access date' when admin enrolled the self assessment on Tracking system

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -32,7 +32,9 @@
                        SelfAssessment. CentreName,
                         SelfAssessment.EnrolmentMethodId,
 						Signoff.SignedOff,
-						Signoff.Verified FROM	(SELECT
+						Signoff.Verified,
+						EnrolledByForename +' '+EnrolledBySurname AS EnrolledByFullName
+                        FROM	(SELECT
                         CA.SelfAssessmentID AS Id,
                         SA.Name,
                         SA.Description,
@@ -52,22 +54,27 @@
                         1 AS IsSelfAssessment,
                         CA.SubmittedDate,
                         CR.CentreName AS CentreName,
-                        CA.EnrolmentMethodId
-                    FROM Centres AS CR INNER JOIN
+                        CA.EnrolmentMethodId,
+						uEnrolledBy.FirstName AS EnrolledByForename,
+                        uEnrolledBy.LastName AS EnrolledBySurname
+                        FROM Centres AS CR INNER JOIN
                         CandidateAssessments AS CA INNER JOIN
                         SelfAssessments AS SA ON CA.SelfAssessmentID = SA.ID ON CR.CentreID = CA.CentreID INNER JOIN
                         CentreSelfAssessments AS csa ON csa.SelfAssessmentID = SA.ID AND csa.CentreID = @centreId LEFT OUTER JOIN
                         Competencies AS C RIGHT OUTER JOIN
                         SelfAssessmentStructure AS SAS ON C.ID = SAS.CompetencyID ON CA.SelfAssessmentID = SAS.SelfAssessmentID LEFT OUTER JOIN
 						CandidateAssessmentSupervisors AS cas ON  ca.ID =cas.CandidateAssessmentID  LEFT OUTER JOIN
-                        CandidateAssessmentSupervisorVerifications    AS casv ON casv.CandidateAssessmentSupervisorID = cas.ID 
+                        CandidateAssessmentSupervisorVerifications    AS casv ON casv.CandidateAssessmentSupervisorID = cas.ID LEFT OUTER JOIN
+                        AdminAccounts AS aaEnrolledBy ON aaEnrolledBy.ID = CA.EnrolledByAdminID LEFT OUTER JOIN
+						Users AS uEnrolledBy ON uEnrolledBy.ID = aaEnrolledBy.UserID
                     WHERE (CA.DelegateUserID = @delegateUserId) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL)
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
                         COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
                         CA.ID,
-                        CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName,CA.EnrolmentMethodId)SelfAssessment LEFT OUTER JOIN
+                        CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName,CA.EnrolmentMethodId,
+						 uEnrolledBy.FirstName,uEnrolledBy.LastName)SelfAssessment LEFT OUTER JOIN
                     (SELECT SelfAssessmentID,casv.SignedOff,MAX(casv.Verified) Verified FROM 
                        CandidateAssessments AS CA LEFT OUTER JOIN
 						CandidateAssessmentSupervisors AS cas ON  ca.ID =cas.CandidateAssessmentID  LEFT OUTER JOIN

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -23,5 +23,6 @@
         public bool IsSameCentre { get; set; }
         public int? DelegateUserId { get; set; }
         public string? DelegateName { get; set; }
+        public string? EnrolledByFullName { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -326,7 +326,8 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                     sessionEnrol.SelfAssessmentSupervisorRoleId.GetValueOrDefault(),
                     sessionEnrol.CompleteByDate,
                     (int)sessionEnrol.DelegateUserID,
-                    centreId
+                    centreId,
+                    GetAdminID()
                     );
 
             }

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -42,7 +42,8 @@ namespace DigitalLearningSolutions.Web.Services
             int selfAssessmentSupervisorRoleId,
             DateTime? completeByDate,
             int delegateUserId,
-            int centreId
+            int centreId,
+            int? enrolledByAdminId
             );
     }
     public class EnrolService : IEnrolService
@@ -185,9 +186,9 @@ namespace DigitalLearningSolutions.Web.Services
             return new Email(EnrolEmailSubject, body, emailAddress);
         }
 
-        public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail, int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId)
+        public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail, int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId, int? enrolledByAdminId)
         {
-           return courseDataService.EnrolOnActivitySelfAssessment(selfAssessmentId, candidateId, supervisorId, adminEmail, selfAssessmentSupervisorRoleId, completeByDate, delegateUserId, centreId);
+           return courseDataService.EnrolOnActivitySelfAssessment(selfAssessmentId, candidateId, supervisorId, adminEmail, selfAssessmentSupervisorRoleId, completeByDate, delegateUserId, centreId, enrolledByAdminId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
@@ -61,7 +61,7 @@
                 string enrolmentMethod = Model.EnrolmentMethodId switch
                 {
                     1 => "Self enrolled",
-                    2 => "Admin/supervisor enrolled",
+                    2 => Model.EnrolledByFullName != null ? "Enrolled by Admin - " + Model.EnrolledByFullName : "Admin/supervisor enrolled",
                     3 => "Group",
                     _ => "System",
                 };


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4269

### Description
I resolved some unboxing a possible null value warning in some method CourseDataService class
Making the Last access date null when the admin enrol self assessment
Adding right enrolment method 
ensuring the enrol by show the admin name 

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/e09cfa2d-855b-4f42-8a25-cba888aad467)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
