### PR TITLE
TD-4946-Name property initialized from UserAccount entity

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/SearchableAdminViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Administrator/SearchableAdminViewModel.cs
@@ -17,7 +17,8 @@
         )
         {
             Id = admin.AdminAccount.Id;
-            Name = admin.SearchableName;
+            Name = string.IsNullOrWhiteSpace(admin.UserAccount.FirstName) ? admin.UserAccount.LastName :
+                    $"{admin.UserAccount.LastName}, {admin.UserAccount.FirstName}";
             CategoryName = admin.AdminAccount.CategoryName ?? "All";
             EmailAddress = admin.EmailForCentreNotifications;
             IsLocked = admin.UserAccount.FailedLoginCount >= AuthHelper.FailedLoginThreshold;


### PR DESCRIPTION
### JIRA link
[_TD-4946_](https://hee-tis.atlassian.net/browse/TD-4946)

### Description
Name property initialized from UserAccount entity

### Screenshots

![image](https://github.com/user-attachments/assets/62ea9dd3-efb6-41a9-8c22-b7b151861982)

![image](https://github.com/user-attachments/assets/666b7c19-647b-4d37-bf5a-96e9698c4438)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
