### PR TITLE
TD-4515 Issue showing console '500' error on the screen when clicked browser back button after submitting request support ticket

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
@@ -236,7 +236,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
         {
             if (!TempData.Any())
             {
-                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 401 });
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             }
             var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
                 MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),

--- a/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
@@ -234,10 +234,14 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
         [Route("/{dlsSubApplication}/RequestSupport/SupportSummary")]
         public IActionResult SupportSummary(DlsSubApplication dlsSubApplication, SupportSummaryViewModel supportSummaryViewModel)
         {
+            if (!TempData.Any())
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 401 });
+            }
             var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
                 MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
                 TempData
-            ).GetAwaiter().GetResult(); ;
+            ).GetAwaiter().GetResult(); 
             var model = new SupportSummaryViewModel(data);
             return View("SupportTicketSummaryPage", model);
         }
@@ -245,12 +249,15 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
         [HttpPost]
         [Route("/{dlsSubApplication}/RequestSupport/SubmitSupportSummary")]
         public IActionResult SubmitSupportSummary(DlsSubApplication dlsSubApplication, SupportSummaryViewModel model)
-
         {
+            if (!TempData.Any())
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 401 });
+            }
             var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
                 MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
                 TempData
-            ).GetAwaiter().GetResult(); ;
+            ).GetAwaiter().GetResult(); 
             data.GroupId = configuration.GetFreshdeskCreateTicketGroupId();
             data.ProductId = configuration.GetFreshdeskCreateTicketProductId();
             List<RequestAttachment> RequestAttachmentList = new List<RequestAttachment>();


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4515
### Description
I check the tempdata to ensure it is not empty then return 401 error

### Screenshots
![image](https://github.com/user-attachments/assets/1c90ac4a-ab60-44d2-9588-e1ef4040a1cf)
![image](https://github.com/user-attachments/assets/0a091523-4d29-4d2e-8ab2-35b8fd1cfdcb)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
