### PR TITLE
TD-4893 Delegate activities - view course delegates resulted in 500 error when course admin field applied filters got deleted

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -2040,6 +2040,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                         ,DiagObjSelect
                         ,HideInLearnerPortal
                         ,NotificationEmails
+                        ,Q1Options
                     FROM Customisations 
 						WHERE CustomisationID = @customisationID ",
                 new { customisationId }).FirstOrDefault();

--- a/DigitalLearningSolutions.Data/Helpers/FilteringHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/FilteringHelper.cs
@@ -66,7 +66,34 @@
                 ? defaultFilterValue
                 : AddNewFilterToFilterString(existingFilterString, newFilterToAdd);
         }
+        public static string? GetFilterString(
+           string? existingFilterString,
+           string? newFilterToAdd,
+           bool clearFilters,
+           HttpRequest request,
+           string cookieName,
+           string? q1Options,
+           string? defaultFilterValue = null
+       )
+        {
+            var cookieHasBeenSet = request.Cookies.ContainsKey(cookieName);
+            var noFiltersInQueryParams = existingFilterString == null && newFilterToAdd == null;
+            var cookieValue = request.Cookies[cookieName];
+            if ((clearFilters) || (q1Options == null && cookieValue != null && cookieValue.Contains("Answer1|Not Allowed") ||
+    (cookieValue != null && cookieValue.Contains("Answer1|Allowed"))))
+            {
+                return null;
+            }
 
+            if (cookieHasBeenSet && noFiltersInQueryParams)
+            {
+                return request.Cookies[cookieName] == EmptyFiltersCookieValue ? null : request.Cookies[cookieName];
+            }
+
+            return noFiltersInQueryParams
+                ? defaultFilterValue
+                : AddNewFilterToFilterString(existingFilterString, newFilterToAdd);
+        }
         public static string? GetCategoryAndTopicFilterString(
             string? categoryFilterString,
             string? topicFilterString

--- a/DigitalLearningSolutions.Data/Models/Courses/Customisation.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/Customisation.cs
@@ -43,6 +43,7 @@
         public string? NotificationEmails { get; set; }
         public int CustomisationId { get; set; }
         public bool Active { get; set; }
+        public string? Q1Options { get; set; }
 
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -95,13 +95,14 @@
 
             sortBy ??= DefaultSortByOptions.Name.PropertyName;
             sortDirection ??= GenericSortingHelper.Ascending;
-
-            existingFilterString = FilteringHelper.GetFilterString(
+          var course =  courseService.GetCourse(customisationId.Value);
+                existingFilterString = FilteringHelper.GetFilterString(
                 existingFilterString,
                 newFilterToAdd,
                 clearFilters,
                 Request,
                 filterCookieName,
+                course.Q1Options,
                 CourseDelegateAccountStatusFilterOptions.Active.FilterValue
             );
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4893

### Description
I added Q1Options property to Customisation class
I add Q1Options as a parameter in the GetFilterString method
I added a check to the GetFilterString method to clear the cookievalue where is neccessary
### Screenshots
![image](https://github.com/user-attachments/assets/aea7358b-3422-46c8-9e92-76d3ed83c4f1)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
