### PR TITLE
TD-5180-When a self assessment sign-off request is rejected, the learner is unable to submit a new one

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1215,7 +1215,7 @@
             SignOffProfileAssessmentViewModel model
         )
         {
-            if ((!ModelState.IsValid) && (model.NumberOfSelfAssessedOptionalCompetencies > 0) && (!model.OptionalCompetenciesChecked))
+            if ((!ModelState.IsValid) && (model.NumberOfSelfAssessedOptionalCompetencies > 0) && (!model.OptionalCompetenciesChecked) && model.SignedOff)
             {
                 SelfAssessmentResultSummary? selfAssessmentSummary =
                     supervisorService.GetSelfAssessmentResultSummary(candidateAssessmentId, supervisorDelegateId);
@@ -1231,7 +1231,10 @@
                     CandidateAssessmentSupervisorVerificationId =
                         selfAssessmentSummary.CandidateAssessmentSupervisorVerificationId,
                     CandidateAssessmentSupervisorVerificationSummaries = verificationsSummary,
-                    NumberOfSelfAssessedOptionalCompetencies = optionalCompetencies.Count(x => x.IncludedInSelfAssessment)
+                    NumberOfSelfAssessedOptionalCompetencies = optionalCompetencies.Count(x => x.IncludedInSelfAssessment),
+                    SupervisorComments = model.SupervisorComments,
+                    SignedOff = model.SignedOff,
+                    IsSignOffverified = model.SignedOff
                 };
                 return View("SignOffProfileAssessment", newModel);
             }

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/SignOffProfileAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/SignOffProfileAssessmentViewModel.cs
@@ -21,5 +21,6 @@
         [Range(1, 1, ErrorMessage = "Please tick to confirm that you have  reviewed the optional competencies included in this self assessment and they are appropriate to the learner’s role.")]
         public bool OptionalCompetenciesChecked { get; set; }
         public int NumberOfSelfAssessedOptionalCompetencies { get; set; }
+        public bool? IsSignOffverified { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -14,6 +14,9 @@
       .Select(q => q.ResultDateTime)
       .DefaultIfEmpty(DateTime.MinValue)
       .Max();
+    bool signedOff = (from record in Model.SupervisorSignOffs
+                      orderby record.ID descending
+                      select record.SignedOff).FirstOrDefault();
     var competencySummaries = from g in Model.CompetencyGroups
                               let questions = g.SelectMany(c => c.AssessmentQuestions).Where(q => q.Required)
                               let selfAssessedCount = questions.Count(q => q.Result.HasValue)
@@ -41,7 +44,7 @@
 }
 
 @section mobilebacklink
-    {
+{
     <p class="nhsuk-breadcrumb__back">
         <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessment"
            asp-route-selfAssessmentId="@Model.SelfAssessment.Id">
@@ -197,7 +200,7 @@
                         </div>
                     }
                     @if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any()
-                   && latestResult > latestSignoff
+                   && (latestResult > latestSignoff || !signedOff)
                    && (Model.NumberOfSelfAssessedOptionalCompetencies >= Model.SelfAssessment.MinimumOptionalCompetencies)
                    )
                     {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SignOffProfileAssessment.cshtml
@@ -2,209 +2,209 @@
 @using DigitalLearningSolutions.Web.ViewModels.Supervisor
 @model SignOffProfileAssessmentViewModel;
 @{
-  var errorHasOccurred = !ViewData.ModelState.IsValid;
-  ViewData["Title"] = "Sign-off Self Assessment";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = "Sign-off Self Assessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-           asp-action="DelegateProfileAssessments"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-            @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-           asp-action="ReviewDelegateSelfAssessment"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-           asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
-            @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ? Model.SelfAssessmentResultSummary.RoleName.Substring(0, 32) + "..." : Model.SelfAssessmentResultSummary.RoleName)
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          Sign-off Self Assessment
-        </li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="ReviewDelegateSelfAssessment"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-       asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
-        Back to @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ?
-      Model.SelfAssessmentResultSummary.RoleName.Substring(0, 32) + "..." : Model.SelfAssessmentResultSummary.RoleName)
-      </a>
-    </p>
-  </nav>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                       asp-action="DelegateProfileAssessments"
+                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                        @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                       asp-action="ReviewDelegateSelfAssessment"
+                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+                       asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
+                        @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ? Model.SelfAssessmentResultSummary.RoleName.Substring(0, 32) + "..." : Model.SelfAssessmentResultSummary.RoleName)
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    Sign-off Self Assessment
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+               asp-action="ReviewDelegateSelfAssessment"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
+                Back to @(Model.SelfAssessmentResultSummary.RoleName.Length > 35 ?
+            Model.SelfAssessmentResultSummary.RoleName.Substring(0, 32) + "..." : Model.SelfAssessmentResultSummary.RoleName)
+            </a>
+        </p>
+    </nav>
 }
 @if (errorHasOccurred)
 {
     <vc:error-summary order-of-property-names="@(new[] {nameof(Model.OptionalCompetenciesChecked) })" />
 }
-  <details class="nhsuk-details nhsuk-expander">
+<details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
-      </h1>
+        <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+            @Model.SupervisorDelegate.FirstName @Model.SupervisorDelegate.LastName
+        </h1>
     </summary>
     <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegate" />
+        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegate" />
     </div>
-  </details>
-  <h2>@Model.SelfAssessmentResultSummary.RoleName</h2>
-  <dl class="nhsuk-summary-list">
+</details>
+<h2>@Model.SelfAssessmentResultSummary.RoleName</h2>
+<dl class="nhsuk-summary-list">
 
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Assessment questions in profile
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.CompetencyAssessmentQuestionCount
-      </dd>
-
-    </div>
-
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Assessment question responses
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.ResultCount
-      </dd>
+        <dt class="nhsuk-summary-list__key">
+            Assessment questions in profile
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.SelfAssessmentResultSummary.CompetencyAssessmentQuestionCount
+        </dd>
 
     </div>
 
     <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Responses verified
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.VerifiedCount
-      </dd>
+        <dt class="nhsuk-summary-list__key">
+            Assessment question responses
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.SelfAssessmentResultSummary.ResultCount
+        </dd>
+
+    </div>
+
+    <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+            Responses verified
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+            @Model.SelfAssessmentResultSummary.VerifiedCount
+        </dd>
 
     </div>
     @if (Model.CandidateAssessmentSupervisorVerificationSummaries.Any())
-  {
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Response confirmers
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @foreach (var candidateAssessmentSupervisorVerificationSummary in Model.CandidateAssessmentSupervisorVerificationSummaries)
-        {
-          <span>
-            @DisplayStringHelper.GetPotentiallyInactiveAdminName(
-        candidateAssessmentSupervisorVerificationSummary.Forename,
-        candidateAssessmentSupervisorVerificationSummary.Surname,
-        candidateAssessmentSupervisorVerificationSummary.AdminActive) (@candidateAssessmentSupervisorVerificationSummary.Email) - @candidateAssessmentSupervisorVerificationSummary.VerifiedCount
-          </span>
+    {
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Response confirmers
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @foreach (var candidateAssessmentSupervisorVerificationSummary in Model.CandidateAssessmentSupervisorVerificationSummaries)
+                {
+                    <span>
+                        @DisplayStringHelper.GetPotentiallyInactiveAdminName(
+                                 candidateAssessmentSupervisorVerificationSummary.Forename,
+                                 candidateAssessmentSupervisorVerificationSummary.Surname,
+                                 candidateAssessmentSupervisorVerificationSummary.AdminActive) (@candidateAssessmentSupervisorVerificationSummary.Email) - @candidateAssessmentSupervisorVerificationSummary.VerifiedCount
+                    </span>
 
-          <br />
-        }
-      </dd>
+                    <br />
+                }
+            </dd>
 
-    </div>
-  }
+        </div>
+    }
 
-  @if (Model.SelfAssessmentResultSummary.UngradedCount < Model.SelfAssessmentResultSummary.ResultCount)
-  {
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Responses meeting role requirements
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.MeetingCount
-      </dd>
+    @if (Model.SelfAssessmentResultSummary.UngradedCount < Model.SelfAssessmentResultSummary.ResultCount)
+    {
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Responses meeting role requirements
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @Model.SelfAssessmentResultSummary.MeetingCount
+            </dd>
 
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Responses partially meeting role requirements
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.PartiallyMeetingCount
-      </dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Responses partially meeting role requirements
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @Model.SelfAssessmentResultSummary.PartiallyMeetingCount
+            </dd>
 
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Responses not meeting role requirements
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.NotMeetingCount
-      </dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Responses not meeting role requirements
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @Model.SelfAssessmentResultSummary.NotMeetingCount
+            </dd>
 
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Responses with no role requirements set
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        @Model.SelfAssessmentResultSummary.UngradedCount
-      </dd>
-    </div>
-  }
+        </div>
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Responses with no role requirements set
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @Model.SelfAssessmentResultSummary.UngradedCount
+            </dd>
+        </div>
+    }
 </dl>
 <div class="nhsuk-card">
-  <div class="nhsuk-card__content">
-    <form method="post">
-      <fieldset class="nhsuk-fieldset">
-        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-          <h2 class="nhsuk-fieldset__heading">
-            Sign-off Self Assessment
-          </h2>
-        </legend>
-        <input type="hidden" asp-for="CandidateAssessmentSupervisorVerificationId" />
+    <div class="nhsuk-card__content">
+        <form method="post">
+            <fieldset class="nhsuk-fieldset">
+                <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                    <h2 class="nhsuk-fieldset__heading">
+                        Sign-off Self Assessment
+                    </h2>
+                </legend>
+                <input type="hidden" asp-for="CandidateAssessmentSupervisorVerificationId" />
                 <input type="hidden" asp-for="NumberOfSelfAssessedOptionalCompetencies" />
-        <nhs-form-group nhs-validation-for="SupervisorComments">
-          <vc:text-area asp-for="SupervisorComments" character-count="null" label="@(Model.SelfAssessmentResultSummary.ReviewerCommentsLabel == null ? "Reviewer comments": Model.SelfAssessmentResultSummary.ReviewerCommentsLabel.ToString())" rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
-        </nhs-form-group>
+                <nhs-form-group nhs-validation-for="SupervisorComments">
+                    <vc:text-area asp-for="SupervisorComments" character-count="null" label="@(Model.SelfAssessmentResultSummary.ReviewerCommentsLabel == null ? "Reviewer comments": Model.SelfAssessmentResultSummary.ReviewerCommentsLabel.ToString())" rows="5" css-class="" hint-text="" populate-with-current-value="true" spell-check="false"></vc:text-area>
+                </nhs-form-group>
 
-        <nhs-form-group nhs-validation-for="SignedOff">
-          <div class="nhsuk-radios nhsuk-radios--inline">
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input" id="rb-verify" name="SignedOff" required="required" type="radio" value="true">
-              <label class="nhsuk-label nhsuk-radios__label" for="rb-verify">
-                Sign-off profile self-assessment
-              </label>
-              <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
-                @Html.Raw(Model.SelfAssessmentResultSummary.SignOffSupervisorStatement == null ?
-                "I confirm that this profile self-assessment accurately captures" +
-                $" {Model.SupervisorDelegate.FirstName} {Model.SupervisorDelegate.LastName}'s " +
-                "current capability in the areas assessed." :
-                Model.SelfAssessmentResultSummary.SignOffSupervisorStatement)
-              </div>
-            </div>
-            <div class="nhsuk-radios__item">
-              <input class="nhsuk-radios__input" id="rb-reject" name="SignedOff" required="required" type="radio" value="false">
-              <label class="nhsuk-label nhsuk-radios__label" for="rb-reject">
-                Reject sign-off request
-              </label>
-              <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
-                You must provide sign-off comments indicating the reason for rejecting sign-off.
-              </div>
-            </div>
-            <span asp-validation-for="SignedOff" class="text-danger"></span>
-          </div>
-        </nhs-form-group>
+                <nhs-form-group nhs-validation-for="SignedOff">
+                    <div class="nhsuk-radios nhsuk-radios--inline">
+                        <div class="nhsuk-radios__item">
+                            <input class="nhsuk-radios__input" id="rb-verify" name="SignedOff" asp-for="IsSignOffverified" required="required" type="radio" value="true">
+                            <label class="nhsuk-label nhsuk-radios__label" for="rb-verify">
+                                Sign-off profile self-assessment
+                            </label>
+                            <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
+                                @Html.Raw(Model.SelfAssessmentResultSummary.SignOffSupervisorStatement == null ?
+                                         "I confirm that this profile self-assessment accurately captures" +
+                                         $" {Model.SupervisorDelegate.FirstName} {Model.SupervisorDelegate.LastName}'s " +
+                                         "current capability in the areas assessed." :
+                                         Model.SelfAssessmentResultSummary.SignOffSupervisorStatement)
+                            </div>
+                        </div>
+                        <div class="nhsuk-radios__item">
+                            <input class="nhsuk-radios__input" id="rb-reject" name="SignedOff" asp-for="IsSignOffverified" required="required" type="radio" value="false">
+                            <label class="nhsuk-label nhsuk-radios__label" for="rb-reject">
+                                Reject sign-off request
+                            </label>
+                            <div class="nhsuk-hint nhsuk-summary-list" id="cb-verify-item-hint">
+                                You must provide sign-off comments indicating the reason for rejecting sign-off.
+                            </div>
+                        </div>
+                        <span asp-validation-for="SignedOff" class="text-danger"></span>
+                    </div>
+                </nhs-form-group>
                 @if (Model.NumberOfSelfAssessedOptionalCompetencies > 0)
                 {
                     <nhs-form-group nhs-validation-for="OptionalCompetenciesChecked">
@@ -217,25 +217,25 @@
                     </nhs-form-group>
                 }
             </fieldset>
-      <button class="nhsuk-button nhsuk-u-margin-bottom-0" type="submit">
-        Submit
-      </button>
-    </form>
-  </div>
+            <button class="nhsuk-button nhsuk-u-margin-bottom-0" type="submit">
+                Submit
+            </button>
+        </form>
+    </div>
 </div>
 <div class="nhsuk-back-link">
-  <a class="nhsuk-back-link__link"
-     asp-controller="Supervisor"
-     asp-action="ReviewDelegateSelfAssessment"
-     asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-     asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
-    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-    </svg>
-    Cancel
-  </a>
+    <a class="nhsuk-back-link__link"
+       asp-controller="Supervisor"
+       asp-action="ReviewDelegateSelfAssessment"
+       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+       asp-route-candidateAssessmentId="@Model.SelfAssessmentResultSummary.ID">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
 </div>
 
 @section scripts {
-  <script src="@Url.Content("~/js/supervisor/assessmentVerify.js")" asp-append-version="true"></script>
+    <script src="@Url.Content("~/js/supervisor/assessmentVerify.js")" asp-append-version="true"></script>
 }


### PR DESCRIPTION
### JIRA link
[_TD-5180_](https://hee-tis.atlassian.net/browse/TD-5180)


### Description
Added verification if sign-off rejected.
Variable 'IsSignOffverified' is added to maintain radio button status on error.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
