### PR TITLE
TD-4785-Set the Removed date as the current date for old duplicate rows in the table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202410091524_UpdateCandidateAssessmentSupervisorsDuplicateRows.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202410091524_UpdateCandidateAssessmentSupervisorsDuplicateRows.cs
@@ -1,0 +1,24 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202410091524)]
+    public class UpdateCandidateAssessmentSupervisorsDuplicateRows : ForwardOnlyMigration
+    {
+        public override void Up()
+        {
+            Execute.Sql(@$"WITH CAS_Duplicates AS (
+                        SELECT ID,
+                            ROW_NUMBER() OVER (PARTITION BY CandidateAssessmentID,SupervisorDelegateId ORDER BY Id DESC) AS RowNum
+                        FROM CandidateAssessmentSupervisors
+	                    WHERE CandidateAssessmentSupervisors.Removed is null
+                    )
+                    UPDATE CandidateAssessmentSupervisors
+                    SET Removed = GETUTCDATE()
+                    FROM CandidateAssessmentSupervisors cas INNER JOIN 
+		                    CAS_Duplicates casd ON cas.ID = casd.ID
+                    WHERE casd.RowNum > 1;");
+        }
+
+    }
+}


### PR DESCRIPTION
### JIRA link
[_TD-4785_](https://hee-tis.atlassian.net/browse/TD-4785)

### Description
Migration code add to Set the Removed date as the current date for old duplicate rows in the table

### Screenshots

Before update:
![image](https://github.com/user-attachments/assets/dd60cd68-463c-43fa-a60f-b24c9b8ac1bc)

After update:
![image](https://github.com/user-attachments/assets/4c69f379-cf31-4488-98d9-9bf46a347ae9)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
