### PR TITLE
TD-4950 Limits result sets by self assessment structure rather than self assessment ID in results table

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202411120903_CreateOrAlterGetOtherCentresForSelfAssessmentFunction.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202411120903_CreateOrAlterGetOtherCentresForSelfAssessmentFunction.cs
@@ -1,0 +1,15 @@
+﻿
+
+namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202411120903)]
+    public class CreateOrAlterGetOtherCentresForSelfAssessmentFunction : ForwardOnlyMigration
+    {
+        public override void Up()
+        {
+            Execute.Sql(Properties.Resources.TD_4950_dboGetOtherCentresForSelfAssessmentCreateOrAlter);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.Designer.cs
@@ -2288,6 +2288,29 @@ namespace DigitalLearningSolutions.Data.Migrations.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /****** Object:  UserDefinedFunction [dbo].[GetOtherCentresForSelfAssessment]    Script Date: 12/11/2024 08:47:08 ******/
+        ///SET ANSI_NULLS ON
+        ///GO
+        ///
+        ///SET QUOTED_IDENTIFIER ON
+        ///GO
+        ///
+        ///-- =============================================
+        ///-- Author:		Kevin Whittaker
+        ///-- Create date: 22/01/2024
+        ///-- Description:	Gets a comma separated list of other centres for a user self assessment
+        ///-- =============================================
+        ///CREATE OR ALTER FUNCTION [dbo].[GetOtherCentresForSelfAssessment]
+        ///(
+        ///	-- Add the para [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TD_4950_dboGetOtherCentresForSelfAssessmentCreateOrAlter {
+            get {
+                return ResourceManager.GetString("TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /****** Object:  StoredProcedure [dbo].[GetActiveAvailableCustomisationsForCentreFiltered_V6]    Script Date: 29/09/2022 19:11:04 ******/
         ///SET ANSI_NULLS ON
         ///GO

--- a/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
+++ b/DigitalLearningSolutions.Data.Migrations/Properties/Resources.resx
@@ -125,22 +125,22 @@
     <value>..\Scripts\CreateOrAlterReorderFrameworkCompetenciesAndGroupsSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_106_CreateOrAlterInsertCustomisation_V3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-106-CreateOrAlterInsertCustomisation_V3.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-106-CreateOrAlterInsertCustomisation_V3.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_106_DropInsertCustomisation_V3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-106-DropInsertCustomisation_V3.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-106-DropInsertCustomisation_V3.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_133_AdjustScoresForFilteredSP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-133-AdjustScoresForFilteredSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-133-AdjustScoresForFilteredSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_133_UnAdjustScoresForFilteredSP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-133-UnAdjustScoresForFilteredSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-133-UnAdjustScoresForFilteredSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_153_DropFilteredFunctionTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-153-DropFilteredFunctionTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-153-DropFilteredFunctionTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_153_DropFilteredSPFixes" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-153-DropFilteredSPFixes.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-153-DropFilteredSPFixes.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_153_FilteredFunctionTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\DLSV2-153-FilteredFunctionTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -176,85 +176,85 @@
     <value>..\Scripts\DLSV2-379-ReorderCompetencyAssessmentQuestionsSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="DLSV2_581_GetActiveAvailableCustomisationsForCentreFiltered_V6" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-581-GetActiveAvailableCustomisationsForCentreFiltered_V6.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-581-GetActiveAvailableCustomisationsForCentreFiltered_V6.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_95_AddSystemVersioning" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-95_AddSystemVersioning.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-95_AddSystemVersioning.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DLSV2_95_RemoveSystemVersioning" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DLSV2-95_RemoveSystemVersioning.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DLSV2-95_RemoveSystemVersioning.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DropActiveAvailableV6" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DropActiveAvailableV6.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DropActiveAvailableV6.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DropApplyLPDefaultsSPChanges" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\DropApplyLPDefaultsSPChanges.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="DropFilteredSPs" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DropFilteredSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DropFilteredSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DropGetActiveAvailableV5" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DropGetActiveAvailableV5.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DropGetActiveAvailableV5.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="DropReorderFrameworkCompetenciesAndGroupsSPs" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\DropReorderFrameworkCompetenciesAndGroupsSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\DropReorderFrameworkCompetenciesAndGroupsSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="FilteredSPs" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\FilteredSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="GetActiveAvailableV5" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\GetActiveAvailableV5.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\GetActiveAvailableV5.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="HEEDLS_667_GetActiveAvailableCustomisationsForCentreFiltered_V5_Signposting_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\HEEDLS-667-GetActiveAvailableCustomisationsForCentreFiltered_V5-Signposting-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="HEEDLS_667_GetActiveAvailableCustomisationsForCentreFiltered_V5_Signposting_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\HEEDLS-667-GetActiveAvailableCustomisationsForCentreFiltered_V5-Signposting-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\HEEDLS-667-GetActiveAvailableCustomisationsForCentreFiltered_V5-Signposting-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="UAR-831-CreateViewsForAdminUsersAndCandidatesTables-UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\UAR-831-CreateViewsForAdminUsersAndCandidatesTables-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\UAR-831-CreateViewsForAdminUsersAndCandidatesTables-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="UAR-831-CreateViewsForAdminUsersAndCandidatesTables-DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\UAR-831-CreateViewsForAdminUsersAndCandidatesTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\UAR-831-CreateViewsForAdminUsersAndCandidatesTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="UAR_858_SnapshotData_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\UAR-858-SnapshotData-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\UAR-858-SnapshotData-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="UAR_859_PopulateUsersTableFromAccountsTables_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\UAR-859-PopulateUsersTableFromAccountsTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\UAR-859-PopulateUsersTableFromAccountsTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD-786-GetSelfRegisteredFlag_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-786-GetSelfRegisteredFlag_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-786-GetSelfRegisteredFlag_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD-786-GetSelfRegisteredFlag_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-786-GetSelfRegisteredFlag_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-786-GetSelfRegisteredFlag_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_1043_getactivitiesforenrolment_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\td-1043-getactivitiesforenrolment_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\td-1043-getactivitiesforenrolment_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_1043_getactivitiesforenrolment" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\td-1043-getactivitiesforenrolment.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\td-1043-getactivitiesforenrolment.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_264_alterviewadminusersaddcentrename_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\td_264_alterviewadminusersaddcentrename_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\td_264_alterviewadminusersaddcentrename_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_264_alterviewadminusersaddcentrename_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\td_264_alterviewadminusersaddcentrename_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\td_264_alterviewadminusersaddcentrename_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_1131_alterviewcandidatesadduserid_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\td_1131_alterviewcandidatesadduserid_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\td_1131_alterviewcandidatesadduserid_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_1131_alterviewcandidatesadduserid_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\td_1131_alterviewcandidatesadduserid_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\td_1131_alterviewcandidatesadduserid_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="CookiePolicy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\CookiePolicy.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\CookiePolicy.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1220_AddSystemVersioning_SelfAssessmentResultSupervisorVerifications" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1220-AddSystemVersioning_SelfAssessmentResultSupervisorVerifications.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1220-AddSystemVersioning_SelfAssessmentResultSupervisorVerifications.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1220_RemoveSystemVersioning_SelfAssessmentResultSupervisorVerifications" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1220-RemoveSystemVersioning_SelfAssessmentResultSupervisorVerifications.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1220-RemoveSystemVersioning_SelfAssessmentResultSupervisorVerifications.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="td_1610_update_getactivitiesfordelegateenrolment_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\td-1610-update_getactivitiesfordelegateenrolment_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -263,10 +263,10 @@
     <value>..\Scripts\td-1610-update_getactivitiesfordelegateenrolment_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_1766_GetActivitiesForDelegateEnrolmentTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1766-GetActivitiesForDelegateEnrolmentTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1766-GetActivitiesForDelegateEnrolmentTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1766_GetActivitiesForDelegateEnrolmentTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1766-GetActivitiesForDelegateEnrolmentTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1766-GetActivitiesForDelegateEnrolmentTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1913_AlterGroupCustomisation_Add_V2_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-1913-AlterGroupCustomisation_Add_V2_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -275,43 +275,43 @@
     <value>..\Scripts\TD-1913-AlterGroupCustomisation_Add_V2_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_2117_CreatePopulateReportSelfAssessmentActivityLog_SP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2117-CreatePopulateReportSelfAssessmentActivityLog-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1766_GetCurrentCoursesForCandidateTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1766-GetCurrentCoursesForCandidateTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1766-GetCurrentCoursesForCandidateTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1766_GetCurrentCoursesForCandidateTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1766-GetCurrentCoursesForCandidateTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1766-GetCurrentCoursesForCandidateTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2094_GetActivitiesForDelegateEnrolmentDelegateStatusPropertyTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2094-GetActivitiesForDelegateEnrolmentDelegateStatusPropertyTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2094-GetActivitiesForDelegateEnrolmentDelegateStatusPropertyTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2094_GetActivitiesForDelegateEnrolmentDelegateStatusPropertyTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2094-GetActivitiesForDelegateEnrolmentDelegateStatusPropertyTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2094-GetActivitiesForDelegateEnrolmentDelegateStatusPropertyTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TermsAndConditionsOldrecord" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TermsAndConditionsOldrecord.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TermsAndConditionsOldrecord.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1766_GetCompletedCoursesForCandidateTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1766-GetCompletedCoursesForCandidateTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1766-GetCompletedCoursesForCandidateTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1766_GetCompletedCoursesForCandidateTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-1766-GetCompletedCoursesForCandidateTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-1766-GetCompletedCoursesForCandidateTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TermsConditions" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TermsConditions.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TermsConditions.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1943_CookiePolicyContentHtmlOldRecord" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD_1943_CookiePolicyContentHtmlOldRecord.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD_1943_CookiePolicyContentHtmlOldRecord.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_1943_CookiesPolicy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD_1943_CookiesPolicy.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD_1943_CookiesPolicy.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2508_GetActivitiesForDelegateEnrolmentHiddenInLearningPortalTweak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2508-GetActivitiesForDelegateEnrolmentHiddenInLearningPortalTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2508-GetActivitiesForDelegateEnrolmentHiddenInLearningPortalTweak.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2508_GetActivitiesForDelegateEnrolmentHiddenInLearningPortalTweak_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2508-GetActivitiesForDelegateEnrolmentHiddenInLearningPortalTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2508-GetActivitiesForDelegateEnrolmentHiddenInLearningPortalTweak_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3000_CheckDelegateStatusForCustomisationFix_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-3000-CheckDelegateStatusForCustomisationFix_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -320,16 +320,16 @@
     <value>..\Scripts\TD-3000-CheckDelegateStatusForCustomisationFix_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_3187_CreateGetAssessmentResultsByDelegate_SP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-3187-CreateGetAssessmentResultsByDelegate-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-3187-CreateGetAssessmentResultsByDelegate-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3187_CreateGetCandidateAssessmentResultsById_SP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-3187-CreateGetCandidateAssessmentResultsById-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-3187-CreateGetCandidateAssessmentResultsById-SP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3190_SendOneMonthSelfAssessmentOverdueRemindersSP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-3190-SendOneMonthSelfAssessmentOverdueRemindersSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-3190-SendOneMonthSelfAssessmentOverdueRemindersSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3190_SendOneMonthSelfAssessmentTBCRemindersSP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-3190-SendOneMonthSelfAssessmentTBCRemindersSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-3190-SendOneMonthSelfAssessmentTBCRemindersSP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3190_FixSelfAssessmentReminderQueriesSP_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-3190-FixSelfAssessmentReminderQueriesSP_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -347,22 +347,22 @@
     <value>..\Scripts\TD-2481-Update_uspReturnSectionsForCandCust_V2_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_2036_SwitchOffPeriodFields_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2036-SwitchOffPeriodFields-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2036-SwitchOffPeriodFields-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2036_SwitchOffPeriodFields_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2036-SwitchOffPeriodFields-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2036-SwitchOffPeriodFields-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2036_SwitchSystemVersioningOffAllTables_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2036-SwitchSystemVersioningOffAllTables-DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3629_DeleteDeprecatedTables_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-3629-DeleteDeprecatedTables_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-3629-DeleteDeprecatedTables_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_2036_SwitchSystemVersioningOffAllTables_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-2036-SwitchSystemVersioningOffAllTables-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-2036-SwitchSystemVersioningOffAllTables-UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3664_RestoreDroppedSPs" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Scripts\TD-3664-RestoreDroppedSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Scripts\TD-3664-RestoreDroppedSPs.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3623_Alter_uspCreateProgressRecordWithCompleteWithinMonthsSPs_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-3623-Alter_uspCreateProgressRecordWithCompleteWithinMonthsSPs_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -377,16 +377,16 @@
     <value>..\Scripts\TD-4015-GetCompletedCoursesForCandidateFix_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_3671_Alter_CheckDelegateStatusForCustomisation_func_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD_3671_Alter_CheckDelegateStatusForCustomisation_func_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD_3671_Alter_CheckDelegateStatusForCustomisation_func_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3671_Alter_GetCurrentCoursesForCandidate_V2_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-3671-Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-3671-Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3671_Alter_CheckDelegateStatusForCustomisation_func_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD_3671_Alter_CheckDelegateStatusForCustomisation_func_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD_3671_Alter_CheckDelegateStatusForCustomisation_func_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_3671_Alter_GetCurrentCoursesForCandidate_V2_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-3671-Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-3671-Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4223_Alter_uspCreateProgressRecord_V3_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-4223-Alter_uspCreateProgressRecord_V3_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -407,10 +407,10 @@
     <value>..\Scripts\TD-4223-Alter_GroupCustomisation_Add_V2_Up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-4243_Alter_GetCurrentCoursesForCandidate_V2_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4436_Alter_uspCreateProgressRecord_V3_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-4436-Alter_uspCreateProgressRecord_V3_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -419,16 +419,16 @@
     <value>..\Scripts\TD-4436-Alter_uspCreateProgressRecord_V3_Up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
   <data name="TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4243_Alter_GetActivitiesForDelegateEnrolment_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-4243_Alter_GetActivitiesForDelegateEnrolment_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4243_Alter_GetCompletedCoursesForCandidate_proc_down" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-4243_Alter_GetCompletedCoursesForCandidate_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-4243_Alter_GetCompletedCoursesForCandidate_proc_down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4243_Alter_GetCompletedCoursesForCandidate_proc_up" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TD-4243_Alter_GetCompletedCoursesForCandidate_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\TD-4243_Alter_GetCompletedCoursesForCandidate_proc_up.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
   </data>
   <data name="TD_4436_Alter_GroupCustomisation_Add_V2_UpdateCompleteBy_Supervisor_Down" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD-4436-Alter_GroupCustomisation_Add_V2_UpdateCompleteBy_Supervisor_Down.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
@@ -448,10 +448,13 @@
   <data name="TD_4634_Alter_GetCompletedCoursesForCandidate_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scripts\TD_4634_Alter_GetCompletedCoursesForCandidate_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
   </data>
-    <data name="TD_4950_Alter_GetAssessmentResultsByDelegate_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>..\Scripts\TD_4950_Alter_GetAssessmentResultsByDelegate_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
-    </data>
-    <data name="TD_4950_Alter_GetAssessmentResultsByDelegate_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>..\Scripts\TD_4950_Alter_GetAssessmentResultsByDelegate_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
-    </data>
+  <data name="TD_4950_Alter_GetAssessmentResultsByDelegate_DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD_4950_Alter_GetAssessmentResultsByDelegate_DOWN.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
+  </data>
+  <data name="TD_4950_Alter_GetAssessmentResultsByDelegate_UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Scripts\TD_4950_Alter_GetAssessmentResultsByDelegate_UP.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-16</value>
+  </data>
+  <data name="TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/DigitalLearningSolutions.Data.Migrations/Resources/TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Resources/TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter.sql
@@ -1,0 +1,39 @@
+/****** Object:  UserDefinedFunction [dbo].[GetOtherCentresForSelfAssessment]    Script Date: 12/11/2024 08:47:08 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 22/01/2024
+-- Description:	Gets a comma separated list of other centres for a user self assessment
+-- =============================================
+CREATE OR ALTER FUNCTION [dbo].[GetOtherCentresForSelfAssessment]
+(
+	-- Add the parameters for the function here
+	 @userId int,
+	 @selfAssessmentId int,
+	 @excludeCentreId int
+)
+RETURNS nvarchar(MAX)
+AS
+BEGIN
+	-- Declare the return variable here
+	DECLARE @ResultVar nvarchar(MAX);
+	-- Add the T-SQL statements to compute the return value here
+SELECT @ResultVar = COALESCE(@ResultVar + ', ','')+ Q1.CentreName
+	FROM  (SELECT DISTINCT c.CentreName
+FROM   Users AS u INNER JOIN
+             DelegateAccounts AS da ON u.ID = da.UserID INNER JOIN
+             Centres AS c ON da.CentreID = c.CentreID INNER JOIN
+             CentreSelfAssessments AS csa ON c.CentreID = csa.CentreID
+WHERE (u.ID = @userId) AND (da.Active = 1) AND (da.Approved = 1) AND (csa.SelfAssessmentID = @selfAssessmentId) AND (c.CentreID <> @excludeCentreId)) AS Q1
+	-- Return the result of the function
+	RETURN @ResultVar
+
+END
+GO
+
+

--- a/DigitalLearningSolutions.Data.Migrations/Scripts/TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter.sql
+++ b/DigitalLearningSolutions.Data.Migrations/Scripts/TD-4950-dboGetOtherCentresForSelfAssessmentCreateOrAlter.sql
@@ -1,0 +1,39 @@
+/****** Object:  UserDefinedFunction [dbo].[GetOtherCentresForSelfAssessment]    Script Date: 12/11/2024 08:47:08 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- =============================================
+-- Author:		Kevin Whittaker
+-- Create date: 22/01/2024
+-- Description:	Gets a comma separated list of other centres for a user self assessment
+-- =============================================
+CREATE OR ALTER FUNCTION [dbo].[GetOtherCentresForSelfAssessment]
+(
+	-- Add the parameters for the function here
+	 @userId int,
+	 @selfAssessmentId int,
+	 @excludeCentreId int
+)
+RETURNS nvarchar(MAX)
+AS
+BEGIN
+	-- Declare the return variable here
+	DECLARE @ResultVar nvarchar(MAX);
+	-- Add the T-SQL statements to compute the return value here
+SELECT @ResultVar = COALESCE(@ResultVar + ', ','')+ Q1.CentreName
+	FROM  (SELECT DISTINCT c.CentreName
+FROM   Users AS u INNER JOIN
+             DelegateAccounts AS da ON u.ID = da.UserID INNER JOIN
+             Centres AS c ON da.CentreID = c.CentreID INNER JOIN
+             CentreSelfAssessments AS csa ON c.CentreID = csa.CentreID
+WHERE (u.ID = @userId) AND (da.Active = 1) AND (da.Approved = 1) AND (csa.SelfAssessmentID = @selfAssessmentId) AND (c.CentreID <> @excludeCentreId)) AS Q1
+	-- Return the result of the function
+	RETURN @ResultVar
+
+END
+GO
+
+

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
@@ -128,7 +128,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.DelegateUserID  = @delegateUserID)
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM CandidateAssessments ca
                 INNER JOIN SelfAssessmentResults s
-                    ON s.DelegateUserID = ca.DelegateUserID AND s.SelfAssessmentID = ca.SelfAssessmentID           
+                    ON s.DelegateUserID = ca.DelegateUserID INNER JOIN SelfAssessmentStructure AS sas ON s.CompetencyID = sas.CompetencyID AND sas.SelfAssessmentID = @candidateAssessmentId           
                 LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
                     ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
                 LEFT OUTER JOIN CandidateAssessmentSupervisors AS cas 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
@@ -20,7 +20,7 @@
                  FROM    SelfAssessmentStructure AS sas1 INNER JOIN
                               CandidateAssessments AS ca1 ON sas1.SelfAssessmentID = ca1.SelfAssessmentID INNER JOIN
                               CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID LEFT OUTER JOIN
-                              SelfAssessmentResults AS sar1 ON sar1.SelfAssessmentID =sas1.SelfAssessmentID and sar1.CompetencyID=sas1.CompetencyID AND sar1.AssessmentQuestionID = caq1.AssessmentQuestionID AND sar1.DelegateUserID = ca1.DelegateUserID LEFT OUTER JOIN
+                              SelfAssessmentResults AS sar1 ON sar1.CompetencyID=sas1.CompetencyID AND sar1.AssessmentQuestionID = caq1.AssessmentQuestionID AND sar1.DelegateUserID = ca1.DelegateUserID LEFT OUTER JOIN
                               CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                  WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) OR
                               (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (caoc1.IncludedInSelfAssessment = 1) OR

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -439,7 +439,7 @@
                      FROM   SelfAssessmentStructure AS sas1 INNER JOIN
              CandidateAssessments AS ca1 ON sas1.SelfAssessmentID = ca1.SelfAssessmentID INNER JOIN
              CompetencyAssessmentQuestions AS caq1 ON sas1.CompetencyID = caq1.CompetencyID LEFT OUTER JOIN
-             SelfAssessmentResults AS sar1 ON sar1.SelfAssessmentID =sas1.SelfAssessmentID and sar1.CompetencyID=sas1.CompetencyID AND sar1.AssessmentQuestionID = caq1.AssessmentQuestionID AND sar1.DelegateUserID = ca1.DelegateUserID
+             SelfAssessmentResults AS sar1 ON sar1.CompetencyID=sas1.CompetencyID AND sar1.AssessmentQuestionID = caq1.AssessmentQuestionID AND sar1.DelegateUserID = ca1.DelegateUserID
                  LEFT OUTER JOIN    CandidateAssessmentOptionalCompetencies AS caoc1 ON sas1.CompetencyID = caoc1.CompetencyID AND sas1.CompetencyGroupID = caoc1.CompetencyGroupID AND ca1.ID = caoc1.CandidateAssessmentID
                   WHERE (ca1.ID = ca.ID) AND (sas1.Optional = 0) AND (NOT (sar1.Result IS NULL)) OR
              (ca1.ID = ca.ID) AND (NOT (sar1.Result IS NULL)) AND (caoc1.IncludedInSelfAssessment = 1) OR

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -32,6 +32,7 @@
                     0 AS UserIsVerifier,
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM SelfAssessmentResults s
+                INNER JOIN SelfAssessmentStructure AS sas ON s.CompetencyID = sas.CompetencyID AND sas.SelfAssessmentID = @selfAssessmentId
                 LEFT OUTER JOIN DelegateAccounts AS da ON s.DelegateUserID = da.UserID
                 LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
                     ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
@@ -43,9 +44,8 @@
 					ON sd.SupervisorAdminID = adu.AdminID
                 LEFT OUTER JOIN CompetencyAssessmentQuestionRoleRequirements rr
                     ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID
-                        AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
+                        AND rr.SelfAssessmentID = @selfAssessmentId AND s.Result = rr.LevelValue
                 WHERE da.ID = @delegateId
-                AND s.SelfAssessmentID = @selfAssessmentId
             )";
 
         private const string SpecificAssessmentResults =
@@ -68,7 +68,8 @@
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM CandidateAssessments ca
                 INNER JOIN SelfAssessmentResults s
-                    ON s.DelegateUserID = ca.DelegateUserID AND s.SelfAssessmentID = ca.SelfAssessmentID
+                    ON s.DelegateUserID = ca.DelegateUserID
+                INNER JOIN SelfAssessmentStructure AS sas ON s.CompetencyID = sas.CompetencyID AND sas.SelfAssessmentID = ca.SelfAssessmentID
                 LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
                     ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
                 LEFT OUTER JOIN CandidateAssessmentSupervisors AS cas 
@@ -79,7 +80,7 @@
 						     ON sd.SupervisorAdminID = adu.AdminID
                 LEFT OUTER JOIN CompetencyAssessmentQuestionRoleRequirements rr
                     ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID
-                        AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
+                        AND rr.SelfAssessmentID = ca.SelfAssessmentID AND s.Result = rr.LevelValue
                 WHERE ca.ID = @candidateAssessmentId
             )";
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -187,33 +187,17 @@
         public SupervisorComment? GetSupervisorComments(int delegateUserId, int resultId)
         {
             return connection.Query<SupervisorComment>(
-                @"SELECT
-                    sar.AssessmentQuestionID,
-                    sea.Name,
-                    au.Forename + ' ' + au.Surname As SupervisorName,
-                    sasr.RoleName,
-                    sasv.Comments,
-                    sar.DelegateUserID,
-                    sar.CompetencyID,
-                    com.Name AS CompetencyName,
-                    sar.SelfAssessmentID,
-                    sasv.CandidateAssessmentSupervisorID,
-                    sasv.SelfAssessmentResultId,
-                    sasv.Verified,
-                    sar.ID,
-                    sstrc.CompetencyGroupID, 
-                    sea.Vocabulary,
-                    sasv.SignedOff,
-                    sea.ReviewerCommentsLabel
+                @"SELECT TOP (1) sar.AssessmentQuestionID, sea.Name, au.Forename + ' ' + au.Surname AS SupervisorName, sasr.RoleName, sasv.Comments, sar.DelegateUserID, sar.CompetencyID, com.Name AS CompetencyName, sar.SelfAssessmentID, sasv.CandidateAssessmentSupervisorID, 
+                        sasv.SelfAssessmentResultId, sasv.Verified, sar.ID, sstrc.CompetencyGroupID, sea.Vocabulary, sasv.SignedOff, sea.ReviewerCommentsLabel
                     FROM   SelfAssessmentResultSupervisorVerifications AS sasv INNER JOIN
-                    SelfAssessmentResults AS sar ON sasv.SelfAssessmentResultId = sar.ID AND sasv.Superceded = 0 INNER JOIN
-                    SelfAssessments AS sea ON sar.SelfAssessmentID = sea.ID INNER JOIN
-                    SelfAssessmentStructure AS sstrc ON sar.CompetencyID = sstrc.CompetencyID INNER JOIN
-                    Competencies AS com ON sar.CompetencyID = com.ID INNER JOIN
-                    CandidateAssessmentSupervisors AS cas ON sasv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
-                    SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
-                    AdminUsers AS au ON sd.SupervisorAdminID = au.AdminID INNER JOIN
-                    SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
+                        SelfAssessmentResults AS sar ON sasv.SelfAssessmentResultId = sar.ID AND sasv.Superceded = 0 INNER JOIN
+                        SelfAssessmentStructure AS sstrc ON sar.CompetencyID = sstrc.CompetencyID INNER JOIN
+                        Competencies AS com ON sar.CompetencyID = com.ID INNER JOIN
+                        CandidateAssessmentSupervisors AS cas ON sasv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
+                        SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN
+                        AdminUsers AS au ON sd.SupervisorAdminID = au.AdminID INNER JOIN
+                        SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID INNER JOIN
+                        SelfAssessments AS sea ON sstrc.SelfAssessmentID = sea.ID
                     WHERE (sar.DelegateUserID = @delegateUserId) AND (sasv.SelfAssessmentResultId = @resultId)",
                 new { delegateUserId, resultId }
             ).FirstOrDefault();

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAsssessmentReportDataService.cs
@@ -52,10 +52,10 @@
                     		, CASE WHEN sv.Verified IS NOT NULL AND sv.SignedOff = 1 AND COALESCE (rr.LevelRAG, 0) = 3 THEN s.ID ELSE NULL END AS Confirmed
                     		, CASE WHEN sas.Optional = 1  THEN s.CompetencyID ELSE NULL END AS Optional
                     FROM   SelfAssessmentResults AS s LEFT OUTER JOIN
-                                 SelfAssessmentStructure AS sas ON s.SelfAssessmentID = sas.SelfAssessmentID AND s.CompetencyID = sas.CompetencyID LEFT OUTER JOIN
+                                 SelfAssessmentStructure AS sas ON sas.SelfAssessmentID = @selfAssessmentId AND s.CompetencyID = sas.CompetencyID LEFT OUTER JOIN
                                  SelfAssessmentResultSupervisorVerifications AS sv ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0 LEFT OUTER JOIN
-                                 CompetencyAssessmentQuestionRoleRequirements AS rr ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID AND s.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
-                    WHERE (s.SelfAssessmentID = @selfAssessmentId)
+                                 CompetencyAssessmentQuestionRoleRequirements AS rr ON s.CompetencyID = rr.CompetencyID AND s.AssessmentQuestionID = rr.AssessmentQuestionID AND sas.SelfAssessmentID = rr.SelfAssessmentID AND s.Result = rr.LevelValue
+                    WHERE (sas.SelfAssessmentID = @selfAssessmentId)
                                 )
                     SELECT 
                         sa.Name AS SelfAssessment


### PR DESCRIPTION
### JIRA link
[TD-4950](https://hee-tis.atlassian.net/browse/TD-4950)

### Description
Reworks the CompetencyDataService latest assessment result queries to join to SelfAssessmentStructure tables to determine which results to include instead of filtering by the SelfAssessmentID in the results table. This ensures that the results are returned regardless of whether the result was added in the self assessment that the user is working on.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4950]: https://hee-tis.atlassian.net/browse/TD-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ