### PR TITLE
TD-4598 Sign off self-assessment appears when filters applied in Supervisor page though proficiencies are not completed

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CompetencySummary.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CompetencySummary.cs
@@ -1,0 +1,9 @@
+﻿namespace DigitalLearningSolutions.Data.Models.SelfAssessments
+{
+    public  class CompetencySummary
+    {
+        public int VerifiedCount { get; set; }
+        public int QuestionsCount { get; set; }
+        public bool CanViewCertificate { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -384,8 +384,8 @@
                     (int)superviseDelegate.DelegateUserID
                 );
             }
-
-            ViewBag.CanViewCertificate = CertificateHelper.CanViewCertificate(reviewedCompetencies, model.SupervisorSignOffs);
+            var competencySummaries = CertificateHelper.CanViewCertificate(reviewedCompetencies, model.SupervisorSignOffs);
+            model.CompetencySummaries = competencySummaries;
             ViewBag.SupervisorSelfAssessmentReview = delegateSelfAssessment.SupervisorSelfAssessmentReview;
             ViewBag.navigatedFrom = selfAssessmentResultId == null;
             TempData["CertificateSupervisorDelegateId"] = supervisorDelegateId;
@@ -1381,50 +1381,19 @@
             var delegateUserId = competencymaindata.LearnerId;
             var recentResults = selfAssessmentService.GetMostRecentResults(competencymaindata.SelfAssessmentID, competencymaindata.LearnerDelegateAccountId).ToList();
             var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(competencymaindata.SelfAssessmentID, delegateUserId);
-            if (!CertificateHelper.CanViewCertificate(recentResults, supervisorSignOffs))
+            var competencySummaries = CertificateHelper.CanViewCertificate(recentResults, supervisorSignOffs);
+            if (!competencySummaries.CanViewCertificate)
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 401 });
             }
-
+           
             var competencycount = selfAssessmentService.GetCompetencyCountSelfAssessmentCertificate(competencymaindata.CandidateAssessmentID);
             var accessors = selfAssessmentService.GetAccessor(competencymaindata.SelfAssessmentID, competencymaindata.LearnerId);
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, competencymaindata.SelfAssessmentID);
             var competencyIds = recentResults.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
-            var competencies = CompetencyFilterHelper.FilterCompetencies(recentResults, competencyFlags, null);
-            foreach (var competency in competencies)
-            {
-                competency.QuestionLabel = assessment.QuestionLabel;
-                foreach (var assessmentQuestion in competency.AssessmentQuestions)
-                {
-                    if (assessmentQuestion.AssessmentQuestionInputTypeID != 2)
-                    {
-                        assessmentQuestion.LevelDescriptors = selfAssessmentService
-                            .GetLevelDescriptorsForAssessmentQuestion(
-                                assessmentQuestion.Id,
-                                assessmentQuestion.MinValue,
-                                assessmentQuestion.MaxValue,
-                                assessmentQuestion.MinValue == 0
-                            ).ToList();
-                    }
-                }
-            }
-
-            var CompetencyGroups = competencies.GroupBy(competency => competency.CompetencyGroup);
-            var competencySummaries = from g in CompetencyGroups
-                                      let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
-                                      let selfAssessedCount = questions.Count(q => q.Result.HasValue)
-                                      let verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required))
-
-                                      select new
-                                      {
-                                          SelfAssessedCount = selfAssessedCount,
-                                          VerifiedCount = verifiedCount,
-                                          Questions = questions.Count()
-                                      };
-
-            int sumVerifiedCount = competencySummaries.Sum(item => item.VerifiedCount);
-            int sumQuestions = competencySummaries.Sum(item => item.Questions);
+            int sumVerifiedCount = competencySummaries.VerifiedCount;
+            int sumQuestions = competencySummaries.QuestionsCount;
             var activitySummaryCompetencySelfAssesment = selfAssessmentService.GetActivitySummaryCompetencySelfAssesment(competencymaindata.Id);
             var model = new ViewModels.LearningPortal.SelfAssessments.CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, "ProfileAssessment", accessors, activitySummaryCompetencySelfAssesment, sumQuestions, sumVerifiedCount, supervisorDelegateId);
             return View("SelfAssessments/CompetencySelfAssessmentCertificate", model);

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
@@ -21,5 +21,7 @@
         }
         public int CandidateAssessmentId { get; set; }
         public bool ExportToExcelHide { get; set; }
+        public CompetencySummary CompetencySummaries { get; set; }
+
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -96,7 +96,7 @@
             </a>
         }
 
-        @if (ViewBag.CanViewCertificate)
+        @if (Model.CompetencySummaries.CanViewCertificate)
         {
             <a class="nhsuk-button"
            asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
@@ -106,14 +106,11 @@
                 Certificate
             </a>
         }
-        @if (
-        Model.DelegateSelfAssessment.SignOffRequested > 0 &&
-        competencySummaries.Sum(c => (int)c["verifiedCount"]) == competencySummaries.Sum(c => (int)c["questionsCount"])
-        )
+        @if (Model.DelegateSelfAssessment.SignOffRequested > 0 && Model.CompetencySummaries.VerifiedCount == Model.CompetencySummaries.QuestionsCount)
         {
             <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
         }
-        @if ((Model.DelegateSelfAssessment.ResultsVerificationRequests > 1) && (competencySummaries.Sum(c => (int)c["verifiedCount"]) < competencySummaries.Sum(c => (int)c["questionsCount"])))
+        @if ((Model.DelegateSelfAssessment.ResultsVerificationRequests > 1) && Model.CompetencySummaries.VerifiedCount < Model.CompetencySummaries.QuestionsCount)
         {
             <a role="button" asp-action="VerifyMultipleResults" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Confirm multiple results</a>
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4598

### Description
I refactor CanViewCertificate method to include QuestionsCount and VerifiedCount
I added CompetencySummary class
I added CompetencySummary class  to  ReviewSelfAssessmentViewModel.cs
I remove and replace the check condition in the ReviewSelfAssessment.cshtml to fixed the signoffrequest button showing when the proficiencies are not completed 
I also refactor the certificate action method to remove and replace it with CanViewCertificate method
### Screenshots
Adding optional proficiencies after making signoffrequest
![image](https://github.com/user-attachments/assets/520ba9f0-fdcf-45d5-b323-d1cf728bebdc)
![image](https://github.com/user-attachments/assets/a98eb611-efdf-4109-a545-9ec05ef6cef6)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
