### PR TITLE
Develop/fixes/td 4134 issue adding digital learning solutions page no longer available text to the 'go back 'links on give page feedback screens

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -52,6 +52,13 @@
                 TaskRating = null,
             };
 
+            if(sourcePageTitle == "Digital Learning Solutions - Page no longer available")
+            {
+                var url = ContentUrlHelper.ReplaceUrlSegment(sourceUrl);
+                _userFeedbackViewModel.SourceUrl  = url;
+                _userFeedbackViewModel.SourcePageTitle = "Welcome";
+            }
+            
             if (_userFeedbackViewModel.UserId == null || _userFeedbackViewModel.UserId == 0)
             {
                 return GuestFeedbackStart(_userFeedbackViewModel);

--- a/DigitalLearningSolutions.Web/Helpers/ContentUrlHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ContentUrlHelper.cs
@@ -22,5 +22,17 @@
 
         public static string? GetNullableContentPath(IConfiguration config, string? videoPath) =>
             videoPath != null ? GetContentPath(config, videoPath) : null;
+
+        public static string ReplaceUrlSegment(string sourceUrl)
+        {
+            string errorSegment = "LearningSolutions/StatusCode/410";
+            string welcomeSegment = "Home/Welcome";
+
+            if (sourceUrl.Contains(errorSegment))
+            {
+                return sourceUrl.Replace(errorSegment, welcomeSegment);
+            }
+            return sourceUrl;
+        }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4134

### Description
I Added a method that check for the 410 Url and I replace it with the welcome Url to prevent 

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/818a8293-ff55-4377-bd56-d4949f78d4bd)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/318dc8db-849f-4186-a195-c1c76825e7a8)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/27124bb9-d63d-44ca-8e74-709a2eb18edd)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
