### PR TITLE
TD-5128 Manage Confirmation request - Outstanding request should display only the request that is matching the admin category

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -288,7 +288,7 @@
                         INNER JOIN DelegateAccounts DA1 ON CA.DelegateUserID = DA1.UserID AND au.CentreID = DA1.CentreID AND DA1.Active=1
                     WHERE (LAR.Verified IS NULL) 
 	                    AND ((LAR.Result IS NOT NULL) OR (LAR.SupportingComments IS NOT NULL)) 
-	                    AND (LAR.Requested IS NOT NULL)
+	                    AND (LAR.Requested IS NOT NULL) AND (au.CategoryID = 0 OR au.CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                     ORDER BY SupervisorVerificationRequested DESC, C.Name",
                 (competency, assessmentQuestion) =>
                 {

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -288,7 +288,7 @@
                         INNER JOIN DelegateAccounts DA1 ON CA.DelegateUserID = DA1.UserID AND au.CentreID = DA1.CentreID AND DA1.Active=1
                     WHERE (LAR.Verified IS NULL) 
 	                    AND ((LAR.Result IS NOT NULL) OR (LAR.SupportingComments IS NOT NULL)) 
-	                    AND (LAR.Requested IS NOT NULL) AND (au.CategoryID = 0 OR au.CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
+	                    AND (LAR.Requested IS NOT NULL) AND (au.CategoryID = 0 OR au.CategoryID = (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                     ORDER BY SupervisorVerificationRequested DESC, C.Name",
                 (competency, assessmentQuestion) =>
                 {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5128

### Description
I modified the query of GetResultSupervisorVerifications method to limit the supervisor to the category that matches the category of the SelfAssessments

### Screenshots
![image](https://github.com/user-attachments/assets/44d1eb74-b179-4302-bdaf-3b4bbea62f0f)
![image](https://github.com/user-attachments/assets/3673cb38-1c28-40c3-8b1c-29ed486850b7)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
