### PR TITLE
TD-4950 Fixes to excel export and clear selection in self assessments

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentExportDataService.cs
@@ -128,7 +128,7 @@ WHERE (ca.ID = @candidateAssessmentId  AND ca.DelegateUserID  = @delegateUserID)
                     COALESCE (rr.LevelRAG, 0) AS ResultRAG
                 FROM CandidateAssessments ca
                 INNER JOIN SelfAssessmentResults s
-                    ON s.DelegateUserID = ca.DelegateUserID INNER JOIN SelfAssessmentStructure AS sas ON s.CompetencyID = sas.CompetencyID AND sas.SelfAssessmentID = @candidateAssessmentId           
+                    ON s.DelegateUserID = ca.DelegateUserID INNER JOIN SelfAssessmentStructure AS sas ON s.CompetencyID = sas.CompetencyID AND sas.SelfAssessmentID = s.SelfAssessmentID         
                 LEFT OUTER JOIN SelfAssessmentResultSupervisorVerifications AS sv
                     ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0
                 LEFT OUTER JOIN CandidateAssessmentSupervisors AS cas 

--- a/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
+++ b/DigitalLearningSolutions.Web/Scripts/learningPortal/selfAssessment.ts
@@ -1,3 +1,5 @@
+import * as Checkboxes from '../checkboxes';
+
 function onSliderUpdate(inputElement: HTMLInputElement) {
   const selectedRatio = parseInt(inputElement.value, 10) / parseInt(inputElement.max, 10);
   // eslint-disable-next-line no-param-reassign
@@ -13,3 +15,4 @@ inputs.forEach((e) => onSliderUpdate(e));
 inputs.forEach((e) => {
   e.addEventListener('change', () => onSliderUpdate(e));
 });
+Checkboxes.default.setUpSelectAndDeselectInGroupButtons();


### PR DESCRIPTION
### JIRA link
[TD-4950](https://hee-tis.atlassian.net/browse/TD-4950)

### Description
Fixes the query join in the export self assessment to Excel data method to ensure correct results are returned. Reinstates the clear selection JavaScript that was mistakenly removed in a previous PR. Other problems reported related to missing CompetencyAssessmentRolRequirements records for the duplicate self assessment which were addressed with a script run on UAT DB.

### Screenshots
![image](https://github.com/user-attachments/assets/45b961cb-89ec-4ff7-9000-798257630391)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
