### PR TITLE
TD-4880 Prevent administrators from viewing Activity Delegates for self assessments in a category that doesn't match their own

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -10,6 +10,7 @@
     using DigitalLearningSolutions.Data.Models.Frameworks;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Data.Models.SelfAssessments.Export;
+    using MailKit;
     using Microsoft.Extensions.Logging;
 
     public interface ISelfAssessmentDataService
@@ -172,6 +173,7 @@
         bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
+        int GetSelfAssessmentCategoryId(int selfAssessmentId);
     }
 
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
@@ -759,6 +761,14 @@
 	                        WHERE (CAOC.IncludedInSelfAssessment = 1)",
                         new { selfAssessmentId, delegateUserId }
                     );
+        }
+
+        public int GetSelfAssessmentCategoryId(int selfAssessmentId)
+        {
+            return connection.ExecuteScalar<int>(
+                @"SELECT CategoryID FROM SelfAssessments WHERE ID = @selfAssessmentId",
+                new { selfAssessmentId}
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -23,6 +23,7 @@
     public class CourseDelegatesControllerTests
     {
         private const int UserCentreId = 3;
+        private const int SelfAssessmentId = 1;
         private ActivityDelegatesController controller = null!;
         private ICourseDelegatesDownloadFileService courseDelegatesDownloadFileService = null!;
         private ICourseDelegatesService courseDelegatesService = null!;
@@ -122,8 +123,10 @@
                     ), 0)
                 );
 
+            A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentCategoryId(1)).Returns(1);
+
             // When
-            var result = controller.Index(2);
+            var result = controller.Index(2,1);
 
             // Then
             result.Should().BeNotFoundResult();
@@ -155,6 +158,7 @@
         {
             // Given
             const int customisationId = 2;
+            const int selfAssessmentId = 2;
             var searchString = string.Empty;
             var sortBy = "SearchableName";
             var sortDirection = "Ascending";
@@ -207,7 +211,7 @@
                 );
 
             // When
-            var result = courseDelegatesController.Index(customisationId);
+            var result = courseDelegatesController.Index(customisationId, selfAssessmentId);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -132,6 +132,13 @@
             var centreId = User.GetCentreIdKnownNotNull();
             var adminCategoryId = User.GetAdminCategoryId();
 
+            var selfAssessmentCategoryId = selfAssessmentService.GetSelfAssessmentCategoryId((int)selfAssessmentId);
+
+            if (adminCategoryId > 0 && adminCategoryId != selfAssessmentCategoryId)
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            }            
+
             bool? isDelegateActive, isProgressLocked, removed, hasCompleted, submitted, signedOff;
             isDelegateActive = isProgressLocked = removed = hasCompleted = submitted = signedOff = null;
 

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -162,7 +162,7 @@
             if (isCourse == "true")
                 delegateActivities = courseService.GetDelegateCourses(searchString ?? string.Empty, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
             if (isSelfAssessment == "true" && courseTopic == "Any" && hasAdminFields == "Any")
-                delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+                delegateAssessments = courseService.GetDelegateAssessmentsByCategoryId(searchString, centreId, categoryName, isActive, categoryId);
 
             delegateAssessments = UpdateCompletedCount(delegateAssessments);
 

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -121,6 +121,7 @@
 
         public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> GetDelegateCourses(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
         public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive);
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentsByCategoryId(string searchString, int centreId, string categoryName, string isActive, int? categoryId);
         IEnumerable<AvailableCourse> GetAvailableCourses(int delegateId, int? centreId, int categoryId);
         bool IsCourseCompleted(int candidateId, int customisationId);
         bool IsCourseCompleted(int candidateId, int customisationId, int progressID);
@@ -566,6 +567,11 @@
         public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive)
         {
             return courseDataService.GetDelegateAssessmentStatisticsAtCentre(searchString, centreId, categoryName, isActive);
+        }
+
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentsByCategoryId(string searchString, int centreId, string categoryName, string isActive, int? categoryId)
+        {
+            return courseDataService.GetDelegateAssessmentStatisticsAtCentreByCategoryId(searchString, centreId, categoryName, isActive, categoryId);
         }
 
         public IEnumerable<AvailableCourse> GetAvailableCourses(int delegateId, int? centreId, int categoryId)

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using DigitalLearningSolutions.Data.DataServices.SelfAssessmentDataService;
+    using DigitalLearningSolutions.Data.ModelBinders;
     using DigitalLearningSolutions.Data.Models.Common.Users;
     using DigitalLearningSolutions.Data.Models.External.Filtered;
     using DigitalLearningSolutions.Data.Models.Frameworks;
@@ -149,6 +150,7 @@
         IEnumerable<CandidateAssessment> GetCandidateAssessments(int delegateUserId, int selfAssessmentId);
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
+        public int GetSelfAssessmentCategoryId(int selfAssessmentId);
 
     }
 
@@ -557,6 +559,11 @@
         public bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId)
         {
             return selfAssessmentDataService.HasMinimumOptionalCompetencies(selfAssessmentId, delegateUserId);
+        }
+
+        public int GetSelfAssessmentCategoryId(int selfAssessmentId)
+        {
+            return selfAssessmentDataService.GetSelfAssessmentCategoryId(selfAssessmentId);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-4880](https://hee-tis.atlassian.net/browse/TD-4880)

### Description
Added a check for the categoryId of the admin users while fetching the self assessments, making sure we only pull the self assessments that matches the categoryId on the admin account of the user, also added an Unauthorized check when anyone tries to manipulate the self assessment delegates using the query string URL being opened. 
If there's a categoryId on the admin account of the user, then show self assessments that are specific to the categoryId, if there's no categoryId on the admin account of the user, continue showing all the self assessments.

### Screenshots
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/661d6793-6172-4888-8b6a-e5fb2acefe9e">
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/978ef244-1e7a-4b44-8c28-a37dda93c83d">
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/87251269-a00e-4f13-a0bc-8b4b91ea7df4">


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4880]: https://hee-tis.atlassian.net/browse/TD-4880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ