### PR TITLE
TD-5108-Activity Delegate - Export and Remove self-assessment URL can be still accessed via URL manipulation when admin category doesn't match

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessSelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/VerifyAdminUserCanAccessSelfAssessment.cs
@@ -1,0 +1,39 @@
+﻿namespace DigitalLearningSolutions.Web.ServiceFilter
+{
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Services;
+    using Microsoft.Extensions.Logging;
+
+    public class VerifyAdminUserCanAccessSelfAssessment : IActionFilter
+    {
+        private readonly ISelfAssessmentService selfAssessmentService;
+        private readonly ILogger<VerifyAdminUserCanAccessSelfAssessment> logger;
+
+        public VerifyAdminUserCanAccessSelfAssessment(ISelfAssessmentService selfAssessmentService,
+            ILogger<VerifyAdminUserCanAccessSelfAssessment> logger)
+        {
+            this.selfAssessmentService = selfAssessmentService;
+            this.logger = logger;
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context) { }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!(context.Controller is Controller controller))
+            {
+                return;
+            }
+            var adminCategoryId = controller.User.GetAdminCategoryId();
+            var selfAssessmentId = int.Parse(context.ActionArguments["selfAssessmentId"].ToString()!);
+            var selfAssessmentCategoryId = selfAssessmentService.GetSelfAssessmentCategoryId((selfAssessmentId));
+            if (adminCategoryId > 0 && adminCategoryId != selfAssessmentCategoryId)
+            {
+                logger.LogWarning($"Attempt to access restricted self assessment {selfAssessmentId} by user {controller.User.GetUserIdKnownNotNull()}");
+                context.Result = new RedirectToActionResult("StatusCode", "LearningSolutions", new { code = 403 });
+            }
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -51,7 +51,6 @@ namespace DigitalLearningSolutions.Web
     using static DigitalLearningSolutions.Web.Services.ICentreApplicationsService;
     using static DigitalLearningSolutions.Web.Services.ICentreSelfAssessmentsService;
     using System;
-    using IsolationLevel = System.Transactions.IsolationLevel;
     using Serilog;
 
     public class Startup
@@ -581,6 +580,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<VerifyUserHasVerifiedPrimaryEmail>();
             services.AddScoped<VerifyAdminAndDelegateUserCentre>();
             services.AddScoped<IsCentreAuthorizedSelfAssessment>();
+            services.AddScoped<VerifyAdminUserCanAccessSelfAssessment>();
         }
 
         public void Configure(IApplicationBuilder app, IMigrationRunner migrationRunner, IFeatureManager featureManager)


### PR DESCRIPTION
### JIRA link
[_TD-5108_](https://hee-tis.atlassian.net/browse/TD-5108)

### Description
Added action filter 'VerifyAdminUserCanAccessSelfAssessment' to restrict access.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
