### PR TITLE
TD-4974-Limit the list of supervisors in the Request sign off view to supervisors with a matching category

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -148,7 +148,8 @@
                     WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (sd.DelegateUserID = @delegateUserId) AND (ca.SelfAssessmentID = @selfAssessmentId)
                         AND (sd.SupervisorAdminID IS NOT NULL) AND (coalesce(sasr.SelfAssessmentReview, 1) = 1)
                         AND (cas.ID NOT IN (SELECT CandidateAssessmentSupervisorID FROM CandidateAssessmentSupervisorVerifications WHERE Verified IS NULL))
-                        AND au.Active = 1 
+                        AND au.Active = 1
+                        AND (au.CategoryID = 0 OR CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                 ORDER BY SupervisorName",
                 new { selfAssessmentId, delegateUserId }
             );


### PR DESCRIPTION
### JIRA link
[_TD-4974_](https://hee-tis.atlassian.net/browse/TD-4974)

### Description
Sign off supervisors list filtered based on self-assessment category

### Screenshots
Tested for 'auldrinG possa (Development Testing Centre)' supervisor for a self-assessment of 'Nursing proficiency passports' category.

1. When 'auldrinG possa (Development Testing Centre)' supervisor with 'All' or 'Nursing proficiency passports' category.

![image](https://github.com/user-attachments/assets/3ce4b341-f6fb-4ce7-8b1d-548567652b60)

2. When 'auldrinG possa (Development Testing Centre)' supervisor with 'Digital Workplace' category.

![image](https://github.com/user-attachments/assets/7ff32504-7d80-46f1-a811-b08ff1529a32)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
