### PR TITLE
TD-5084 Self-assessments Sign off should not be allowed through URL manipulation 

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CertificateHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CertificateHelper.cs
@@ -46,5 +46,25 @@ namespace DigitalLearningSolutions.Web.Helpers
             };
             return model;
         }
+        public static CompetencySummary CompetencySummation(List<Competency> reviewedCompetencies)
+        {
+            var CompetencyGroups = reviewedCompetencies.GroupBy(competency => competency.CompetencyGroup);
+            var competencySummaries = CompetencyGroups.Select(g =>
+            {
+                var questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required);
+                var verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required));
+                return new
+                {
+                    QuestionsCount = questions.Count(),
+                    VerifiedCount = verifiedCount
+                };
+            });
+            var model = new CompetencySummary()
+            {
+                VerifiedCount = competencySummaries.Sum(item => item.VerifiedCount),
+                QuestionsCount = competencySummaries.Sum(item => item.QuestionsCount),
+            };
+            return model;
+        }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5084

### Description
I added the CompetencySummation method to sum the assessment Proficiencies 
I added a check in the RequestSignOff action method to ensure the Proficiencies  are completed before requesting signoff

### Screenshots
![image](https://github.com/user-attachments/assets/a8319858-f42d-4c33-917d-39bd124a5172)

![image](https://github.com/user-attachments/assets/1ef80f99-20ef-432c-aed4-a2ef312e3e25)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
