### PR TITLE
TD-4427 Check the minimum optional competencies have been added before enabling Request Sign-off

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -25,7 +25,8 @@
         { "selfAssessedCount", selfAssessedCount },
         { "verifiedCount", verifiedCount }
       };
-
+    var competencyQuestionsSummary = competencySummaries.Sum(c => (int)c["questionsCount"]);
+    var competencyVerifiedSummary = competencySummaries.Sum(c => (int)c["verifiedCount"]);
     Layout = "SelfAssessments/_Layout";
     ViewData["Title"] = "Self Assessment - Proficiencies";
     ViewData["SelfAssessmentTitle"] = Model.SelfAssessment.Name;
@@ -199,10 +200,13 @@
                         All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
                         before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
                     </p>
+                    @if (competencyQuestionsSummary == competencyVerifiedSummary)
+                     {
                     <p class="nhsuk-body-l">
                         Your self assessment does not contain enough optional proficiencies to request sign off.
                         Go to Manage Optional Competencies to choose the optional competencies that you wish to include..
                     </p>
+                     }
                 }
             </div>
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4427

### Description
I sum the competency questions summary and competency verified summary
I put a check to competency questions summary and competency verified summary are the same before showing the message

### Screenshots
_Attach screenshots on mobile, tablet and desktop._
[TD-4427.docx](https://github.com/user-attachments/files/16981967/TD-4427.docx)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
