### PR TITLE
TD-4697- Feature added to display AddOptionalCompetencies page when selected optional competencies less than minimum required.

### DIFF
--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -3,9 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using AngleSharp.Attributes;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
-    using DigitalLearningSolutions.Data.Models.Centres;
     using DigitalLearningSolutions.Data.Models.Common.Users;
     using DigitalLearningSolutions.Data.Models.External.Filtered;
     using DigitalLearningSolutions.Data.Models.Frameworks;
@@ -150,6 +148,7 @@
         bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
         IEnumerable<CandidateAssessment> GetCandidateAssessments(int delegateUserId, int selfAssessmentId);
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
+        bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
 
     }
 
@@ -553,6 +552,11 @@
         public bool IsCentreSelfAssessment(int selfAssessmentId, int centreId)
         {
             return selfAssessmentDataService.IsCentreSelfAssessment(selfAssessmentId, centreId);
+        }
+
+        public bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId)
+        {
+            return selfAssessmentDataService.HasMinimumOptionalCompetencies(selfAssessmentId, delegateUserId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/AddOptionalCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/AddOptionalCompetenciesViewModel.cs
@@ -1,0 +1,14 @@
+﻿using DigitalLearningSolutions.Data.Models.SelfAssessments;
+using DigitalLearningSolutions.Web.Helpers;
+
+namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
+{
+    public class AddOptionalCompetenciesViewModel
+    {
+        public CurrentSelfAssessment SelfAssessment { get; set; }
+        public string VocabPlural()
+        {
+            return FrameworkVocabularyHelper.VocabularyPlural(SelfAssessment.Vocabulary);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddOptionalCompetencies.cshtml
@@ -23,7 +23,7 @@
 <form method="post" asp-action="AddOptionalCompetencies" asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
-            <h1 id="page-heading" class="nhsuk-heading-xl">Add optional proficiency to your assessment?</h1>
+            <h1 id="page-heading" class="nhsuk-heading-xl">Add optional @Model.VocabPlural().ToLower() to your assessment?</h1>
         </div>
         <div class="nhsuk-grid-column-two-thirds">
             <p class="nhsuk-u-padding-top-5">During your assessment you will need to add one or more optional proficiencies to your assessment to be certified within your role</p>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddOptionalCompetencies.cshtml
@@ -1,0 +1,46 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
+@model AddOptionalCompetenciesViewModel
+@{
+    ViewData["Title"] = "Add optional " + Model.VocabPlural().ToLower();
+    Layout = "SelfAssessments/_Layout";
+}
+@section breadcrumbs {
+    <li class="nhsuk-breadcrumb__item">
+        <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
+    </li>
+    <li class="nhsuk-breadcrumb__item">Add optional @(Model.VocabPlural().ToLower())?</li>
+}
+
+@section mobilebacklink
+{
+    <p class="nhsuk-breadcrumb__back">
+        <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+            Back to @Model.SelfAssessment.Name
+        </a>
+    </p>
+}
+<form method="post" asp-action="AddOptionalCompetencies" asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
+    <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full">
+            <h1 id="page-heading" class="nhsuk-heading-xl">Add optional proficiency to your assessment?</h1>
+        </div>
+        <div class="nhsuk-grid-column-two-thirds">
+            <p class="nhsuk-u-padding-top-5">During your assessment you will need to add one or more optional proficiencies to your assessment to be certified within your role</p>
+            <details class="nhsuk-details">
+                <summary class="nhsuk-details__summary nhsuk-u-padding-10">
+                    <span class="nhsuk-u-margin-bottom-0">
+                        <span class="nhsuk-details__summary-text">What are optional proficiencies?</span>
+                    </span>
+                </summary>
+                <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
+                    <p>Optional proficiencies refer to specific skills or competencies that are not part of the core requirements but may be added based on your role, specialisation, or the needs of your workplace.</p>
+                </div>
+            </details>
+            <p class="nhsuk-u-padding-bottom-5">These proficiencies might be different depending on your role or organization so you may need to discuss this with your educator or manager</p>
+
+            <button class="nhsuk-button" type="submit">Add optional @Model.VocabPlural().ToLower() to assessment</button>
+            <a class="nhsuk-button nhsuk-button--secondary trigger-loader" role="button" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Remind me later</a>
+        </div>
+    </div>
+</form>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -1,13 +1,26 @@
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
+@using DigitalLearningSolutions.Web.Extensions
 @model ManageOptionalCompetenciesViewModel
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     Layout = "SelfAssessments/_Layout";
     ViewData["Title"] = "Self Assessment - Optional Proficiencies";
     ViewData["SelfAssessmentTitle"] = @Model.SelfAssessment.Name;
+    var backLinkData = Html.GetRouteValues();
 }
-
-@section breadcrumbs {
+@if (ViewBag.FromAddOptionalPage != null)
+{
+    @section breadcrumbs {
+    <li class="nhsuk-breadcrumb__item">
+        <div style="max-height:10px">
+            <vc:back-link asp-controller="LearningPortal" asp-action="AddOptionalCompetencies" asp-all-route-data="@backLinkData" link-text="Go back" />
+        </div>
+    </li>
+    }
+}
+else
+{
+    @section breadcrumbs {
     <li class="nhsuk-breadcrumb__item">
         <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
     </li>
@@ -15,17 +28,32 @@
         <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.VocabPlural() home</a>
     </li>
     <li class="nhsuk-breadcrumb__item">Manage optional @Model.VocabPlural()</li>
+    }
 }
+
 
 @section mobilebacklink
 {
-    <p class="nhsuk-breadcrumb__back">
-        <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessmentOverview"
-           asp-route-vocabulary="@Model.VocabPlural()"
-           asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
-            Back to @Model.VocabPlural()
-        </a>
-    </p>
+    @if (ViewBag.FromAddOptionalPage != null)
+    {
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-action="AddOptionalCompetencies"
+               asp-route-vocabulary="@Model.VocabPlural()"
+               asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+                Back to add optional @Model.VocabPlural().ToLower()?
+            </a>
+        </p>
+    }
+    else
+    {
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessmentOverview"
+               asp-route-vocabulary="@Model.VocabPlural()"
+               asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
+                Back to @Model.VocabPlural()
+            </a>
+        </p>
+    }
 }
 
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/selfAssessment.css")" asp-append-version="true">
@@ -96,14 +124,28 @@
 </form>
 
 <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link"
-       asp-action="SelfAssessmentOverview"
-       asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        Cancel
-    </a>
+    @if (ViewBag.FromAddOptionalPage != null)
+    {
+        <a class="nhsuk-back-link__link"
+           asp-action="AddOptionalCompetencies"
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
+        </a>
+    }
+    else
+    {
+        <a class="nhsuk-back-link__link"
+           asp-action="SelfAssessmentOverview"
+           asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
+        </a>
+    }
 </div>
 
 @section scripts {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
@@ -17,7 +17,7 @@
     <li class="nhsuk-breadcrumb__item">@Model.Name introduction</li>
 }
 @section mobilebacklink
-    {
+{
     <p class="nhsuk-breadcrumb__back">
         <a class="nhsuk-breadcrumb__link trigger-loader" asp-action="Current">
             Back to Current activities
@@ -37,7 +37,7 @@
         </div>
         <div class="nhsuk-grid-column-one-third">
             <partial name="Shared/_SupervisorsCard"
-                 model="@Model.Supervisors" />
+                     model="@Model.Supervisors" />
         </div>
     </div>
 }
@@ -66,7 +66,7 @@ else
 }
 else
 {
-    <a class="nhsuk-button trigger-loader" role="button" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural" asp-route-selfAssessmentId="@Model.Id">View @Model.VocabPlural</a>
+    <a class="nhsuk-button trigger-loader" role="button" asp-action="AddOptionalCompetencies" asp-route-vocabulary="@Model.VocabPlural" asp-route-selfAssessmentId="@Model.Id">View @Model.VocabPlural</a>
     @if (Model.UserBookmark != null && bookmarkIsRelevant)
     {
         <a role="button" class="nhsuk-button nhsuk-button--secondary trigger-loader" href="@Configuration["AppRootPath"]@Model.UserBookmark">Continue where I left off</a>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -78,7 +78,10 @@
         <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
             <div class="nhsuk-width-container">
                 <ol class="nhsuk-breadcrumb__list">
-                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="LearningPortal" asp-action="Current">Current activities</a></li>
+                    @if (ViewBag.FromAddOptionalPage == null)
+                    {
+                        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="LearningPortal" asp-action="Current">Current activities</a></li>
+                    }
                     @RenderSection("breadcrumbs", required: false)
                 </ol>
                 @RenderSection("mobilebacklink", required: false)


### PR DESCRIPTION
### JIRA link
[_TD-4697_](https://hee-tis.atlassian.net/browse/TD-4697)

### Description
Added AddOptionalCompetencies veiew
Modified code to redirect to AddOptionalCompetencies view when selected optional competencies less than minimum required competencies.
Service method 'HasMinimumOptionalCompetencies' added to check if self assessments has selected minimum required competencies.

### Screenshots
![image](https://github.com/user-attachments/assets/df38aaa9-2b6b-474d-ad84-1cd0f27333fe)

![image](https://github.com/user-attachments/assets/7fd56ec1-a83d-4a9f-bf22-9bdc7018b733)

![image](https://github.com/user-attachments/assets/0d7a592f-54aa-4d81-8f8d-db95a8af2ad9)

![image](https://github.com/user-attachments/assets/6522843f-b94d-4ed5-b300-25f761c88cab)

![image](https://github.com/user-attachments/assets/56a95a15-82ea-4102-a902-ef0d31d7fc6f)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
