### PR TITLE
TD-4206 Mismatch of count of courses seeing on 'Centre Dashboard' when compared to the 'Centre course set up' screen

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -651,7 +651,6 @@ namespace DigitalLearningSolutions.Data.DataServices
                         INNER JOIN dbo.CentreApplications AS ca ON ca.ApplicationID = cu.ApplicationID
                         INNER JOIN dbo.Applications AS ap ON ap.ApplicationID = ca.ApplicationID
                         WHERE (ap.CourseCategoryID = @adminCategoryId OR @adminCategoryId IS NULL)
-                            AND cu.Active = 1
                             AND cu.CentreID = @centreId
                             AND ca.CentreID = @centreId
                             AND ap.DefaultContentTypeID <> 4",


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4206
### Description
I edited the existing query to  count all course which include active, inactive and archived course on Centre dashboard page
I ensure the course count is the same with the count of the Centre course setup page

### Screenshots
Bedfordshire Hospitals NHS Foundation Trust course count Centre dashboard
![image](https://github.com/user-attachments/assets/5dbae0b7-92d4-427c-b99e-f4f08625e02e)


Bedfordshire Hospitals NHS Foundation Trust course count Centre course setup 
![image](https://github.com/user-attachments/assets/0805ace6-f634-45df-8998-51cb1ef81749)


##NHS England Demo Centre## count  course Centre dashboard
![image](https://github.com/user-attachments/assets/a1c25440-21c7-4d02-b562-28071bc5ad52)

##NHS England Demo Centre## count courses  on Centre course setup 
![image](https://github.com/user-attachments/assets/25de6889-9bd0-4673-8b70-1fd93d8ab651)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
