### PR TITLE
TD-4595 Remove the legacy tracking system tile from the application selector

### DIFF
--- a/DigitalLearningSolutions.Web/appSettings.UAT.json
+++ b/DigitalLearningSolutions.Web/appSettings.UAT.json
@@ -11,7 +11,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": true,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "WorkforceManagerInterface": false,
     "SupervisorProfileAssessmentInterface": false,
     "RefactoredSuperAdminInterface": true,

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101_uar;Integrated Security=True;TrustServerCertificate=true;",
+   "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101_uar;Integrated Security=True;TrustServerCertificate=true;",
     "UnitTestConnection": "Data Source=localhost;Initial Catalog=mbdbx101_uar_test;Integrated Security=True;TrustServerCertificate=true;"
   },
   "CurrentSystemBaseUrl": "https://localhost:5001",
@@ -11,7 +11,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": true,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "SupervisorProfileAssessmentInterface": true,
     "WorkforceManagerInterface": true,
     "RefactoredSuperAdminInterface": true,

--- a/DigitalLearningSolutions.Web/appsettings.Development.json
+++ b/DigitalLearningSolutions.Web/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-   "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101_uar;Integrated Security=True;TrustServerCertificate=true;",
+    "DefaultConnection": "Data Source=localhost;Initial Catalog=mbdbx101_uar;Integrated Security=True;TrustServerCertificate=true;",
     "UnitTestConnection": "Data Source=localhost;Initial Catalog=mbdbx101_uar_test;Integrated Security=True;TrustServerCertificate=true;"
   },
   "CurrentSystemBaseUrl": "https://localhost:5001",

--- a/DigitalLearningSolutions.Web/appsettings.Production.json
+++ b/DigitalLearningSolutions.Web/appsettings.Production.json
@@ -11,7 +11,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": true,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "WorkforceManagerInterface": false,
     "SupervisorProfileAssessmentInterface": false,
     "RefactoredSuperAdminInterface": true,

--- a/DigitalLearningSolutions.Web/appsettings.SIT.json
+++ b/DigitalLearningSolutions.Web/appsettings.SIT.json
@@ -10,7 +10,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": true,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "SupervisorProfileAssessmentInterface": true,
     "WorkforceManagerInterface": true,
     "RefactoredSuperAdminInterface": true,

--- a/DigitalLearningSolutions.Web/appsettings.Test.json
+++ b/DigitalLearningSolutions.Web/appsettings.Test.json
@@ -11,7 +11,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": true,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "SupervisorProfileAssessmentInterface": true,
     "WorkforceManagerInterface": true,
     "RefactoredSuperAdminInterface": true,

--- a/DigitalLearningSolutions.Web/appsettings.UarTest.json
+++ b/DigitalLearningSolutions.Web/appsettings.UarTest.json
@@ -11,7 +11,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": true,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "WorkforceManagerInterface": false,
     "SupervisorProfileAssessmentInterface": false,
     "RefactoredSuperAdminInterface": false,

--- a/DigitalLearningSolutions.Web/appsettings.json
+++ b/DigitalLearningSolutions.Web/appsettings.json
@@ -12,7 +12,7 @@
   "MonthsToPromptUserDetailsCheck": 6,
   "FeatureManagement": {
     "RefactoredTrackingSystem": false,
-    "ShowAppCardForLegacyTrackingSystem": true,
+    "ShowAppCardForLegacyTrackingSystem": false,
     "RefactoredSuperAdminInterface": false,
     "UseSignposting": true,
     "PricingPage": true,


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4595

### Description
Change ShowAppCardForLegacyTrackingSystem to false 

### Screenshots
![image](https://github.com/user-attachments/assets/71e31c8e-b3f7-48bf-855b-16102da7a9da)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
