### PR TITLE
TD-4324 Include "Optional" in the Filter options on the learner competencies menu

### DIFF
--- a/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
+++ b/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
@@ -2,6 +2,7 @@
 {
     public enum SelfAssessmentCompetencyFilter
     {
+        Optional = -11,
         AwaitingConfirmation = -10,
         PendingConfirmation = -9,
         RequiresSelfAssessment = -8,

--- a/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
@@ -48,6 +48,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.AwaitingConfirmation) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null && q.UserIsVerifier == true))
                                        || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
+                                       ||  (filters.Contains((int)SelfAssessmentCompetencyFilter.Optional) && c.Optional )
                                        where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
                                            && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAnyQuestion)
                                        select c;
@@ -111,6 +112,7 @@ namespace DigitalLearningSolutions.Web.Helpers
         {
             var responseStatusFilters = new int[]
             {
+                (int)SelfAssessmentCompetencyFilter.Optional,
                 (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment,
                 (int)SelfAssessmentCompetencyFilter.SelfAssessed,
                 (int)SelfAssessmentCompetencyFilter.Verified,


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4324

### Description

I added the Optional to the enum 
I added the enum to the filter dropdown
I added the optional filter condition  to the where clause in the linq 

### Screenshots
![image](https://github.com/user-attachments/assets/dc0e1401-f252-4b78-b517-133ec3b31b34)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
