### PR TITLE
TD-5131 Self-assessmentManageSupervisorstilldisplaystheSupervisoreventhoughsupervisorroleisremovedfromtheAdministrator

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentSupervisorDataService.cs
@@ -78,7 +78,7 @@
             return connection.Query<SelfAssessmentSupervisor>(
                 @$"{SelectSelfAssessmentSupervisorQuery}
                     WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (ca.DelegateUserID = @delegateUserId)
-                            AND (ca.SelfAssessmentID = @selfAssessmentId)
+                            AND (ca.SelfAssessmentID = @selfAssessmentId) AND (au.Supervisor = 1 or au.NominatedSupervisor = 1)
                             AND (au.CategoryID = 0 OR au.CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                         ORDER BY SupervisorName",
                 new { selfAssessmentId, delegateUserId }
@@ -95,7 +95,7 @@
                     WHERE (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (sd.DelegateUserID = @delegateUserId)
                         AND (ca.SelfAssessmentID = @selfAssessmentId) AND (sd.SupervisorAdminID IS NOT NULL)
                         AND (coalesce(sasr.ResultsReview, 1) = 1)
-                        AND au.Active = 1
+                        AND au.Active = 1 AND (au.Supervisor = 1 or au.NominatedSupervisor = 1)
                         AND (au.CategoryID = 0 OR au.CategoryID IN (select CategoryID from SelfAssessments where ID = @selfAssessmentId))
                     ORDER BY SupervisorName",
                 new { selfAssessmentId, delegateUserId }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5131

### Description
I included checking if the admin have a supervisor or nominated supervisor role to the GetAllSupervisorsForSelfAssessmentId and GetResultReviewSupervisorsForSelfAssessmentId methods where clause query

### Screenshots
![image](https://github.com/user-attachments/assets/e58b2ba7-05d1-4dfb-8d49-2e7bef73fe95)
![image](https://github.com/user-attachments/assets/1e380ef4-4c5f-4ea6-8a8f-92c4072eab66)
![image](https://github.com/user-attachments/assets/bc68a0d2-3da9-45d1-a6b5-1b049f699981)
![image](https://github.com/user-attachments/assets/ada196f8-5363-41ea-9c95-37e001294c94)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
