### PR TITLE
TD-4233- Display competency flags in the Choose optional competencies screen

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -447,7 +447,8 @@
         {
             return connection.Query<Competency>(
                 @"SELECT
-                        SAS.ID AS Id,
+                        C.ID AS Id,
+                        SAS.ID AS SelfAssessmentStructureId,
                         ROW_NUMBER() OVER (ORDER BY SAS.Ordering) as RowNo,
                         C.Name AS Name,
                         C.Description AS Description,

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
@@ -27,6 +27,7 @@
         public int? CandidateAssessmentSupervisorId { get; set; }
         public string? SupervisorName { get; set; }
         public string? CentreName { get; set; }
+        public int? SelfAssessmentStructureId { get; set; }
         public List<AssessmentQuestion> AssessmentQuestions { get; set; } = new List<AssessmentQuestion>();
         public IEnumerable<CompetencyFlag> CompetencyFlags { get; set; } = new List<CompetencyFlag>();
     }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1420,6 +1420,12 @@
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var optionalCompetencies =
                 selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
+            var competencyIds = optionalCompetencies.Select(c => c.Id).ToArray();
+            var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
+
+            foreach (var competency in optionalCompetencies)
+                competency.CompetencyFlags = competencyFlags.Where(f => f.CompetencyId == competency.Id);
+
             var includedSelfAssessmentStructureIds =
                 selfAssessmentService.GetCandidateAssessmentIncludedSelfAssessmentStructureIds(
                     selfAssessmentId,

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -73,8 +73,17 @@
                     @foreach (var competency in competencyGroup)
                     {
                         <div class="nhsuk-checkboxes__item">
-                            <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.Id" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.Id) : false)" type="checkbox" value="@competency.Id">
-                            <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.Id">
+                            <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.SelfAssessmentStructureId" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.SelfAssessmentStructureId) : false)" type="checkbox" value="@competency.SelfAssessmentStructureId">
+                            <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.SelfAssessmentStructureId">
+                                @foreach (var flag in competency.CompetencyFlags)
+                                {
+                                    <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
+                                        <strong class="nhsuk-tag @flag.FlagTagClass">
+                                            @flag.FlagName
+                                        </strong>
+                                    </span>
+                                }
+
                                 @competency.Name
                             </label>
                         </div>


### PR DESCRIPTION
### JIRA link
[_TD-4233_](https://hee-tis.atlassian.net/browse/TD-4233)

### Description
Competency flags added to optional competencies.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/c111ce68-351a-43f1-8054-36cdb8f391a4)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/1d7f125a-2c84-43f6-b08f-3cea2fa8c20b)

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/86329a6e-c9b5-4766-ae71-d057d87ccfe0)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
