### PR TITLE
TD-4206 Mismatch of count of courses seeing on 'Centre Dashboard' when compared to the 'Centre course set up' screen

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -652,7 +652,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                             AND cu.Active = 1
                             AND cu.CentreID = @centreId
                             AND ca.CentreID = @centreId
-                            AND ap.DefaultContentTypeID <> 4",
+                            AND ap.DefaultContentTypeID <> 4
+                            AND (ap.ArchivedDate IS NULL)",
                 new { centreId, adminCategoryId }
             ));
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4206
### Description
I edited the query that count the course on the centre dashboard page, I added the where clause that is missing that make the count on the two pages to not be the same

For the active count of courses on the Centre dashboard and Centre course setup to be the same 
 add 'ArchivedDate IS NULL'  to the where clause of centre  dashboard query

For the inactive/archived count of courses on the Centre dashboard and Centre course setup to be the same 
firstly remove cu.Active = 1
secondly add (cu.Active = 0 OR ap.ArchivedDate IS NOT NULL) to the where clause of centre  dashboard query

### Screenshots
Active course count Centre dashboard 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/f8348432-4f09-4e11-8855-ea938a5c9df1)

Active course count Centre course setup 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/f6662c86-32dd-4787-adba-d5266f9e87be)

Inactive/archived course count Centre course setup 
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/123654949/ddf29703-d8b4-4bd5-bcd1-4172a9cde82f)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
