### PR TITLE
TD-4428 Additional optional competencies checkbox on the learner signoff request screen

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1475,10 +1475,12 @@
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var supervisors =
                 selfAssessmentService.GetSignOffSupervisorsForSelfAssessmentId(selfAssessmentId, delegateUserId);
+            var optionalCompetencies = selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
             var model = new RequestSignOffViewModel
             {
                 SelfAssessment = assessment,
                 Supervisors = supervisors,
+                NumberOfSelfAssessedOptionalCompetencies = optionalCompetencies.Count(x => x.IncludedInSelfAssessment)
             };
             return View("SelfAssessments/RequestSignOff", model);
         }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1495,10 +1495,12 @@
                 var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
                 var supervisors =
                     selfAssessmentService.GetSignOffSupervisorsForSelfAssessmentId(selfAssessmentId, delegateUserId);
+                var optionalCompetencies = selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
                 var newModel = new RequestSignOffViewModel
                 {
                     SelfAssessment = assessment,
                     Supervisors = supervisors,
+                    NumberOfSelfAssessedOptionalCompetencies = optionalCompetencies.Count(x => x.IncludedInSelfAssessment)
                 };
                 return View("SelfAssessments/RequestSignOff", newModel);
             }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/RequestSignOffViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/RequestSignOffViewModel.cs
@@ -14,6 +14,11 @@
         [Required]
         [Range(1, 1, ErrorMessage = "Please tick to confirm that you understand the request sign-off statement")]
         public bool StatementChecked { get; set; }
+        [Required]
+        [Range(1, 1, ErrorMessage = "Please tick to confirm that you have include optional competencies that are appropriate to your role before requesting sign-off")]
+        public bool OptionalCompetenciesChecked { get; set; }
+        public int NumberOfSelfAssessedOptionalCompetencies { get; set; }
+
         public string VocabPlural()
         {
             if (SelfAssessment != null)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
@@ -64,8 +64,8 @@
             {
                 <nhs-form-group nhs-validation-for="OptionalCompetenciesChecked">
                     <div class="nhsuk-checkboxes__item">
-                    <input class="nhsuk-checkboxes__input" id="cb-sign-off" name="OptionalCompetenciesChecked" asp-for="OptionalCompetenciesChecked" type="checkbox">
-                    <label class="nhsuk-label nhsuk-checkboxes__label" for="cb-sign-off">
+                        <input class="nhsuk-checkboxes__input" id="optional-ompetencies" name="OptionalCompetenciesChecked" asp-for="OptionalCompetenciesChecked" type="checkbox">
+                        <label class="nhsuk-label nhsuk-checkboxes__label" for="optional-competencies">
                         I have reviewed the optional competencies available for this self assessment and included those that are appropriate to my role.
                     </label>
                 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
@@ -60,6 +60,17 @@
                     </label>
                 </div>
             </nhs-form-group>
+            @if (Model.NumberOfSelfAssessedOptionalCompetencies >= Model.SelfAssessment.MinimumOptionalCompetencies)
+            {
+                <nhs-form-group nhs-validation-for="OptionalCompetenciesChecked">
+                    <div class="nhsuk-checkboxes__item">
+                    <input class="nhsuk-checkboxes__input" id="cb-sign-off" name="OptionalCompetenciesChecked" asp-for="OptionalCompetenciesChecked" type="checkbox">
+                    <label class="nhsuk-label nhsuk-checkboxes__label" for="cb-sign-off">
+                        I have reviewed the optional competencies available for this self assessment and included those that are appropriate to my role.
+                    </label>
+                </div>
+            </nhs-form-group>
+            }
         </fieldset>
 
         <button class="nhsuk-button" type="submit">


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4428

### Description
I added NumberOfSelfAssessedOptionalCompetencies count to the get and post action method in the SelfAssessmentOverviewViewModel.cs
I added NumberOfSelfAssessedOptionalCompetencies property in   the RequestSignOffViewModel.cs
I introduce a new checkbox that should be displayed only if the self assessment includes optional competencies
I added a label to the checkbox
I added a validation to the checkbox

### Screenshots
![image](https://github.com/user-attachments/assets/8413e1ac-84ba-47e9-a212-f281ae6c2f25)
![image](https://github.com/user-attachments/assets/e9b38762-29dd-4839-ae2d-0c505bf83575)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
