### PR TITLE
TD-4774 UI changes on proficiencies page

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -41,7 +41,7 @@
 }
 
 @section mobilebacklink
-{
+    {
     <p class="nhsuk-breadcrumb__back">
         <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
            asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
@@ -64,10 +64,25 @@
                          view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
             </div>
         }
+        <partial name="_OverviewActionButtons.cshtml" model=Model />
+        @if (competencyQuestionsSummary == competencyVerifiedSummary)
+        {
+            <div class="nhsuk-warning-callout">
+                <h3 class="nhsuk-warning-callout__label">
+                    <span role="text">
+                        <span class="nhsuk-u-visually-hidden">Important: </span>
+                        You need to add optional @(Model.VocabPlural().ToLower())
+                    </span>
+                </h3>
+                <p>
+                    Your self assessment does not contain enough optional @(Model.VocabPlural().ToLower()) to request sign off.
+                    Go to Manage optional @(Model.VocabPlural().ToLower()) to choose the optional @(Model.VocabPlural().ToLower()) that you wish to include.
+                </p>
+            </div>
+        }
         <partial name="SelfAssessments/_SearchSelfAssessmentOverview"
                  model="@Model.SearchViewModel"
                  view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
-        <partial name="_OverviewActionButtons.cshtml" model=Model />
         <p><span role="alert">@Model.CompetencyGroups.Sum(g => g.Count()) matching @Model.VocabPlural().ToLower()</span></p>
         @if (Model.CompetencyGroups.Any())
         {
@@ -200,13 +215,6 @@
                         All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
                         before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
                     </p>
-                    @if (competencyQuestionsSummary == competencyVerifiedSummary)
-                     {
-                    <p class="nhsuk-body-l">
-                        Your self assessment does not contain enough optional proficiencies to request sign off.
-                        Go to Manage Optional Competencies to choose the optional competencies that you wish to include..
-                    </p>
-                     }
                 }
             </div>
         }


### PR DESCRIPTION
### JIRA link
[TD-4774](https://hee-tis.atlassian.net/browse/TD-4774)

### Description
1. Changed the top set of buttons' location above the search bar
2. Added  warning callout
3. Removed the above text from the bottom of the page.
4. Used vocab for correct term

### Screenshots
![image](https://github.com/user-attachments/assets/baed082f-35ff-4fd9-971b-1b0d7607bdc4)

![image](https://github.com/user-attachments/assets/e2504cdc-d2cb-4a40-b48d-debe12f56acc)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
