### PR TITLE
TD-4471 Issues with 'Search' functionality when JS turned off on 'Tracking system - Centre administrators' screen

### DIFF
--- a/DigitalLearningSolutions.Data/Helpers/NameQueryHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/NameQueryHelper.cs
@@ -6,5 +6,12 @@
         {
             return string.IsNullOrWhiteSpace(firstName) ? lastName : $"{lastName}, {firstName}";
         }
+
+        public static string GetSortableFullName(string? firstName, string lastName, string? primaryEmail, string? centreEmail)
+        {
+            var name = string.IsNullOrWhiteSpace(firstName) ? lastName : $"{lastName}, {firstName}";
+         var   email = CentreEmailHelper.GetEmailForCentreNotifications(  primaryEmail!,  centreEmail  );
+            return $"{name} ({email})";
+        }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
+++ b/DigitalLearningSolutions.Data/Models/User/AdminEntity.cs
@@ -48,7 +48,7 @@
         public override string SearchableName
         {
             get => SearchableNameOverrideForFuzzySharp ??
-                   NameQueryHelper.GetSortableFullName(UserAccount.FirstName, UserAccount.LastName);
+                   NameQueryHelper.GetSortableFullName(UserAccount.FirstName, UserAccount.LastName, UserAccount.PrimaryEmail, UserCentreDetails?.Email);
             set => SearchableNameOverrideForFuzzySharp = value;
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/Administrator/AdministratorController.cs
@@ -68,7 +68,7 @@
                 Request,
                 AdminFilterCookieName
             );
-
+            searchString = searchString == null ? null : searchString.Trim();
             var centreId = User.GetCentreIdKnownNotNull();
             var adminsAtCentre = userService.GetAdminsByCentreId(centreId);
             var categories = courseCategoriesService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4471

### Description
I trim the search parameter to remove the whitespace
I included the primary and center emails in the search 

### Screenshots
_Attach screenshots on mobile, tablet and desktop._
![image](https://github.com/user-attachments/assets/38575844-1f4d-44e9-9ae5-b10d553e95f9)
![image](https://github.com/user-attachments/assets/a533d019-ca96-4267-abb0-87b1966640e1)
![image](https://github.com/user-attachments/assets/4b8988bf-3385-4381-be26-5aa93b78a901)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
