### PR TITLE
TD- 4426 Add a minimum optional competencies int field to the self assessments table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/AddMinimumOptionalCompetenciesToSelfAssessmentsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/AddMinimumOptionalCompetenciesToSelfAssessmentsTable.cs
@@ -1,0 +1,22 @@
+﻿
+using FluentMigrator;
+using System.Diagnostics.Metrics;
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202401081132)]
+    public  class AddMinimumOptionalCompetenciesToSelfAssessmentsTable : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments").AddColumn("MinimumOptionalCompetencies").AsInt32().NotNullable().WithDefaultValue(0);
+        }
+
+        public override void Down()
+        {
+            Delete.Column("MinimumOptionalCompetencies").FromTable("SelfAssessments");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4426

### Description
I added a migration to add MinimumOptionalCompetencies field to the SelfAssessments table

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
