### PR TITLE
TD-4702 Download self-assessment certificate link URL can be manipulated and able to download other user valid certificates

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1652,26 +1652,15 @@
         {
             int supervisorDelegateId = 0;
             var adminId = User.GetAdminId();
-           var competencymaindata = selfAssessmentService.GetCompetencySelfAssessmentCertificate(CandidateAssessmentId);
-            if ((competencymaindata == null)|| ( competencymaindata.LearnerId != User.GetUserIdKnownNotNull()) || (CandidateAssessmentId == 0))
+            var userId = User.GetUserIdKnownNotNull();
+            var competencymaindata = selfAssessmentService.GetCompetencySelfAssessmentCertificate(CandidateAssessmentId);
+            if ((competencymaindata == null)|| ( competencymaindata.LearnerId != User.GetUserIdKnownNotNull()) || (CandidateAssessmentId == 0) || (userId != competencymaindata.LearnerId))
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
             var delegateUserId = competencymaindata.LearnerId;
-            if (vocabulary == "Supervise")
-            {
-                var supervisorDelegateDetails = supervisorService.GetSupervisorDelegateDetailsForAdminId(adminId.Value);
-             var checkSupervisorDelegate = supervisorDelegateDetails.Where(x=> x.DelegateUserID == competencymaindata.LearnerId).FirstOrDefault();
-                if (checkSupervisorDelegate == null)
-                {
-                    return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
-                }
-                var supervisorDelegate = supervisorService.GetSupervisorDelegate(User.GetAdminIdKnownNotNull(), delegateUserId);
-                supervisorDelegateId = supervisorDelegate.ID;
-            }
-            var recentResults = selfAssessmentService.GetMostRecentResults(competencymaindata.SelfAssessmentID, competencymaindata.LearnerDelegateAccountId).ToList();
+             var recentResults = selfAssessmentService.GetMostRecentResults(competencymaindata.SelfAssessmentID, competencymaindata.LearnerDelegateAccountId).ToList();
             var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(competencymaindata.SelfAssessmentID, delegateUserId);
-
             if (!CertificateHelper.CanViewCertificate(recentResults, supervisorSignOffs))
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 401 });
@@ -1720,8 +1709,9 @@
             var model = new CompetencySelfAssessmentCertificateViewModel(competencymaindata, competencycount, vocabulary, accessors, activitySummaryCompetencySelfAssesment, sumQuestions, sumVerifiedCount, supervisorDelegateId);
             return View("SelfAssessments/CompetencySelfAssessmentCertificate", model);
         }
-        [Route("DownloadCertificate")]
-        public async Task<IActionResult> DownloadCertificate(int candidateAssessmentId)
+
+        [Route("/LearningPortal/selfAssessments/{CandidateAssessmentId:int}/{vocabulary}/DownloadCertificate")]
+        public async Task<IActionResult> DownloadCertificate(int candidateAssessmentId, string vocabulary)
         {
             PdfReportStatusResponse pdfReportStatusResponse = new PdfReportStatusResponse();
             var delegateId = User.GetCandidateIdKnownNotNull();
@@ -1729,6 +1719,19 @@
             if (competencymaindata == null || candidateAssessmentId == 0)
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            }
+            if (vocabulary == "Proficiencies")
+            {
+                var userId = User.GetUserIdKnownNotNull();
+                if(userId != competencymaindata.LearnerId ) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+
+            }
+            if (vocabulary == "ProfileAssessment")
+            {
+                var adminId = User.GetAdminId();
+                var supervisorDelegateDetails = supervisorService.GetSupervisorDelegateDetailsForAdminId(adminId.Value);
+                var checkSupervisorDelegate = supervisorDelegateDetails.Where(x => x.DelegateUserID == competencymaindata.LearnerId).FirstOrDefault();
+                if (checkSupervisorDelegate == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
             var delegateUserId = competencymaindata.LearnerId;
             var competencycount = selfAssessmentService.GetCompetencyCountSelfAssessmentCertificate(candidateAssessmentId);
@@ -1739,6 +1742,11 @@
             var competencyIds = recentResults.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
             var competencies = CompetencyFilterHelper.FilterCompetencies(recentResults, competencyFlags, null);
+            var supervisorSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(competencymaindata.SelfAssessmentID, delegateUserId);
+            if (!CertificateHelper.CanViewCertificate(recentResults, supervisorSignOffs))
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 401 });
+            }
             foreach (var competency in competencies)
             {
                 competency.QuestionLabel = assessment.QuestionLabel;

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/CompetencySelfAssessmentCertificate.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/CompetencySelfAssessmentCertificate.cshtml
@@ -80,6 +80,7 @@
             <a class="nhsuk-button "
                asp-controller="LearningPortal"
                asp-route-candidateAssessmentId="@Model.CompetencySelfAssessmentCertificates.CandidateAssessmentID"
+               asp-route-vocabulary="@Model.VocabPlural"
                asp-action="DownloadCertificate"
                role="button">
                 Download certificate


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4702

### Description
I change the route to the download certificate action method
I added validation to the action method to ensure that unauthorized persons can not access the action method

### Screenshots
![image](https://github.com/user-attachments/assets/7385c905-4402-4369-b074-84daaae4c247)

![image](https://github.com/user-attachments/assets/8efb747b-fd95-4875-9dc8-6db5e457f8ef)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
