### PR TITLE
TD-4445-Prevent a course from being enrolled by a learner from URL if course is configured to not allow self enrolment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningMenuController/LearningMenuController.cs
@@ -62,6 +62,17 @@
         {
             var centreId = User.GetCentreIdKnownNotNull();
             var candidateId = User.GetCandidateIdKnownNotNull();
+
+            if (courseService.GetAvailableCourses(candidateId, centreId)
+            .Where(c => c.Id == customisationId && (!c.SelfRegister || c.HideInLearnerPortal)).Any())
+            {
+                logger.LogError(
+                    "Redirecting to 410 as course/centre id was not available for self enrolled. " +
+                    $"Candidate id: {candidateId}, customisation id: {customisationId}, " +
+                    $"centre id: {centreId.ToString() ?? "null"}");
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
+            }
+
             var courseContent = courseContentService.GetCourseContent(candidateId, customisationId);
             if (courseContent == null)
             {


### PR DESCRIPTION
### JIRA link
[_TD-4445_](https://hee-tis.atlassian.net/browse/TD-4445)

### Description

Learning portal - Added restrictions to enrolment for courses without SelfRegister or HideInLearnerPortal.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
