### PR TITLE
TD-4889 When a supervisor promotes a learner to the Nominated supervisor role, assign them to the same category as the supervisor

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
@@ -32,6 +32,7 @@
         private IClockUtility clockUtility = null!;
         private ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService = null!;
         private IPdfService pdfService = null!;
+        private  ICourseCategoriesService courseCategoriesService = null!;
 
         [SetUp]
         public void Setup()
@@ -55,6 +56,7 @@
             clockUtility = A.Fake<IClockUtility>();
             candidateAssessmentDownloadFileService = A.Fake<ICandidateAssessmentDownloadFileService>();
             pdfService = A.Fake<IPdfService>();
+            courseCategoriesService = A.Fake<ICourseCategoriesService>();
             A.CallTo(() => candidateAssessmentDownloadFileService.GetCandidateAssessmentDownloadFileForCentre(A<int>._, A<int>._, A<bool>._))
                 .Returns(new byte[] { });
         }
@@ -83,7 +85,8 @@
                    emailService,
                    candidateAssessmentDownloadFileService,
                    clockUtility,
-                   pdfService
+                   pdfService,
+                   courseCategoriesService
                );
             string expectedFileName = $"{((selfAssessmentName.Length > 30) ? selfAssessmentName.Substring(0, 30) : selfAssessmentName)} - {delegateName} - {clockUtility.UtcNow:yyyy-MM-dd}.xlsx";
 

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1273,9 +1273,13 @@
         [Route("/Supervisor/Staff/{supervisorDelegateId}/NominateSupervisor")]
         public IActionResult NominateSupervisor(int supervisorDelegateId, ReturnPageQuery returnPageQuery)
         {
+            var centreId = User.GetCentreIdKnownNotNull();
+            var loggedInAdmin = userService.GetAdminById(GetAdminId());
             var superviseDelegate =
                 supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
-            var model = new SupervisorDelegateViewModel(superviseDelegate, returnPageQuery);
+            var categories = courseCategoriesService.GetCategoriesForCentreAndCentrallyManagedCourses(centreId);
+            categories = categories.Prepend(new Category { CategoryName = "All", CourseCategoryID = 0 });
+            var model = new SupervisorDelegateViewModel(superviseDelegate, returnPageQuery, categories, loggedInAdmin.CategoryId);
             if (TempData["NominateSupervisorError"] != null)
             {
                 if (Convert.ToBoolean(TempData["NominateSupervisorError"].ToString()))
@@ -1300,13 +1304,13 @@
                     supervisorDelegateDetail.DelegateUserID,
                     (int)User.GetCentreId()
                 );
-
+                supervisorDelegate.SelfAssessmentCategory = supervisorDelegate.SelfAssessmentCategory == 0   ? adminUser.CategoryId.Value  : supervisorDelegate.SelfAssessmentCategory;
                 var centreName = adminUser.CentreName;
 
                 var adminRoles = new AdminRoles(false, false, true, false, false, false, false, false);
                 if (supervisorDelegateDetail.DelegateUserID != null)
                 {
-                    registrationService.PromoteDelegateToAdmin(adminRoles, categoryId, (int)supervisorDelegateDetail.DelegateUserID, (int)User.GetCentreId(), true);
+                    registrationService.PromoteDelegateToAdmin(adminRoles, supervisorDelegate.SelfAssessmentCategory, (int)supervisorDelegateDetail.DelegateUserID, (int)User.GetCentreId(), true);
 
                     if (delegateUser != null && adminUser != null)
                     {

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/SupervisorController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/SupervisorController.cs
@@ -27,6 +27,7 @@
         private readonly ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService;
         private readonly IClockUtility clockUtility;
         private readonly IPdfService pdfService;
+        private readonly ICourseCategoriesService courseCategoriesService;
 
         public SupervisorController(
            ISupervisorService supervisorService,
@@ -47,7 +48,8 @@
            IEmailService emailService,
            ICandidateAssessmentDownloadFileService candidateAssessmentDownloadFileService,
            IClockUtility clockUtility,
-           IPdfService pdfService
+           IPdfService pdfService,
+           ICourseCategoriesService courseCategoriesService
            )
         {
             this.supervisorService = supervisorService;
@@ -65,6 +67,7 @@
             this.candidateAssessmentDownloadFileService = candidateAssessmentDownloadFileService;
             this.clockUtility = clockUtility;
             this.pdfService = pdfService;
+            this.courseCategoriesService = courseCategoriesService;
         }
 
         private int GetCentreId()

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateViewModel.cs
@@ -3,10 +3,29 @@
     using DigitalLearningSolutions.Data.Models.SearchSortFilterPaginate;
     using DigitalLearningSolutions.Data.Models.Supervisor;
     using DigitalLearningSolutions.Web.Attributes;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using System.Collections.Generic;
     using System.ComponentModel;
+    using DigitalLearningSolutions.Data.Models.Common;
+    using DigitalLearningSolutions.Web.Helpers;
+    using System.Linq;
 
     public class SupervisorDelegateViewModel
     {
+        public SupervisorDelegateViewModel(SupervisorDelegateDetail detail, ReturnPageQuery returnPageQuery, IEnumerable<Category> categories, int? adminCategoryId)
+        {
+            Id = detail.ID;
+            FirstName = detail.FirstName;
+            LastName = detail.LastName;
+            DelegateEmail = detail.DelegateEmail;
+            CandidateAssessmentCount = detail.CandidateAssessmentCount;
+            ReturnPageQuery = returnPageQuery;
+            SelfAssessmentCategory = AdminCategoryHelper.CategoryIdToAdminCategory(adminCategoryId);
+            SelfAssessmentCategories = SelectListHelper.MapOptionsToSelectListItems(
+                categories.Select(c => (c.CourseCategoryID, c.CategoryName)),
+                adminCategoryId
+            );
+        }
         public SupervisorDelegateViewModel(SupervisorDelegateDetail detail, ReturnPageQuery returnPageQuery)
         {
             Id = detail.ID;
@@ -23,10 +42,11 @@
         public int CandidateAssessmentCount { get; set; }
         public string DelegateEmail { get; set; }
         public ReturnPageQuery ReturnPageQuery { get; set; }
-
         [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm you wish to perform this action")]
         public bool ActionConfirmed { get; set; }
         [DefaultValue(false)]
         public bool ConfirmedRemove { get; set; }
+        public int SelfAssessmentCategory { get; set; }
+        public IEnumerable<SelectListItem> SelfAssessmentCategories { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/NominateSupervisor.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/NominateSupervisor.cshtml
@@ -3,53 +3,65 @@
 @model SupervisorDelegateViewModel;
 @inject IConfiguration Configuration;
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Application"] = "Supervisor";
-  ViewData["Title"] = "Confirm Nominated supervisor";
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/Supervisor/MyStaff";
-  ViewData["HeaderPathName"] = "My Staff";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Application"] = "Supervisor";
+    ViewData["Title"] = "Confirm Nominated supervisor";
+    ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/Supervisor/MyStaff";
+    ViewData["HeaderPathName"] = "My Staff";
 }
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  <div class="nhsuk-grid-row">
+<div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      @if (errorHasOccurred)
-    {
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
-    }
-    <h1 id="page-heading">@ViewData["Title"]</h1>
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
-        <div class="nhsuk-u-font-weight-bold">
-          Staff member:
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
+        }
+        <h1 id="page-heading">@ViewData["Title"]</h1>
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-one-quarter nhsuk-heading-l">
+                <div class="nhsuk-u-font-weight-bold">
+                    Staff member:
+                </div>
+            </div>
+            <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
+                @Model.FirstName @Model.LastName (@Model.DelegateEmail)
+            </div>
         </div>
-      </div>
-      <div class="nhsuk-grid-column-three-quarters nhsuk-heading-l nhsuk-u-font-weight-normal">
-        @Model.FirstName @Model.LastName (@Model.DelegateEmail)
-      </div>
-    </div>
-    <p class="nhsuk-body-m">By promoting this member of staff to the Nominated supervisor role, you are confirming their competence to assess the capability of others.</p>
-    <p>Once the Nominated supervisor role has been assigned, it can only be removed by a Centre Manager or Clinical Centre Manager.</p>
-    <form method="post" asp-controller="Supervisor">
-      <div class="nhsuk-checkboxes__item">
-        <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
-                            label="I am sure that I wish to promote @Model.FirstName @Model.LastName to the Nominated supervisor role"
-                            hint-text="I understand that the Nominated supervisor role can only be removed by a Centre Manager or Clinical Centre Manager." />
-      </div>
-      <button type="submit" class="nhsuk-button nhsuk-u-margin-top-4" asp-action="ConfirmNominateSupervisor">
-        Confirm
-      </button>
-      @Html.HiddenFor(m => m.Id)
-      @Html.HiddenFor(m => m.FirstName)
-      @Html.HiddenFor(m => m.LastName)
-      @Html.HiddenFor(m => m.DelegateEmail)
-      @Html.HiddenFor(m => m.CandidateAssessmentCount)
-      @Html.HiddenFor(m => m.ReturnPageQuery)
-    </form>
+        <p class="nhsuk-body-m">By promoting this member of staff to the Nominated supervisor role, you are confirming their competence to assess the capability of others.</p>
+        <p>Once the Nominated supervisor role has been assigned, it can only be removed by a Centre Manager or Clinical Centre Manager.</p>
+        <form method="post" asp-controller="Supervisor">
+            <div class="nhsuk-checkboxes__item">
+                <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
+                                    label="I am sure that I wish to promote @Model.FirstName @Model.LastName to the Nominated supervisor role"
+                                    hint-text="I understand that the Nominated supervisor role can only be removed by a Centre Manager or Clinical Centre Manager." />
+            </div>
+            @if(Model.SelfAssessmentCategory == 0)
+            {
+            <vc:select-list asp-for="SelfAssessmentCategory"
+                            label="Self assessment category (optional)"
+                            value="@Model.SelfAssessmentCategory.ToString()"
+                            hint-text="Limits the nominated supervisor to self assessments in a particular category."
+                            required="false"
+                            css-class="nhsuk-u-width-one-half"
+                            default-option=""
+                            select-list-options="@Model.SelfAssessmentCategories" />
+            }
+            <button type="submit" class="nhsuk-button nhsuk-u-margin-top-4" asp-action="ConfirmNominateSupervisor">
+                Confirm
+            </button>
+            @Html.HiddenFor(m => m.Id)
+            @Html.HiddenFor(m => m.FirstName)
+            @Html.HiddenFor(m => m.LastName)
+            @Html.HiddenFor(m => m.DelegateEmail)
+            @Html.HiddenFor(m => m.CandidateAssessmentCount)
+            @Html.HiddenFor(m => m.ReturnPageQuery)
+            @Html.HiddenFor(m => m.SelfAssessmentCategories)
+        </form>
 
-    <vc:cancel-link-with-return-page-query asp-controller="Supervisor" asp-action="MyStaffList" return-page-query="@Model.ReturnPageQuery" />
-  </div>
+        <vc:cancel-link-with-return-page-query asp-controller="Supervisor" asp-action="MyStaffList" return-page-query="@Model.ReturnPageQuery" />
+    </div>
 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4889

### Description
I added the Learning category drop-down list on the confirm page which only shows when the supervisor categoryId is null if not I pass the supervisor categoryId 
I also ensure that The categories listed are limited to categories that are associated with self assessments that are published to the centre

### Screenshots
![image](https://github.com/user-attachments/assets/7f73d2ff-313d-4f63-a371-b5353d1c5a4f)
![image](https://github.com/user-attachments/assets/b78bd796-44e6-4b35-a88d-cfd9631bf252)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
