### PR TITLE
TD-4406- Super Admin: Issue not showing the 'Admin' links for the centres when user account is reactivated on 'User centre roles' screen

### DIFF
--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Users/UserCentreAccounts.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Users/UserCentreAccounts.cshtml
@@ -52,11 +52,11 @@
                                 <td role="cell" class="nhsuk-table__cell choose-centre-td">
                                     <span class="nhsuk-table-responsive__heading">Roles: </span>
                                     <div class="centre-role-tags">
-                                        @if (centreRow.IsActiveAdmin)
+                                        @if (Model.UserEntity.AdminAccounts.Any())
                                         {
                                             foreach (var admin in Model.UserEntity.AdminAccounts)
                                             {
-                                                if (centreRow.CentreId==admin.CentreId)
+                                                if (centreRow.CentreId == admin.CentreId)
                                                 {
                                                     <a asp-action="RedirectToAdmin" asp-route-AdminId="@admin.Id">Admin</a>
                                                 }


### PR DESCRIPTION
### JIRA link
[_TD-4406_](https://hee-tis.atlassian.net/browse/TD-4406)

### Description

Added check if admin account exists.


### Screenshots

![image](https://github.com/user-attachments/assets/441ad8ea-d498-4cb1-84fd-2bc586623425)

![image](https://github.com/user-attachments/assets/a6f91540-eeb5-49e7-bbe5-e838f90b8521)

![image](https://github.com/user-attachments/assets/aefcd43b-ad35-4ae9-b707-9c5b3e001856)

![image](https://github.com/user-attachments/assets/f6b1e0fc-129e-43a3-a29b-e244d8a5fa6f)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
