### PR TITLE
TD-4243 Few 'add on' courses showing on 'Learning Portal' not showing on 'Course set up' & 'Delegate activities' screens

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202407221026_AlterGetCurrentCoursesForCandidate_V2.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202407221026_AlterGetCurrentCoursesForCandidate_V2.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202407221027)]
+    public class AlterGetCurrentCoursesForCandidate_V2_new : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up);
+        }
+        public override void Down()
+        {
+            Execute.Sql(Properties.Resources.TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -1787,7 +1787,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecordWithCompleteWithinMonths]    Script Date: 27/02/2024 10:27:26 ******/
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecord_V3]    Script Date: 27/06/2024 09:35:55 ******/
         ///SET ANSI_NULLS ON
         ///GO
         ///
@@ -1797,11 +1797,11 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///
         ///-- =============================================
         ///-- Author:		Kevin Whittaker
-        ///-- Create date: 23/10/2018
+        ///-- Create date: 15 February 2012
         ///-- Description:	Creates the Progress and aspProgress record for a new user
         ///-- Returns:		0 : success, progress created
         ///--       		1 : Failed - progress already exists
-        ///--       		100 : Failed - CentreID and Cust [rest of string was truncated]&quot;;.
+        ///--       		100 : Failed - CentreID and CustomisationID don [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_4223_Alter_uspCreateProgressRecord_V3_Down {
             get {
@@ -1810,7 +1810,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecordWithCompleteWithinMonths]    Script Date: 27/02/2024 10:27:26 ******/
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecord_V3]    Script Date: 27/06/2024 09:35:33 ******/
         ///SET ANSI_NULLS ON
         ///GO
         ///
@@ -1818,13 +1818,14 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///GO
         ///
         ///
+        ///
         ///-- =============================================
         ///-- Author:		Kevin Whittaker
-        ///-- Create date: 23/10/2018
+        ///-- Create date: 15 February 2012
         ///-- Description:	Creates the Progress and aspProgress record for a new user
         ///-- Returns:		0 : success, progress created
         ///--       		1 : Failed - progress already exists
-        ///--       		100 : Failed - CentreID and Cust [rest of string was truncated]&quot;;.
+        ///--       		100 : Failed - CentreID and CustomisationID d [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_4223_Alter_uspCreateProgressRecord_V3_Up {
             get {
@@ -1833,21 +1834,21 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecordWithCompleteWithinMonths]    Script Date: 27/02/2024 10:27:26 ******/
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2]    Script Date: 27/06/2024 09:37:38 ******/
         ///SET ANSI_NULLS ON
         ///GO
         ///
         ///SET QUOTED_IDENTIFIER ON
         ///GO
         ///
-        ///
         ///-- =============================================
         ///-- Author:		Kevin Whittaker
-        ///-- Create date: 23/10/2018
-        ///-- Description:	Creates the Progress and aspProgress record for a new user
-        ///-- Returns:		0 : success, progress created
-        ///--       		1 : Failed - progress already exists
-        ///--       		100 : Failed - CentreID and Cust [rest of string was truncated]&quot;;.
+        ///-- Create date: 11/04/2019
+        ///-- Description:	Creates the Progress and aspProgress record for a new user with no return value
+        ///-- Returns:		Nothing
+        ///
+        ///-- =============================================
+        ///ALTER PROCEDURE [dbo].[uspCreatePr [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Down {
             get {
@@ -1856,7 +1857,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecordWithCompleteWithinMonths]    Script Date: 27/02/2024 10:27:26 ******/
+        ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2]    Script Date: 27/06/2024 09:38:12 ******/
         ///SET ANSI_NULLS ON
         ///GO
         ///
@@ -1866,15 +1867,63 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///
         ///-- =============================================
         ///-- Author:		Kevin Whittaker
-        ///-- Create date: 23/10/2018
-        ///-- Description:	Creates the Progress and aspProgress record for a new user
-        ///-- Returns:		0 : success, progress created
-        ///--       		1 : Failed - progress already exists
-        ///--       		100 : Failed - CentreID and Cust [rest of string was truncated]&quot;;.
+        ///-- Create date: 11/04/2019
+        ///-- Description:	Creates the Progress and aspProgress record for a new user with no return value
+        ///-- Returns:		Nothing
+        ///
+        ///-- =============================================
+        ///ALTER PROCEDURE [dbo].[uspCreate [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Up {
             get {
                 return ResourceManager.GetString("TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Up", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ////****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/07/2024 10:11:35 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        /// 
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        /// 
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 16/12/2016
+        ///-- Description:	Returns a list of active progress records for the candidate.
+        ///-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+        ///-- =============================================
+        ///ALTER PROCEDURE [dbo].[GetC [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down {
+            get {
+                return ResourceManager.GetString("TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        /// 
+        ////****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/07/2024 10:11:35 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        /// 
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        /// 
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 16/12/2016
+        ///-- Description:	Returns a list of active progress records for the candidate.
+        ///-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+        ///-- =============================================
+        ///ALTER PROCEDURE [dbo].[Ge [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up {
+            get {
+                return ResourceManager.GetString("TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up", resourceCulture);
             }
         }
         

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -388,18 +388,22 @@
   <data name="TD_3671_Alter_GetCurrentCoursesForCandidate_V2_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\TD-3671-Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
-    
-    <data name="TD_4223_Alter_uspCreateProgressRecord_V3_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecord_V3_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
-    </data>
-    <data name="TD_4223_Alter_uspCreateProgressRecord_V3_Up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecord_V3_Up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
-    </data>
-
-    <data name="TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
-    </data>
-    <data name="TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
-    </data>
+  <data name="TD_4223_Alter_uspCreateProgressRecord_V3_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecord_V3_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
+  </data>
+  <data name="TD_4223_Alter_uspCreateProgressRecord_V3_Up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecord_V3_Up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
+  </data>
+  <data name="TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
+  </data>
+  <data name="TD_4223_Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecordWithCompleteWithinMonths_Quiet_V2_Up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
+  </data>
+  <data name="TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql
@@ -1,0 +1,47 @@
+
+/****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/07/2024 10:11:35 ******/
+SET ANSI_NULLS ON
+GO
+ 
+SET QUOTED_IDENTIFIER ON
+GO
+ 
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 16/12/2016
+-- Description:	Returns a list of active progress records for the candidate.
+-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+-- =============================================
+ALTER PROCEDURE [dbo].[GetCurrentCoursesForCandidate_V2]
+	-- Add the parameters for the stored procedure here
+	@CandidateID int
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+ 
+    -- Insert statements for procedure here
+	SELECT p.ProgressID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, p.CustomisationID, p.SubmittedTime AS LastAccessed, 
+               p.FirstSubmittedTime AS StartedDate, p.DiagnosticScore, p.PLLocked, cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(p.CustomisationID, 0) 
+               AS HasDiagnostic, dbo.CheckCustomisationSectionHasLearning(p.CustomisationID, 0) AS HasLearning,
+                   COALESCE
+                             ((SELECT        COUNT(Passes) AS Passes
+                                 FROM            (SELECT        COUNT(AssessAttemptID) AS Passes
+                                                           FROM            AssessAttempts AS aa
+                                                           WHERE        (CandidateID = p.CandidateID) AND (CustomisationID = p.CustomisationID) AND (Status = 1)
+                                                           GROUP BY SectionNumber) AS derivedtbl_2), 0) AS Passes,
+                   (SELECT COUNT(SectionID) AS Sections
+                    FROM   Sections AS s
+                    WHERE (ApplicationID = cu.ApplicationID)) AS Sections, p.CompleteByDate, CAST(CASE WHEN p.CompleteByDate IS NULL THEN 0 WHEN p.CompleteByDate < getDate() 
+                         THEN 2 WHEN p.CompleteByDate < DATEADD(M, + 1, getDate()) THEN 1 ELSE 0 END AS INT) AS OverDue, p.EnrollmentMethodID, dbo.GetCohortGroupCustomisationID(p.ProgressID) AS GroupCustomisationID, p.SupervisorAdminID
+ 
+FROM  Progress AS p INNER JOIN
+               Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+               Applications AS a ON cu.ApplicationID = a.ApplicationID
+WHERE (p.Completed IS NULL) AND (p.RemovedDate IS NULL) AND (p.CandidateID = @CandidateID)AND (cu.CustomisationName <> 'ESR') AND (a.ArchivedDate IS NULL) AND(cu.Active = 1) AND 
+((p.SubmittedTime > DATEADD(M, -6, getDate()) OR (EnrollmentMethodID <> 1)) OR NOT (p.CompleteByDate IS NULL) AND NOT
+(p.SubmittedTime < DATEADD(MONTH, -6, GETDATE()) AND (p.EnrollmentMethodID = 1) AND (p.CompleteByDate < GETDATE())))
+ORDER BY p.SubmittedTime Desc
+END
+GO

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql
@@ -1,0 +1,49 @@
+
+ 
+/****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/07/2024 10:11:35 ******/
+SET ANSI_NULLS ON
+GO
+ 
+SET QUOTED_IDENTIFIER ON
+GO
+ 
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 16/12/2016
+-- Description:	Returns a list of active progress records for the candidate.
+-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
+-- =============================================
+ALTER PROCEDURE [dbo].[GetCurrentCoursesForCandidate_V2]
+	-- Add the parameters for the stored procedure here
+	@CandidateID int
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+ 
+    -- Insert statements for procedure here
+	SELECT p.ProgressID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, p.CustomisationID, p.SubmittedTime AS LastAccessed, 
+               p.FirstSubmittedTime AS StartedDate, p.DiagnosticScore, p.PLLocked, cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(p.CustomisationID, 0) 
+               AS HasDiagnostic, dbo.CheckCustomisationSectionHasLearning(p.CustomisationID, 0) AS HasLearning,
+                   COALESCE
+                             ((SELECT        COUNT(Passes) AS Passes
+                                 FROM            (SELECT        COUNT(AssessAttemptID) AS Passes
+                                                           FROM            AssessAttempts AS aa
+                                                           WHERE        (CandidateID = p.CandidateID) AND (CustomisationID = p.CustomisationID) AND (Status = 1)
+                                                           GROUP BY SectionNumber) AS derivedtbl_2), 0) AS Passes,
+                   (SELECT COUNT(SectionID) AS Sections
+                    FROM   Sections AS s
+                    WHERE (ApplicationID = cu.ApplicationID)) AS Sections, p.CompleteByDate, CAST(CASE WHEN p.CompleteByDate IS NULL THEN 0 WHEN p.CompleteByDate < getDate() 
+                         THEN 2 WHEN p.CompleteByDate < DATEADD(M, + 1, getDate()) THEN 1 ELSE 0 END AS INT) AS OverDue, p.EnrollmentMethodID, dbo.GetCohortGroupCustomisationID(p.ProgressID) AS GroupCustomisationID, p.SupervisorAdminID
+ 
+FROM  Progress AS p INNER JOIN
+               Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+               Applications AS a ON cu.ApplicationID = a.ApplicationID INNER JOIN 
+			   CentreApplications AS ca ON ca.ApplicationID = a.ApplicationID AND ca.CentreID = cu.CentreID
+WHERE (p.Completed IS NULL) AND (p.RemovedDate IS NULL) AND (p.CandidateID = @CandidateID)AND (cu.CustomisationName <> 'ESR') AND (a.ArchivedDate IS NULL) AND(cu.Active = 1) AND 
+((p.SubmittedTime > DATEADD(M, -6, getDate()) OR (EnrollmentMethodID <> 1)) OR NOT (p.CompleteByDate IS NULL) AND NOT
+(p.SubmittedTime < DATEADD(MONTH, -6, GETDATE()) AND (p.EnrollmentMethodID = 1) AND (p.CompleteByDate < GETDATE())))
+ORDER BY p.SubmittedTime Desc
+END
+GO


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4243

### Description
I modify the store procedure by adding CentreApplications table to the store procedure, so that courses that is not publish to the centre will not reflect in the current activities, as it is in Course set up & Delegate activities


### Screenshots
![image](https://github.com/user-attachments/assets/3dfb4a9a-0f91-426d-bf65-b17d5c7b9916)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
