### PR TITLE
TD-4269 Enrolment method changed to Enrolled by Admin/Supervisor everywhere to avoid confusion

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateSelfAssessmentInfoViewModel.cs
@@ -55,7 +55,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
             EnrolmentMethod = delegateInfo.EnrolmentMethodId switch
             {
                 1 => "Self enrolled",
-                2 => enrolledByFullName == null ? "Admin/supervisor enrolled" : "Enrolled by " + enrolledByFullName,
+                2 => enrolledByFullName == null ? "Admin/supervisor enrolled" : "Enrolled by Admin/Supervisor - " + enrolledByFullName,
                 3 => "Group",
                 _ => "System",
             };

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
@@ -61,7 +61,7 @@
                 string enrolmentMethod = Model.EnrolmentMethodId switch
                 {
                     1 => "Self enrolled",
-                    2 => Model.EnrolledByFullName != null ? "Enrolled by Supervisor - " + Model.EnrolledByFullName : "Admin/supervisor enrolled",
+                    2 => Model.EnrolledByFullName != null ? "Enrolled by Admin/Supervisor - " + Model.EnrolledByFullName : "Admin/Supervisor enrolled",
                     3 => "Group",
                     _ => "System",
                 };


### PR DESCRIPTION
### JIRA link
[TD-4269](https://hee-tis.atlassian.net/browse/TD-4269)

### Description
Enrolment method changed to Enrolled by Admin/Supervisor everywhere to avoid confusion

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4269]: https://hee-tis.atlassian.net/browse/TD-4269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ