### PR TITLE
TD-4137  switch application navigation link should be removed from give page feedback screens for logged in user

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -37,7 +37,7 @@
         public IActionResult Index(string sourceUrl, string sourcePageTitle)
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
-
+            ViewBag.HideSwitchApplication = true;
             _multiPageFormService.ClearMultiPageFormData(MultiPageFormDataFeature.AddUserFeedback, TempData);
             
             _userFeedbackViewModel = new()
@@ -122,6 +122,7 @@
         public IActionResult StartUserFeedbackSession(UserFeedbackViewModel userFeedbackViewModel)
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
+            ViewBag.HideSwitchApplication = true;
 
             var userFeedbackSessionData = new UserFeedbackTempData()
             {

--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -37,7 +37,6 @@
         public IActionResult Index(string sourceUrl, string sourcePageTitle)
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
-            ViewBag.HideSwitchApplication = true;
             _multiPageFormService.ClearMultiPageFormData(MultiPageFormDataFeature.AddUserFeedback, TempData);
             
             _userFeedbackViewModel = new()
@@ -129,7 +128,6 @@
         public IActionResult StartUserFeedbackSession(UserFeedbackViewModel userFeedbackViewModel)
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
-            ViewBag.HideSwitchApplication = true;
 
             var userFeedbackSessionData = new UserFeedbackTempData()
             {

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -138,12 +138,15 @@
 
                                 @if (User.IsAdminAccount())
                                 {
-                                    <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
-                                        <a class="nhsuk-header__navigation-link" asp-controller="ApplicationSelector" asp-action="Index">
-                                            Switch application
-                                            <partial name="_NhsChevronRight" />
-                                        </a>
-                                    </li>
+                                    if ((bool?)ViewBag.HideSwitchApplication == false)
+                                    {
+                                        <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
+                                            <a class="nhsuk-header__navigation-link" asp-controller="ApplicationSelector" asp-action="Index">
+                                                Switch application
+                                                <partial name="_NhsChevronRight" />
+                                            </a>
+                                        </li>
+                                    }
                                 }
                             </ul>
                         </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -138,15 +138,16 @@
 
                                 @if (User.IsAdminAccount())
                                 {
-                                    if ((bool?)ViewBag.HideSwitchApplication == false)
+                                   if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] != true)
                                     {
-                                        <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
+                                         <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.SwitchApplication)">
                                             <a class="nhsuk-header__navigation-link" asp-controller="ApplicationSelector" asp-action="Index">
                                                 Switch application
                                                 <partial name="_NhsChevronRight" />
                                             </a>
                                         </li>
                                     }
+                                    
                                 }
                             </ul>
                         </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4137

### Description
I hide the ‘Switch application’ link use the user is the logged in user feedback page
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/19026386-39ba-44af-a873-1faec308b5fe)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/cdb9bb24-ecf8-4a9f-afd8-a6644d4d92d1)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/b80a9b5d-bed4-436b-9c3f-2833fdee5023)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/7823eeee-c8eb-47ab-9637-b7903adba8e3)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/6272ab23-8acc-4eee-a5f1-78fcc7733e36)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/e4c1ec7e-f315-481c-ae57-9ae8fccf17c6)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
