### PR TITLE
TD-4364 Back links For Mobile View Added

### DIFF
--- a/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackStart.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/GuestFeedbackStart.cshtml
@@ -4,73 +4,76 @@
 @model UserFeedbackViewModel;
 
 @{
-  ViewData["Title"] = "Feedback";
+    ViewData["Title"] = "Feedback";
 }
 
 <link rel="stylesheet" href="@Url.Content("~/css/userFeedback/userFeedback.css")" asp-append-version="true">
 
 @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
-            @if (Model.SourcePageTitle != String.Empty)
-            {
-              <div><partial name="_NhsChevronLeft" class="feedback-chevron" />  Go back to Welcome page</div>
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
+                        @if (Model.SourcePageTitle != String.Empty)
+                        {
+                            <div><partial name="_NhsChevronLeft" class="feedback-chevron" />  Go back to Welcome page</div>
 
-            }
-            @if (Model.SourcePageTitle == String.Empty)
-            {
-              <div><partial name="_NhsChevronLeft" class="feedback-chevron" />  Go back</div>
-            }
-          </a>
-        </li>
-      </ol>
-    </div>
-  </nav>
+                        }
+                        @if (Model.SourcePageTitle == String.Empty)
+                        {
+                            <div><partial name="_NhsChevronLeft" class="feedback-chevron" />  Go back</div>
+                        }
+                    </a>
+                </li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__link" href="@Model.SourceUrl">Go back to @Model.SourcePageTitle</a>
+            </p>
+        </div>
+    </nav>
 }
 
-  <div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
-      <h1 id="page-heading" class="nhsuk-heading-xl">Give us feedback about what you were trying to achieve</h1>
+        <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
+        <h1 id="page-heading" class="nhsuk-heading-xl">Give us feedback about what you were trying to achieve</h1>
     </div>
     <div class="nhsuk-grid-column-two-thirds">
 
-      <form method="post" asp-action="GuestFeedbackComplete">
+        <form method="post" asp-action="GuestFeedbackComplete">
 
-        <vc:text-input asp-for="TaskAttempted"
-                     label="What task did you come to do today?"
-                     populate-with-current-value="true"
-                     type="text"
-                     spell-check="false"
-                     hint-text=""
-                     autocomplete="off"
-                     css-class="nhsuk-input"
-                     required = "false" />
+            <vc:text-input asp-for="TaskAttempted"
+                           label="What task did you come to do today?"
+                           populate-with-current-value="true"
+                           type="text"
+                           spell-check="false"
+                           hint-text=""
+                           autocomplete="off"
+                           css-class="nhsuk-input"
+                           required="false" />
 
-        <vc:text-area asp-for="FeedbackText"
-                    label="Please describe in detail your experience and what you came here to achieve."
-                    populate-with-current-value="true"
-                    rows="5"
-                    type="text"
-                    spell-check="false"
-                    hint-text=""
-                    autocomplete="off"
-                    css-class="nhsuk-u-width-full"
-                    character-count="null" />
+            <vc:text-area asp-for="FeedbackText"
+                          label="Please describe in detail your experience and what you came here to achieve."
+                          populate-with-current-value="true"
+                          rows="5"
+                          type="text"
+                          spell-check="false"
+                          hint-text=""
+                          autocomplete="off"
+                          css-class="nhsuk-u-width-full"
+                          character-count="null" />
 
-        <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
+            <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
 
-        <div class="nhsuk-u-float-right">
-          <button class="nhsuk-button" type="submit">
-            Submit Feedback
-            <span class="feedback-chevron">
-              <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
-            </span>
-          </button>
-        </div>
-      </form>
+            <div class="nhsuk-u-float-right">
+                <button class="nhsuk-button" type="submit">
+                    Submit Feedback
+                    <span class="feedback-chevron">
+                        <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
+                    </span>
+                </button>
+            </div>
+        </form>
     </div>
-  </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackComplete.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackComplete.cshtml
@@ -25,6 +25,9 @@
                     </a>
                 </li>
             </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__link" href="@Model.SourceUrl">Go back to @Model.SourcePageTitle</a>
+            </p>
         </div>
     </nav>
 }

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAchieved.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAchieved.cshtml
@@ -4,88 +4,92 @@
 @model UserFeedbackViewModel;
 
 @{
-  ViewData["Title"] = "Feedback";
+    ViewData["Title"] = "Feedback";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/userFeedback/userFeedback.css")" asp-append-version="true">
 
 @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
-            @if (Model.SourcePageTitle != String.Empty)
-            {
-              <div>&lt Go back to @Model.SourcePageTitle</div>
-            }
-            @if (Model.SourcePageTitle == String.Empty)
-            {
-              <div>&lt Go back</div>
-            }
-          </a>
-        </li>
-      </ol>
-    </div>
-  </nav>
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
+                        @if (Model.SourcePageTitle != String.Empty)
+                        {
+                            <div>&lt Go back to @Model.SourcePageTitle</div>
+                        }
+                        @if (Model.SourcePageTitle == String.Empty)
+                        {
+                            <div>&lt Go back</div>
+                        }
+                    </a>
+                </li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__link" href="@Model.SourceUrl">Go back to @Model.SourcePageTitle</a>
+            </p>
+        </div>
+    </nav>
 }
 
-  <div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
-      <h1 id="page-heading" class="nhsuk-heading-xl">Did you achieve everything you came to do today?</h1>
+        <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
+        <h1 id="page-heading" class="nhsuk-heading-xl">Did you achieve everything you came to do today?</h1>
     </div>
     <div class="nhsuk-grid-column-two-thirds">
 
-      <div class="nhsuk-warning-callout">
-        <h3 class="nhsuk-warning-callout__label">
-          <span role="text">
-            <span class="nhsuk-u-visually-hidden">Important: </span>
-            We do not reply to this inbox.
-          </span>
-        </h3>
-        <p>If you need support please contact your centre. This might be your Centre Manager or Clinical Centre Manager.</p>
-      </div>
-
-      <p class="nhsuk-body-l">Step 1 of 4</p>
-
-      <form method="post" asp-action="UserFeedbackTaskAchievedSet">
-        <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
-        <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
-        <div class="nhsuk-hint" id="task-achieve-hint">
-          Did you achieve everything you came to do today?
+        <div class="nhsuk-warning-callout">
+            <h3 class="nhsuk-warning-callout__label">
+                <span role="text">
+                    <span class="nhsuk-u-visually-hidden">Important: </span>
+                    We do not reply to this inbox.
+                </span>
+            </h3>
+            <p>If you need support please contact your centre. This might be your Centre Manager or Clinical Centre Manager.</p>
         </div>
-        <fieldset class="nhsuk-fieldset" id="feedback-achieved-form" aria-describedby="task-achieve-hint">
-          <div class="nhsuk-u-margin-bottom-6">
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input"
-                   id="feedback-achieved-yes"
-                   asp-for="TaskAchieved"
-                   type="radio"
-                   value="true">
-              <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-yes">
-                Yes
-              </label>
+
+        <p class="nhsuk-body-l">Step 1 of 4</p>
+
+        <form method="post" asp-action="UserFeedbackTaskAchievedSet">
+            <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
+            <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
+            <div class="nhsuk-hint" id="task-achieve-hint">
+                Did you achieve everything you came to do today?
             </div>
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input"
-                   id="feedback-achieved-no"
-                   asp-for="TaskAchieved"
-                   type="radio"
-                   value="false" />
-              <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-no">
-                No
-              </label>
+            <fieldset class="nhsuk-fieldset" id="feedback-achieved-form" aria-describedby="task-achieve-hint">
+                <div class="nhsuk-u-margin-bottom-6">
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="feedback-achieved-yes"
+                               asp-for="TaskAchieved"
+                               type="radio"
+                               value="true">
+                        <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-yes">
+                            Yes
+                        </label>
+                    </div>
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="feedback-achieved-no"
+                               asp-for="TaskAchieved"
+                               type="radio"
+                               value="false" />
+                        <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-no">
+                            No
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+            <div class="nhsuk-u-float-right">
+                <button class="nhsuk-button" type="submit">
+                    Continue
+                    <span class="feedback-chevron">
+                        <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
+                    </span>
+                </button>
             </div>
-          </div>
-        </fieldset>
-        <div class="nhsuk-u-float-right">
-          <button class="nhsuk-button" type="submit">Continue
-          <span class="feedback-chevron">
-            <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
-          </span>
-        </button>
-        </div>
-      </form>
+        </form>
     </div>
-  </div>
+</div>
 

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAttempted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAttempted.cshtml
@@ -4,70 +4,75 @@
 @model UserFeedbackViewModel;
 
 @{
-  ViewData["Title"] = "Feedback";
+    ViewData["Title"] = "Feedback";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/userFeedback/userFeedback.css")" asp-append-version="true">
 
 @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
-            @if (Model.SourcePageTitle != String.Empty) {
-              <div>&lt Go back to @Model.SourcePageTitle</div>
-            }
-            @if (Model.SourcePageTitle == String.Empty) {
-              <div>&lt Go back</div>
-            }
-          </a>
-        </li>
-      </ol>
-    </div>
-  </nav>
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
+                        @if (Model.SourcePageTitle != String.Empty)
+                        {
+                            <div>&lt Go back to @Model.SourcePageTitle</div>
+                        }
+                        @if (Model.SourcePageTitle == String.Empty)
+                        {
+                            <div>&lt Go back</div>
+                        }
+                    </a>
+                </li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__link" href="@Model.SourceUrl">Go back to @Model.SourcePageTitle</a>
+            </p>
+        </div>
+    </nav>
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
-    <h1 id="page-heading" class="nhsuk-heading-xl">Give us feedback about what you were trying to achieve</h1>
-  </div>
-  <div class="nhsuk-grid-column-two-thirds">
-    <form method="post" asp-action="UserFeedbackTaskAttemptedSet">
-      <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
-      <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
+    <div class="nhsuk-grid-column-full">
+        <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
+        <h1 id="page-heading" class="nhsuk-heading-xl">Give us feedback about what you were trying to achieve</h1>
+    </div>
+    <div class="nhsuk-grid-column-two-thirds">
+        <form method="post" asp-action="UserFeedbackTaskAttemptedSet">
+            <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
+            <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
 
-      <p class="nhsuk-body-l">Step 2 of 4</p>
+            <p class="nhsuk-body-l">Step 2 of 4</p>
 
-      <vc:text-input asp-for="TaskAttempted"
-                     label="What task did you come to do today?"
-                     populate-with-current-value="true"
-                     type="text"
-                     spell-check="false"
-                     hint-text=""
-                     autocomplete="off"
-                     css-class="nhsuk-input"
-                     required = "false" />
+            <vc:text-input asp-for="TaskAttempted"
+                           label="What task did you come to do today?"
+                           populate-with-current-value="true"
+                           type="text"
+                           spell-check="false"
+                           hint-text=""
+                           autocomplete="off"
+                           css-class="nhsuk-input"
+                           required="false" />
 
-      <vc:text-area asp-for="FeedbackText"
-                    label="Please describe in detail your experience and what you came here to achieve."
-                    populate-with-current-value="true"
-                    rows="5"
-                    type="text"
-                    spell-check="false"
-                    hint-text=""
-                    autocomplete="off"
-                    css-class="nhsuk-u-width-full"
-                    character-count="null" />
+            <vc:text-area asp-for="FeedbackText"
+                          label="Please describe in detail your experience and what you came here to achieve."
+                          populate-with-current-value="true"
+                          rows="5"
+                          type="text"
+                          spell-check="false"
+                          hint-text=""
+                          autocomplete="off"
+                          css-class="nhsuk-u-width-full"
+                          character-count="null" />
 
-      <div class="nhsuk-u-float-right">
-        <button class="nhsuk-button" type="submit">
-          Continue
-          <span class="feedback-chevron">
-            <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
-          </span>
-        </button>
-      </div>
-    </form>
-  </div>
+            <div class="nhsuk-u-float-right">
+                <button class="nhsuk-button" type="submit">
+                    Continue
+                    <span class="feedback-chevron">
+                        <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
+                    </span>
+                </button>
+            </div>
+        </form>
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskDifficulty.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskDifficulty.cshtml
@@ -4,96 +4,101 @@
 @model UserFeedbackViewModel;
 
 @{
-  ViewData["Title"] = "Feedback";
+    ViewData["Title"] = "Feedback";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/userFeedback/userFeedback.css")" asp-append-version="true">
 
 @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
-            @if (Model.SourcePageTitle != String.Empty) {
-              <div><partial name="_NhsChevronLeft" /> Go back to @Model.SourcePageTitle</div>
-            }
-            @if (Model.SourcePageTitle == String.Empty) {
-              <div><partial name="_NhsChevronLeft" /> Go back</div>
-            }
-          </a>
-        </li>
-      </ol>
-    </div>
-  </nav>
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" href="@Model.SourceUrl">
+                        @if (Model.SourcePageTitle != String.Empty)
+                        {
+                            <div><partial name="_NhsChevronLeft" /> Go back to @Model.SourcePageTitle</div>
+                        }
+                        @if (Model.SourcePageTitle == String.Empty)
+                        {
+                            <div><partial name="_NhsChevronLeft" /> Go back</div>
+                        }
+                    </a>
+                </li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back">
+                <a class="nhsuk-breadcrumb__link" href="@Model.SourceUrl">Go back to @Model.SourcePageTitle</a>
+            </p>
+        </div>
+    </nav>
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
-    <h1 id="page-heading" class="nhsuk-heading-xl">How easy or difficult was it to achieve your task?</h1>
-  </div>
-  <div class="nhsuk-grid-column-two-thirds">
-    <p class="nhsuk-body-l">Step 3 of 4</p>
-    
-    <form method="post" asp-action="UserFeedbackTaskDifficultySet">
-      <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
-      <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
+    <div class="nhsuk-grid-column-full">
+        <h2 class="nhsuk-caption-l">Give page or website feedback</h2>
+        <h1 id="page-heading" class="nhsuk-heading-xl">How easy or difficult was it to achieve your task?</h1>
+    </div>
+    <div class="nhsuk-grid-column-two-thirds">
+        <p class="nhsuk-body-l">Step 3 of 4</p>
 
-      <div class="nhsuk-hint" id="feedback-difficulty-hint">
-        Please select an option
-      </div>
-      <fieldset class="nhsuk-fieldset" id="feedback-achieved-form" aria-describedby="feedback-difficulty-hint">
-        <div class="nhsuk-u-margin-bottom-6">
-          <div class="nhsuk-radios__item">
-            <input class="nhsuk-radios__input"
-                   id="task-difficulty-veryeasy"
-                   asp-for="TaskRating"
-                   type="radio"
-                   value="1">
-            <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-veryeasy">
-              Very Easy
-            </label>
-          </div>
-          <div class="nhsuk-radios__item">
-            <input class="nhsuk-radios__input"
-                   id="task-difficulty-easy"
-                   asp-for="TaskRating"
-                   type="radio"
-                   value="2">
-            <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-easy">
-              Easy
-            </label>
-          </div>
-          <div class="nhsuk-radios__item">
-            <input class="nhsuk-radios__input"
-                   id="task-difficulty-difficult"
-                   asp-for="TaskRating"
-                   type="radio"
-                   value="3">
-            <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-difficult">
-              Difficult
-            </label>
-          </div>
-          <div class="nhsuk-radios__item">
-            <input class="nhsuk-radios__input"
-                   id="task-difficulty-verydifficult"
-                   asp-for="TaskRating"
-                   type="radio"
-                   value="4">
-            <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-verydifficult">
-              Very Difficult
-            </label>
-          </div>
-        </div>
-      </fieldset>
-      <div class="nhsuk-u-float-right">
-        <button class="nhsuk-button" type="submit">
-          Submit feedback
-          <span class="feedback-chevron">
-            <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
-          </span>
-        </button>
-      </div>
-    </form>
-  </div>
+        <form method="post" asp-action="UserFeedbackTaskDifficultySet">
+            <input type="hidden" asp-for="SourceUrl" value="@Model.SourceUrl" />
+            <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
+
+            <div class="nhsuk-hint" id="feedback-difficulty-hint">
+                Please select an option
+            </div>
+            <fieldset class="nhsuk-fieldset" id="feedback-achieved-form" aria-describedby="feedback-difficulty-hint">
+                <div class="nhsuk-u-margin-bottom-6">
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="task-difficulty-veryeasy"
+                               asp-for="TaskRating"
+                               type="radio"
+                               value="1">
+                        <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-veryeasy">
+                            Very Easy
+                        </label>
+                    </div>
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="task-difficulty-easy"
+                               asp-for="TaskRating"
+                               type="radio"
+                               value="2">
+                        <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-easy">
+                            Easy
+                        </label>
+                    </div>
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="task-difficulty-difficult"
+                               asp-for="TaskRating"
+                               type="radio"
+                               value="3">
+                        <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-difficult">
+                            Difficult
+                        </label>
+                    </div>
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="task-difficulty-verydifficult"
+                               asp-for="TaskRating"
+                               type="radio"
+                               value="4">
+                        <label class="nhsuk-label nhsuk-radios__label" for="task-difficulty-verydifficult">
+                            Very Difficult
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+            <div class="nhsuk-u-float-right">
+                <button class="nhsuk-button" type="submit">
+                    Submit feedback
+                    <span class="feedback-chevron">
+                        <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
+                    </span>
+                </button>
+            </div>
+        </form>
+    </div>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-4364](https://hee-tis.atlassian.net/browse/TD-4364)

### Description
Backlinks For Mobile View Added for user feedback pages.

### Screenshots
Mobile view for feedback page that shows the back link is now added-
![image](https://github.com/user-attachments/assets/a8b38368-dd28-43b9-af84-bed417e3ed18)

Wave analysis of the web view that shows nothing is broken-
![image](https://github.com/user-attachments/assets/934f4bf3-b6ce-4acf-9c61-cddadb93426b)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4364]: https://hee-tis.atlassian.net/browse/TD-4364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ