### PR TITLE
TD-4559 Added Flag GroupOptionalCompetencies To SelfAssessmentStructure Table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202409110900_AddGroupOptionalCompetenciesToSelfAssessmentStructureTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202409110900_AddGroupOptionalCompetenciesToSelfAssessmentStructureTable.cs
@@ -1,0 +1,23 @@
+﻿
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202409110900)]
+    public  class AddGroupOptionalCompetenciesToSelfAssessmentStructureTable : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessmentStructure")
+                .AddColumn("GroupOptionalCompetencies")
+                .AsCustom("BIT")
+                .NotNullable()
+                .WithDefaultValue(0);
+        }
+
+        public override void Down()
+        {
+            Delete.Column("GroupOptionalCompetencies").FromTable("SelfAssessmentStructure");
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-4559](https://hee-tis.atlassian.net/browse/TD-4559)

### Description
Added Flag GroupOptionalCompetencies To SelfAssessmentStructure Table with datatype as Bit.

### Screenshots
After running the migration on local - 
![image](https://github.com/user-attachments/assets/dcb833d5-5ab9-448f-945a-8c78ab20537e)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4559]: https://hee-tis.atlassian.net/browse/TD-4559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ