### PR TITLE
TD-4697-'Cancel' link redirected to proficiencies page.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AddOptionalCompetencies.cshtml
@@ -26,18 +26,18 @@
             <h1 id="page-heading" class="nhsuk-heading-xl">Add optional @Model.VocabPlural().ToLower() to your assessment?</h1>
         </div>
         <div class="nhsuk-grid-column-two-thirds">
-            <p class="nhsuk-u-padding-top-5">During your assessment you will need to add one or more optional proficiencies to your assessment to be certified within your role</p>
+            <p class="nhsuk-u-padding-top-5">During your assessment you will need to add one or more optional @Model.VocabPlural().ToLower() to your assessment to be certified within your role</p>
             <details class="nhsuk-details">
                 <summary class="nhsuk-details__summary nhsuk-u-padding-10">
                     <span class="nhsuk-u-margin-bottom-0">
-                        <span class="nhsuk-details__summary-text">What are optional proficiencies?</span>
+                        <span class="nhsuk-details__summary-text">What are optional @Model.VocabPlural().ToLower()?</span>
                     </span>
                 </summary>
                 <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
-                    <p>Optional proficiencies refer to specific skills or competencies that are not part of the core requirements but may be added based on your role, specialisation, or the needs of your workplace.</p>
+                    <p>Optional @Model.VocabPlural().ToLower() refer to specific skills or competencies that are not part of the core requirements but may be added based on your role, specialisation, or the needs of your workplace.</p>
                 </div>
             </details>
-            <p class="nhsuk-u-padding-bottom-5">These proficiencies might be different depending on your role or organization so you may need to discuss this with your educator or manager</p>
+            <p class="nhsuk-u-padding-bottom-5">These @Model.VocabPlural().ToLower() might be different depending on your role or organization so you may need to discuss this with your educator or manager</p>
 
             <button class="nhsuk-button" type="submit">Add optional @Model.VocabPlural().ToLower() to assessment</button>
             <a class="nhsuk-button nhsuk-button--secondary trigger-loader" role="button" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Remind me later</a>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -124,28 +124,14 @@ else
 </form>
 
 <div class="nhsuk-back-link">
-    @if (ViewBag.FromAddOptionalPage != null)
-    {
-        <a class="nhsuk-back-link__link"
-           asp-action="AddOptionalCompetencies"
-           asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
-            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-            </svg>
-            Cancel
-        </a>
-    }
-    else
-    {
-        <a class="nhsuk-back-link__link"
-           asp-action="SelfAssessmentOverview"
-           asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
-            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-            </svg>
-            Cancel
-        </a>
-    }
+    <a class="nhsuk-back-link__link"
+       asp-action="SelfAssessmentOverview"
+       asp-route-selfAssessmentId="@Model.SelfAssessment.Id" asp-route-vocabulary="@Model.VocabPlural()">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
 </div>
 
 @section scripts {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
@@ -48,7 +48,7 @@ else
 
 @if (Model.LinearNavigation)
 {
-    <a role="button" class="nhsuk-button @(Model.UserBookmark != null || bookmarkIsRelevant ? "nhsuk-button--secondary" : "") trigger-loader" asp-action="SelfAssessmentOverview" asp-route-selfAssessmentId="@Model.Id" asp-route-vocabulary="@Model.VocabPlural">View @Model.VocabPlural</a>
+    <a role="button" class="nhsuk-button @(Model.UserBookmark != null || bookmarkIsRelevant ? "nhsuk-button--secondary" : "") trigger-loader" asp-action="AddOptionalCompetencies" asp-route-selfAssessmentId="@Model.Id" asp-route-vocabulary="@Model.VocabPlural">View @Model.VocabPlural</a>
     @if (Model.UserBookmark != null)
     {
         if (bookmarkIsRelevant)


### PR DESCRIPTION
### JIRA link
[_TD-4697_](https://hee-tis.atlassian.net/browse/TD-4697)

### Description
'Cancel' link redirected to proficiencies page.
Plural vocabulary added in the AddOptionalCompetencies page text.
Call to AddOptionalCompetencies action updated for button control when self assessments with LinearNavigation is true.

### Screenshots

![image](https://github.com/user-attachments/assets/adcd0755-f62f-44bd-83d7-cc9b9740b398)

![image](https://github.com/user-attachments/assets/29e2453c-6847-4e45-96df-2519b4c7f078)

![image](https://github.com/user-attachments/assets/2130c812-8d90-4bd6-84ff-3a7dcbd7f700)

![image](https://github.com/user-attachments/assets/d178a902-558c-4eee-9fa3-6735fe11383a)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
