### PR TITLE
TD-4887- Limit the supervisors that are available in the Manage Supervisors "Quick add" list to supervisors with a category that matches the self assessment 

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -103,9 +103,6 @@
             int delegateUserId
         )
         {
-            var selfAssessmentCategoryId = connection.ExecuteScalar<int>(@"SELECT CategoryID FROM SelfAssessments WHERE ID = @selfAssessmentId",
-                    new { selfAssessmentId });
-
             return connection.Query<SelfAssessmentSupervisor>(
                 @"SELECT DISTINCT
                     sd.ID AS SupervisorDelegateID,
@@ -125,9 +122,9 @@
                 WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (sd.SupervisorAdminID IS NOT NULL) AND (sd.DelegateUserID = @delegateUserId)
 		            AND (au.Supervisor = 1 OR au.NominatedSupervisor = 1) AND (au.Active = 1)
 		            AND (ca.SelfAssessmentID <> @selfAssessmentId)
-                    AND (au.CategoryID = 0 OR au.CategoryID = @selfAssessmentCategoryId)
+                    AND (au.CategoryID = 0 OR au.CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                 ORDER BY SupervisorName",
-                new { selfAssessmentId, delegateUserId, selfAssessmentCategoryId }
+                new { selfAssessmentId, delegateUserId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -103,6 +103,9 @@
             int delegateUserId
         )
         {
+            var selfAssessmentCategoryId = connection.ExecuteScalar<int>(@"SELECT CategoryID FROM SelfAssessments WHERE ID = @selfAssessmentId",
+                    new { selfAssessmentId });
+
             return connection.Query<SelfAssessmentSupervisor>(
                 @"SELECT DISTINCT
                     sd.ID AS SupervisorDelegateID,
@@ -122,8 +125,9 @@
                 WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (sd.SupervisorAdminID IS NOT NULL) AND (sd.DelegateUserID = @delegateUserId)
 		            AND (au.Supervisor = 1 OR au.NominatedSupervisor = 1) AND (au.Active = 1)
 		            AND (ca.SelfAssessmentID <> @selfAssessmentId)
+                    AND (au.CategoryID = 0 OR au.CategoryID = @selfAssessmentCategoryId)
                 ORDER BY SupervisorName",
-                new { selfAssessmentId, delegateUserId }
+                new { selfAssessmentId, delegateUserId, selfAssessmentCategoryId }
             );
         }
 


### PR DESCRIPTION
### JIRA link
[_TD-4887_](https://hee-tis.atlassian.net/browse/TD-4887)

### Description
GetOtherSupervisorsForCandidate(+) => SQL query modified to return supervisors based on self-assessment category

### Screenshots

Tested for 'uat.dlstester3@gmail.com' supervisor for a self-assessment of 'Nursing proficiency passports' category.

1. When 'uat.dlstester3@gmail.com' supervisor  with 'All' or 'Nursing proficiency passports' category.

![image](https://github.com/user-attachments/assets/3b2c7471-08c9-4f93-bf3f-f38809bb5219)

2. When 'uat.dlstester3@gmail.com' supervisor  with 'Digital Workplace' category.

![image](https://github.com/user-attachments/assets/4ab4ba9f-c974-4087-88be-11fd78d0f942)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
