### PR TITLE
TD-5028 Supervise - Remove staff member doesn't remove the supervisor (For Supervisor when added via 'Add myself to try self-assessment')

### DIFF
--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SupervisorDelegateViewModel.cs
@@ -47,6 +47,6 @@
         [DefaultValue(false)]
         public bool ConfirmedRemove { get; set; }
         public int SelfAssessmentCategory { get; set; }
-        public IEnumerable<SelectListItem> SelfAssessmentCategories { get; set; }
+        public IEnumerable<SelectListItem>? SelfAssessmentCategories { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5028

### Description
I check the validation attributes on the SupervisorDelegateViewModel properties. I ensure that all  properties of SupervisorDelegateViewModel are bound correctly in the RemoveSupervisorDelegateConfirmed action method

### Screenshots
![image](https://github.com/user-attachments/assets/d691df75-0c27-4fcb-967a-2817cb10a9f9)
![image](https://github.com/user-attachments/assets/f6996f57-d33f-4083-834b-84928ddad8b4)
![image](https://github.com/user-attachments/assets/f6dded02-a04a-4741-9e8c-2a2ec62f47c8)
![image](https://github.com/user-attachments/assets/8e8c600d-ba3f-40f3-adde-ef054eeed002)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
