### PR TITLE
TD-5026 Limit the self assessment activities listed in the manage delegate view to the category associated with the admin

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -8,6 +8,85 @@
 
     public partial class SelfAssessmentDataService
     {
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminIdCategoryID)
+        {
+            return connection.Query<CurrentSelfAssessment>(
+                @"SELECT  SelfAssessment.Id,
+                        SelfAssessment.Name,
+                        SelfAssessment.Description,
+                        SelfAssessment.IncludesSignposting,
+                        SelfAssessment.IncludeRequirementsFilters,
+                         SelfAssessment. IsSupervisorResultsReviewed,
+                        SelfAssessment.ReviewerCommentsLabel,
+                         SelfAssessment. Vocabulary,
+                         SelfAssessment. NumberOfCompetencies,
+                        SelfAssessment.StartedDate,
+                        SelfAssessment.LastAccessed,
+                        SelfAssessment.CompleteByDate,
+                        SelfAssessment.CandidateAssessmentId,
+                        SelfAssessment.UserBookmark,
+                        SelfAssessment.UnprocessedUpdates,
+                        SelfAssessment.LaunchCount,
+                        SelfAssessment. IsSelfAssessment,
+                         SelfAssessment.SubmittedDate,
+                       SelfAssessment. CentreName,
+                        SelfAssessment.EnrolmentMethodId,
+						Signoff.SignedOff,
+						Signoff.Verified,
+						EnrolledByForename +' '+EnrolledBySurname AS EnrolledByFullName
+                        FROM	(SELECT
+                        CA.SelfAssessmentID AS Id,
+                        SA.Name,
+                        SA.Description,
+                        SA.IncludesSignposting,
+                        SA.IncludeRequirementsFilters,
+                        SA.SupervisorResultsReview AS IsSupervisorResultsReviewed,
+                        SA.ReviewerCommentsLabel,
+                        COALESCE(SA.Vocabulary, 'Capability') AS Vocabulary,
+                        COUNT(C.ID) AS NumberOfCompetencies,
+                        CA.StartedDate,
+                        CA.LastAccessed,
+                        CA.CompleteByDate,
+                        CA.ID AS CandidateAssessmentId,
+                        CA.UserBookmark,
+                        CA.UnprocessedUpdates,
+                        CA.LaunchCount,
+                        1 AS IsSelfAssessment,
+                        CA.SubmittedDate,
+                        CR.CentreName AS CentreName,
+                        CA.EnrolmentMethodId,
+						uEnrolledBy.FirstName AS EnrolledByForename,
+                        uEnrolledBy.LastName AS EnrolledBySurname
+                        FROM Centres AS CR INNER JOIN
+                        CandidateAssessments AS CA INNER JOIN
+                        SelfAssessments AS SA ON CA.SelfAssessmentID = SA.ID ON CR.CentreID = CA.CentreID INNER JOIN
+                        CentreSelfAssessments AS csa ON csa.SelfAssessmentID = SA.ID AND csa.CentreID = @centreId LEFT OUTER JOIN
+                        Competencies AS C RIGHT OUTER JOIN
+                        SelfAssessmentStructure AS SAS ON C.ID = SAS.CompetencyID ON CA.SelfAssessmentID = SAS.SelfAssessmentID LEFT OUTER JOIN
+						CandidateAssessmentSupervisors AS cas ON  ca.ID =cas.CandidateAssessmentID  LEFT OUTER JOIN
+                        CandidateAssessmentSupervisorVerifications    AS casv ON casv.CandidateAssessmentSupervisorID = cas.ID LEFT OUTER JOIN
+                        AdminAccounts AS aaEnrolledBy ON aaEnrolledBy.ID = CA.EnrolledByAdminID LEFT OUTER JOIN
+						Users AS uEnrolledBy ON uEnrolledBy.ID = aaEnrolledBy.UserID
+                    WHERE (CA.DelegateUserID = @delegateUserId) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL)
+                    AND (ISNULL(@adminIdCategoryID, 0) = 0 OR sa.CategoryID = @adminIdCategoryId)
+                    GROUP BY
+                        CA.SelfAssessmentID, SA.Name, SA.Description, SA.IncludesSignposting, SA.SupervisorResultsReview,
+                        SA.ReviewerCommentsLabel, SA.IncludeRequirementsFilters,
+                        COALESCE(SA.Vocabulary, 'Capability'), CA.StartedDate, CA.LastAccessed, CA.CompleteByDate,
+                        CA.ID,
+                        CA.UserBookmark, CA.UnprocessedUpdates, CA.LaunchCount, CA.SubmittedDate, CR.CentreName,CA.EnrolmentMethodId,
+						 uEnrolledBy.FirstName,uEnrolledBy.LastName)SelfAssessment LEFT OUTER JOIN
+                    (SELECT SelfAssessmentID,casv.SignedOff,MAX(casv.Verified) Verified FROM 
+                       CandidateAssessments AS CA LEFT OUTER JOIN
+						CandidateAssessmentSupervisors AS cas ON  ca.ID =cas.CandidateAssessmentID  LEFT OUTER JOIN
+                        CandidateAssessmentSupervisorVerifications    AS casv ON casv.CandidateAssessmentSupervisorID = cas.ID 
+						 WHERE (CA.DelegateUserID = @delegateUserId) AND (CA.RemovedDate IS NULL) AND (CA.CompletedDate IS NULL) AND (casv.SignedOff = 1) AND
+						(casv.Verified IS NOT NULL)
+                    GROUP BY SelfAssessmentID,casv.SignedOff
+                    )Signoff ON  SelfAssessment.Id =Signoff.SelfAssessmentID",
+                new { delegateUserId, centreId, adminIdCategoryID }
+            );
+        }
         public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
         {
             return connection.Query<CurrentSelfAssessment>(
@@ -86,7 +165,6 @@
                 new { delegateUserId, centreId }
             );
         }
-
         public CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId)
         {
             return connection.QueryFirstOrDefault<CurrentSelfAssessment>(

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -72,8 +72,8 @@
 
         // CandidateAssessmentsDataService
 
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminIdCategoryID);
         IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
-
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
 
         void UpdateLastAccessed(int selfAssessmentId, int delegateUserId);
@@ -174,7 +174,6 @@
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
         int GetSelfAssessmentCategoryId(int selfAssessmentId);
     }
-
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
     {
         private readonly IDbConnection connection;

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ViewDelegateController.cs
@@ -83,7 +83,7 @@
             }
 
             var selfAssessments =
-                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateEntity.UserAccount.Id, centreId);
+                selfAssessmentService.GetSelfAssessmentsForCandidate(delegateEntity.UserAccount.Id, centreId, categoryIdFilter);
 
             foreach (var selfassessment in selfAssessments)
             {

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -15,8 +15,8 @@
         //Self Assessments
         string? GetSelfAssessmentNameById(int selfAssessmentId);
         // Candidate Assessments
+        IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminIdCategoryID);
         IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId);
-
         CurrentSelfAssessment? GetSelfAssessmentForCandidateById(int delegateUserId, int selfAssessmentId);
 
         void SetBookmark(int selfAssessmentId, int delegateUserId, string bookmark);
@@ -404,11 +404,14 @@
             return selfAssessmentDataService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId);
         }
 
+        public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId, int? adminIdCategoryID)
+        {
+            return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId, centreId, adminIdCategoryID);
+        }
         public IEnumerable<CurrentSelfAssessment> GetSelfAssessmentsForCandidate(int delegateUserId, int centreId)
         {
             return selfAssessmentDataService.GetSelfAssessmentsForCandidate(delegateUserId, centreId);
         }
-
         public IEnumerable<Competency> GetMostRecentResults(int selfAssessmentId, int delegateId)
         {
             return selfAssessmentDataService.GetMostRecentResults(selfAssessmentId, delegateId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5026

### Description
I used method overloading to  add GetSelfAssessmentsForCandidate method, adminIdCategoryID parament and include the adminIdCategoryID to the where condition in the query so that logged in admin can only see the course category assigned to the admin 

### Screenshots
![image](https://github.com/user-attachments/assets/0b3aea8e-dcb2-48c7-87cd-dcfe0ba111dc)
![image](https://github.com/user-attachments/assets/a1399823-6ba2-4846-8223-e4a4034c89f2)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
