### PR TITLE
TD-4339- Issue showing console '500' error when 'Edit details' on 'Manage centre' screen

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -233,18 +233,20 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
         [Route("SuperAdmin/Centres/{centreId=0:int}/EditCentreDetails")]
         public IActionResult EditCentreDetails(EditCentreDetailsSuperAdminViewModel model)
         {
-            var centres = centresService.GetAllCentres().ToList();
-            bool isExistingCentreName = centres.Where(center => center.Item1 == model.CentreId)
-                .Select(center => center.Item2)
-                .FirstOrDefault()
-                .Equals(model.CentreName.Trim());
-            bool isCentreNamePresent = centres.Any(center => string.Equals(center.Item2.Trim(), model.CentreName?.Trim(), StringComparison.OrdinalIgnoreCase));
-
-            if (isCentreNamePresent && !isExistingCentreName)
+            if (!string.IsNullOrEmpty(model.CentreName))
             {
-                ModelState.AddModelError("CentreName", CommonValidationErrorMessages.CentreNameAlreadyExist);
-            }
+                var centres = centresService.GetAllCentres().ToList();
+                bool isExistingCentreName = centres.Where(center => center.Item1 == model.CentreId)
+                    .Select(center => center.Item2)
+                    .FirstOrDefault()
+                    .Equals(model.CentreName.Trim());
+                bool isCentreNamePresent = centres.Any(center => string.Equals(center.Item2.Trim(), model.CentreName?.Trim(), StringComparison.OrdinalIgnoreCase));
 
+                if (isCentreNamePresent && !isExistingCentreName)
+                {
+                    ModelState.AddModelError("CentreName", CommonValidationErrorMessages.CentreNameAlreadyExist);
+                }
+            }
             if (!ModelState.IsValid)
             {
                 var regions = regionService.GetRegionsAlphabetical().ToList();


### PR DESCRIPTION
### JIRA link
[_TD-4339_](https://hee-tis.atlassian.net/browse/TD-4339)

### Description
null/empty check added for centre name.

### Screenshots

![image](https://github.com/TechnologyEnhancedLearning/DLSV2/assets/115799039/b5f0dee5-3b34-4a23-ae90-5b2fb65480da)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
