### PR TITLE
TD-4354 Converting MB into GB for per delegate upload space

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/ManageCentre.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Centres/ManageCentre.cshtml
@@ -12,8 +12,7 @@
             </ol>
             <p class="nhsuk-breadcrumb__back">
                 <a class="nhsuk-breadcrumb__backlink"
-                 asp-controller="Centres" asp-action="Index"
-                >Back to Centres</a>
+                   asp-controller="Centres" asp-action="Index">Back to Centres</a>
             </p>
         </div>
     </nav>
@@ -187,7 +186,14 @@
                         <b>Per delegate upload space</b>
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                        @Model.CandidateByteLimit MB
+                        @if (@Model.CandidateByteLimit == 1024)
+                        {
+                            @($"{Model.CandidateByteLimit / 1024} GB")
+                        }
+                        else
+                        {
+                            @($"{Model.CandidateByteLimit} MB")
+                        }
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
@@ -208,7 +214,7 @@
                asp-controller="Centres"
                asp-action="CentreRoleLimits"
                asp-route-centreId="@Model.CentreId">
-              Customise role limits
+                Customise role limits
             </a>
         </div>
     </div>


### PR DESCRIPTION
### JIRA link
[TD-4354](https://hee-tis.atlassian.net/browse/TD-4354)

### Description
Converting MB into GB for per delegate upload space when the value is 1024 MB

### Screenshots
![image](https://github.com/user-attachments/assets/826c147b-e8b0-4bf8-b8cb-bd921d50eb48)
![image](https://github.com/user-attachments/assets/99719dd5-3f03-4588-a161-414fc536c407)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4354]: https://hee-tis.atlassian.net/browse/TD-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ