### PR TITLE
TD-4787- Changed role from Educator/Manager to Assessor for nominated supervisors

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202412020900_UpdateCandidateAssessmentSupervisorsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202412020900_UpdateCandidateAssessmentSupervisorsTable.cs
@@ -1,0 +1,36 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202412020900)]
+    public class UpdateCandidateAssessmentSupervisorsTable : ForwardOnlyMigration
+    {
+        public override void Up()
+        {
+            Execute.Sql($@"UPDATE cas 
+                SET SelfAssessmentSupervisorRoleID = (SELECT ID FROM SelfAssessmentSupervisorRoles 
+								        WHERE SelfAssessmentID = ssr.SelfAssessmentID and AllowDelegateNomination = 1) 
+                FROM CandidateAssessmentSupervisors cas INNER JOIN 
+                    SelfAssessmentSupervisorRoles ssr ON cas.SelfAssessmentSupervisorRoleID = ssr.ID 
+                    AND cas.Removed IS NULL AND ssr.AllowDelegateNomination = 0 INNER JOIN 
+                    SupervisorDelegates sd ON cas.SupervisorDelegateId = sd.ID INNER JOIN 
+                    AdminAccounts aa ON sd.SupervisorAdminID = aa.ID 
+		        WHERE aa.IsSupervisor = 0 AND aa.IsNominatedSupervisor = 1
+				        -- to exclude duplicate CandidateAssessmentID from update
+				        AND cas.CandidateAssessmentID NOT IN (
+					        SELECT CandidateAssessmentID FROM CandidateAssessmentSupervisors WHERE CandidateAssessmentID in (
+						        SELECT Cas2.CandidateAssessmentID
+						        FROM CandidateAssessmentSupervisors cas2 with (nolock) INNER JOIN 
+							        SelfAssessmentSupervisorRoles ssr2 with (nolock) ON cas2.SelfAssessmentSupervisorRoleID = ssr2.ID 
+							        AND cas2.Removed IS NULL AND ssr2.AllowDelegateNomination = 0 INNER JOIN
+							        SupervisorDelegates sd2 with (nolock) ON cas2.SupervisorDelegateId = sd2.ID INNER JOIN
+							        AdminAccounts aa2 with (nolock) ON sd2.SupervisorAdminID = aa2.ID
+						        WHERE aa2.IsSupervisor = 0 AND aa2.IsNominatedSupervisor = 1
+					        )
+					        GROUP BY CandidateAssessmentID,SupervisorDelegateId
+					        HAVING COUNT(*)>1
+					        )"
+            );
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link
[_TD-4787_](https://hee-tis.atlassian.net/browse/TD-4787)

### Description
Changed role from Educator/Manager to Assessor for nominated supervisors.
We have excluded duplicate records from update.

### Screenshots
N/A
There is no data available to update such nominated supervisor role on dev and UAT environment.
The current list of nominated supervisors in production is as follows to update.
'SelfAssessmentSupervisorRoleID' is the current one and 'Roleid' is the role to be updated.

[TD-4787-Prod-Data.xlsx](https://github.com/user-attachments/files/17975644/TD-4787-Prod-Data.xlsx)


-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
