### PR TITLE
TD-4376 Issue with not trimming of the  trailing/leading end spaces on Super Admin search screens

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Administrators/AdminAccountsController.cs
@@ -71,6 +71,7 @@
           string? ExistingFilterString = ""
         )
         {
+            Search = Search == null ? string.Empty : Search.Trim();
             var loggedInSuperAdmin = userService.GetAdminById(User.GetAdminId()!.Value);
             if (loggedInSuperAdmin.AdminAccount.Active == false)
             {

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Delegates/DelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Delegates/DelegatesController.cs
@@ -52,6 +52,7 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Delegates
           string? SearchString = "",
           string? ExistingFilterString = "")
         {
+            Search = Search == null ? string.Empty : Search.Trim();
 
             if (string.IsNullOrEmpty(SearchString) || string.IsNullOrEmpty(ExistingFilterString))
             {

--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Users/UsersController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Users/UsersController.cs
@@ -99,6 +99,8 @@
           string? ExistingFilterString = ""
         )
         {
+            Search = Search == null ? string.Empty : Search.Trim();
+
             if (string.IsNullOrEmpty(SearchString) || string.IsNullOrEmpty(ExistingFilterString))
             {
                 page = 1;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4376

### Description
I trimmed the search parameter to remove the whitespace on Administrator, user account and delegate page
### Screenshots
![image](https://github.com/user-attachments/assets/22d8c684-a731-4d8a-865c-9e7edf17a3e8)
![image](https://github.com/user-attachments/assets/44e51b38-71a1-44e7-bd12-b0ca5fb2b6bb)
![image](https://github.com/user-attachments/assets/570bb3af-740e-4c02-ada2-c50a5edd1ecc)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
