### PR TITLE
TD-4384 Correction for test failed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/UserFeedbackController.cs
@@ -30,7 +30,7 @@
             this._userFeedbackService = userFeedbackService;
             this._multiPageFormService = multiPageFormService;
             this._userFeedbackViewModel = new UserFeedbackViewModel();
-            this.config = config; 
+            this.config = config;
         }
 
         [Route("/Index")]
@@ -38,7 +38,7 @@
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
             _multiPageFormService.ClearMultiPageFormData(MultiPageFormDataFeature.AddUserFeedback, TempData);
-            
+
             _userFeedbackViewModel = new()
             {
                 UserId = User.GetUserId(),
@@ -51,13 +51,13 @@
                 TaskRating = null,
             };
 
-            if(sourcePageTitle == "Digital Learning Solutions - Page no longer available")
+            if (sourcePageTitle == "Digital Learning Solutions - Page no longer available")
             {
                 var url = ContentUrlHelper.ReplaceUrlSegment(sourceUrl);
-                _userFeedbackViewModel.SourceUrl  = url;
+                _userFeedbackViewModel.SourceUrl = url;
                 _userFeedbackViewModel.SourcePageTitle = "Welcome";
             }
-            
+
             if (_userFeedbackViewModel.UserId == null || _userFeedbackViewModel.UserId == 0)
             {
                 return GuestFeedbackStart(_userFeedbackViewModel);
@@ -198,8 +198,6 @@
         {
             ViewData[LayoutViewDataKeys.DoNotDisplayUserFeedbackBar] = true;
 
-            //set the source URL to the sequentially previous page route which is Task Achieved
-            userFeedbackViewModel.SourceUrl ??= "/UserFeedbackTaskAchieved";
             userFeedbackViewModel = MapMultiformDataToViewModel(userFeedbackViewModel);
 
             return View("UserFeedbackTaskAttempted", userFeedbackViewModel);

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAchieved.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAchieved.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.UserFeedback
+@using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 
 @model UserFeedbackViewModel;
@@ -51,44 +52,45 @@
 
         <p class="nhsuk-body-l">Step 1 of 4</p>
 
-      <form method="post" asp-action="UserFeedbackTaskAchievedSet">
-        <input type="hidden" asp-for="SourceUrl" value="@Context.Request.Path" /> @* changing the value of source URL to the current route *@
-        <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
-        <div class="nhsuk-hint" id="task-achieve-hint">
-          Did you achieve everything you came to do today?
-        </div>
-        <fieldset class="nhsuk-fieldset" id="feedback-achieved-form" aria-describedby="task-achieve-hint">
-          <div class="nhsuk-u-margin-bottom-6">
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input"
-                   id="feedback-achieved-yes"
-                   asp-for="TaskAchieved"
-                   type="radio"
-                   value="true">
-              <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-yes">
-                Yes
-              </label>
+        <form method="post" asp-action="UserFeedbackTaskAchievedSet">
+            <input type="hidden" asp-for="SourceUrl" value="@Context.Request.GetDisplayUrl()" /> @* changing the value of source URL to the current route *@
+            <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
+            <div class="nhsuk-hint" id="task-achieve-hint">
+                Did you achieve everything you came to do today?
             </div>
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input"
-                   id="feedback-achieved-no"
-                   asp-for="TaskAchieved"
-                   type="radio"
-                   value="false" />
-              <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-no">
-                No
-              </label>
+            <fieldset class="nhsuk-fieldset" id="feedback-achieved-form" aria-describedby="task-achieve-hint">
+                <div class="nhsuk-u-margin-bottom-6">
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="feedback-achieved-yes"
+                               asp-for="TaskAchieved"
+                               type="radio"
+                               value="true">
+                        <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-yes">
+                            Yes
+                        </label>
+                    </div>
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                               id="feedback-achieved-no"
+                               asp-for="TaskAchieved"
+                               type="radio"
+                               value="false" />
+                        <label class="nhsuk-label nhsuk-radios__label" for="feedback-achieved-no">
+                            No
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+            <div class="nhsuk-u-float-right">
+                <button class="nhsuk-button" type="submit">
+                    Continue
+                    <span class="feedback-chevron">
+                        <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
+                    </span>
+                </button>
             </div>
-          </div>
-        </fieldset>
-        <div class="nhsuk-u-float-right">
-          <button class="nhsuk-button" type="submit">Continue
-          <span class="feedback-chevron">
-            <partial name="_NhsChevronRightOffset" class="feedback-chevron" />
-          </span>
-        </button>
-        </div>
-      </form>
+        </form>
     </div>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAttempted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskAttempted.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.UserFeedback
+@using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 
 @model UserFeedbackViewModel;
@@ -29,7 +30,7 @@
     </div>
     <div class="nhsuk-grid-column-two-thirds">
         <form method="post" asp-action="UserFeedbackTaskAttemptedSet">
-            <input type="hidden" asp-for="SourceUrl" value="@Context.Request.Path" />
+            <input type="hidden" asp-for="SourceUrl" value="@Context.Request.GetDisplayUrl()" />
             <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
 
             <p class="nhsuk-body-l">Step 2 of 4</p>

--- a/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskDifficulty.cshtml
+++ b/DigitalLearningSolutions.Web/Views/UserFeedback/UserFeedbackTaskDifficulty.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.UserFeedback
+@using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 
 @model UserFeedbackViewModel;
@@ -31,7 +32,7 @@
         <p class="nhsuk-body-l">Step 3 of 4</p>
 
         <form method="post" asp-action="UserFeedbackTaskDifficultySet">
-            <input type="hidden" asp-for="SourceUrl" value="@Context.Request.Path" />
+            <input type="hidden" asp-for="SourceUrl" value="@Context.Request.GetDisplayUrl()" />
             <input type="hidden" asp-for="SourcePageTitle" value="@Model.SourcePageTitle" />
 
             <div class="nhsuk-hint" id="feedback-difficulty-hint">


### PR DESCRIPTION
TD-4384 correction for test failed, using GetDirectURL() instead of path property within the context request object

### JIRA link
[TD-4384](https://hee-tis.atlassian.net/browse/TD-4384)

### Description
BackLinks were failing in UAT, when the user feedback questionnaire was being worked on by the user.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._
![image](https://github.com/user-attachments/assets/f7512d16-9b1d-4674-9c1d-0bacb8a46937)
![image](https://github.com/user-attachments/assets/8a8e13d7-cc01-4afc-a757-8ad6567ae250)
![image](https://github.com/user-attachments/assets/ce5b1f2b-4c9b-4afa-be12-c3100d10220c)
![image](https://github.com/user-attachments/assets/39aec4ef-ad60-46c8-8b4d-bc257637294e)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4384]: https://hee-tis.atlassian.net/browse/TD-4384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ