### PR TITLE
TD-4793-Unit tests added for deactivate delegate controller

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DeactivateDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DeactivateDelegateControllerTests.cs
@@ -104,6 +104,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
         public void Index_post_returns_view_for_deactivate_delegate_only()
         {
             // Given
+            int? centreId = controller.User.GetCentreId();
             var formData = new DeactivateDelegateAccountViewModel
             {
                 DelegateId = 1,
@@ -118,16 +119,21 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
             var result = controller.Index(formData);
 
             // Then
+            A.CallTo(() => userService.DeactivateDelegateUser(DelegateId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => userService.DeactivateAdminAccount(formData.UserId, centreId.Value)).MustNotHaveHappened();
+
             result.Should().BeRedirectToActionResult()
                 .WithControllerName("ViewDelegate")
                 .WithActionName("Index")
                 .WithRouteValue("delegateId", formData.DelegateId);
+
         }
 
         [Test]
         public void Index_post_returns_view_for_deactivate_delegate_and_admin()
         {
             // Given
+            int? centreId = controller.User.GetCentreId();
             var formData = new DeactivateDelegateAccountViewModel
             {
                 DelegateId = 1,
@@ -142,6 +148,9 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
             var result = controller.Index(formData);
 
             // Then
+            A.CallTo(() => userService.DeactivateDelegateUser(DelegateId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => userService.DeactivateAdminAccount(formData.UserId, centreId.Value)).MustHaveHappenedOnceExactly();
+
             result.Should().BeRedirectToActionResult()
                 .WithControllerName("ViewDelegate")
                 .WithActionName("Index")

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DeactivateDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DeactivateDelegateControllerTests.cs
@@ -1,0 +1,152 @@
+﻿using DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates;
+using DigitalLearningSolutions.Web.Services;
+using DigitalLearningSolutions.Web.Tests.ControllerHelpers;
+using DigitalLearningSolutions.Web.Tests.TestHelpers;
+using DigitalLearningSolutions.Web.Helpers;
+using FakeItEasy;
+using FluentAssertions;
+using FluentAssertions.AspNetCore.Mvc;
+using NUnit.Framework;
+using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.DeactivateDelegate;
+using DigitalLearningSolutions.Data.Models.User;
+using System.Collections.Generic;
+
+namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegates
+{
+    public class DeactivateDelegateControllerTests
+    {
+        private const int DelegateId = 1;
+        private DeactivateDelegateController controller = null!;
+        private IUserService userService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            userService = A.Fake<IUserService>();
+
+            controller = new DeactivateDelegateController(userService)
+                .WithDefaultContext()
+                .WithMockUser(true);
+        }
+
+        [Test]
+        public void Index_returns_not_found_with_null_delegate()
+        {
+            // Given
+            A.CallTo(() => userService.CheckDelegateIsActive(DelegateId)).Returns(null);
+
+            // When
+            var result = controller.Index(DelegateId);
+
+            // Then
+            result.Should()
+               .BeRedirectToActionResult()
+               .WithControllerName("LearningSolutions")
+               .WithActionName("StatusCode")
+               .WithRouteValue("code", 410);
+        }
+
+        [Test]
+        public void Index_returns_view_when_service_returns_valid_delegate()
+        {
+            // Given
+            A.CallTo(() => userService.CheckDelegateIsActive(DelegateId)).Returns(DelegateId);
+            int? centreId = controller.User.GetCentreId();
+
+            var delegateEntity = UserTestHelper.GetDefaultDelegateEntity(DelegateId, centreId.Value);
+            A.CallTo(() => userService.GetDelegateById(DelegateId)).Returns(delegateEntity);
+
+            var userEntity = new UserEntity(
+                UserTestHelper.GetDefaultUserAccount(),
+                new List<AdminAccount> { UserTestHelper.GetDefaultAdminAccount(centreId.Value) },
+                new List<DelegateAccount> { UserTestHelper.GetDefaultDelegateAccount(centreId.Value) }
+            );
+
+            A.CallTo(() => userService.GetUserById(delegateEntity.DelegateAccount.UserId)).Returns(userEntity);
+
+            // When
+            var result = controller.Index(DelegateId);
+
+            // Then
+            result.Should().BeViewResult().WithDefaultViewName();
+            result.Should().BeViewResult().ModelAs<DeactivateDelegateAccountViewModel>().DelegateId.Should().Be(DelegateId);
+            result.Should().BeViewResult().ModelAs<DeactivateDelegateAccountViewModel>().Name.Should().Be(delegateEntity.UserAccount.FirstName + " " + delegateEntity.UserAccount.LastName);
+            result.Should().BeViewResult().ModelAs<DeactivateDelegateAccountViewModel>().Email.Should().Be(delegateEntity.UserAccount.PrimaryEmail);
+            result.Should().BeViewResult().ModelAs<DeactivateDelegateAccountViewModel>().UserId.Should().Be(delegateEntity.UserAccount.Id);
+        }
+
+        [Test]
+        public void Index_post_returns_error_when_no_option_selected_to_deactivate()
+        {
+            // Given
+            var formData = new DeactivateDelegateAccountViewModel
+            {
+                DelegateId = 1,
+                Name = "Firstname Test",
+                Roles = new List<string>(),
+                Email = "email@test.com",
+                UserId = 2,
+                Deactivate = null
+            };
+
+            controller.ModelState.AddModelError("key", "Invalid for testing.");
+
+            // When
+            var result = controller.Index(formData);
+
+            // Then
+            result.Should().BeViewResult().ModelAs<DeactivateDelegateAccountViewModel>().DelegateId.Should().Be(DelegateId);
+            Assert.IsFalse(controller.ModelState.IsValid);
+        }
+
+
+        [Test]
+        public void Index_post_returns_view_for_deactivate_delegate_only()
+        {
+            // Given
+            var formData = new DeactivateDelegateAccountViewModel
+            {
+                DelegateId = 1,
+                Name = "Firstname Test",
+                Roles = new List<string>(),
+                Email = "email@test.com",
+                UserId = 2,
+                Deactivate = true
+            };
+
+            // When
+            var result = controller.Index(formData);
+
+            // Then
+            result.Should().BeRedirectToActionResult()
+                .WithControllerName("ViewDelegate")
+                .WithActionName("Index")
+                .WithRouteValue("delegateId", formData.DelegateId);
+        }
+
+        [Test]
+        public void Index_post_returns_view_for_deactivate_delegate_and_admin()
+        {
+            // Given
+            var formData = new DeactivateDelegateAccountViewModel
+            {
+                DelegateId = 1,
+                Name = "Firstname Test",
+                Roles = new List<string>(),
+                Email = "email@test.com",
+                UserId = 2,
+                Deactivate = false
+            };
+
+            // When
+            var result = controller.Index(formData);
+
+            // Then
+            result.Should().BeRedirectToActionResult()
+                .WithControllerName("ViewDelegate")
+                .WithActionName("Index")
+                .WithRouteValue("delegateId", formData.DelegateId);
+        }
+
+    }
+}


### PR DESCRIPTION
### JIRA link
[_TD-4793_](https://hee-tis.atlassian.net/browse/TD-4793)

### Description
Unit tests added for deactivate delegate controller

### Screenshots
![image](https://github.com/user-attachments/assets/7f66390e-8d02-49f5-89aa-cc5508b69dc3)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
