### PR TITLE
TD-4888-Limit the supervisors that are available to add to self assessment from "Manage supervisors" to supervisors with a matching category

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -120,7 +120,7 @@
 
         SupervisorComment? GetSupervisorComments(int delegateUserId, int resultId);
 
-        IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId, int delegateUserId);
+        IEnumerable<Administrator> GetValidSupervisorsForActivity(int selfAssessmentId, int delegateUserId);
 
         Administrator GetSupervisorByAdminId(int supervisorAdminId);
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -220,7 +220,6 @@
         }
 
         public IEnumerable<Administrator> GetValidSupervisorsForActivity(
-            int centreId,
             int selfAssessmentId,
             int delegateUserId
         )
@@ -258,7 +257,7 @@
                         )
                         AND (Supervisor = 1 OR NominatedSupervisor = 1) AND (Active = 1) AND (Email LIKE '%@%')
                         ORDER BY Forename, Surname",
-                new { centreId, selfAssessmentId, delegateUserId }
+                new { selfAssessmentId, delegateUserId }
             );
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -694,7 +694,6 @@
             );
 
             var distinctSupervisorCentres = selfAssessmentService.GetValidSupervisorsForActivity(
-               User.GetCentreIdKnownNotNull(),
                selfAssessmentId,
                User.GetUserIdKnownNotNull()
            ).Select(c => new { c.CentreID, c.CentreName }).Distinct().OrderBy(o => o.CentreName).ToList();
@@ -728,7 +727,6 @@
                 TempData
             );
             var supervisors = selfAssessmentService.GetValidSupervisorsForActivity(
-                User.GetCentreIdKnownNotNull(),
                 selfAssessmentId,
                 User.GetUserIdKnownNotNull()
             ).ToList();
@@ -776,7 +774,6 @@
                 TempData
             );
             var supervisors = selfAssessmentService.GetValidSupervisorsForActivity(
-                User.GetCentreIdKnownNotNull(),
                 selfAssessmentId,
                 User.GetUserIdKnownNotNull()
             );
@@ -873,7 +870,6 @@
                 TempData
             );
             var distinctCentres = selfAssessmentService.GetValidSupervisorsForActivity(
-                User.GetCentreIdKnownNotNull(),
                 selfAssessmentId,
                 User.GetUserIdKnownNotNull()
             ).Select(c => new { c.CentreID, c.CentreName }).Distinct().OrderBy(o => o.CentreName).ToList();
@@ -911,7 +907,6 @@
             if (!ModelState.IsValid)
             {
                 var distinctCentres = selfAssessmentService.GetValidSupervisorsForActivity(
-                User.GetCentreIdKnownNotNull(),
                 model.SelfAssessmentID,
                 User.GetUserIdKnownNotNull()
                 ).Select(c => new { c.CentreID, c.CentreName }).Distinct().OrderBy(o => o.CentreName).ToList();
@@ -1072,7 +1067,6 @@
             var roles = supervisorService.GetDelegateNominatableSupervisorRolesForSelfAssessment(selfAssessmentId);
             var supervisor = selfAssessmentService.GetSupervisorByAdminId(sessionAddSupervisor.SupervisorAdminId);
             var distinctCentres = selfAssessmentService.GetValidSupervisorsForActivity(
-                User.GetCentreIdKnownNotNull(),
                 selfAssessmentId,
                 User.GetUserIdKnownNotNull()
             ).Select(c => new { c.CentreID, c.CentreName }).Distinct().OrderBy(o => o.CentreName).ToList();
@@ -1756,7 +1750,7 @@
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-                if (userId != competencymaindata.LearnerId) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            if (userId != competencymaindata.LearnerId) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             var delegateUserId = competencymaindata.LearnerId;
             var competencycount = selfAssessmentService.GetCompetencyCountSelfAssessmentCertificate(candidateAssessmentId);
             var accessors = selfAssessmentService.GetAccessor(competencymaindata.SelfAssessmentID, competencymaindata.LearnerId);

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -87,7 +87,7 @@
 
         IEnumerable<SelfAssessmentSupervisor> GetOtherSupervisorsForCandidate(int selfAssessmentId, int delegateUserId);
 
-        IEnumerable<Administrator> GetValidSupervisorsForActivity(int centreId, int selfAssessmentId, int delegateUserId);
+        IEnumerable<Administrator> GetValidSupervisorsForActivity(int selfAssessmentId, int delegateUserId);
 
         Administrator GetSupervisorByAdminId(int supervisorAdminId);
 
@@ -253,12 +253,11 @@
         }
 
         public IEnumerable<Administrator> GetValidSupervisorsForActivity(
-            int centreId,
             int selfAssessmentId,
             int delegateUserId
         )
         {
-            return selfAssessmentDataService.GetValidSupervisorsForActivity(centreId, selfAssessmentId, delegateUserId).Where(c => !Guid.TryParse(c.Email, out _));
+            return selfAssessmentDataService.GetValidSupervisorsForActivity(selfAssessmentId, delegateUserId).Where(c => !Guid.TryParse(c.Email, out _));
         }
 
         public Administrator GetSupervisorByAdminId(int supervisorAdminId)


### PR DESCRIPTION
### JIRA link
[_TD-4888_](https://hee-tis.atlassian.net/browse/TD-4888)

### Description
1. Limiting the supervisors while adding new supervisor, is working as expected. No code change required.
2. Removed unused parameter 'centreId' from the service method

### Screenshots

Tested for '[uat.dlstester3@gmail.com](mailto:uat.dlstester3@gmail.com)' supervisor for a self-assessment of 'Nursing proficiency passports' category.

1. When 'auldrin.possa@hee.nhs.uk' supervisor with 'All' or 'Nursing proficiency passports' category.

![image](https://github.com/user-attachments/assets/405ce911-15b9-43a3-b9b6-034f40d0aea8)

2. When 'auldrin.possa@hee.nhs.uk' supervisor with 'Digital Workplace' category.

![image](https://github.com/user-attachments/assets/0dab9597-d926-4027-ae6c-13de1d401734)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
