### PR TITLE
TD-4405- Issue with Custom prompts configured for the assessment questions on 'Frameworks' interface not showing correctly on the self assessment screens

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewCompetencySelfAsessment.cshtml
@@ -19,14 +19,14 @@
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
                 <li class="nhsuk-breadcrumb__item">
                     <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-                   asp-action="DelegateProfileAssessments"
-                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName</a>
+                       asp-action="DelegateProfileAssessments"
+                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">@Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName</a>
                 </li>
                 <li class="nhsuk-breadcrumb__item">
                     <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-                   asp-action="ReviewDelegateSelfAssessment"
-                   asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-                   asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
+                       asp-action="ReviewDelegateSelfAssessment"
+                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+                       asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
                         @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
                     </a>
                 </li>
@@ -37,9 +37,9 @@
         </div>
         <p class="nhsuk-breadcrumb__back">
             <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-           asp-action="ReviewDelegateSelfAssessment"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-           asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
+               asp-action="ReviewDelegateSelfAssessment"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID">
                 Back to  @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
             </a>
         </p>
@@ -122,13 +122,15 @@
     }
     @if (Model.Competency.AssessmentQuestions.First().IncludeComments)
     {
+        var promptText = string.IsNullOrEmpty(Model.Competency.AssessmentQuestions.First()?.CommentsPrompt) ?
+        Model.DelegateSelfAssessment.ReviewerCommentsLabel : Model.Competency.AssessmentQuestions.First()?.CommentsPrompt;
         <div class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">
                 @(((Model.Competency.AssessmentQuestions.First().SignedOff == true && Model.Competency.AssessmentQuestions.First().Verified.HasValue)
                     || (Model.Competency.AssessmentQuestions.First().ResultId != null && Model.Competency.AssessmentQuestions.First().Verified == null && Model.Competency.AssessmentQuestions.First().Requested != null && Model.Competency.AssessmentQuestions.First().UserIsVerifier == false)
                     || (Model.Competency.AssessmentQuestions.First().Verified == null && Model.Competency.AssessmentQuestions.First().Requested != null)
                     && (!String.IsNullOrEmpty(Model.DelegateSelfAssessment.ReviewerCommentsLabel)))
-                    ? Model.DelegateSelfAssessment.ReviewerCommentsLabel : "Comments")
+                    ? promptText : "Comments")
             </dt>
             <dd class="nhsuk-summary-list__value">
                 @Html.Raw(Model.Competency.AssessmentQuestions.First().SupportingComments)


### PR DESCRIPTION
### JIRA link
[_TD-4405_](https://hee-tis.atlassian.net/browse/TD-4405)

### Description
Check added to verify comment prompt. If comment prompt exist then it will display a comment prompt instead of "Action Plan".

### Screenshots
![image](https://github.com/user-attachments/assets/e65efd96-129e-4470-a246-01916f480d58)

![image](https://github.com/user-attachments/assets/5bf59148-de23-492e-b88d-c0d808db5374)

![image](https://github.com/user-attachments/assets/6be7d7bd-b788-4e5f-ba73-bb6e5b2c9485)

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
