### PR TITLE
TD-4884 Prevent supervisors from viewing/reviewing self assessments in a category that doesn't match their own

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -19,7 +19,7 @@
         SupervisorDelegate GetSupervisorDelegate(int adminId, int delegateUserId);
         int? ValidateDelegate(int centreId, string delegateEmail);
         IEnumerable<DelegateSelfAssessment> GetSelfAssessmentsForSupervisorDelegateId(int supervisorDelegateId, int? adminIdCategoryId);
-        DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId);
+        DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedSignOffs(int adminId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedReviews(int adminId);
         DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId);
@@ -570,7 +570,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 );
         }
 
-        public DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId)
+        public DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId)
         {
             return connection.Query<DelegateSelfAssessment>(
                 @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, sa.ReviewerCommentsLabel, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup, sa.SupervisorResultsReview AS IsSupervisorResultsReviewed,
@@ -590,8 +590,8 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                              NRPSubGroups AS sg ON sa.NRPSubGroupID = sg.ID LEFT OUTER JOIN
                              NRPRoles AS r ON sa.NRPRoleID = r.ID
                              LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
-                WHERE (ca.ID = @candidateAssessmentId) AND (cas.Removed IS NULL) AND (sd.SupervisorAdminID = @adminId)",
-                new { candidateAssessmentId, adminId }
+                WHERE (ca.ID = @candidateAssessmentId) AND (cas.Removed IS NULL) AND (sd.SupervisorAdminID = @adminId) AND (sa.CategoryID = @adminIdCategoryId)",
+                new { candidateAssessmentId, adminId, adminIdCategoryId }
                 ).FirstOrDefault();
         }
         public bool UpdateSelfAssessmentResultSupervisorVerifications(int selfAssessmentResultSupervisorVerificationId, string? comments, bool signedOff, int adminId)

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
@@ -107,7 +107,8 @@
                emailService,
                candidateAssessmentDownloadFileService,
                clockUtility,
-               pdfService
+               pdfService,
+               courseCategoriesService
            );
             controller.ControllerContext = new ControllerContext
             { HttpContext = new DefaultHttpContext { User = user } };
@@ -161,6 +162,7 @@
             // Given
             int candidateAssessmentId = 1;
             int supervisorDelegateId = 2;
+            int? adminIdCategoryId = 0;
             var superviseDelegate = SupervisorTagTestHelper.CreateDefaultSupervisorDelegateDetail();
             var delegateSelfAssessment = SupervisorTagTestHelper.CreateDefaultDelegateSelfAssessment();
             var appliedFilterViewModel = new List<AppliedFilterViewModel>();
@@ -190,7 +192,7 @@
 
             A.CallTo(() => supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, AdminId, 0))
                 .Returns(superviseDelegate);
-            A.CallTo(() => supervisorService.GetSelfAssessmentByCandidateAssessmentId(candidateAssessmentId, AdminId))
+            A.CallTo(() => supervisorService.GetSelfAssessmentByCandidateAssessmentId(candidateAssessmentId, AdminId, adminIdCategoryId))
                  .Returns(delegateSelfAssessment);
             A.CallTo(() => selfAssessmentService.GetMostRecentResults(SelfAssessmentId, DelegateUserId))
                 .Returns(competencies);

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -377,7 +377,7 @@
                 IsSupervisorResultsReviewed = delegateSelfAssessment.IsSupervisorResultsReviewed,
                 SearchViewModel = searchModel,
                 CandidateAssessmentId = candidateAssessmentId,
-                ExportToExcelHide = delegateSelfAssessment.SupervisorRoleTitle.Contains("Assessor"),
+                ExportToExcelHide = delegateSelfAssessment.SupervisorRoleTitle?.Contains("Assessor") ?? false,
             };
 
             var flags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(reviewedCompetencies.Select(c => c.Id).ToArray());

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -355,12 +355,14 @@
         public IActionResult ReviewDelegateSelfAssessment(int supervisorDelegateId, int candidateAssessmentId, int? selfAssessmentResultId = null, SearchSupervisorCompetencyViewModel searchModel = null)
         {
             var adminId = GetAdminId();
+            var loggedInAdminUser = userService.GetAdminUserById(adminId);
             var superviseDelegate =
                 supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
             var reviewedCompetencies = PopulateCompetencyLevelDescriptors(
                 selfAssessmentService.GetCandidateAssessmentResultsById(candidateAssessmentId, adminId, selfAssessmentResultId).ToList()
             );
-            var delegateSelfAssessment = supervisorService.GetSelfAssessmentByCandidateAssessmentId(candidateAssessmentId, adminId);
+            var delegateSelfAssessment = supervisorService.GetSelfAssessmentByCandidateAssessmentId(candidateAssessmentId, adminId, loggedInAdminUser.CategoryId);
+            if (delegateSelfAssessment == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             var competencyIds = reviewedCompetencies.Select(c => c.Id).ToArray();
             var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
             var competencies = SupervisorCompetencyFilterHelper.FilterCompetencies(reviewedCompetencies, competencyFlags, searchModel);

--- a/DigitalLearningSolutions.Web/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Web/Services/SupervisorService.cs
@@ -16,7 +16,7 @@ namespace DigitalLearningSolutions.Web.Services
         SupervisorDelegate GetSupervisorDelegate(int adminId, int delegateUserId);
         int? ValidateDelegate(int centreId, string delegateEmail);
         IEnumerable<DelegateSelfAssessment> GetSelfAssessmentsForSupervisorDelegateId(int supervisorDelegateId, int? adminIdCategoryId);
-        DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId);
+        DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedSignOffs(int adminId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedReviews(int adminId);
         DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId);
@@ -117,9 +117,9 @@ namespace DigitalLearningSolutions.Web.Services
             return supervisorDataService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
         }
 
-        public DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId)
+        public DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId)
         {
-            return supervisorDataService.GetSelfAssessmentByCandidateAssessmentId(candidateAssessmentId, adminId);
+            return supervisorDataService.GetSelfAssessmentByCandidateAssessmentId(candidateAssessmentId, adminId, adminIdCategoryId);
         }
 
         public DelegateSelfAssessment? GetSelfAssessmentBySupervisorDelegateCandidateAssessmentId(int candidateAssessmentId, int supervisorDelegateId)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4884

### Description
I added adminCategoryId to the method parameter and where the condition of  GetSelfAssessmentsForSupervisorDelegateId method to limit supervisor view to the SelfAssessments that do not belong to the supervisor category 
I added adminCategoryId to the method parameter and where the condition of  GetSelfAssessmentByCandidateAssessmentId method to ensure that the supervisor can not view or review SelfAssessments that do not belong to the supervisor category 
### Screenshots
When the admin categoryId is  null
![image](https://github.com/user-attachments/assets/58502fd5-4ef5-4cd7-8111-de35ebdb736e)
When the admin categoryId is 34
![image](https://github.com/user-attachments/assets/cc837e67-34a1-4652-afa4-1908c8a74b0b)
![image](https://github.com/user-attachments/assets/bf53fde5-d0f6-4002-830c-80978344e0f5)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.