### PR TITLE
TD-4975-Limit the supervisor task list to show only sign off and confirmation requests that are for self assessments that match the supervisors category

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -540,8 +540,11 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                     SelfAssessments AS sa ON ca.SelfAssessmentID = sa.ID INNER JOIN
                     SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
                     CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID INNER JOIN
-                    Users AS u ON ca.DelegateUserID = u.ID
-                WHERE (sd.SupervisorAdminID = @adminId) AND (casv.Verified IS NULL) AND (cas.Removed IS NULL) AND (sd.Removed IS NULL)", new { adminId }
+                    Users AS u ON ca.DelegateUserID = u.ID INNER JOIN
+					AdminAccounts As aa ON sd.SupervisorAdminID = aa.ID
+                WHERE (sd.SupervisorAdminID = @adminId) AND (casv.Verified IS NULL) AND (cas.Removed IS NULL)
+                        AND (sd.Removed IS NULL)
+                        AND (aa.CategoryID is null or sa.CategoryID = aa.CategoryID)", new { adminId }
                 );
         }
         public IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedReviews(int adminId)
@@ -559,8 +562,10 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 						    SELECT TOP 1 sar2.DateTime
 						    FROM SelfAssessmentResults AS sar2
 						    WHERE sar2.ID = sar.ID AND sar2.SelfAssessmentID = sar.SelfAssessmentID AND sar2.CompetencyID = co.ID AND sar2.Result != 0 ORDER BY sar2.ID DESC
-					)
+					) INNER JOIN
+		            AdminAccounts AS aa ON sd.SupervisorAdminID = aa.ID
                 WHERE (sd.SupervisorAdminID = @adminId) AND (cas.Removed IS NULL) AND (sasv.Verified IS NULL) AND (sd.Removed IS NULL)
+                        AND (aa.CategoryID is null or sa.CategoryID = aa.CategoryID)
 				GROUP BY sa.ID, ca.ID, sd.ID, u.FirstName, u.LastName, sa.Name,cast(sasv.Requested as date)", new { adminId }
                 );
         }


### PR DESCRIPTION
### JIRA link
[_TD-4975_](https://hee-tis.atlassian.net/browse/TD-4975)

### Description

To-do items for requested signoffs/confirmations are filtered by admin category.

### Screenshots

When admin with 'All' or 'Nursing proficiency passports' category.

![image](https://github.com/user-attachments/assets/d74fceca-6738-4c17-b0c3-ad4009f4ae06)

When admin with 'Digital Workplace' category.

![image](https://github.com/user-attachments/assets/1400d04d-bd3b-4626-a208-256797ccc3c0)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
