### PR TITLE
TD-4333 Corrections In Course Admin Fields Area

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
@@ -46,14 +46,14 @@
       <div class="nhsuk-grid-row divider">
         <div class="nhsuk-grid-column-one-half">
           <vc:text-input asp-for="@nameof(Model.Answer)"
-                         label="Add a new response?"
+                         label="Add a new response"
                          populate-with-current-value="true"
                          type="text"
                          spell-check="true"
                          autocomplete=""
                          hint-text=""
                          css-class="nhsuk-u-width-full"
-                         required="false" />
+                         required="true" />
           <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.AddPromptAction">Add</button>
         </div>
       </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddBulkAdminFieldAnswers.cshtml
@@ -3,34 +3,38 @@
 @model AddBulkAdminFieldAnswersViewModel
 
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Configure responses in bulk" : "Configure responses in bulk";
-  var cancelLinkData = Html.GetRouteValues();
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Configure responses in bulk" : "Configure responses in bulk";
+    var cancelLinkData = Html.GetRouteValues();
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    @if (errorHasOccurred) {
-      <vc:error-summary order-of-property-names="@(new []{ nameof(Model.OptionsString) })" />
-    }
+    <div class="nhsuk-grid-column-full">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new []{ nameof(Model.OptionsString) })" />
+        }
 
-    <h1 class="nhsuk-heading-xl">Configure responses in bulk</h1>
+        <h1 class="nhsuk-heading-xl">Configure responses in bulk</h1>
 
-    <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddAdminFieldAnswersBulk">
+        <form class="nhsuk-u-margin-bottom-3" method="post" novalidate asp-action="AddAdminFieldAnswersBulk">
 
-      <vc:text-area asp-for="@nameof(Model.OptionsString)"
-                    label="Enter each response option on a separate line (max 1000 characters in total). The order of responses will be the order they appear on the dropdown for users."
-                    populate-with-current-value="true"
-                    rows="5"
-                    spell-check="false"
-                    hint-text=""
-                    css-class=""
-                    character-count="1000" />
+            <vc:text-area asp-for="@nameof(Model.OptionsString)"
+                          label="Enter each response option on a separate line (max 1000 characters in total). The order of responses will be the order they appear on the dropdown for users."
+                          populate-with-current-value="true"
+                          rows="5"
+                          spell-check="false"
+                          hint-text=""
+                          css-class=""
+                          character-count="null" />
+            <span class="nhsuk-hint" id="bulk-response-hint">
+                The complete list of responses must be 1000 characters or fewer and each response must be 100 characters or fewer
+            </span>
 
-      <button class="nhsuk-button" type="submit">Submit</button>
-    </form>
+            <button class="nhsuk-button" type="submit">Submit</button>
+        </form>
 
-    <vc:cancel-link asp-controller="AdminFields" asp-action="AddAdminField" asp-all-route-data="@cancelLinkData" />
+        <vc:cancel-link asp-controller="AdminFields" asp-action="AddAdminField" asp-all-route-data="@cancelLinkData" />
 
-  </div>
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -41,14 +41,14 @@
       <div class="nhsuk-grid-row divider">
         <div class="nhsuk-grid-column-one-half">
           <vc:text-input asp-for="@nameof(Model.Answer)"
-                         label="Add a new response?"
+                         label="Add a new response"
                          populate-with-current-value="true"
                          type="text"
                          spell-check="true"
                          autocomplete=""
                          hint-text=""
                          css-class="nhsuk-u-width-full"
-                         required="false" />
+                         required="true" />
           <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.AddPromptAction">Add</button>
         </div>
       </div>


### PR DESCRIPTION
### JIRA link
[TD-4333](https://hee-tis.atlassian.net/browse/TD-4333)

### Description
1. AddAdminField - Made the response option mandatory
2. EditAdminField - Made the response option mandatory
3. AddBulkAdminFieldAnswers - Changed the hint text.

### Screenshots
1. 
![image](https://github.com/user-attachments/assets/a23f14ef-e5e5-47b7-bd1f-92399eda7d86)
![image](https://github.com/user-attachments/assets/34b15635-30a9-4f0a-90c2-09b9fb02f030)


2. 
![image](https://github.com/user-attachments/assets/e043b77e-b2f4-4dd5-b01a-b34347908299)
![image](https://github.com/user-attachments/assets/8d19d8b8-a8a8-408d-a3b1-531b64aaeffb)


3. 
![image](https://github.com/user-attachments/assets/5da8bdad-b1b9-4aff-b828-6b49192cf9c0)

![image](https://github.com/user-attachments/assets/1d8f7726-a321-4e0c-8127-ff56e6c912ee)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4333]: https://hee-tis.atlassian.net/browse/TD-4333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ