### PR TITLE
TD-4560 Change the Manage optional competencies view to allow selection of competencies by group

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -456,7 +456,8 @@
                         CG.ID AS CompetencyGroupID,
                         'Capability' AS Vocabulary,
                         SAS.Optional,
-                        COALESCE (CAOC.IncludedInSelfAssessment, 0) AS IncludedInSelfAssessment
+                        COALESCE (CAOC.IncludedInSelfAssessment, 0) AS IncludedInSelfAssessment,
+                        SAS.GroupOptionalCompetencies 
                     FROM Competencies AS C
                     INNER JOIN CandidateAssessments AS CA
                         ON CA.SelfAssessmentID = @selfAssessmentId AND CA.DelegateUserID = @delegateUserId AND CA.RemovedDate IS NULL

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/Competency.cs
@@ -16,6 +16,7 @@
         public string CompetencyGroupDescription { get; set; } = string.Empty;
         public string? Vocabulary { get; set; }
         public bool Optional { get; set; }
+        public bool GroupOptionalCompetencies { get; set; }
         public bool AlwaysShowDescription { get; set; }
         public bool IncludedInSelfAssessment { get; set; }
         public DateTime? Verified { get; set; }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -100,21 +100,47 @@ else
                 <div class="nhsuk-checkboxes">
                     @foreach (var competency in competencyGroup)
                     {
-                        <div class="nhsuk-checkboxes__item">
-                            <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.SelfAssessmentStructureId" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.SelfAssessmentStructureId) : false)" type="checkbox" value="@competency.SelfAssessmentStructureId">
-                            <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.SelfAssessmentStructureId">
-                                @foreach (var flag in competency.CompetencyFlags)
-                                {
-                                    <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
-                                        <strong class="nhsuk-tag @flag.FlagTagClass">
-                                            @flag.FlagName
-                                        </strong>
-                                    </span>
-                                }
+                        @if (competency.GroupOptionalCompetencies)
+                        {
+                            <div class="nhsuk-checkboxes__item">
 
-                                @competency.Name
-                            </label>
-                        </div>
+                                <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@competency.SelfAssessmentStructureId" name="resultChecked" type="checkbox" value="@competency.SelfAssessmentStructureId">
+                                <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@competency.SelfAssessmentStructureId">
+                                    <h3 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">  @competencyGroup.Key</h3>
+                                </label>
+                            </div>
+
+                            <details class="nhsuk-details">
+                                <summary class="nhsuk-details__summary nhsuk-u-padding-0">
+                                    <span class="nhsuk-u-margin-bottom-0">
+                                        <span class="nhsuk-details__summary-text"> &nbsp;&nbsp; What&rsquo;s included in the @competency.CompetencyGroup   </span>
+                                    </span>
+                                </summary>
+
+                                <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
+                                    @(Html.Raw(@competency.Name))
+                                </div>
+                            </details>
+                            <br />
+                        }
+                        else
+                        {
+                            <div class="nhsuk-checkboxes__item">
+                                <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.SelfAssessmentStructureId" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.SelfAssessmentStructureId) : false)" type="checkbox" value="@competency.SelfAssessmentStructureId">
+                                <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.SelfAssessmentStructureId">
+                                    @foreach (var flag in competency.CompetencyFlags)
+                                    {
+                                        <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
+                                            <strong class="nhsuk-tag @flag.FlagTagClass">
+                                                @flag.FlagName
+                                            </strong>
+                                        </span>
+                                    }
+
+                                    @competency.Name
+                                </label>
+                            </div>
+                        }
                     }
                 </div>
             </fieldset>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4560

### Description
I added GroupOptionalCompetencies flag into the Manage optional competencies view model
I display a check box for the group name (H3) as per wireframe
I display the competencies in an expander beneath
### Screenshots
![image](https://github.com/user-attachments/assets/2589f13a-b417-4858-8ff9-b898b377e8bb)
![image](https://github.com/user-attachments/assets/bea0322d-a67d-4186-8b79-afaa56e472e6)
Mobile view
![image](https://github.com/user-attachments/assets/357051ac-645f-498a-8af5-1cefa8b03901)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
