### PR TITLE
TD-4395 'Enrolled' field label needs to change to 'First enrolled' same as on 'Delegate activities' for the self assessments

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_Dates.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_Dates.cshtml
@@ -6,7 +6,7 @@
 
 <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-        Enrolled
+        First enrolled
     </dt>
     <dd class="nhsuk-summary-list__value" data-name-for-sorting="started-date">
         @Model.StartedDate.ToShortDateString()

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCourseProgressDetailsWithStatusTags.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateCourseProgressDetailsWithStatusTags.cshtml
@@ -36,7 +36,7 @@
     </div>
     <div class="nhsuk-summary-list__row details-list-with-button__row">
         <dt class="nhsuk-summary-list__key">
-            Enrolled
+            First enrolled
         </dt>
         <dd class="nhsuk-summary-list__value" data-name-for-sorting="enrolled-date">
             @Model.Enrolled

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentProgressDetails.cshtml
@@ -5,7 +5,7 @@
 <dl class="nhsuk-summary-list details-list-with-button word-break">
     <div class="nhsuk-summary-list__row details-list-with-button__row">
         <dt class="nhsuk-summary-list__key">
-            Enrolled
+            First enrolled
         </dt>
         <dd class="nhsuk-summary-list__value" data-name-for-sorting="enrolled-date">
             @Model.StartedDate.ToString(DateHelper.StandardDateAndTimeFormat)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4395

### Description
I changed the enrolled label to First  enrolled   on the Dates partial view and the Index view of view delegate
### Screenshots
![image](https://github.com/user-attachments/assets/8a95b1b5-b9b4-40b5-af99-8faccac868e6)
![image](https://github.com/user-attachments/assets/9d431621-fc7e-4d6c-b3d9-fffc82d392fe)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
