### PR TITLE
TD-4320-Supervisor emails should be shown on 'Manage Supervisors' list/ 'Quick add'

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -269,7 +269,7 @@
             const string supervisorFields = @"
                 LAR.EmailSent,
                 LAR.Requested AS SupervisorVerificationRequested,
-                COALESCE(au.Forename + ' ' + au.Surname + (CASE WHEN au.Active = 1 THEN '' ELSE ' (Inactive)' END), sd.SupervisorEmail) AS SupervisorName,
+                au.Forename + ' ' + au.Surname + (CASE WHEN au.Active = 1 THEN '' ELSE ' (Inactive)' END) + ' (' + sd.SupervisorEmail + ')' AS SupervisorName,
                 au.CentreName,
                 SelfAssessmentResultSupervisorVerificationId AS SupervisorVerificationId,
                 CandidateAssessmentSupervisorID";

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageSupervisors.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageSupervisors.cshtml
@@ -61,8 +61,9 @@
                 <tr role="row" class="nhsuk-table__row">
                     <td class="nhsuk-table__cell">
                         <span class="nhsuk-table-responsive__heading">Name/role </span>
-                        @supervisor.SupervisorName, @supervisor.RoleName
-
+                        <span class="text-wrap word-break">
+                            @supervisor.SupervisorName (@supervisor.SupervisorEmail), @supervisor.RoleName
+                        </span>
                     </td>
                     <td class="nhsuk-table__cell">
                         <span class="nhsuk-table-responsive__heading">Centre </span>
@@ -110,7 +111,9 @@ else
                 <tr role="row" class="nhsuk-table__row">
                     <td class="nhsuk-table__cell">
                         <span class="nhsuk-table-responsive__heading">Name/role </span>
-                        @supervisor.SupervisorName, @supervisor.RoleName
+                        <span class="text-wrap word-break">
+                            @supervisor.SupervisorName (@supervisor.SupervisorEmail), @supervisor.RoleName
+                        </span>
                     </td>
                     <td class="nhsuk-table__cell">
                         <span class="nhsuk-table-responsive__heading">Centre </span>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ReviewConfirmationRequests.cshtml
@@ -77,8 +77,10 @@
                         </td>
                         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
                             <span class="nhsuk-table-responsive__heading">Request </span>
-                            @competency.SupervisorName (@competency.CentreName)<br />
-                            @competency.SupervisorVerificationRequested?.ToString("dd/MM/yyyy")<br />
+                            <span class="text-wrap word-break">
+                                @competency.SupervisorName @competency.CentreName<br />
+                                @competency.SupervisorVerificationRequested?.ToString("dd/MM/yyyy")<br />
+                            </span>
                             <div class="nhsuk-u-one-half-tablet" style="white-space: nowrap;">
                                 <div class="nhsuk-grid-row nhsuk-u-padding-0">
                                     @if (competency.EmailSent.HasValue && clockUtility.UtcNow.Subtract(competency.EmailSent.Value) > TimeSpan.FromHours(1))


### PR DESCRIPTION
### JIRA link
[_TD-4320_](https://hee-tis.atlassian.net/browse/TD-4320)

### Description
Supervisor email added to manage supervisor list. CSS classes used to manage mobile view.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1da9f8ee-2289-4da9-944a-62220e594b01)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/2baf35bc-bcbf-4aa1-92ce-cbdd4d133ddb)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/770b9b1b-3270-4cd3-81ed-687f694cb3e5)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c72111ee-6181-401f-a313-0fcb951bc842)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b5b7ef05-5049-40d3-9543-940e3355c299)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/97295513-4837-4b1e-844f-b960d862d789)



-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
