### PR TITLE
TD-4244 Added hidden in learning portal added for inactive courses as well

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -104,16 +104,13 @@
             {
                 tags.Add(new SearchableTagViewModel(CourseStatusFilterOptions.IsInactive));
             }
-            if (courseStatistics.Active)
+            if (courseStatistics.HideInLearnerPortal)
             {
-                if (courseStatistics.HideInLearnerPortal)
-                {
-                    tags.Add(new SearchableTagViewModel(CourseVisibilityFilterOptions.IsHiddenInLearningPortal));
-                }
-                else
-                {
-                    tags.Add(new SearchableTagViewModel(CourseVisibilityFilterOptions.IsNotHiddenInLearningPortal));
-                }
+                tags.Add(new SearchableTagViewModel(CourseVisibilityFilterOptions.IsHiddenInLearningPortal));
+            }
+            else
+            {
+                tags.Add(new SearchableTagViewModel(CourseVisibilityFilterOptions.IsNotHiddenInLearningPortal));
             }
             return tags;
         }
@@ -235,7 +232,7 @@
              ? new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.SignedOff)
              : new SearchableTagViewModel(SelfAssessmentSignedOffFilterOptions.NotSignedOff);
                 tags.Add(signedOffTag);
-                
+
             }
 
             return tags;


### PR DESCRIPTION
### JIRA link
[TD-4244](https://hee-tis.atlassian.net/browse/TD-4244)

### Description
Removed the condition which made the "hidden in learning portal" tag hidden for inactive courses.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/126668828/3e3a5ef8-07e6-400e-9fb7-78256ea5c9f3)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4244]: https://hee-tis.atlassian.net/browse/TD-4244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ