### PR TITLE
TD-4333 Making course admin fields optional again

### DIFF
--- a/DigitalLearningSolutions.Data/Helpers/NewlineSeparatedStringListHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/NewlineSeparatedStringListHelper.cs
@@ -17,7 +17,7 @@
         public static string AddStringToNewlineSeparatedList(string? list, string newItem)
         {
             var options = list != null ? SplitNewlineSeparatedList(list) : new List<string>();
-            options.Add(newItem.Trim());
+            options.Add(newItem?.Trim());
             return JoinNewlineSeparatedList(options);
         }
 

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldAnswersViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/CourseSetup/AdminFieldAnswersViewModel.cs
@@ -23,7 +23,6 @@
 
         public List<string> Options => NewlineSeparatedStringListHelper.SplitNewlineSeparatedList(OptionsString);
 
-        [Required(ErrorMessage = "Enter a response")]
         [MaxLength(100, ErrorMessage = "Response must be 100 characters or fewer")]
         public string? Answer { get; set; }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/AddAdminField.cshtml
@@ -53,7 +53,7 @@
                          autocomplete=""
                          hint-text=""
                          css-class="nhsuk-u-width-full"
-                         required="true" />
+                         required="false" />
           <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.AddPromptAction">Add</button>
         </div>
       </div>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AdminFields/EditAdminField.cshtml
@@ -6,65 +6,66 @@
 <link rel="stylesheet" href="@Url.Content("~/css/shared/cardWithButtons.css")" asp-append-version="true">
 
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = errorHasOccurred ? "Error: Edit course admin field" : "Edit course admin field";
-  var cancelLinkData = Html.GetRouteValues();
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Edit course admin field" : "Edit course admin field";
+    var cancelLinkData = Html.GetRouteValues();
 }
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    @if (errorHasOccurred) {
-      <vc:error-summary order-of-property-names="@(new []{ nameof(EditAdminFieldViewModel.OptionsString), nameof(EditAdminFieldViewModel.Answer)})" />
-    }
-    <h1 class="nhsuk-heading-xl">Edit course admin field</h1>
+    <div class="nhsuk-grid-column-full">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new []{ nameof(EditAdminFieldViewModel.OptionsString), nameof(EditAdminFieldViewModel.Answer)})" />
+        }
+        <h1 class="nhsuk-heading-xl">Edit course admin field</h1>
 
-    <form method="post" novalidate asp-action="EditAdminField">
-      <div class="hidden-submit">
-        <button name="action" class="nhsuk-button" value="@AdminFieldsController.AddPromptAction" aria-hidden="true" tabindex="-1">Add</button>
-      </div>
+        <form method="post" novalidate asp-action="EditAdminField">
+            <div class="hidden-submit">
+                <button name="action" class="nhsuk-button" value="@AdminFieldsController.AddPromptAction" aria-hidden="true" tabindex="-1">Add</button>
+            </div>
 
-      <input type="hidden" asp-for="OptionsString" />
-      <input type="hidden" asp-for="Prompt" />
-      <input type="hidden" asp-for="PromptNumber" />
+            <input type="hidden" asp-for="OptionsString" />
+            <input type="hidden" asp-for="Prompt" />
+            <input type="hidden" asp-for="PromptNumber" />
 
-      <vc:field-name-value-display display-name="Field" field-value="@Model.Prompt" />
+            <vc:field-name-value-display display-name="Field" field-value="@Model.Prompt" />
 
-      @if (string.IsNullOrEmpty(Model.OptionsString))
-      {
-        <partial name="_NoConfiguredAnswers" />
-      }
-      else
-      {
-        <partial name="_AdminFieldAnswerTable" model="Model" />
-      }
+            @if (string.IsNullOrEmpty(Model.OptionsString))
+            {
+                <partial name="_NoConfiguredAnswers" />
+            }
+            else
+            {
+                <partial name="_AdminFieldAnswerTable" model="Model" />
+            }
 
-      <div class="nhsuk-grid-row divider">
-        <div class="nhsuk-grid-column-one-half">
-          <vc:text-input asp-for="@nameof(Model.Answer)"
-                         label="Add a new response"
-                         populate-with-current-value="true"
-                         type="text"
-                         spell-check="true"
-                         autocomplete=""
-                         hint-text=""
-                         css-class="nhsuk-u-width-full"
-                         required="true" />
-          <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.AddPromptAction">Add</button>
-        </div>
-      </div>
+            <div class="nhsuk-grid-row divider">
+                <div class="nhsuk-grid-column-one-half">
+                    <vc:text-input asp-for="@nameof(Model.Answer)"
+                                   label="Add a new response"
+                                   populate-with-current-value="true"
+                                   type="text"
+                                   spell-check="true"
+                                   autocomplete=""
+                                   hint-text=""
+                                   css-class="nhsuk-u-width-full"
+                                   required="false" />
+                    <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.AddPromptAction">Add</button>
+                </div>
+            </div>
 
-      <div class="nhsuk-grid-row divider">
-        <div class="nhsuk-grid-column-one-half">
-          <p class="nhsuk-label">Want to edit responses in bulk?</p>
-          <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.BulkAction">Bulk edit</button>
-        </div>
-      </div>
+            <div class="nhsuk-grid-row divider">
+                <div class="nhsuk-grid-column-one-half">
+                    <p class="nhsuk-label">Want to edit responses in bulk?</p>
+                    <button name="action" class="nhsuk-button nhsuk-button--secondary" value="@AdminFieldsController.BulkAction">Bulk edit</button>
+                </div>
+            </div>
 
-      <div class="nhsuk-u-margin-bottom-3">
-        <button name="action" class="nhsuk-button" value="@AdminFieldsController.SaveAction">Save</button>
-      </div>
-    </form>
+            <div class="nhsuk-u-margin-bottom-3">
+                <button name="action" class="nhsuk-button" value="@AdminFieldsController.SaveAction">Save</button>
+            </div>
+        </form>
 
-    <vc:cancel-link asp-controller="AdminFields" asp-action="Index" asp-all-route-data="@cancelLinkData" />
-  </div>
+        <vc:cancel-link asp-controller="AdminFields" asp-action="Index" asp-all-route-data="@cancelLinkData" />
+    </div>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-4333](https://hee-tis.atlassian.net/browse/TD-4333)

### Description
Making course admin fields optional again

### Screenshots
![image](https://github.com/user-attachments/assets/0f462a81-53c8-4470-b4cf-7476ee85c425)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4333]: https://hee-tis.atlassian.net/browse/TD-4333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ