### PR TITLE
Limit the self assessment activities listed in the manage delegate view to the category associated with the admin

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -8,7 +8,7 @@
 
     public partial class SelfAssessmentDataService
     {
-        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminCategoryId)
         {
             return connection.Query<CurrentSelfAssessment>(
                 @"SELECT  SelfAssessment.Id,
@@ -67,7 +67,7 @@
                         CandidateAssessmentSupervisorVerifications    AS casv ON casv.CandidateAssessmentSupervisorID = cas.ID LEFT OUTER JOIN
                         AdminAccounts AS aaEnrolledBy ON aaEnrolledBy.ID = CA.EnrolledByAdminID LEFT OUTER JOIN
 						Users AS uEnrolledBy ON uEnrolledBy.ID = aaEnrolledBy.UserID
-                    WHERE (CA.DelegateUserID = @delegateUserId) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL)
+                    WHERE (CA.DelegateUserID = @delegateUserId) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL) AND (ISNULL(@adminCategoryId, 0) = 0 OR sa.CategoryID = @adminCategoryId)
                     GROUP BY
                         CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
@@ -83,7 +83,7 @@
 						(casv.Verified IS NOT NULL)
                     GROUP BY SelfAssessmentID,casv.SignedOff
                     )Signoff ON  SelfAssessment.Id =Signoff.SelfAssessmentID",
-                new { delegateUserId, centreId }
+                new { delegateUserId, centreId, adminCategoryId }
             );
         }
 

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -72,7 +72,7 @@
 
         // CandidateAssessmentsDataService
 
-        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminCategoryId);
 
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/LearningPortal/CurrentTests.cs
@@ -44,7 +44,7 @@
 
             var bannerText = "bannerText";
             A.CallTo(() => courseService.GetCurrentCourses(CandidateId)).Returns(currentCourses);
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(DelegateUserId, A<int>._)).Returns(selfAssessments);
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(DelegateUserId, A<int>._, A<int>._)).Returns(selfAssessments);
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(DelegateUserId))
                 .Returns((actionPlanResources, apiIsAccessible));
             A.CallTo(() => centresService.GetBannerText(CentreId)).Returns(bannerText);
@@ -426,7 +426,7 @@
         private void GivenCurrentActivitiesAreEmptyLists()
         {
             A.CallTo(() => courseService.GetCurrentCourses(A<int>._)).Returns(new List<CurrentCourse>());
-            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(A<int>._, A<int>._))
+            A.CallTo(() => selfAssessmentService.GetSelfAssessmentsForCandidate(A<int>._, A<int>._, A<int>._))
                 .Returns(new List<CurrentSelfAssessment>());
             A.CallTo(() => actionPlanService.GetIncompleteActionPlanResources(A<int>._))
                 .Returns((new List<ActionPlanResource>(), false));

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Current.cs
@@ -44,7 +44,7 @@
 
             var centreId = User.GetCentreIdKnownNotNull();
             var selfAssessments =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId, 0);
 
             var (learningResources, apiIsAccessible) =
                 await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
@@ -81,7 +81,7 @@
             var centreId = User.GetCentreIdKnownNotNull();
 
             var selfAssessment =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateUserId, centreId, 0);
 
             var (learningResources, _) = await GetIncompleteActionPlanResourcesIfSignpostingEnabled(delegateUserId);
             var model = new AllCurrentItemsPageViewModel(currentCourses, selfAssessment, learningResources);

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -81,9 +81,10 @@
                 course.LastUpdated = DateHelper.GetLocalDateTime(course.LastUpdated);
                 course.Completed = course.Completed?.TimeOfDay == TimeSpan.Zero ? course.Completed : DateHelper.GetLocalDateTime(course.Completed);
             }
+            
 
             var selfAssessments =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateEntity.UserAccount.Id, centreId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateEntity.UserAccount.Id, centreId, categoryIdFilter);
 
             foreach (var selfassessment in selfAssessments)
             {

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -15,7 +15,7 @@
         //Self Assessments
         string? GetSelfAssessmentNameById(int selfAssessmentId);
         // Candidate Assessments
-        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminCategoryId);
 
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
 
@@ -404,9 +404,9 @@
             return selfAssessmentDataService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
         }
 
-        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminCategoryId)
         {
-            return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
+            return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId, centreId, adminCategoryId);
         }
 
         public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateId)


### PR DESCRIPTION
Limiting the self assessment shown in the manage delegate section.

### JIRA link
[TD-5026](https://hee-tis.atlassian.net/browse/TD-5026)

### Description
Added a query check based on the admin categoryID of the logged in user to show the self assessments that match with the specific categoryId for the delegate user in their manage delegate section.

### Screenshots

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5026]: https://hee-tis.atlassian.net/browse/TD-5026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ