### PR TITLE
TD-4502 Issue not listing the delegates on 'Send welcome message' screen for whose Password is set and unclaimed

### DIFF
--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -275,7 +275,7 @@ namespace DigitalLearningSolutions.Web.Services
         public IEnumerable<DelegateUserCard> GetDelegateUserCardsForWelcomeEmail(int centreId)
         {
             return userDataService.GetDelegateUserCardsByCentreId(centreId).Where(
-                user => user.Approved && !user.SelfReg && (string.IsNullOrEmpty(user.Password) || !string.IsNullOrEmpty(user.Password)) &&
+                user => user.Approved && !user.SelfReg && 
                         !string.IsNullOrEmpty(user.EmailAddress)
                         && !Guid.TryParse(user.EmailAddress, out _)
                         && user.RegistrationConfirmationHash != null

--- a/DigitalLearningSolutions.Web/Services/UserService.cs
+++ b/DigitalLearningSolutions.Web/Services/UserService.cs
@@ -275,7 +275,7 @@ namespace DigitalLearningSolutions.Web.Services
         public IEnumerable<DelegateUserCard> GetDelegateUserCardsForWelcomeEmail(int centreId)
         {
             return userDataService.GetDelegateUserCardsByCentreId(centreId).Where(
-                user => user.Approved && !user.SelfReg && string.IsNullOrEmpty(user.Password) &&
+                user => user.Approved && !user.SelfReg && (string.IsNullOrEmpty(user.Password) || !string.IsNullOrEmpty(user.Password)) &&
                         !string.IsNullOrEmpty(user.EmailAddress)
                         && !Guid.TryParse(user.EmailAddress, out _)
                         && user.RegistrationConfirmationHash != null


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4502

### Description
I added  password set  and unclaimed delegate to the list delegate on the send welcome message

### Screenshots
![image](https://github.com/user-attachments/assets/53f3daea-3d86-4c2f-b105-bd0c3fcc180f)
![image](https://github.com/user-attachments/assets/ac8964db-5c37-4566-8ff7-ee367b8ced24)
![image](https://github.com/user-attachments/assets/efcc9e89-946e-4263-b82d-9ba1444af214)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
