### PR TITLE
TD-4207 Clicking browser back button after deleting the 'Delegate Group' showing console '404' error instead of '410' error

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessGroup.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessGroup.cs
@@ -26,7 +26,11 @@
             var groupId = int.Parse(context.RouteData.Values["groupId"].ToString()!);
             var groupCentreId = groupsService.GetGroupCentreId(groupId);
 
-            if (controller.User.GetCentreIdKnownNotNull() != groupCentreId)
+            if (groupCentreId == 0)
+            {
+                context.Result = new RedirectToActionResult("StatusCode", "LearningSolutions", new { code = 410 });
+            }
+            else if (controller.User.GetCentreIdKnownNotNull() != groupCentreId)
             {
                 context.Result = new NotFoundResult();
             }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4207

### Description
In the service filter I added a check to see if the group is not in the database then should return error 410

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/e7eb09cb-eec1-4692-b2bf-bc2fbd7288a0)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/bce99357-69ff-4663-a77c-98c901164094)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/c792d119-1e44-4eea-a348-4c85967603f3)
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/a36862ed-c9c2-41b8-85e3-c64f1d4f4876)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
