### PR TITLE
TD-4243 Few 'add on' courses showing on 'Learning Portal' not showing on 'Course set up' & 'Delegate activities' screens

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202408201645_AlterAvailableandCompletedCoursesForDelegate.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202408201645_AlterAvailableandCompletedCoursesForDelegate.cs
@@ -1,0 +1,19 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202408201645)]
+    public class AlterAvailableandCompletedCoursesForDelegate : Migration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_up);
+            Execute.Sql(Properties.Resources.TD_4243_Alter_GetCompletedCoursesForCandidate_proc_up);
+        }
+        public override void Down()
+        {
+            Execute.Sql(Properties.Resources.TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_down);
+            Execute.Sql(Properties.Resources.TD_4243_Alter_GetCompletedCoursesForCandidate_proc_down);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -1926,6 +1926,94 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to 
+        ////****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 20/08/2024 11:57:38 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 24/01/2023
+        ///-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+        ///-- ======= [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_down {
+            get {
+                return ResourceManager.GetString("TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ////****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 20/08/2024 11:57:38 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 24/01/2023
+        ///-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+        ///-- ======= [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_up {
+            get {
+                return ResourceManager.GetString("TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_up", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ////****** Object:  StoredProcedure [dbo].[GetCompletedCoursesForCandidate]    Script Date: 20/08/2024 11:58:45 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 16/12/2016
+        ///-- Description:	Returns a list of completed courses for the candidate.
+        ///-- 21/06/2021: Adds Applications.ArchivedDate field to output.
+        ///-- =============================================
+        ///ALTER PROCEDURE [dbo].[GetCompletedCourses [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4243_Alter_GetCompletedCoursesForCandidate_proc_down {
+            get {
+                return ResourceManager.GetString("TD_4243_Alter_GetCompletedCoursesForCandidate_proc_down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ////****** Object:  StoredProcedure [dbo].[GetCompletedCoursesForCandidate]    Script Date: 20/08/2024 11:58:45 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 16/12/2016
+        ///-- Description:	Returns a list of completed courses for the candidate.
+        ///-- 21/06/2021: Adds Applications.ArchivedDate field to output.
+        ///-- =============================================
+        ///ALTER PROCEDURE [dbo].[GetCompletedCourses [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4243_Alter_GetCompletedCoursesForCandidate_proc_up {
+            get {
+                return ResourceManager.GetString("TD_4243_Alter_GetCompletedCoursesForCandidate_proc_up", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
         ////****** Object:  StoredProcedure [dbo].[GetCurrentCoursesForCandidate_V2]    Script Date: 22/07/2024 10:11:35 ******/
         ///SET ANSI_NULLS ON
         ///GO
@@ -1939,7 +2027,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///-- Description:	Returns a list of active progress records for the candidate.
         ///-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
         ///-- =============================================
-        ///ALTER PROCEDURE [dbo].[GetC [rest of string was truncated]&quot;;.
+        ///ALTER PROCEDU [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down {
             get {
@@ -1963,7 +2051,7 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         ///-- Description:	Returns a list of active progress records for the candidate.
         ///-- Change 18/09/2018: Adds logic to exclude Removed courses from returned results.
         ///-- =============================================
-        ///ALTER PROCEDURE [dbo].[Ge [rest of string was truncated]&quot;;.
+        ///ALTER PROC [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up {
             get {

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -412,4 +412,16 @@
   <data name="TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_4243_Alter_GetCompletedCoursesForCandidate_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4243_Alter_GetCompletedCoursesForCandidate_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="TD_4243_Alter_GetCompletedCoursesForCandidate_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4243_Alter_GetCompletedCoursesForCandidate_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_down.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_down.sql
@@ -1,0 +1,67 @@
+
+/****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 20/08/2024 11:57:38 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 24/01/2023
+-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+-- =============================================
+ALTER   PROCEDURE [dbo].[GetActivitiesForDelegateEnrolment]
+	-- Add the parameters for the stored procedure here
+	@CentreID as Int = 0,
+	@DelegateID as int,
+	@CategoryId as Int = 0
+AS
+	BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+			SELECT * FROM
+			-- Insert statements for procedure here
+			(SELECT cu.CustomisationID, cu.Active, cu.CurrentVersion, cu.CentreID, cu.ApplicationID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, cu.CustomisationText, 0 AS IncludesSignposting, 0 AS IsSelfAssessment, cu.SelfRegister AS SelfRegister,
+					   cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(cu.CustomisationID, 0) AS HasDiagnostic, 
+					   dbo.CheckCustomisationSectionHasLearning(cu.CustomisationID, 0) AS HasLearning, (SELECT BrandName FROM Brands WHERE BrandID = a.BrandID) AS Brand, (SELECT CategoryName FROM CourseCategories WHERE CourseCategoryID = a.CourseCategoryID) AS Category, (SELECT CourseTopic FROM CourseTopics WHERE CourseTopicID = a.CourseTopicID) AS Topic, dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) AS DelegateStatus,
+                       cu.HideInLearnerPortal
+			FROM  Customisations AS cu INNER JOIN
+					   Applications AS a 
+					   ON cu.ApplicationID = a.ApplicationID 
+					   WHERE ((cu.CentreID = @CentreID) OR (cu.AllCentres = 1 AND (EXISTS(SELECT CentreApplicationID FROM CentreApplications WHERE ApplicationID = a.ApplicationID AND CentreID = @CentreID AND Active = 1)))) AND 
+					   (cu.Active = 1) AND 
+					   (a.ASPMenu = 1) AND 
+					   (a.ArchivedDate IS NULL) AND 
+					   (dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) IN (0,1,4)) AND 
+					   (cu.CustomisationName <> 'ESR') AND
+					   (a.CourseCategoryID = @CategoryId OR @CategoryId =0)
+					   UNION ALL
+					   SELECT SA.ID AS CustomisationID, 1 AS Active, 1 AS CurrentVersion, CSA.CentreID as CentreID, 0 AS ApplicationID, SA.Name AS CourseName, SA.Description AS CustomisationText, SA.IncludesSignposting, 1 AS IsSelfAssessment, CSA.AllowEnrolment AS SelfRegister, 0 AS IsAssessed, 0 AS HasDiagnostic, 0 AS HasLearning,
+										 (SELECT BrandName
+										 FROM    Brands
+										 WHERE (BrandID = SA.BrandID)) AS Brand,
+										 (SELECT CategoryName
+										 FROM    CourseCategories
+										 WHERE (CourseCategoryID = SA.CategoryID)) AS Category,
+										 '' AS Topic, IIF(CA.RemovedDate IS NULL,0,1) AS DelegateStatus,
+                                         0 AS HideInLearnerPortal
+						FROM   SelfAssessments AS SA 
+		INNER JOIN CentreSelfAssessments AS CSA ON SA.Id = CSA.SelfAssessmentID AND CSA.CentreId = @centreId
+		LEFT JOIN CandidateAssessments AS CA ON CSA.SelfAssessmentID=CA.SelfAssessmentID AND CA.DelegateUserID = (SELECT UserID from DelegateAccounts where ID=@DelegateID)
+						WHERE (SA.ID NOT IN
+										 (SELECT SelfAssessmentID
+										 FROM    CandidateAssessments AS CA
+										 INNER JOIN Users AS U ON CA.DelegateUserID = U.ID
+										 INNER JOIN DelegateAccounts AS DA ON U.ID = DA.UserID
+										 WHERE (DA.ID = @DelegateID) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL))) AND
+					   (SA.CategoryID = @CategoryId OR @CategoryId =0)
+										 )
+										 AS Q1
+						ORDER BY Q1.CourseName
+		END
+GO
+
+
+

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_up.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_up.sql
@@ -1,0 +1,68 @@
+
+/****** Object:  StoredProcedure [dbo].[GetActivitiesForDelegateEnrolment]    Script Date: 20/08/2024 11:57:38 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 24/01/2023
+-- Description:	Returns active available for delegate enrolment based on original GetActiveAvailableCustomisationsForCentreFiltered_V6 sproc but adjusted for user account refactor and filters properly for category.
+-- =============================================
+ALTER   PROCEDURE [dbo].[GetActivitiesForDelegateEnrolment]
+	-- Add the parameters for the stored procedure here
+	@CentreID as Int = 0,
+	@DelegateID as int,
+	@CategoryId as Int = 0
+AS
+	BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+			SELECT * FROM
+			-- Insert statements for procedure here
+			(SELECT cu.CustomisationID, cu.Active, cu.CurrentVersion, cu.CentreID, cu.ApplicationID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, cu.CustomisationText, 0 AS IncludesSignposting, 0 AS IsSelfAssessment, cu.SelfRegister AS SelfRegister,
+					   cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(cu.CustomisationID, 0) AS HasDiagnostic, 
+					   dbo.CheckCustomisationSectionHasLearning(cu.CustomisationID, 0) AS HasLearning, (SELECT BrandName FROM Brands WHERE BrandID = a.BrandID) AS Brand, (SELECT CategoryName FROM CourseCategories WHERE CourseCategoryID = a.CourseCategoryID) AS Category, (SELECT CourseTopic FROM CourseTopics WHERE CourseTopicID = a.CourseTopicID) AS Topic, dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) AS DelegateStatus,
+                       cu.HideInLearnerPortal
+			FROM  Customisations AS cu INNER JOIN
+					   Applications AS a 
+					   ON cu.ApplicationID = a.ApplicationID   INNER JOIN 
+					   CentreApplications AS ca ON ca.ApplicationID = a.ApplicationID AND ca.CentreID = cu.CentreID
+					   WHERE ((cu.CentreID = @CentreID) OR (cu.AllCentres = 1 AND (EXISTS(SELECT CentreApplicationID FROM CentreApplications WHERE ApplicationID = a.ApplicationID AND CentreID = @CentreID AND Active = 1)))) AND 
+					   (cu.Active = 1) AND 
+					   (a.ASPMenu = 1) AND 
+					   (a.ArchivedDate IS NULL) AND 
+					   (dbo.CheckDelegateStatusForCustomisation(cu.CustomisationID, @DelegateID) IN (0,1,4)) AND 
+					   (cu.CustomisationName <> 'ESR') AND
+					   (a.CourseCategoryID = @CategoryId OR @CategoryId =0)
+					   UNION ALL
+					   SELECT SA.ID AS CustomisationID, 1 AS Active, 1 AS CurrentVersion, CSA.CentreID as CentreID, 0 AS ApplicationID, SA.Name AS CourseName, SA.Description AS CustomisationText, SA.IncludesSignposting, 1 AS IsSelfAssessment, CSA.AllowEnrolment AS SelfRegister, 0 AS IsAssessed, 0 AS HasDiagnostic, 0 AS HasLearning,
+										 (SELECT BrandName
+										 FROM    Brands
+										 WHERE (BrandID = SA.BrandID)) AS Brand,
+										 (SELECT CategoryName
+										 FROM    CourseCategories
+										 WHERE (CourseCategoryID = SA.CategoryID)) AS Category,
+										 '' AS Topic, IIF(CA.RemovedDate IS NULL,0,1) AS DelegateStatus,
+                                         0 AS HideInLearnerPortal
+						FROM   SelfAssessments AS SA 
+		INNER JOIN CentreSelfAssessments AS CSA ON SA.Id = CSA.SelfAssessmentID AND CSA.CentreId = @centreId
+		LEFT JOIN CandidateAssessments AS CA ON CSA.SelfAssessmentID=CA.SelfAssessmentID AND CA.DelegateUserID = (SELECT UserID from DelegateAccounts where ID=@DelegateID)
+						WHERE (SA.ID NOT IN
+										 (SELECT SelfAssessmentID
+										 FROM    CandidateAssessments AS CA
+										 INNER JOIN Users AS U ON CA.DelegateUserID = U.ID
+										 INNER JOIN DelegateAccounts AS DA ON U.ID = DA.UserID
+										 WHERE (DA.ID = @DelegateID) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL))) AND
+					   (SA.CategoryID = @CategoryId OR @CategoryId =0)
+										 )
+										 AS Q1
+						ORDER BY Q1.CourseName
+		END
+GO
+
+
+

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCompletedCoursesForCandidate_proc_down.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCompletedCoursesForCandidate_proc_down.sql
@@ -1,0 +1,47 @@
+
+/****** Object:  StoredProcedure [dbo].[GetCompletedCoursesForCandidate]    Script Date: 20/08/2024 11:58:45 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 16/12/2016
+-- Description:	Returns a list of completed courses for the candidate.
+-- 21/06/2021: Adds Applications.ArchivedDate field to output.
+-- =============================================
+ALTER PROCEDURE [dbo].[GetCompletedCoursesForCandidate]
+	-- Add the parameters for the stored procedure here
+	@CandidateID int
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+
+    -- Insert statements for procedure here
+    SELECT p.ProgressID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, p.CustomisationID, p.SubmittedTime AS LastAccessed, p.Completed, 
+               p.FirstSubmittedTime AS StartedDate, p.RemovedDate, p.DiagnosticScore, p.PLLocked, cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(p.CustomisationID, 0) 
+               AS HasDiagnostic, dbo.CheckCustomisationSectionHasLearning(p.CustomisationID, 0) AS HasLearning,
+                     COALESCE
+                             ((SELECT        COUNT(Passes) AS Passes
+                                 FROM            (SELECT        COUNT(AssessAttemptID) AS Passes
+                                                           FROM            AssessAttempts AS aa
+                                                           WHERE        (CandidateID = p.CandidateID) AND (CustomisationID = p.CustomisationID) AND (Status = 1)
+                                                           GROUP BY SectionNumber) AS derivedtbl_2), 0) AS Passes,
+                   (SELECT COUNT(SectionID) AS Sections
+                    FROM   Sections AS s
+                    WHERE (ApplicationID = cu.ApplicationID)) AS Sections, p.Evaluated, p.FollupUpEvaluated, a.ArchivedDate
+FROM  Progress AS p INNER JOIN
+               Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+               Applications AS a ON cu.ApplicationID = a.ApplicationID
+WHERE (NOT (p.Completed IS NULL)) AND (p.CandidateID = @CandidateID)
+ORDER BY p.Completed DESC
+	
+END
+GO
+
+
+

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCompletedCoursesForCandidate_proc_up.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4243_Alter_GetCompletedCoursesForCandidate_proc_up.sql
@@ -1,0 +1,48 @@
+
+/****** Object:  StoredProcedure [dbo].[GetCompletedCoursesForCandidate]    Script Date: 20/08/2024 11:58:45 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 16/12/2016
+-- Description:	Returns a list of completed courses for the candidate.
+-- 21/06/2021: Adds Applications.ArchivedDate field to output.
+-- =============================================
+ALTER PROCEDURE [dbo].[GetCompletedCoursesForCandidate]
+	-- Add the parameters for the stored procedure here
+	@CandidateID int
+AS
+BEGIN
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+
+    -- Insert statements for procedure here
+    SELECT p.ProgressID, (CASE WHEN cu.CustomisationName <> '' THEN a.ApplicationName + ' - ' + cu.CustomisationName ELSE a.ApplicationName END) AS CourseName, p.CustomisationID, p.SubmittedTime AS LastAccessed, p.Completed, 
+               p.FirstSubmittedTime AS StartedDate, p.RemovedDate, p.DiagnosticScore, p.PLLocked, cu.IsAssessed, dbo.CheckCustomisationSectionHasDiagnostic(p.CustomisationID, 0) 
+               AS HasDiagnostic, dbo.CheckCustomisationSectionHasLearning(p.CustomisationID, 0) AS HasLearning,
+                     COALESCE
+                             ((SELECT        COUNT(Passes) AS Passes
+                                 FROM            (SELECT        COUNT(AssessAttemptID) AS Passes
+                                                           FROM            AssessAttempts AS aa
+                                                           WHERE        (CandidateID = p.CandidateID) AND (CustomisationID = p.CustomisationID) AND (Status = 1)
+                                                           GROUP BY SectionNumber) AS derivedtbl_2), 0) AS Passes,
+                   (SELECT COUNT(SectionID) AS Sections
+                    FROM   Sections AS s
+                    WHERE (ApplicationID = cu.ApplicationID)) AS Sections, p.Evaluated, p.FollupUpEvaluated, a.ArchivedDate
+FROM  Progress AS p INNER JOIN
+               Customisations AS cu ON p.CustomisationID = cu.CustomisationID INNER JOIN
+               Applications AS a ON cu.ApplicationID = a.ApplicationID INNER JOIN 
+		       CentreApplications AS ca ON ca.ApplicationID = a.ApplicationID AND ca.CentreID = cu.CentreID
+WHERE (NOT (p.Completed IS NULL)) AND (p.CandidateID = @CandidateID)
+ORDER BY p.Completed DESC
+	
+END
+GO
+
+
+

--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -324,7 +324,8 @@ namespace DigitalLearningSolutions.Data.DataServices
             LEFT OUTER JOIN Users AS uEnrolledBy ON uEnrolledBy.ID = aaEnrolledBy.UserID
             INNER JOIN DelegateAccounts AS da ON da.ID = pr.CandidateID
             INNER JOIN Users AS u ON u.ID = da.UserID
-            LEFT JOIN UserCentreDetails AS ucd ON ucd.UserID = da.UserID AND ucd.centreID = da.CentreID";
+            LEFT JOIN UserCentreDetails AS ucd ON ucd.UserID = da.UserID AND ucd.centreID = da.CentreID
+            INNER JOIN CentreApplications AS ca ON ca.ApplicationID = ap.ApplicationID AND ca.CentreID = cu.CentreID";
 
         private readonly string courseAssessmentDetailsQuery = $@"SELECT
                         c.CustomisationID,


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4243

### Description
I modify GetActivitiesForDelegateEnrolment, GetCompletedCoursesForCandidate store procedure  by adding CentreApplications table to the store procedure, so that courses that is not publish to the centre will not reflect in the ‘Available activities’/'Enrol on activity', completed activities, as it is in Course set up & Delegate activities

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
