### PR TITLE
Prevent administrators from viewing Activity Delegates for self assessments in a category that doesn't match their own

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -136,7 +136,8 @@ namespace DigitalLearningSolutions.Data.DataServices
 
         public IEnumerable<CourseStatistics> GetDelegateCourseStatisticsAtCentre(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
 
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive);
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive, int? categoryId);
+
         bool IsSelfEnrollmentAllowed(int customisationId);
         Customisation? GetCourse(int customisationId);
     }
@@ -541,9 +542,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                         new { candidateAssessmentId, enrolmentMethodId, completeByDateDynamic }
                     );
             }
-
             if (candidateAssessmentId > 1 && supervisorDelegateId !=0)
-
             {
                 string sqlQuery = $@"
                 BEGIN TRANSACTION
@@ -1976,7 +1975,7 @@ namespace DigitalLearningSolutions.Data.DataServices
             return courseStatistics;
         }
 
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive)
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessmentStatisticsAtCentre(string searchString, int centreId, string categoryName, string isActive, int? categoryId)
         {
             string assessmentStatisticsSelectQuery = $@"SELECT
                         sa.Name AS Name,
@@ -2006,11 +2005,12 @@ namespace DigitalLearningSolutions.Data.DataServices
                         WHERE csa.CentreID= @centreId
                                 AND sa.[Name] LIKE '%' + @searchString + '%'
 		                        AND ((@categoryName = 'Any') OR (cc.CategoryName = @categoryName))
+                                AND (ISNULL(@categoryId, 0) = 0 OR sa.CategoryID = @categoryId)
 		                        AND ((@isActive = 'Any') OR (@isActive = 'true' AND  sa.ArchivedDate IS NULL) OR (@isActive = 'false' AND sa.ArchivedDate IS NOT NULL))
                                 ";
 
             IEnumerable<DelegateAssessmentStatistics> delegateAssessmentStatistics = connection.Query<DelegateAssessmentStatistics>(assessmentStatisticsSelectQuery,
-                new { searchString, centreId, categoryName, isActive }, commandTimeout: 3000);
+                new { searchString, centreId, categoryName, isActive, categoryId }, commandTimeout: 3000);
             return delegateAssessmentStatistics;
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -244,7 +244,7 @@
 
                 WHERE sa.ID = @selfAssessmentId 
                 AND da.CentreID = @centreID AND csa.CentreID = @centreID
-                AND (ca.RemovedDate IS NULL) AND ( aaEnrolledBy.CategoryID IS NULL OR sa.CategoryID = aaEnrolledBy.CategoryID)
+                AND (ca.RemovedDate IS NULL)
                 AND ( u.FirstName + ' ' + u.LastName + ' ' + COALESCE(ucd.Email, u.PrimaryEmail) + ' ' + COALESCE(da.CandidateNumber, '') LIKE N'%' + @searchString + N'%')
                 AND ((@isDelegateActive IS NULL) OR (@isDelegateActive = 1 AND (da.Active = 1)) OR (@isDelegateActive = 0 AND (da.Active = 0)))
 				AND ((@removed IS NULL) OR (@removed = 1 AND (ca.RemovedDate IS NOT NULL)) OR (@removed = 0 AND (ca.RemovedDate IS NULL)))

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -172,6 +172,7 @@
         bool IsUnsupervisedSelfAssessment(int selfAssessmentId);
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
+        int GetSelfAssessmentCategoryId(int selfAssessmentId);
     }
 
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
@@ -759,6 +760,14 @@
 	                        WHERE (CAOC.IncludedInSelfAssessment = 1)",
                         new { selfAssessmentId, delegateUserId }
                     );
+        }
+
+        public int GetSelfAssessmentCategoryId(int selfAssessmentId)
+        {
+            return connection.ExecuteScalar<int>(
+                @"SELECT CategoryID FROM SelfAssessments WHERE ID = @selfAssessmentId",
+                new { selfAssessmentId }
+            );
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -95,7 +95,7 @@
             var selfAssessmentDelegate = new SelfAssessmentDelegate(6, "Lname");
 
             A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentDelegatesPerPage("", 0, 10, "SearchableName", "Ascending",
-                6, UserCentreId, null, null, null, null))
+                6, UserCentreId, null, null, null, null, null))
                 .Returns((new SelfAssessmentDelegatesData(
                         new List<SelfAssessmentDelegate> { selfAssessmentDelegate }
                     ), 1)
@@ -137,7 +137,7 @@
             var selfAssessmentDelegate = new SelfAssessmentDelegate(6, "Lname");
 
             A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentDelegatesPerPage("", 0, 10, "SearchableName", "Ascending",
-                10, UserCentreId, null, null, null, null))
+                10, UserCentreId, null, null, null, null, null))
                 .Returns((new SelfAssessmentDelegatesData(
                         new List<SelfAssessmentDelegate> { selfAssessmentDelegate }
                     ), 0)
@@ -147,8 +147,7 @@
             var result = controller.Index(null, 10);
 
             // Then
-            result.Should().BeViewResult().ModelAs<ActivityDelegatesViewModel>()
-            .DelegatesDetails?.Delegates?.Should().BeEmpty();
+            result.Should().BeRedirectToActionResult();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -23,6 +23,7 @@
     public class CourseDelegatesControllerTests
     {
         private const int UserCentreId = 3;
+        private const int selfAssessmentId = 3;
         private ActivityDelegatesController controller = null!;
         private ICourseDelegatesDownloadFileService courseDelegatesDownloadFileService = null!;
         private ICourseDelegatesService courseDelegatesService = null!;
@@ -123,7 +124,7 @@
                 );
 
             // When
-            var result = controller.Index(2);
+            var result = controller.Index(2, selfAssessmentId);
 
             // Then
             result.Should().BeNotFoundResult();
@@ -207,7 +208,7 @@
                 );
 
             // When
-            var result = courseDelegatesController.Index(customisationId);
+            var result = courseDelegatesController.Index(customisationId, selfAssessmentId);
 
             // Then
             using (new AssertionScope())

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateCoursesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DelegateCoursesControllerTests.cs
@@ -99,7 +99,9 @@
                 var delegateCourses = Builder<CourseStatisticsWithAdminFieldResponseCounts>.CreateListOfSize(5).Build();
                 A.CallTo(() => courseService.GetDelegateCourses(string.Empty, 1, 1, true, true, string.Empty, string.Empty, string.Empty, string.Empty)).Returns(delegateCourses);
 
-                A.CallTo(() => courseService.GetDelegateAssessments(A<string>._, A<int>._, A<string>._, A<string>._)).MustHaveHappened();
+
+                var delegateSelfAssessments = Builder<DelegateAssessmentStatistics>.CreateListOfSize(5).Build();
+                A.CallTo(() => courseService.GetDelegateAssessments(A<string>._, A<int>._, A<string>._, A<string>._, A<int>._)).Returns(delegateSelfAssessments);
                 A.CallTo(
                     () => paginateService.Paginate(A<IEnumerable<CourseStatistics>>._,
                          A<int>._,

--- a/DigitalLearningSolutions.Web.Tests/Services/CourseServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/CourseServiceTests.cs
@@ -982,15 +982,15 @@
         {
             // Given
             var delegateAssessments = Builder<DelegateAssessmentStatistics>.CreateListOfSize(5).Build();
-            A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(string.Empty, 1, string.Empty, string.Empty)).Returns(delegateAssessments);
+            A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(string.Empty, 1, string.Empty, string.Empty, 1)).Returns(delegateAssessments);
 
             // When
-            var result = courseService.GetDelegateAssessments(string.Empty, 1, string.Empty, string.Empty);
+            var result = courseService.GetDelegateAssessments(string.Empty, 1, string.Empty, string.Empty, 1);
 
             // Then
             using (new AssertionScope())
             {
-                A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(string.Empty, 1, string.Empty, string.Empty))
+                A.CallTo(() => courseDataService.GetDelegateAssessmentStatisticsAtCentre(string.Empty, 1, string.Empty, string.Empty, 1))
                     .MustHaveHappenedOnceExactly();
                 result.Count().Should().BeGreaterOrEqualTo(0);
             }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -131,6 +131,12 @@
 
             var centreId = User.GetCentreIdKnownNotNull();
             var adminCategoryId = User.GetAdminCategoryId();
+            var selfAssessmentCategoryId = selfAssessmentService.GetSelfAssessmentCategoryId((int)selfAssessmentId);
+
+            if (adminCategoryId > 0 && adminCategoryId != selfAssessmentCategoryId)
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            }
 
             bool? isDelegateActive, isProgressLocked, removed, hasCompleted, submitted, signedOff;
             isDelegateActive = isProgressLocked = removed = hasCompleted = submitted = signedOff = null;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateCoursesController.cs
@@ -156,13 +156,13 @@
             {
                 delegateActivities = courseService.GetDelegateCourses(searchString, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
                 if (courseTopic == "Any" && hasAdminFields == "Any")
-                    delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+                    delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive, categoryId);
             }
 
             if (isCourse == "true")
                 delegateActivities = courseService.GetDelegateCourses(searchString ?? string.Empty, centreId, categoryId, true, null, isActive, categoryName, courseTopic, hasAdminFields).ToList();
             if (isSelfAssessment == "true" && courseTopic == "Any" && hasAdminFields == "Any")
-                delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+                delegateAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive, categoryId);
 
             delegateAssessments = UpdateCompletedCount(delegateAssessments);
 

--- a/DigitalLearningSolutions.Web/Services/CourseDelegatesDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseDelegatesDownloadFileService.cs
@@ -227,12 +227,12 @@
             {
                 courses = GetCoursesToExport(centreId, adminCategoryId, searchString, sortBy, filterString, sortDirection);
                 if (courseTopic == "Any" && hasAdminFields == "Any")
-                    selfAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+                    selfAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive, adminCategoryId);
             }
             if (isCourse == "true")
                 courses = GetCoursesToExport(centreId, adminCategoryId, searchString, sortBy, filterString, sortDirection);
             if (isSelfAssessment == "true" && courseTopic == "Any" && hasAdminFields == "Any")
-                selfAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive);
+                selfAssessments = courseService.GetDelegateAssessments(searchString, centreId, categoryName, isActive, adminCategoryId);
 
             if (selfAssessments.Any())
             {

--- a/DigitalLearningSolutions.Web/Services/CourseService.cs
+++ b/DigitalLearningSolutions.Web/Services/CourseService.cs
@@ -120,7 +120,7 @@
            string isActive, string categoryName, string courseTopic, string hasAdminFields);
 
         public IEnumerable<CourseStatisticsWithAdminFieldResponseCounts> GetDelegateCourses(string searchString, int centreId, int? categoryId, bool allCentreCourses, bool? hideInLearnerPortal, string isActive, string categoryName, string courseTopic, string hasAdminFields);
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive);
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive, int? categoryId);
         IEnumerable<AvailableCourse> GetAvailableCourses(int delegateId, int? centreId, int categoryId);
         bool IsCourseCompleted(int candidateId, int customisationId);
         bool IsCourseCompleted(int candidateId, int customisationId, int progressID);
@@ -563,9 +563,9 @@
             );
         }
 
-        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive)
+        public IEnumerable<DelegateAssessmentStatistics> GetDelegateAssessments(string searchString, int centreId, string categoryName, string isActive, int? categoryId)
         {
-            return courseDataService.GetDelegateAssessmentStatisticsAtCentre(searchString, centreId, categoryName, isActive);
+            return courseDataService.GetDelegateAssessmentStatisticsAtCentre(searchString, centreId, categoryName, isActive, categoryId);
         }
 
         public IEnumerable<AvailableCourse> GetAvailableCourses(int delegateId, int? centreId, int categoryId)

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -128,8 +128,8 @@
         );
 
         void RemoveEnrolment(int selfAssessmentId, int delegateUserId);
-        public (SelfAssessmentDelegatesData, int) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
+        public (SelfAssessmentDelegatesData, int?) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int? adminCategoryId);
         public SelfAssessmentDelegatesData GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff);
         public int GetSelfAssessmentActivityDelegatesExportCount(string searchString, string sortBy, string sortDirection,
@@ -448,9 +448,18 @@
             return selfAssessmentDataService.GetSelfAssessmentNameById(selfAssessmentId);
         }
 
-        public (SelfAssessmentDelegatesData, int) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff)
+        public (SelfAssessmentDelegatesData, int?) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int? adminCategoryId)
         {
+
+            var selfAssessmentCategoryId = selfAssessmentDataService.GetSelfAssessmentCategoryId((int)selfAssessmentId);
+
+            if (adminCategoryId > 0  && adminCategoryId != selfAssessmentCategoryId)
+            {
+                // return null variants of the object when the categoryID mismatches 
+                return (new SelfAssessmentDelegatesData(), null);      
+            }
+
             (var delegateselfAssessments, int resultCount) = selfAssessmentDataService.GetSelfAssessmentDelegates(searchString, offSet, itemsPerPage, sortBy, sortDirection,
             selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
 

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -149,6 +149,7 @@
         IEnumerable<CandidateAssessment> GetCandidateAssessments(int delegateUserId, int selfAssessmentId);
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
+        public int GetSelfAssessmentCategoryId(int selfAssessmentId);
 
     }
 
@@ -556,6 +557,11 @@
         public bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId)
         {
             return selfAssessmentDataService.HasMinimumOptionalCompetencies(selfAssessmentId, delegateUserId);
+        }
+
+        public int GetSelfAssessmentCategoryId(int selfAssessmentId)
+        {
+            return selfAssessmentDataService.GetSelfAssessmentCategoryId(selfAssessmentId);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-4880](https://hee-tis.atlassian.net/browse/TD-4880)

### Description
Added a check for the categoryId of the admin users while fetching the self assessments, making sure we only pull the self assessments that matches the categoryId on the admin account of the user, also added an Unauthorized check when anyone tries to manipulate the self assessment delegates using the query string URL being opened.
If there's a categoryId on the admin account of the user, then show self assessments that are specific to the categoryId, if there's no categoryId on the admin account of the user, continue showing all the self assessments.

### Screenshots
When categoryId is set to null on the admin account, the user can see all the self assessments and can access delegates from all the self assessments. 
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/0ce68184-e870-4383-aa90-4ee41a87255f">

When categoryid has  a value on the admin account, the user can only see the self assessments with that specific categoryID.
In the below example categoryId is set to 34 and it has only 5 assessments that have the same categoryId on them. 
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/3d7960cb-8d73-45e0-97e6-49b25db209fa">

If the user tries to manipulate the URL and passess a different selfAssessmentId in the querystring parameter and that self assessment has a different categoryId on it which doesn't match with the one on the user's admin account then show an Unauthorised page.
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/d95ab940-4cf7-4038-a744-53b9555d17dd">

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4880]: https://hee-tis.atlassian.net/browse/TD-4880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ