### PR TITLE
TD-4884 Prevent supervisors from confirm self assessments in a category that doesn't match their own

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -22,7 +22,7 @@
         DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedSignOffs(int adminId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedReviews(int adminId);
-        DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId);
+        DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId, int? adminIdCategoryId);
         IEnumerable<RoleProfile> GetAvailableRoleProfilesForDelegate(int candidateId, int centreId, int? categoryId);
         RoleProfile? GetRoleProfileById(int selfAssessmentId);
         IEnumerable<SelfAssessmentSupervisorRole> GetSupervisorRolesForSelfAssessment(int selfAssessmentId);
@@ -594,7 +594,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 WHERE  (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = @supervisorDelegateId)  AND (cas.Removed IS NULL) AND (sa.ID = @selfAssessmentId)", new { selfAssessmentId, supervisorDelegateId }
                ).FirstOrDefault();
         }
-        public DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId)
+        public DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId, int? adminIdCategoryId )
         {
             return connection.Query<DelegateSelfAssessment>(
                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.QuestionLabel, sa.DescriptionLabel, sa.ReviewerCommentsLabel,
@@ -611,7 +611,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 FROM CandidateAssessmentSupervisors AS cas INNER JOIN
                          CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
                 SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID
-                WHERE (ca.ID = @candidateAssessmentId)", new { candidateAssessmentId }
+                WHERE (ca.ID = @candidateAssessmentId) AND (ISNULL(@adminIdCategoryID, 0) = 0 OR sa.CategoryID = @adminIdCategoryId)", new { candidateAssessmentId, adminIdCategoryId }
                ).FirstOrDefault();
         }
         public DelegateSelfAssessment? GetSelfAssessmentBySupervisorDelegateCandidateAssessmentId(int candidateAssessmentId, int supervisorDelegateId)

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -594,7 +594,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 WHERE  (ca.RemovedDate IS NULL) AND (cas.SupervisorDelegateId = @supervisorDelegateId)  AND (cas.Removed IS NULL) AND (sa.ID = @selfAssessmentId)", new { selfAssessmentId, supervisorDelegateId }
                ).FirstOrDefault();
         }
-        public DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId, int? adminIdCategoryId )
+        public DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId, int? adminIdCategoryId)
         {
             return connection.Query<DelegateSelfAssessment>(
                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.QuestionLabel, sa.DescriptionLabel, sa.ReviewerCommentsLabel,

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -515,7 +515,7 @@
         )
         {
             var model = ReviewCompetencySelfAsessmentData(supervisorDelegateId, candidateAssessmentId, resultId);
-            if (model  == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            if (model == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             return View("ReviewCompetencySelfAsessment", model);
         }
 
@@ -589,7 +589,7 @@
                 );
             var loggedInAdminUser = userService.GetAdminUserById(adminId);
             var delegateSelfAssessment =
-                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, loggedInAdminUser.CategoryId );
+                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, loggedInAdminUser.CategoryId);
             if (delegateSelfAssessment == null) return null;
             var assessmentQuestion = GetLevelDescriptorsForAssessmentQuestion(competency.AssessmentQuestions.First());
             competency.CompetencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyId(competency.Id);

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -515,7 +515,7 @@
         )
         {
             var model = ReviewCompetencySelfAsessmentData(supervisorDelegateId, candidateAssessmentId, resultId);
-
+            if (model  == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             return View("ReviewCompetencySelfAsessment", model);
         }
 
@@ -587,8 +587,10 @@
                     candidateAssessmentId,
                     adminId
                 );
+            var loggedInAdminUser = userService.GetAdminUserById(adminId);
             var delegateSelfAssessment =
-                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
+                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, loggedInAdminUser.CategoryId );
+            if (delegateSelfAssessment == null) return null;
             var assessmentQuestion = GetLevelDescriptorsForAssessmentQuestion(competency.AssessmentQuestions.First());
             competency.CompetencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyId(competency.Id);
             var model = new ReviewCompetencySelfAsessmentViewModel()
@@ -610,10 +612,12 @@
         public IActionResult VerifyMultipleResults(int supervisorDelegateId, int candidateAssessmentId)
         {
             var adminId = GetAdminId();
+            var loggedInAdminUser = userService.GetAdminUserById(adminId);
             var superviseDelegate =
                 supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
             var delegateSelfAssessment =
-                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
+                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, loggedInAdminUser.CategoryId);
+            if (delegateSelfAssessment == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             var reviewedCompetencies = PopulateCompetencyLevelDescriptors(
                 selfAssessmentService.GetCandidateAssessmentResultsForReviewById(candidateAssessmentId, adminId)
                     .ToList()
@@ -638,10 +642,11 @@
             if (resultChecked.Count == 0)
             {
                 var adminId = GetAdminId();
+                var loggedInAdminUser = userService.GetAdminUserById(adminId);
                 var superviseDelegate =
                     supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
                 var delegateSelfAssessment =
-                    supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
+                    supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, loggedInAdminUser.CategoryId);
                 var reviewedCompetencies = PopulateCompetencyLevelDescriptors(
                     selfAssessmentService.GetCandidateAssessmentResultsForReviewById(candidateAssessmentId, adminId)
                         .ToList()
@@ -1260,10 +1265,12 @@
         public IActionResult SignOffHistory(int supervisorDelegateId, int candidateAssessmentId)
         {
             var adminId = GetAdminId();
+            var loggedInAdminUser = userService.GetAdminUserById(adminId);
             var superviseDelegate =
                 supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, GetAdminId(), 0);
             var delegateSelfAssessment =
-                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
+                supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, loggedInAdminUser.CategoryId);
+            if (delegateSelfAssessment == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             var model = new SignOffHistoryViewModel()
             {
                 DelegateSelfAssessment = delegateSelfAssessment,

--- a/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
@@ -351,7 +351,7 @@ If this looks like a mistake, please contact {supervisorDelegate.SupervisorName}
             int candidateAssessmentId = candidateAssessmentSupervisor.CandidateAssessmentID;
             var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateUserId);
             string centreName = GetCentreName(centreId);
-            var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID,0);
+            var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID, 0);
             string emailSubjectLine = $"{delegateSelfAssessment.SupervisorRoleTitle} Self Assessment Results Review Request - Digital Learning Solutions";
             string? profileReviewUrl = GetSupervisorProfileReviewUrl(supervisorDelegateId, candidateAssessmentId, selfAssessmentResultId);
             BodyBuilder? builder = new BodyBuilder();

--- a/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
@@ -351,7 +351,7 @@ If this looks like a mistake, please contact {supervisorDelegate.SupervisorName}
             int candidateAssessmentId = candidateAssessmentSupervisor.CandidateAssessmentID;
             var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateUserId);
             string centreName = GetCentreName(centreId);
-            var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID);
+            var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID,0);
             string emailSubjectLine = $"{delegateSelfAssessment.SupervisorRoleTitle} Self Assessment Results Review Request - Digital Learning Solutions";
             string? profileReviewUrl = GetSupervisorProfileReviewUrl(supervisorDelegateId, candidateAssessmentId, selfAssessmentResultId);
             BodyBuilder? builder = new BodyBuilder();
@@ -369,7 +369,7 @@ If this looks like a mistake, please contact {supervisorDelegate.SupervisorName}
             int candidateAssessmentId = candidateAssessmentSupervisor.CandidateAssessmentID;
             var supervisorDelegate = supervisorService.GetSupervisorDelegateDetailsById(supervisorDelegateId, 0, delegateUserId);
             string centreName = GetCentreName(centreId);
-            var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID);
+            var delegateSelfAssessment = supervisorService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentSupervisor.CandidateAssessmentID, 0);
             string emailSubjectLine = $"{delegateSelfAssessment.SupervisorRoleTitle} Self Assessment Sign-off Request - Digital Learning Solutions";
             string? profileReviewUrl = GetSupervisorProfileReviewUrl(supervisorDelegateId, candidateAssessmentId);
             BodyBuilder? builder = new BodyBuilder();

--- a/DigitalLearningSolutions.Web/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Web/Services/SupervisorService.cs
@@ -19,7 +19,7 @@ namespace DigitalLearningSolutions.Web.Services
         DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedSignOffs(int adminId);
         IEnumerable<SupervisorDashboardToDoItem> GetSupervisorDashboardToDoItemsForRequestedReviews(int adminId);
-        DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId);
+        DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId, int? adminIdCategoryId);
         IEnumerable<RoleProfile> GetAvailableRoleProfilesForDelegate(int candidateId, int centreId, int? categoryId);
         RoleProfile? GetRoleProfileById(int selfAssessmentId);
         IEnumerable<SelfAssessmentSupervisorRole> GetSupervisorRolesForSelfAssessment(int selfAssessmentId);
@@ -115,9 +115,9 @@ namespace DigitalLearningSolutions.Web.Services
             return supervisorDataService.GetRoleProfileById(selfAssessmentId);
         }
 
-        public DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId)
+        public DelegateSelfAssessment? GetSelfAssessmentBaseByCandidateAssessmentId(int candidateAssessmentId, int? adminIdCategoryId)
         {
-            return supervisorDataService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId);
+            return supervisorDataService.GetSelfAssessmentBaseByCandidateAssessmentId(candidateAssessmentId, adminIdCategoryId);
         }
 
         public DelegateSelfAssessment? GetSelfAssessmentByCandidateAssessmentId(int candidateAssessmentId, int adminId, int? adminIdCategoryId)

--- a/DigitalLearningSolutions.Web/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Web/Services/SupervisorService.cs
@@ -275,7 +275,7 @@ namespace DigitalLearningSolutions.Web.Services
         }
         public SupervisorDelegateDetail GetSupervisorDelegateDetailsByIdWithoutRemoveClause(int supervisorDelegateId, int adminId, int delegateUserId)
         {
-            return supervisorDataService.GetSupervisorDelegateDetailsByIdWithoutRemoveClause(supervisorDelegateId,adminId, delegateUserId);
+            return supervisorDataService.GetSupervisorDelegateDetailsByIdWithoutRemoveClause(supervisorDelegateId, adminId, delegateUserId);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4884

### Description
I added adminCategoryId to the method parameter and where condition query of GetSelfAssessmentBaseByCandidateAssessmentId and  to other places where the method is reference 
I added a check to ReviewCompetencySelfAssessment and VerifyMultipleResults action method to ensure that the supervisor that wanted to confirm the assessment request is eligible to do that 
### Screenshots
![image](https://github.com/user-attachments/assets/0463544c-124f-410d-8a92-f49a865a462c)
![image](https://github.com/user-attachments/assets/362d61ea-e92f-43ba-a09e-f8f6629db6aa)
![image](https://github.com/user-attachments/assets/b9194dab-41f5-410d-b21a-d42f941e1a89)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
