### PR TITLE
TD-4560 Change the Manage optional competencies view to allow selection of competencies by group

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1538,6 +1538,23 @@
                     );
                 }
             }
+            if (model.GroupOptionalCompetenciesChecked != null)
+            {
+                var optionalCompetencies =
+               selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
+                foreach (var competencyGroup in model.GroupOptionalCompetenciesChecked)
+                {
+                    var IncludedSelfAssessmentStructureIds = optionalCompetencies.Where(x => x.CompetencyGroup == competencyGroup).Select(x => x.SelfAssessmentStructureId).ToList();
+                    foreach (var selfAssessmentStructureId in IncludedSelfAssessmentStructureIds)
+                    {
+                        selfAssessmentService.UpdateCandidateAssessmentOptionalCompetencies(
+                            selfAssessmentStructureId.Value,
+                            delegateUserId
+                        );
+                    }
+                }
+
+            }
 
             return RedirectToAction("SelfAssessmentOverview", new { selfAssessmentId, vocabulary });
         }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/ManageOptionalCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/ManageOptionalCompetenciesViewModel.cs
@@ -10,6 +10,7 @@
         public CurrentSelfAssessment? SelfAssessment { get; set; }
         public IEnumerable<IGrouping<string, Competency>>? CompetencyGroups { get; set; }
         public List<int>? IncludedSelfAssessmentStructureIds { get; set; }
+        public List<string>? GroupOptionalCompetenciesChecked { get; set; }
         public string VocabPlural()
         {
             return FrameworkVocabularyHelper.VocabularyPlural(SelfAssessment.Vocabulary);

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -8,6 +8,11 @@
     ViewData["SelfAssessmentTitle"] = @Model.SelfAssessment.Name;
     var backLinkData = Html.GetRouteValues();
 }
+<style>
+    .nhsuk-details__summary-text {
+        padding: 10px;
+    }
+</style>
 @if (ViewBag.FromAddOptionalPage != null)
 {
     @section breadcrumbs {
@@ -89,60 +94,85 @@ else
                 </legend>
                 @if (competencyGroup.Count() > 1)
                 {
-                    <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
-                        <div class="nhsuk-grid-column-full">
-                            <a class="nhsuk-button select-all-button select-all status-tag  nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural().ToLower()</a>
-                            <a class="nhsuk-button select-all-button deselect-all status-tag  nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural().ToLower()</a>
-                        </div>
-                    </div>
-                }
-
-                <div class="nhsuk-checkboxes">
-                    @foreach (var competency in competencyGroup)
+                    @if (competencyGroup.Any(x => x.GroupOptionalCompetencies))
                     {
-                        @if (competency.GroupOptionalCompetencies)
-                        {
-                            <div class="nhsuk-checkboxes__item">
+                        <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
+                            <div class="nhsuk-grid-column-full">
 
-                                <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@competency.SelfAssessmentStructureId" name="resultChecked" type="checkbox" value="@competency.SelfAssessmentStructureId">
-                                <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@competency.SelfAssessmentStructureId">
-                                    <h3 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">  @competencyGroup.Key</h3>
-                                </label>
-                            </div>
+                                <div class="nhsuk-checkboxes__item">
 
-                            <details class="nhsuk-details">
-                                <summary class="nhsuk-details__summary nhsuk-u-padding-0">
-                                    <span class="nhsuk-u-margin-bottom-0">
-                                        <span class="nhsuk-details__summary-text"> &nbsp;&nbsp; What&rsquo;s included in the @competency.CompetencyGroup   </span>
-                                    </span>
-                                </summary>
-
-                                <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
-                                    @(Html.Raw(@competency.Name))
+                                    <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@competencyGroup.Key" name="groupOptionalCompetenciesChecked" checked="@(competencyGroup.Any(x => x.IncludedInSelfAssessment == true) ? true : false)" type="checkbox" value="@competencyGroup.Key">
+                                    <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@competencyGroup.Key">
+                                        <h3 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">  Select all @Model.VocabPlural().ToLower()</h3>
+                                    </label>
                                 </div>
-                            </details>
-                            <br />
-                        }
-                        else
-                        {
-                            <div class="nhsuk-checkboxes__item">
-                                <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.SelfAssessmentStructureId" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.SelfAssessmentStructureId) : false)" type="checkbox" value="@competency.SelfAssessmentStructureId">
-                                <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.SelfAssessmentStructureId">
-                                    @foreach (var flag in competency.CompetencyFlags)
-                                    {
-                                        <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
-                                            <strong class="nhsuk-tag @flag.FlagTagClass">
-                                                @flag.FlagName
-                                            </strong>
-                                        </span>
-                                    }
 
-                                    @competency.Name
-                                </label>
                             </div>
-                        }
+                        </div>
+                        <details class="nhsuk-details">
+                            <summary class="nhsuk-details__summary nhsuk-u-padding-0">
+                                <h3 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+                                    <span class="nhsuk-u-margin-bottom-0">
+                                        <span class="nhsuk-details__summary-text"  id="@competencyGroup.Key">
+                                            What&rsquo;s included in the @competencyGroup.Key   </span>
+                                        </span>
+                                    
+                                </h3>
+                            </summary>
+
+                            <div class="nhsuk-details__text nhsuk-card">
+                                <dl class="nhsuk-summary-list">
+
+                                    @foreach (var competency in competencyGroup) 
+                                    {
+                                        <div class="nhsuk-summary-list__row">
+                                            <dd class="nhsuk-summary-list__value">
+                                                @competency.Name
+                                            </dd>
+                                        </div>
+                                    }
+                                </dl>
+
+
+                            </div>
+
+
+                        </details>
                     }
-                </div>
+                    else
+                    {
+                        <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
+                            <div class="nhsuk-grid-column-full">
+                                <a class="nhsuk-button select-all-button select-all status-tag  nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural().ToLower()</a>
+                                <a class="nhsuk-button select-all-button deselect-all status-tag  nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural().ToLower()</a>
+                            </div>
+                        </div>
+                        <div class="nhsuk-checkboxes">
+                            @foreach (var competency in competencyGroup)
+                            {
+
+
+
+                                <div class="nhsuk-checkboxes__item">
+                                    <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.SelfAssessmentStructureId" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.SelfAssessmentStructureId) : false)" type="checkbox" value="@competency.SelfAssessmentStructureId">
+                                    <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.SelfAssessmentStructureId">
+                                        @foreach (var flag in competency.CompetencyFlags)
+                                        {
+                                            <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
+                                                <strong class="nhsuk-tag @flag.FlagTagClass">
+                                                    @flag.FlagName
+                                                </strong>
+                                            </span>
+                                        }
+
+                                        @competency.Name
+                                    </label>
+                                </div>
+
+                            }
+                        </div>
+                    }
+                }
             </fieldset>
         }
     </nhs-form-group>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -103,7 +103,7 @@ else
 
                                     <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@competencyGroup.Key" name="groupOptionalCompetenciesChecked" checked="@(competencyGroup.Any(x => x.IncludedInSelfAssessment == true) ? true : false)" type="checkbox" value="@competencyGroup.Key">
                                     <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@competencyGroup.Key">
-                                        <h3 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">  Select all @Model.VocabPlural().ToLower()</h3>
+                                        <h3>  Select all @Model.VocabPlural().ToLower()</h3>
                                     </label>
                                 </div>
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -87,45 +87,48 @@ else
         @foreach (var competencyGroup in Model.CompetencyGroups)
         {
             <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-4">
-                <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <span class="nhsuk-fieldset__heading">
-                        @competencyGroup.Key
-                    </span>
-                </legend>
+
                 @if (competencyGroup.Count() > 1)
                 {
                     @if (competencyGroup.Any(x => x.GroupOptionalCompetencies))
                     {
-                        <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
-                            <div class="nhsuk-grid-column-full">
 
-                                <div class="nhsuk-checkboxes__item">
-
-                                    <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@competencyGroup.Key" name="groupOptionalCompetenciesChecked" checked="@(competencyGroup.Any(x => x.IncludedInSelfAssessment == true) ? true : false)" type="checkbox" value="@competencyGroup.Key">
-                                    <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@competencyGroup.Key">
-                                        <h3>  Select all @Model.VocabPlural().ToLower()</h3>
-                                    </label>
-                                </div>
-
-                            </div>
+                        <div class="nhsuk-checkboxes__item">
+                            <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@competencyGroup.Key" name="groupOptionalCompetenciesChecked" checked="@(competencyGroup.Any(x => x.IncludedInSelfAssessment == true) ? true : false)" type="checkbox" value="@competencyGroup.Key">
+                            <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@competencyGroup.Key">
+                                <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                                    <span class="nhsuk-fieldset__heading">
+                                        @competencyGroup.Key
+                                    </span>
+                                </legend>
+                            </label>
                         </div>
                         <details class="nhsuk-details">
                             <summary class="nhsuk-details__summary nhsuk-u-padding-0">
                                 <h3 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
                                     <span class="nhsuk-u-margin-bottom-0">
-                                        <span class="nhsuk-details__summary-text"  id="@competencyGroup.Key">
-                                            What&rsquo;s included in the @competencyGroup.Key   </span>
+                                        <span class="nhsuk-details__summary-text" id="@competencyGroup.Key">
+                                            What&rsquo;s included in the @competencyGroup.Key
                                         </span>
-                                    
+                                    </span>
+
                                 </h3>
                             </summary>
 
                             <div class="nhsuk-details__text nhsuk-card">
                                 <dl class="nhsuk-summary-list">
 
-                                    @foreach (var competency in competencyGroup) 
+                                    @foreach (var competency in competencyGroup)
                                     {
                                         <div class="nhsuk-summary-list__row">
+                                            @foreach (var flag in competency.CompetencyFlags)
+                                            {
+                                                <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
+                                                    <strong class="nhsuk-tag @flag.FlagTagClass">
+                                                        @flag.FlagName
+                                                    </strong>
+                                                </span>
+                                            }
                                             <dd class="nhsuk-summary-list__value">
                                                 @competency.Name
                                             </dd>
@@ -141,6 +144,11 @@ else
                     }
                     else
                     {
+                        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                            <span class="nhsuk-fieldset__heading">
+                                @competencyGroup.Key
+                            </span>
+                        </legend>
                         <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
                             <div class="nhsuk-grid-column-full">
                                 <a class="nhsuk-button select-all-button select-all status-tag  nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural().ToLower()</a>
@@ -150,9 +158,6 @@ else
                         <div class="nhsuk-checkboxes">
                             @foreach (var competency in competencyGroup)
                             {
-
-
-
                                 <div class="nhsuk-checkboxes__item">
                                     <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.Key" id="competency-check-@competency.SelfAssessmentStructureId" name="IncludedSelfAssessmentStructureIds" checked="@(Model.IncludedSelfAssessmentStructureIds != null ? Model.IncludedSelfAssessmentStructureIds.Contains((int)competency.SelfAssessmentStructureId) : false)" type="checkbox" value="@competency.SelfAssessmentStructureId">
                                     <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.SelfAssessmentStructureId">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4560

### Description
I display a check box to select all GroupOptionalCompetencies and put the group name in the wireframe
I display the competencies in an expander beneath

### Screenshots
![image](https://github.com/user-attachments/assets/0e1fe299-e192-4d8e-bdb5-f4de2fe6f443)
![image](https://github.com/user-attachments/assets/2712be5c-3711-48cb-8e42-e26ce8cef6ca)
Mobile view
![image](https://github.com/user-attachments/assets/33691688-0618-49c2-87ec-c729e3ab63a0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
