### PR TITLE
TD-4603 Use the TD-4595 feature flag to also hide the view old ticket…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/Request.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/Request.cshtml
@@ -20,18 +20,19 @@
         </ul>
         <p>Once you have submitted a ticket, you will receive an email when a member of support team responds to it.</p>
         <a class="nhsuk-button" asp-controller="RequestSupportTicket" asp-action="TypeofRequest" role="button" asp-route-dlsSubApplication="@DlsSubApplication.TrackingSystem.UrlSegment">Start</a>
-
-        <div class="nhsuk-inset-text">
-            <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p>
-                If you raised any tickets in the old support ticket system, you can view them here:
-                <a class="nhsuk-link--no-visited-state"
-                   asp-controller="SupportTickets"
-                   asp-action="Index"
-                   asp-route-dlsSubApplication="@DlsSubApplication.TrackingSystem.UrlSegment">
-                    View old support tickets
-                </a>
-            </p>
-        </div>
+        <feature name="@(FeatureFlags.ShowAppCardForLegacyTrackingSystem)">
+            <div class="nhsuk-inset-text">
+                <span class="nhsuk-u-visually-hidden">Information: </span>
+                <p>
+                    If you raised any tickets in the old support ticket system, you can view them here:
+                    <a class="nhsuk-link--no-visited-state"
+                       asp-controller="SupportTickets"
+                       asp-action="Index"
+                       asp-route-dlsSubApplication="@DlsSubApplication.TrackingSystem.UrlSegment">
+                        View old support tickets
+                    </a>
+                </p>
+            </div>
+        </feature>
     </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4603

### Description
I added feature flag to the support request page to hide view old support ticket and its content

### Screenshots
![image](https://github.com/user-attachments/assets/7d6ed326-a7eb-4931-befb-9be72c01ed17)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
