### PR TITLE
TD-4509 Issue with 'Search' showing various search results based on leading/trailing end spaces given on 'All Frameworks' & 'My Frameworks' screens

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
@@ -59,6 +59,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             var adminId = GetAdminId();
             var isFrameworkDeveloper = GetIsFrameworkDeveloper();
             var isFrameworkContributor = GetIsFrameworkContributor();
+            searchString = searchString == null ? null : searchString.Trim();
             IEnumerable<BrandedFramework> frameworks;
 
             if (tabname == "All") frameworks = frameworkService.GetAllFrameworks(adminId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4509

### Description
I added validation that checked the search parameter and trim the search parameter when it is not null

### Screenshots
searching adding whitespace
![image](https://github.com/user-attachments/assets/a7ad1a78-84ec-49df-b1e9-e642b006c17b)
after searching
![image](https://github.com/user-attachments/assets/c6d721ab-284a-42c7-b676-7a196755ed6d)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
