### PR TITLE
TD-5058 Fix add similar competency 500 error

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -189,14 +189,10 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     FrameworkGroupId = frameworkCompetencyGroupId,
                     FrameworkCompetencyId = frameworkCompetencyId,
                     FrameworkConfig = detailFramework?.FrameworkConfig,
-                    Competency = new FrameworkCompetency()
-                    {
-                        Name = frameworkCompetency.Name,
-                        Description = frameworkCompetency.Description
-                    },
+                    Competency = frameworkCompetency,
                     MatchingSearchResults = matchingSearchResults.Count,
                     SameCompetency = similarItems,
-                    selectedFlagIds = selectedFlagIds.Any() ? selectedFlagIds.Select(a => a.ToString()).Aggregate((b, c) => b + "," + c) : string.Empty,
+                    selectedFlagIds = selectedFlagIds != null ? selectedFlagIds.Select(a => a.ToString()).Aggregate((b, c) => b + "," + c) : string.Empty
                 };
                 return View("Developer/SimilarCompetency", model);
             }


### PR DESCRIPTION
### JIRA link
TD-5058

### Description
When a new competency is added without any flags that has similar competencies, a 500 error was being thrown because the list of flags was null rather than empty. This change checks for none null rather than non-empty.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
