### PR TITLE
TD-4755 My Account - Active value is listed as one of the Admin roles

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/MyAccountController.cs
@@ -588,7 +588,7 @@
             {
                 var adminentity = new AdminEntity(adminAccount, userEntity.UserAccount, null);
                 CultureInfo currentCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
-                roles = FilterableTagHelper.GetCurrentTagsForAdmin(adminentity).Where(s => s.Hidden == false)
+                roles = FilterableTagHelper.GetCurrentTagsForAdmin(adminentity).Where(s => s.Hidden == false && s.DisplayText != "Active")
                                                 .Select(d => d.DisplayText).ToList<string>();
             }
             return roles;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4755

### Description
I exclude the Active from the admin role

### Screenshots
![image](https://github.com/user-attachments/assets/a7dfa3e4-5741-45e9-b45c-0c9774115f36)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
