### PR TITLE
TD-5158 Implements add questions to which competencies page

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
@@ -1,14 +1,14 @@
-﻿using ClosedXML.Excel;
+﻿using AngleSharp.Dom;
+using ClosedXML.Excel;
 using DigitalLearningSolutions.Data.Exceptions;
 using DigitalLearningSolutions.Web.Helpers;
 using DigitalLearningSolutions.Web.Models;
 using DigitalLearningSolutions.Web.Services;
 using DigitalLearningSolutions.Web.ViewModels.Frameworks.Import;
-using DocumentFormat.OpenXml.Office2010.ExcelAc;
+using DocumentFormat.OpenXml.EMMA;
 using GDS.MultiPageFormData.Enums;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.DotNet.Scaffolding.Shared.Project;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -85,7 +85,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 var resultsModel = new ImportCompetenciesPreProcessViewModel(results, data) { IsNotBlank = data.IsNotBlank, TabName = data.TabName };
                 data.CompetenciesToProcessCount = resultsModel.ToProcessCount;
                 data.CompetenciesToAddCount = resultsModel.CompetenciesToAddCount;
-                data.CompetenciesToUpdateCount = resultsModel.CompetenciesToUpdateCount;
+                data.CompetenciesToUpdateCount = resultsModel.ToUpdateOrSkipCount;
                 setBulkUploadData(data);
                 return View("Developer/Import/ImportCompleted", resultsModel);
             }
@@ -153,8 +153,45 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             {
                 data.CustomAssessmentQuestionID = null;
             }
+            if (data.CompetenciesToUpdateCount > 0)
+            {
+                data.AddAssessmentQuestionsOption = 2;
+                setBulkUploadData(data);
+                return RedirectToAction("AddQuestionsToWhichCompetencies", "Frameworks", new { frameworkId = data.FrameworkId, tabname = data.TabName });
+            }
+            else
+            {
+                data.AddAssessmentQuestionsOption = 1;
+                setBulkUploadData(data);
+                return RedirectToAction("Summary", "Frameworks", new { frameworkId = data.FrameworkId, tabname = data.TabName });
+            }
+        }
+        [Route("/Framework/{frameworkId}/{tabname}/Import/AssessmentQuestions/Competencies")]
+        public IActionResult AddQuestionsToWhichCompetencies()
+        {
+            var data = GetBulkUploadData();
+            var model = new AddQuestionsToWhichCompetenciesViewModel
+                (
+                data.FrameworkId,
+                data.FrameworkName,
+                data.FrameworkVocubulary,
+                data.DefaultQuestionIDs,
+                data.CustomAssessmentQuestionID,
+                data.AddAssessmentQuestionsOption,
+                data.CompetenciesToProcessCount,
+                data.CompetenciesToAddCount,
+                data.CompetenciesToUpdateCount
+                );
+            return View("Developer/Import/AddQuestionsToWhichCompetencies", model);
+        }
+        [HttpPost]
+        [Route("/Framework/{frameworkId}/{tabname}/Import/AssessmentQuestions/Competencies")]
+        public IActionResult AddQuestionsToWhichCompetencies(int AddAssessmentQuestionsOption)
+        {
+            var data = GetBulkUploadData();
+            data.AddAssessmentQuestionsOption = AddAssessmentQuestionsOption;
             setBulkUploadData(data);
-            return RedirectToAction("AddQuestionsToWhichCompetencies");
+            return RedirectToAction("Summary", "Frameworks", new { frameworkId = data.FrameworkId, tabname = data.TabName });
         }
         private void setupBulkUploadData(int frameworkId, int adminUserID, string competenciessFileName, string tabName, bool isNotBlank)
         {

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
@@ -1,11 +1,9 @@
-﻿using AngleSharp.Dom;
-using ClosedXML.Excel;
+﻿using ClosedXML.Excel;
 using DigitalLearningSolutions.Data.Exceptions;
 using DigitalLearningSolutions.Web.Helpers;
 using DigitalLearningSolutions.Web.Models;
 using DigitalLearningSolutions.Web.Services;
 using DigitalLearningSolutions.Web.ViewModels.Frameworks.Import;
-using DocumentFormat.OpenXml.EMMA;
 using GDS.MultiPageFormData.Enums;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/DigitalLearningSolutions.Web/Models/BulkCompetenciesData.cs
+++ b/DigitalLearningSolutions.Web/Models/BulkCompetenciesData.cs
@@ -27,10 +27,11 @@ namespace DigitalLearningSolutions.Web.Models
         public int AdminUserId { get; set; }
         public bool IsNotBlank { get; set; }
         public string CompetenciesFileName { get; set; }
-        public List<int> DefaultQuestionIDs { get; set; } = [];
-        public int? CustomAssessmentQuestionID { get; set; }
         public bool AddDefaultAssessmentQuestions { get; set; } = true;
         public bool AddCustomAssessmentQuestion { get; set; } = false;
+        public List<int> DefaultQuestionIDs { get; set; } = [];
+        public int? CustomAssessmentQuestionID { get; set; }
+        public int AddAssessmentQuestionsOption { get; set; } //1 = only added, 2 = added and updated, 3 = all uploaded
         public int CompetenciesToProcessCount { get; set; }
         public int CompetenciesToAddCount { get; set; }
         public int CompetenciesToUpdateCount { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/AddQuestionsToWhichCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/AddQuestionsToWhichCompetenciesViewModel.cs
@@ -1,0 +1,41 @@
+﻿using DigitalLearningSolutions.Web.Helpers;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
+{
+    public class AddQuestionsToWhichCompetenciesViewModel
+    {
+        public AddQuestionsToWhichCompetenciesViewModel
+            (
+            int frameworkId,
+            string frameworkName,
+            string frameworkVocabulary,
+            List<int> defaultQuestions,
+            int? customQuestionId,
+            int addAssessmentQuestionsOption,
+            int competenciesToProcessCount,
+            int competenciesToAddCount,
+            int competenciesToUpdateCount)
+        {
+            FrameworkID = frameworkId;
+            FrameworkName = frameworkName;
+            FrameworkVocabularySingular = FrameworkVocabularyHelper.VocabularySingular(frameworkVocabulary);
+            FrameworkVocabularyPlural = FrameworkVocabularyHelper.VocabularyPlural(frameworkVocabulary);
+            TotalQuestions = defaultQuestions.Count + (customQuestionId != null ? 1 : 0);
+            AddAssessmentQuestionsOption = addAssessmentQuestionsOption;
+            CompetenciesToProcessCount = competenciesToProcessCount;
+            CompetenciesToAddCount = competenciesToAddCount;
+            CompetenciesToUpdateCount = competenciesToUpdateCount;
+        }
+        public int FrameworkID { get; set; }
+        public string FrameworkName { get; set; }
+        public string FrameworkVocabularySingular { get; set; }
+        public string FrameworkVocabularyPlural { get; set; }
+        public int TotalQuestions { get; set; }
+        public int AddAssessmentQuestionsOption { get; set; } = 1; //1 = only added, 2 = added and updated, 3 = all uploaded
+        public int CompetenciesToProcessCount { get; set; }
+        public int CompetenciesToAddCount { get; set; }
+        public int CompetenciesToUpdateCount { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ImportCompetenciesPreProcessViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ImportCompetenciesPreProcessViewModel.cs
@@ -18,8 +18,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
             ToProcessCount = bulkCompetenciesResult.ProcessedCount;
             CompetenciesToAddCount = bulkCompetenciesResult.CompetencyAddedCount;
             ToUpdateOrSkipCount = bulkCompetenciesResult.CompetencyUpdatedCount;
-            CompetencyGroupsToAddCount = bulkCompetenciesResult.GroupAddedCount;
-            CompetencyGroupsToUpdateCount = bulkCompetenciesResult.GroupUpdatedCount;
             Errors = bulkCompetenciesResult.Errors.Select(x => (x.RowNumber, MapReasonToErrorMessage(x.Reason, FrameworkVocabularyHelper.VocabularySingular(bulkCompetenciesData.FrameworkVocubulary))));
         }
         public string? FrameworkName { get; set; }
@@ -30,9 +28,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
         public int ErrorCount => Errors.Count();
         public int ToProcessCount { get; set; }
         public int CompetenciesToAddCount { get; set; }
-        public int CompetenciesToUpdateCount { get; set; }
-        public int CompetencyGroupsToAddCount { get; set; }
-        public int CompetencyGroupsToUpdateCount { get; set; }
         public int ToUpdateOrSkipCount { get; set; }
         public string? ImportFile { get; set; }
         public bool IsNotBlank { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/AddQuestionsToWhichCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/AddQuestionsToWhichCompetencies.cshtml
@@ -1,0 +1,87 @@
+﻿@using DigitalLearningSolutions.Web.Extensions
+@using DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
+
+@model AddQuestionsToWhichCompetenciesViewModel
+
+@{
+    ViewData["Application"] = "Framework Service";
+    ViewData["HeaderPathName"] = "Framework Service";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Add Assessment Questions" : "Add Assessment Questions";
+    var cancelLinkData = Html.GetRouteValues();
+}
+<link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Framework Structure</a></li>
+                <li class="nhsuk-breadcrumb__item">Bulk upload</li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Back to framework structure</a></p>
+        </div>
+    </nav>
+}
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+        <div class="nhsuk-u-reading-width">
+            <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="SubmitAddWhoToGroup" enctype="multipart/form-data">
+                <fieldset class="nhsuk-fieldset">
+                    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                        <h1 class="nhsuk-fieldset__heading">
+                            Which @Model.FrameworkVocabularyPlural.ToLower() should the questions be added to?
+                        </h1>
+                    </legend>
+                    <div class="nhsuk-hint nhsuk-u-margin-bottom-2">
+                        Choose which @Model.FrameworkVocabularyPlural.ToLower() you want to add the @Model.TotalQuestions assessment questions to
+                    </div>
+                    <div class="nhsuk-hint">
+                        Select one option
+                    </div>
+                    <div class="nhsuk-form-group">
+                        <div class="nhsuk-radios">
+                            @if (Model.CompetenciesToAddCount > 0)
+                            {
+                                <div class="nhsuk-radios__item">
+                                    <input class="nhsuk-radios__input" id="option-1" asp-for="@Model.AddAssessmentQuestionsOption" type="radio" value="1" aria-describedby="option-1-hint">
+                                    <label class="nhsuk-label nhsuk-radios__label" for="option-1">
+                                        Only add questions to new @Model.FrameworkVocabularyPlural.ToLower()
+                                    </label>
+                                    <div class="nhsuk-hint nhsuk-radios__hint" id="option-1-hint">
+                                        @Model.TotalQuestions assessment questions will be added to the @Model.CompetenciesToAddCount new @Model.FrameworkVocabularyPlural.ToLower()
+                                    </div>
+                                </div>
+                            }
+                            <div class="nhsuk-radios__item">
+                                <input class="nhsuk-radios__input" id="option-2" asp-for="@Model.AddAssessmentQuestionsOption" type="radio" value="2" aria-describedby="option-2-hint">
+                                <label class="nhsuk-label nhsuk-radios__label" for="option-2">
+                                    Only add questions to @(Model.CompetenciesToAddCount > 0 ? Model.CompetenciesToAddCount + " new and " : "") modified @Model.FrameworkVocabularyPlural.ToLower()
+                                </label>
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="option-2-hint">
+                                    @(Model.CompetenciesToAddCount > 0 ? Model.CompetenciesToAddCount + " new @Model.FrameworkVocabularyPlural.ToLower() and only those of the " : "Only those of the ") @Model.CompetenciesToUpdateCount existing @Model.FrameworkVocabularyPlural.ToLower() that have been modified in the sheet will have the assessment questions added
+                                </div>
+                            </div>
+                            <div class="nhsuk-radios__item">
+                                <input class="nhsuk-radios__input" id="option-3" asp-for="@Model.AddAssessmentQuestionsOption" type="radio" value="3" aria-describedby="option-3-hint">
+                                <label class="nhsuk-label nhsuk-radios__label" for="option-3">
+                                    Add questions to all @Model.FrameworkVocabularyPlural.ToLower() in my uploaded sheet
+                                </label>
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="option-3-hint">
+                                    All @(Model.CompetenciesToProcessCount) @Model.FrameworkVocabularyPlural.ToLower() in the sheet that are will have the assessment questions added to them
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </fieldset>
+                <a asp-controller="Frameworks" asp-action="AddAssessmentQuestions" asp-all-route-data="@cancelLinkData" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
+                <button class="nhsuk-button" type="submit">Next</button>
+            </form>
+            <vc:back-link asp-controller="Frameworks" asp-action="Index" asp-all-route-data="@null" link-text="Cancel" />
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### JIRA link
[TD-5158](https://hee-tis.atlassian.net/browse/TD-5158)

### Description
Implements add questions to which competencies page with logic to store posted choice to tempdata.

### Screenshots
![image](https://github.com/user-attachments/assets/792201a8-4ef0-4418-bbc5-680ba62cab79)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

[TD-5158]: https://hee-tis.atlassian.net/browse/TD-5158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ