### PR TITLE
td-4322 Introduce "Optional" tag in the learner competencies menu (Overview)

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -30,8 +30,8 @@
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
                 <li class="nhsuk-breadcrumb__item">
                     <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-                       asp-action="DelegateProfileAssessments"
-                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                   asp-action="DelegateProfileAssessments"
+                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
                         @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
                     </a>
                 </li>
@@ -44,15 +44,15 @@
             @if (ViewBag.navigatedFrom)
             {
                 <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-                   asp-action="Index">
+           asp-action="Index">
                     Back to Supervisor Dashboard
                 </a>
             }
             else
             {
                 <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-                   asp-action="DelegateProfileAssessments"
-                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+           asp-action="DelegateProfileAssessments"
+           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
                     Back to @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
                 </a>
             }
@@ -86,12 +86,12 @@
         @if (!Model.ExportToExcelHide)
         {
             <a class="nhsuk-button nhsuk-button--secondary"
-               asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
-               asp-route-selfAssessmentName="@Model.DelegateSelfAssessment.RoleName"
-               asp-route-delegateUserID="@Model.DelegateSelfAssessment.DelegateUserID"
-               asp-route-delegateName="@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName"
-               asp-action="ExportCandidateAssessment"
-               role="button">
+           asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
+           asp-route-selfAssessmentName="@Model.DelegateSelfAssessment.RoleName"
+           asp-route-delegateUserID="@Model.DelegateSelfAssessment.DelegateUserID"
+           asp-route-delegateName="@Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName"
+           asp-action="ExportCandidateAssessment"
+           role="button">
                 Export to Excel
             </a>
         }
@@ -99,11 +99,11 @@
         @if (ViewBag.CanViewCertificate)
         {
             <a class="nhsuk-button"
-               asp-controller="LearningPortal"
-               asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
-               asp-action="CompetencySelfAssessmentCertificate"
-               asp-route-route="3"
-               role="button">
+           asp-controller="LearningPortal"
+           asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
+           asp-action="CompetencySelfAssessmentCertificate"
+           asp-route-route="3"
+           role="button">
                 Certificate
             </a>
         }
@@ -164,7 +164,10 @@
                 {
                     <tr role="row" class="nhsuk-table__row first-row">
                         <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
-                            <partial name="Shared/_TagRow" model="@competency.Optional" />
+                            @if(competency.Optional)
+                            {
+                            <partial name="Shared/_TagRow"  />
+                            }
                             <b> <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span></b>
                             <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />
                             @if (competency.Description != null && !competency.AlwaysShowDescription)
@@ -196,15 +199,15 @@
                             }
                         </td>
                         <partial name="Shared/_AssessmentQuestionReviewCells"
-                                 model="competency.AssessmentQuestions.First()"
-                                 view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
+                     model="competency.AssessmentQuestions.First()"
+                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
                     </tr>
                     @foreach (var question in competency.AssessmentQuestions.Skip(1))
                     {
                         <tr role="row" class="nhsuk-table__row">
                             <partial name="Shared/_AssessmentQuestionReviewCells"
-                                     model="question"
-                                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
+                     model="question"
+                     view-data="@(new ViewDataDictionary(ViewData) {{ "isSupervisorResultsReviewed", Model.IsSupervisorResultsReviewed }, { "ReviewerCommentsLabel", Model.DelegateSelfAssessment.ReviewerCommentsLabel} } )" />
                         </tr>
                     }
                 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -164,7 +164,8 @@
                 {
                     <tr role="row" class="nhsuk-table__row first-row">
                         <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
-                            <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
+                            <partial name="Shared/_TagRow" model="@competency.Optional" />
+                            <b> <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span></b>
                             <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />
                             @if (competency.Description != null && !competency.AlwaysShowDescription)
                             {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -166,7 +166,7 @@
                         <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
                             @if(competency.Optional)
                             {
-                            <partial name="Shared/_TagRow"  />
+                            <partial name="Shared/_TagRow" />
                             }
                             <b> <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span></b>
                             <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -166,7 +166,7 @@
                         <td role="cell" rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
                             @if(competency.Optional)
                             {
-                            <partial name="Shared/_TagRow" />
+                                <partial name="Shared/_TagRow"/>
                             }
                             <b> <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span></b>
                             <partial name="_CompetencyFlags" model="competency.CompetencyFlags" />

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_TagRow.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_TagRow.cshtml
@@ -1,14 +1,8 @@
-﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
-
-@model bool;
-
+﻿
 
 <div class="tags">
-        @if (Model)
-        {
-            <div class="card-filter-tag">
-                <strong class="nhsuk-tag nhsuk-tag--blue">Optional</strong>
-            </div>
-        }
-    
+
+    <div class="card-filter-tag">
+        <strong class="nhsuk-tag nhsuk-tag--blue">Optional</strong>
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_TagRow.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_TagRow.cshtml
@@ -1,0 +1,14 @@
+﻿@using DigitalLearningSolutions.Data.Models.SelfAssessments;
+
+@model bool;
+
+
+<div class="tags">
+        @if (Model)
+        {
+            <div class="card-filter-tag">
+                <strong class="nhsuk-tag nhsuk-tag--blue">Optional</strong>
+            </div>
+        }
+    
+</div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_TagRow.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_TagRow.cshtml
@@ -1,6 +1,4 @@
-﻿
-
-<div class="tags">
+﻿<div class="tags">
 
     <div class="card-filter-tag">
         <strong class="nhsuk-tag nhsuk-tag--blue">Optional</strong>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4322

### Description
I added a partial view tag to the supervisor shared folder
I added the optional tag to the ReviewSelfAssessment razor page
### Screenshots
![image](https://github.com/user-attachments/assets/6f5fde62-c7d5-47e6-9501-f4d4d452381c)

![image](https://github.com/user-attachments/assets/c8853169-d41a-4b06-8856-2830108d1af3)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
