### PR TITLE
TD-4436 - Issue with the Enrolment date/time for the courses when enrolled by 'Group' 

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseContentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseContentDataService.cs
@@ -251,7 +251,7 @@
                             WHERE S1.CandidateID = Progress.CandidateID
                               AND S1.CustomisationID = Progress.CustomisationID
                               AND S1.LoginTime >= Progress.FirstSubmittedTime),
-                            SubmittedTime = GETUTCDATE()
+                            SubmittedTime = GETDATE()
                         WHERE Progress.ProgressID = @progressId",
                 new { progressId }
             );

--- a/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/ProgressDataService.cs
@@ -15,7 +15,8 @@
     {
         IEnumerable<Progress> GetDelegateProgressForCourse(int delegateId, int customisationId);
 
-        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate, int enrollmentMethodID, DateTime? firstSubmittedTime);
+        void UpdateProgressSupervisorAndCompleteByDate(int progressId, int supervisorAdminId, DateTime? completeByDate, int enrollmentMethodID);
+        void UpdateProgressSupervisor(int progressId, int supervisorAdminId);
         int CreateNewDelegateProgress(
             int delegateId,
             int customisationId,
@@ -144,21 +145,31 @@
             int progressId,
             int supervisorAdminId,
             DateTime? completeByDate,
-            int enrollmentMethodID,
-            DateTime? firstSubmittedTime
+            int enrollmentMethodID
         )
         {
             connection.Execute(
                 @"UPDATE Progress SET
                         SupervisorAdminID = @supervisorAdminId,
                         CompleteByDate = @completeByDate,
-                        EnrollmentMethodID = @enrollmentMethodID,
-                        FirstSubmittedTime= @firstSubmittedTime
+                        EnrollmentMethodID = @enrollmentMethodID
                     WHERE ProgressID = @progressId",
-                new { progressId, supervisorAdminId, completeByDate, enrollmentMethodID, @firstSubmittedTime }
+                new { progressId, supervisorAdminId, completeByDate, enrollmentMethodID }
             );
         }
 
+        public void UpdateProgressSupervisor(
+            int progressId,
+            int supervisorAdminId
+        )
+        {
+            connection.Execute(
+                @"UPDATE Progress SET
+                        SupervisorAdminID = @supervisorAdminId
+                    WHERE ProgressID = @progressId",
+                new { progressId, supervisorAdminId }
+            );
+        }
         public int CreateNewDelegateProgress(
             int delegateId,
             int customisationId,

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -357,8 +357,7 @@
                         reusableProgressRecord.ProgressId,
                         A<int>._,
                         A<DateTime?>._,
-                        A<int>._,
-                        A<DateTime?>._
+                        A<int>._
                     )
                 ).MustHaveHappened();
             }
@@ -395,8 +394,7 @@
                         reusableProgressRecord.ProgressId,
                         reusableProgressRecord.SupervisorAdminId,
                         A<DateTime?>._,
-                        A<int>._,
-                         A<DateTime?>._
+                        A<int>._
                     )
                 ).MustHaveHappened();
             }
@@ -433,8 +431,7 @@
                         reusableProgressRecord.ProgressId,
                         supervisorId,
                         A<DateTime?>._,
-                        A<int>._,
-                        A<DateTime?>._
+                        A<int>._
                     )
                 ).MustHaveHappened();
             }
@@ -471,8 +468,7 @@
                         reusableProgressRecord.ProgressId,
                         A<int>._,
                         null,
-                         A<int>._,
-                          A<DateTime?>._
+                         A<int>._
                     )
                 ).MustHaveHappened();
             }
@@ -511,8 +507,7 @@
                         reusableProgressRecord.ProgressId,
                         A<int>._,
                         expectedFutureDate,
-                         A<int>._,
-                          A<DateTime?>._
+                         A<int>._
                     )
                 ).MustHaveHappened();
             }

--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceTests.cs
@@ -721,7 +721,7 @@
         private void DelegateProgressRecordMustNotHaveBeenUpdated()
         {
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._)
             ).MustNotHaveHappened();
         }
 
@@ -765,7 +765,7 @@
             A.CallTo(() => groupsDataService.AddDelegateToGroup(A<int>._, A<int>._, A<DateTime>._, A<int>._))
                 .DoesNothing();
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._)
             ).DoesNothing();
             A.CallTo(
                 () => progressDataService.CreateNewDelegateProgress(

--- a/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ProgressServiceTests.cs
@@ -58,7 +58,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisor(A<int>._, A<int>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)
@@ -80,12 +80,9 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(
+                () => progressDataService.UpdateProgressSupervisor(
                     progressId,
-                    newSupervisorId,
-                    A<DateTime?>._,
-                    A<int>._,
-                     A<DateTime?>._
+                    newSupervisorId
                 )
             ).MustHaveHappened();
             A.CallTo(
@@ -107,7 +104,7 @@
 
             // Then
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(progressId, 0, A<DateTime?>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisor(progressId, 0)
             ).MustHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(progressId)
@@ -124,7 +121,7 @@
             // Then
             Assert.Throws<ProgressNotFoundException>(() => progressService.UpdateSupervisor(progressId, null));
             A.CallTo(
-                () => progressDataService.UpdateProgressSupervisorAndCompleteByDate(A<int>._, A<int>._, A<DateTime?>._, A<int>._, A<DateTime?>._)
+                () => progressDataService.UpdateProgressSupervisor(A<int>._, A<int>._)
             ).MustNotHaveHappened();
             A.CallTo(
                 () => progressDataService.ClearAspProgressVerificationRequest(A<int>._)

--- a/DigitalLearningSolutions.Web/Services/EnrolService.cs
+++ b/DigitalLearningSolutions.Web/Services/EnrolService.cs
@@ -104,9 +104,7 @@ namespace DigitalLearningSolutions.Web.Services
                         progressRecord.ProgressId,
                         supervisorAdminId ?? 0,
                         completeByDate,
-                        2,
-                       clockUtility.UtcNow
-                        );
+                        2);
                 }
             }
             else
@@ -188,7 +186,7 @@ namespace DigitalLearningSolutions.Web.Services
 
         public int EnrolOnActivitySelfAssessment(int selfAssessmentId, int candidateId, int supervisorId, string adminEmail, int selfAssessmentSupervisorRoleId, DateTime? completeByDate, int delegateUserId, int centreId, int? enrolledByAdminId)
         {
-           return courseDataService.EnrolOnActivitySelfAssessment(selfAssessmentId, candidateId, supervisorId, adminEmail, selfAssessmentSupervisorRoleId, completeByDate, delegateUserId, centreId, enrolledByAdminId);
+            return courseDataService.EnrolOnActivitySelfAssessment(selfAssessmentId, candidateId, supervisorId, adminEmail, selfAssessmentSupervisorRoleId, completeByDate, delegateUserId, centreId, enrolledByAdminId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -744,9 +744,7 @@
                         progressRecord.ProgressId,
                         updatedSupervisorAdminId,
                         completeByDate,
-                       3,
-                      clockUtility.UtcNow
-                    );
+                       3);
                 }
             }
             else

--- a/DigitalLearningSolutions.Web/Services/ProgressService.cs
+++ b/DigitalLearningSolutions.Web/Services/ProgressService.cs
@@ -102,13 +102,7 @@
 
             using var transaction = new TransactionScope();
 
-            progressDataService.UpdateProgressSupervisorAndCompleteByDate(
-                progressId,
-                supervisorId,
-                courseInfo.CompleteBy,
-                2,
-               clockUtility.UtcNow
-            );
+            progressDataService.UpdateProgressSupervisor(progressId, supervisorId);
 
             progressDataService.ClearAspProgressVerificationRequest(progressId);
 


### PR DESCRIPTION
### JIRA link
[_TD-4436_](https://hee-tis.atlassian.net/browse/TD-4436)

### Description
Removed FirstSubmittedTime from UpdateProgressSupervisorAndCompleteByDate(+)
Created new service method to edit progress supervisor.

### Screenshots

Self enrolled

![image](https://github.com/user-attachments/assets/41f61586-8701-40bf-a324-62923eefd6b1)

Course added to group
![image](https://github.com/user-attachments/assets/971c17d0-ba87-4b2f-9be6-f5730ace5a75)

Delegate added to group
![image](https://github.com/user-attachments/assets/e7f8f4c9-0500-464a-9c33-93ecaf9efb31)

![image](https://github.com/user-attachments/assets/aef2dada-3c73-452c-b7a3-86a34d6512ac)

Supervisor added
![image](https://github.com/user-attachments/assets/2f5be890-0899-4e9f-a6c7-7207550c3b96)




-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
