### PR TITLE
TD-4469 fix date range labels on summary report

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/ActivityServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/ActivityServiceTests.cs
@@ -436,7 +436,7 @@
 
             var filterData = new ActivityFilterData(
                 DateTime.Parse("2020-9-1"),
-                DateTime.Parse("2021-9-1"),
+                DateTime.Parse("2021-9-30"),
                 null,
                 null,
                 null,

--- a/DigitalLearningSolutions.Web/Services/ActivityService.cs
+++ b/DigitalLearningSolutions.Web/Services/ActivityService.cs
@@ -140,7 +140,7 @@
                     last.DateInformation.GetDateRangeLabel(
                         DateHelper.StandardDateFormat,
                         filterData.EndDate ?? clockUtility.UtcNow,
-                        true
+                        false
                     ),
                     last.Enrolments,
                     last.Completions,


### PR DESCRIPTION
### JIRA link
[TD-4469](https://hee-tis.atlassian.net/browse/TD-4469)

### Description
Fixes the date range label for the last row of the summary report.

### Screenshots
<img width="443" alt="image" src="https://github.com/user-attachments/assets/fe61f2d5-19b1-4980-a624-776493320f9f">

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4469]: https://hee-tis.atlassian.net/browse/TD-4469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ