### PR TITLE
TD-4535 Changed the column for storing email in centres table

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CentresDataService.cs
@@ -179,7 +179,7 @@
                             c.ContactSurname,
                             c.ContactEmail,
                             c.ContactTelephone,
-                            c.pwEmail AS CentreEmail,
+                            c.AutoRegisterManagerEmail AS CentreEmail,
                             c.ShowOnMap,
                             c.CMSAdministrators AS CmsAdministratorSpots,
                             c.CMSManagers AS CmsManagerSpots,
@@ -231,7 +231,7 @@
                             c.ContactEmail,
                             c.ContactTelephone,
                             c.pwTelephone AS CentreTelephone,
-                            c.pwEmail AS CentreEmail,
+                            c.AutoRegisterManagerEmail AS CentreEmail,
                             c.pwPostCode AS CentrePostcode,
                             c.ShowOnMap,
                             c.Long AS Longitude,
@@ -460,7 +460,7 @@
                     CentreName = @centreName,
                     CentreTypeId = @centreTypeId,
                     RegionId = @regionId,
-                    pwEmail = @centreEmail,
+                    AutoRegisterManagerEmail = @centreEmail,
                     IPPrefix = @ipPrefix,
                     ShowOnMap = @showOnMap
                 WHERE CentreId = @centreId",
@@ -504,7 +504,7 @@
                     ContactTelephone,
                     CentreTypeID,
                     RegionID,
-                    pwEmail,
+                    AutoRegisterManagerEmail,
                     IPPrefix,
                     ShowOnMap
                     )


### PR DESCRIPTION
### JIRA link
[TD-4535](https://hee-tis.atlassian.net/browse/TD-4535)

### Description
Changed the column for storing email in the centres table from pwEmail to the AutoRegisterManagerEmail.

### Screenshots
Before changes -
![image](https://github.com/user-attachments/assets/78192adb-7931-4ba5-9236-a4ad26bad312)

After changes and updating the centre email - 
![image](https://github.com/user-attachments/assets/9b5dc949-eb7f-48cc-ba7b-db30ce13c6c6)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4535]: https://hee-tis.atlassian.net/browse/TD-4535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ