### PR TITLE
TD-5188 Investigate the build failure for the dependabot Pull Request

### DIFF
--- a/DigitalLearningSolutions.Web.AutomatedUiTests/DigitalLearningSolutions.Web.AutomatedUiTests.csproj
+++ b/DigitalLearningSolutions.Web.AutomatedUiTests/DigitalLearningSolutions.Web.AutomatedUiTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Selenium.Axe" Version="4.0.21" />

--- a/DigitalLearningSolutions.Web.IntegrationTests/DigitalLearningSolutions.Web.IntegrationTests.csproj
+++ b/DigitalLearningSolutions.Web.IntegrationTests/DigitalLearningSolutions.Web.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="3.2.0" />
+    <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/DigitalLearningSolutions.Web.Tests/DigitalLearningSolutions.Web.Tests.csproj
+++ b/DigitalLearningSolutions.Web.Tests/DigitalLearningSolutions.Web.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="3.2.0" />
+    <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="4.1.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/DigitalLearningSolutions.Web.Tests/DigitalLearningSolutions.Web.Tests.csproj
+++ b/DigitalLearningSolutions.Web.Tests/DigitalLearningSolutions.Web.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="3.2.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />

--- a/DigitalLearningSolutions.Web.Tests/Services/CentresServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/CentresServiceTests.cs
@@ -135,7 +135,7 @@
             var result = centresService.GetCentreSummaryForContactDisplay(selectedCenter);
 
             // Then
-            result.Should().Equals(1);
+            result.Should().NotBeNull();
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SessionTestHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SessionTestHelper.cs
@@ -66,7 +66,7 @@
 
         public static void SessionsShouldBeApproximatelyEquivalent(Session session1, Session session2)
         {
-            const int tenSecondsInMilliseconds = 10000;
+            var tenSecondsInMilliseconds = TimeSpan.FromMilliseconds(10000);
 
             session1.CandidateId.Should().Be(session2.CandidateId);
             session1.CustomisationId.Should().Be(session2.CustomisationId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5188
### Description
I updated the FluentAssertions, FluentAssertions.AspNetCore.Mvc to the latest stable version
I changed the int to Timespan cause the method parameter  expected Timespan  instead of the int
### Screenshots
![image](https://github.com/user-attachments/assets/98437b87-db6f-455e-b03b-fbc822c60f61)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
