### PR TITLE
TD-4324 “Optional“ filter should appear after confirmation rejected filter

### DIFF
--- a/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
+++ b/DigitalLearningSolutions.Data/Enums/SelfAssessmentCompetencyFilter.cs
@@ -2,14 +2,14 @@
 {
     public enum SelfAssessmentCompetencyFilter
     {
-        Optional = -11,
-        AwaitingConfirmation = -10,
-        PendingConfirmation = -9,
-        RequiresSelfAssessment = -8,
-        SelfAssessed = -7,
-        ConfirmationRequested = -6,
-        Verified = -5, /* Confirmed */
-        ConfirmationRejected = -4,
+        AwaitingConfirmation = -11,
+        PendingConfirmation = -10,
+        RequiresSelfAssessment = -9,
+        SelfAssessed = -8,
+        ConfirmationRequested = -7,
+        Verified = -6, /* Confirmed */
+        ConfirmationRejected = -5,
+        Optional = -4,
         MeetingRequirements = -3,
         PartiallyMeetingRequirements = -2,
         NotMeetingRequirements = -1        


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4324

### Description
I Changed the position of the optional filter, I ensured the optional filter appeared after confirmation rejected filter 

### Screenshots
![image](https://github.com/user-attachments/assets/04e56166-d40c-4368-b5fa-a67024df0761)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
