### PR TITLE
TD-4972-Limit the list of existing supervisors in the Manage Supervisors list to supervisors with a matching category

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -76,7 +76,9 @@
         {
             return connection.Query<SelfAssessmentSupervisor>(
                 @$"{SelectSelfAssessmentSupervisorQuery}
-                    WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (ca.DelegateUserID = @delegateUserId) AND (ca.SelfAssessmentID = @selfAssessmentId)
+                    WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (ca.DelegateUserID = @delegateUserId)
+                            AND (ca.SelfAssessmentID = @selfAssessmentId)
+                            AND (au.CategoryID = 0 OR au.CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                         ORDER BY SupervisorName",
                 new { selfAssessmentId, delegateUserId }
             );


### PR DESCRIPTION
### JIRA link
[_TD-4972_](https://hee-tis.atlassian.net/browse/TD-4972)

### Description
Added comparison of supervisor CategoryID with self-assessment CategoryID in the GetAllSupervisorsForSelfAssessmentId(+) to get supervisors based on category.

### Screenshots

Tested for 'delegate.user8@gmail.com' supervisor for a self-assessment of 'Nursing proficiency passports' category.

1. When 'delegate.user8@gmail.com' supervisor with 'All' or 'Nursing proficiency passports' category.

![image](https://github.com/user-attachments/assets/f90f1e6b-a312-495e-b827-000bdf043c06)

2. When 'delegate.user8@gmail.com' supervisor with 'Digital Workplace' category.

![image](https://github.com/user-attachments/assets/a25d5c8c-f125-4b23-aa98-fb776121ac43)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
