### PR TITLE
TD-5186 Investigate the build failure for the dependabot Pull Request

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Login/LoginControllerTests.cs
@@ -138,7 +138,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
 
             // Then
             result.Should().BeViewResult().WithViewName("Index").ModelAs<LoginViewModel>();
-            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.That(controller.ModelState.IsValid, Is.False);
         }
 
         [Test]
@@ -263,7 +263,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
 
             // Then
             result.Should().BeViewResult().WithViewName("Index").ModelAs<LoginViewModel>();
-            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.That(controller.ModelState.IsValid, Is.False);
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.Login
 
             // Then
             result.Should().BeViewResult().WithViewName("Index").ModelAs<LoginViewModel>();
-            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.That(controller.ModelState.IsValid, Is.False);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/ClaimAccountControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/ClaimAccountControllerTests.cs
@@ -515,7 +515,7 @@
                 .ModelAs<ClaimAccountCompleteRegistrationViewModel>().Should()
                 .BeEquivalentTo(completeRegistrationViewModel);
 
-            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.That(controller.ModelState.IsValid, Is.False);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/SupervisorController/SupervisorControllerTests.cs
@@ -150,8 +150,8 @@
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(result);
-                Assert.AreEqual(expectedFileName, result!.FileDownloadName);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result!.FileDownloadName, Is.EqualTo(expectedFileName));
             });
         }
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/CentreConfigurationControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Centre/Configuration/CentreConfigurationControllerTests.cs
@@ -87,7 +87,7 @@
             // Then
             result.Should().BeViewResult().WithDefaultViewName()
                 .ModelAs<EditCentreWebsiteDetailsViewModel>();
-            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.That(controller.ModelState.IsValid, Is.False);
         }
 
         [TestCase("OVER_DAILY_LIMIT")]

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DeactivateDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/DeactivateDelegateControllerTests.cs
@@ -96,7 +96,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
 
             // Then
             result.Should().BeViewResult().ModelAs<DeactivateDelegateAccountViewModel>().DelegateId.Should().Be(DelegateId);
-            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.That(controller.ModelState.IsValid, Is.False);
         }
 
 

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EnrolControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EnrolControllerTests.cs
@@ -72,7 +72,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
 
                 result.Should().BeRedirectToActionResult().WithActionName("Index");
 
-                Assert.AreEqual(0, tempDataDictionary.Keys.Count);
+                Assert.That(tempDataDictionary.Keys.Count, Is.EqualTo(0));
             }
         }
     }

--- a/DigitalLearningSolutions.Web.Tests/DigitalLearningSolutions.Web.Tests.csproj
+++ b/DigitalLearningSolutions.Web.Tests/DigitalLearningSolutions.Web.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="3.2.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>

--- a/DigitalLearningSolutions.Web.Tests/Services/CryptoServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/CryptoServiceTests.cs
@@ -20,7 +20,7 @@
             var passwordIsCorrect = cryptoService.VerifyHashedPassword(null, "password");
 
             // Then
-            Assert.IsFalse(passwordIsCorrect);
+            Assert.That(passwordIsCorrect, Is.False);
         }
 
         [Test]
@@ -32,7 +32,7 @@
             var passwordIsCorrect = cryptoService.VerifyHashedPassword(passwordHash, password);
 
             // Then
-            Assert.IsTrue(passwordIsCorrect);
+            Assert.That(passwordIsCorrect, Is.True);
         }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Services/FreshdeskServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/FreshdeskServiceTests.cs
@@ -40,7 +40,7 @@
             var apiResponse = freshdeskService.CreateNewTicket(ticketRequest);
 
             //Assert 
-            Assert.AreEqual(expectedResponse, apiResponse);
+            Assert.That(apiResponse, Is.EqualTo(expectedResponse));
         }
         [Test]
         public void CreateNewTicket_returns_API_Authentication_error()
@@ -60,7 +60,7 @@
             var apiResponse = freshdeskService.CreateNewTicket(ticketRequest);
 
             //Assert 
-            Assert.AreEqual(expectedResponse, apiResponse);
+            Assert.That(apiResponse, Is.EqualTo(expectedResponse));
         }
         [Test]
         public void CreateNewTicket_returns_API_error()
@@ -80,7 +80,7 @@
             var apiResponse = freshdeskService.CreateNewTicket(ticketRequest);
 
             //Assert 
-            Assert.AreEqual(expectedResponse, apiResponse);
+            Assert.That(apiResponse, Is.EqualTo(expectedResponse));
         }
         [Test]
         public async Task CreateNewTicket_returns_API_data_if_retrieved()
@@ -100,7 +100,7 @@
             var apiResponse = freshdeskService.CreateNewTicket(ticketRequest);
 
             //Assert 
-            Assert.AreEqual(expectedResponse, apiResponse);
+            Assert.That(apiResponse, Is.EqualTo(expectedResponse));
         }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5186

### Description
I replaced Assert.IsFalse with Assert.That is more expressive and supported by NUnit
I replaced Assert.AreEqual with Assert.That and Is.EqualTo for comparing values.
I replaced Assert.IsNotNull with Assert.That and Is.Not.Null for comparing values.
### Screenshots
![image](https://github.com/user-attachments/assets/98437b87-db6f-455e-b03b-fbc822c60f61)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [x] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
