### PR TITLE
TD-5220 reorder competencies option page

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
@@ -100,6 +100,7 @@
 
         Competency? GetFrameworkCompetencyForPreview(int frameworkCompetencyId);
         IEnumerable<BulkCompetency> GetBulkCompetenciesForFramework(int frameworkId);
+        List<int> GetFrameworkCompetencyOrder(int frameworkId, List<int> frameworkCompetencyIds);
 
         //  Comments:
         IEnumerable<CommentReplies> GetCommentsForFrameworkId(int frameworkId, int adminId);
@@ -2428,6 +2429,17 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
                             );
             }
 
+        }
+        public List<int> GetFrameworkCompetencyOrder(int frameworkId, List<int> frameworkCompetencyIds)
+        {
+            return connection.Query<int>(
+                @"SELECT fc.ID
+                    FROM   FrameworkCompetencies AS fc INNER JOIN
+                                 FrameworkCompetencyGroups AS fcg ON fc.FrameworkCompetencyGroupID = fcg.ID
+                    WHERE (fc.FrameworkID = @frameworkId) AND (fc.ID IN @frameworkCompetencyIds)
+                    ORDER BY fcg.Ordering, fc.Ordering",
+                                new { frameworkId, frameworkCompetencyIds }
+                            ).ToList();
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Frameworks/Import/CompetencyTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/Import/CompetencyTableRow.cs
@@ -9,6 +9,7 @@
         CompetencyGroupAndCompetencyInserted,
         CompetencyInserted,
         CompetencyUpdated,
+        CompetencyUpdatedAndReordered,
         CompetencyGroupInserted,
         CompetencyGroupUpdated,
         CompetencyGroupAndCompetencyUpdated,

--- a/DigitalLearningSolutions.Data/Models/Frameworks/Import/ImportCompetenciesResult.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/Import/ImportCompetenciesResult.cs
@@ -22,7 +22,8 @@
         {
             ProcessedCount = competencyTableRows.Count;
             CompetencyAddedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyInserted | dr.RowStatus == RowStatus.CompetencyGroupAndCompetencyInserted);
-            CompetencyUpdatedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyUpdated);
+            CompetencyUpdatedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyUpdated | dr.RowStatus == RowStatus.CompetencyUpdatedAndReordered);
+            CompetencyReorderedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyUpdatedAndReordered);
             GroupAddedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyGroupInserted | dr.RowStatus == RowStatus.CompetencyGroupAndCompetencyInserted);
             SkippedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.Skipped);
             Errors = competencyTableRows.Where(dr => dr.Error.HasValue).Select(dr => (dr.RowNumber, dr.Error!.Value));
@@ -47,6 +48,7 @@
         public int ProcessedCount { get; set; }
         public int CompetencyAddedCount { get; set; }
         public int CompetencyUpdatedCount { get; set; }
+        public int CompetencyReorderedCount { get; set; }
         public int GroupAddedCount { get; set; }
         public int GroupUpdatedCount { get; set; }
         public int SkippedCount { get; set; }

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
@@ -217,6 +217,15 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             setBulkUploadData(data);
             return RedirectToAction("Summary", "Frameworks", new { frameworkId = data.FrameworkId, tabname = data.TabName });
         }
+        [Route("CancelImport")]
+        public IActionResult CancelImport()
+        {
+            var data = GetBulkUploadData();
+            var frameworkId = data.FrameworkId;
+            FileHelper.DeleteFile(webHostEnvironment, data.CompetenciesFileName);
+            TempData.Clear();
+            return RedirectToAction("ViewFramework", new { frameworkId, tabname = "Structure" });
+        }
         private void setupBulkUploadData(int frameworkId, int adminUserID, string competenciessFileName, string tabName, bool isNotBlank)
         {
             TempData.Clear();

--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
@@ -84,6 +84,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 data.CompetenciesToProcessCount = resultsModel.ToProcessCount;
                 data.CompetenciesToAddCount = resultsModel.CompetenciesToAddCount;
                 data.CompetenciesToUpdateCount = resultsModel.ToUpdateOrSkipCount;
+                data.CompetenciesToReorderCount = results.CompetencyReorderedCount;
                 setBulkUploadData(data);
                 return View("Developer/Import/ImportCompleted", resultsModel);
             }
@@ -92,6 +93,30 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 FileHelper.DeleteFile(webHostEnvironment, data.CompetenciesFileName);
                 return View("Developer/Import/ImportFailed");
             }
+        }
+        [Route("/Framework/{frameworkId}/{tabname}/Import/Ordering")]
+        public IActionResult ApplyCompetencyOrdering()
+        {
+            var data = GetBulkUploadData();
+            if (data.CompetenciesToReorderCount > 0)
+            {
+                var model = new ApplyCompetencyOrderingViewModel(data.FrameworkId, data.FrameworkName, data.FrameworkVocubulary, data.CompetenciesToReorderCount, data.ReorderCompetenciesOption);
+                return View("Developer/Import/ApplyCompetencyOrdering", model);
+            }
+            return RedirectToAction("AddAssessmentQuestions", "Frameworks", new { frameworkId = data.FrameworkId, tabname = data.TabName });
+        }
+        [HttpPost]
+        [Route("/Framework/{frameworkId}/{tabname}/Import/Ordering")]
+        public IActionResult ApplyCompetencyOrdering(int reorderCompetenciesOption)
+        {
+            var data = GetBulkUploadData();
+
+            if (data.ReorderCompetenciesOption != reorderCompetenciesOption)
+            {
+                data.ReorderCompetenciesOption = reorderCompetenciesOption;
+                setBulkUploadData(data);
+            }
+            return RedirectToAction("AddAssessmentQuestions", "Frameworks", new { frameworkId = data.FrameworkId, tabname = data.TabName });
         }
         [Route("/Framework/{frameworkId}/{tabname}/Import/AssessmentQuestions")]
         public IActionResult AddAssessmentQuestions()
@@ -119,6 +144,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                 data.PublishStatusID,
                 data.CompetenciesToAddCount,
                 data.CompetenciesToUpdateCount,
+                data.CompetenciesToReorderCount,
                 defaultQuestions,
                 questionSelectList
                 );

--- a/DigitalLearningSolutions.Web/Models/BulkCompetenciesData.cs
+++ b/DigitalLearningSolutions.Web/Models/BulkCompetenciesData.cs
@@ -35,6 +35,8 @@ namespace DigitalLearningSolutions.Web.Models
         public int CompetenciesToProcessCount { get; set; }
         public int CompetenciesToAddCount { get; set; }
         public int CompetenciesToUpdateCount { get; set; }
+        public int CompetenciesToReorderCount { get; set; }
+        public int ReorderCompetenciesOption { get; set; } = 1; //1 = ignore order, 2 = apply order
         public int LastRowProcessed { get; set; }
         public int SubtotalCompetenciesAdded { get; set; }
         public int SubtotalCompetenciesUpdated { get; set; }

--- a/DigitalLearningSolutions.Web/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkService.cs
@@ -57,6 +57,7 @@ namespace DigitalLearningSolutions.Web.Services
 
         int GetMaxFrameworkCompetencyGroupID();
         IEnumerable<BulkCompetency> GetBulkCompetenciesForFramework(int frameworkId);
+        List<int> GetFrameworkCompetencyOrder(int frameworkId, List<int> frameworkCompetencyIds);
 
         //  Assessment questions:
         IEnumerable<AssessmentQuestion> GetAllCompetencyQuestions(int adminId);
@@ -384,6 +385,11 @@ namespace DigitalLearningSolutions.Web.Services
         public IEnumerable<BulkCompetency> GetBulkCompetenciesForFramework(int frameworkId)
         {
             return frameworkDataService.GetBulkCompetenciesForFramework(frameworkId);
+        }
+
+        public List<int> GetFrameworkCompetencyOrder(int frameworkId, List<int> frameworkCompetencyIds)
+        {
+            return frameworkDataService.GetFrameworkCompetencyOrder(frameworkId, frameworkCompetencyIds);
         }
 
         public CollaboratorNotification? GetCollaboratorNotification(int id, int invitedByAdminId)

--- a/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
@@ -35,8 +35,7 @@ namespace DigitalLearningSolutions.Web.Services
             var table = OpenCompetenciesTable(workbook, vocabulary);
             var competencyRows = table.Rows().Skip(1).Select(row => new CompetencyTableRow(table, row)).ToList();
             var newCompetencyIds = competencyRows.Select(row => row.ID ?? 0).ToList();
-            var existingCompetencies = frameworkService.GetBulkCompetenciesForFramework(frameworkId);
-            var existingIds = existingCompetencies.Select(bc => (int)bc.ID).ToList();
+            var existingIds = frameworkService.GetFrameworkCompetencyOrder(frameworkId, newCompetencyIds);
             foreach (var competencyRow in competencyRows)
             {
                 PreProcessCompetencyRow(competencyRow, newCompetencyIds, existingIds);

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/AddAssessmentQuestionsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/AddAssessmentQuestionsViewModel.cs
@@ -12,6 +12,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
         int publishStatusId,
         int newCompetencies,
         int existingCompetencies,
+        int competenciesToReorderCount,
         IEnumerable<AssessmentQuestion> defaultQuestions,
         SelectList questionSelectList
         ) : AddAssessmentQuestionsFormData
@@ -23,6 +24,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
         public int PublishStatusID { get; set; } = publishStatusId;
         public int NewCompetencies { get; set; } = newCompetencies;
         public int ExistingCompetencies { get; set; } = existingCompetencies;
+        public int CompetenciesToReorderCount { get; set; } = competenciesToReorderCount;
         public IEnumerable<AssessmentQuestion>? DefaultQuestions { get; set; } = defaultQuestions;
         public SelectList? QuestionSelectList { get; set; } = questionSelectList;
     }

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/AddQuestionsToWhichCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/AddQuestionsToWhichCompetenciesViewModel.cs
@@ -37,5 +37,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
         public int CompetenciesToProcessCount { get; set; }
         public int CompetenciesToAddCount { get; set; }
         public int CompetenciesToUpdateCount { get; set; }
+        
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ApplyCompetencyOrderingViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ApplyCompetencyOrderingViewModel.cs
@@ -1,0 +1,30 @@
+﻿using DigitalLearningSolutions.Web.Helpers;
+
+namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
+{
+    public class ApplyCompetencyOrderingViewModel
+    {
+        public ApplyCompetencyOrderingViewModel
+            (
+            int frameworkId,
+            string frameworkName,
+            string frameworkVocabulary,
+            int competenciesToReorderCount,
+            int reorderCompetenciesOption
+            )
+        {
+            FrameworkID = frameworkId;
+            FrameworkName = frameworkName;
+            FrameworkVocabularySingular = FrameworkVocabularyHelper.VocabularySingular(frameworkVocabulary);
+            FrameworkVocabularyPlural = FrameworkVocabularyHelper.VocabularyPlural(frameworkVocabulary);
+            CompetenciesToReorderCount = competenciesToReorderCount;
+            ReorderCompetenciesOption = reorderCompetenciesOption;
+        }
+        public int FrameworkID { get; set; }
+        public string FrameworkName { get; set; }
+        public string FrameworkVocabularySingular { get; set; }
+        public string FrameworkVocabularyPlural { get; set; }
+        public int ReorderCompetenciesOption { get; set; } = 1; //1 = ignore order, 2 = apply order
+        public int CompetenciesToReorderCount { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ImportCompetenciesPreProcessViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ImportCompetenciesPreProcessViewModel.cs
@@ -17,6 +17,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
             FrameworkVocabularyPlural = FrameworkVocabularyHelper.VocabularyPlural(bulkCompetenciesData.FrameworkVocubulary);
             ToProcessCount = bulkCompetenciesResult.ProcessedCount;
             CompetenciesToAddCount = bulkCompetenciesResult.CompetencyAddedCount;
+            CompetenciesToReorderCount = bulkCompetenciesResult.CompetencyReorderedCount;
             ToUpdateOrSkipCount = bulkCompetenciesResult.CompetencyUpdatedCount;
             Errors = bulkCompetenciesResult.Errors.Select(x => (x.RowNumber, MapReasonToErrorMessage(x.Reason, FrameworkVocabularyHelper.VocabularySingular(bulkCompetenciesData.FrameworkVocubulary))));
             FlagCount = bulkCompetenciesResult.FlagCount;
@@ -31,6 +32,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
         public int ErrorCount => Errors.Count();
         public int ToProcessCount { get; set; }
         public int CompetenciesToAddCount { get; set; }
+        public int CompetenciesToReorderCount { get; set; }
         public int ToUpdateOrSkipCount { get; set; }
         public string? ImportFile { get; set; }
         public bool IsNotBlank { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/AddAssessmentQuestions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/AddAssessmentQuestions.cshtml
@@ -96,9 +96,10 @@
                         </div>
                     </fieldset>
                 </div>
+                <a asp-controller="Frameworks" asp-action="@(Model.CompetenciesToReorderCount == 0 ? "ImportCompleted" : "ApplyCompetencyOrdering")" asp-all-route-data="@cancelLinkData" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
                 <button class="nhsuk-button" type="submit">Next</button>
             </form>
-            <vc:back-link asp-controller="Frameworks" asp-action="Index" asp-all-route-data="@null" link-text="Cancel" />
+            <vc:cancel-link asp-controller="Frameworks" asp-action="CancelImport" asp-all-route-data="@cancelLinkData" link-text="Cancel" />
         </div>
     </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/AddQuestionsToWhichCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/AddQuestionsToWhichCompetencies.cshtml
@@ -29,7 +29,7 @@
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
         <div class="nhsuk-u-reading-width">
-            <form class="nhsuk-u-margin-bottom-3" method="post" asp-action="SubmitAddWhoToGroup" enctype="multipart/form-data">
+            <form class="nhsuk-u-margin-bottom-3" method="post" enctype="multipart/form-data">
                 <fieldset class="nhsuk-fieldset">
                     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
                         <h1 class="nhsuk-fieldset__heading">
@@ -81,7 +81,7 @@
                 <a asp-controller="Frameworks" asp-action="AddAssessmentQuestions" asp-all-route-data="@cancelLinkData" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
                 <button class="nhsuk-button" type="submit">Next</button>
             </form>
-            <vc:back-link asp-controller="Frameworks" asp-action="Index" asp-all-route-data="@null" link-text="Cancel" />
+            <vc:cancel-link asp-controller="Frameworks" asp-action="CancelImport" asp-all-route-data="@cancelLinkData" link-text="Cancel" />
         </div>
     </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
@@ -1,0 +1,75 @@
+﻿@using DigitalLearningSolutions.Web.Extensions
+@using DigitalLearningSolutions.Web.ViewModels.Frameworks.Import
+
+@model ApplyCompetencyOrderingViewModel
+
+@{
+    ViewData["Application"] = "Framework Service";
+    ViewData["HeaderPathName"] = "Framework Service";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = errorHasOccurred ? "Error: Add Assessment Questions" : "Add Assessment Questions";
+    var cancelLinkData = Html.GetRouteValues();
+}
+<link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Framework Structure</a></li>
+                <li class="nhsuk-breadcrumb__item">Bulk upload</li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure">Back to framework structure</a></p>
+        </div>
+    </nav>
+}
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+        <div class="nhsuk-u-reading-width">
+            <form class="nhsuk-u-margin-bottom-3" method="post" enctype="multipart/form-data">
+                <fieldset class="nhsuk-fieldset">
+                    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                        <h1 class="nhsuk-fieldset__heading">
+                            Apply @Model.FrameworkVocabularySingular.ToLower() sequence changes?
+                        </h1>
+                    </legend>
+                    <div class="nhsuk-hint nhsuk-u-margin-bottom-2">
+                        Your uploaded file includes changes to the sequence of existing @Model.FrameworkVocabularyPlural.ToLower(). Choose whether to store the changes to @Model.FrameworkVocabularySingular.ToLower() sequence during update.
+                    </div>
+                    <div class="nhsuk-hint">
+                        Select an option
+                    </div>
+                    <div class="nhsuk-form-group">
+                        <div class="nhsuk-radios">
+                            <div class="nhsuk-radios__item">
+                                <input class="nhsuk-radios__input" id="option-1" asp-for="@Model.ReorderCompetenciesOption" type="radio" value="1" aria-describedby="option-1-hint">
+                                <label class="nhsuk-label nhsuk-radios__label" for="option-1">
+                                    Ignore changes to @Model.FrameworkVocabularySingular.ToLower() sequence
+                                </label>
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="option-1-hint">
+                                    @Model.FrameworkVocabularyPlural will be updated if they have changed but there sequence/order in the framework will not change.
+                                </div>
+                            </div>
+                            <div class="nhsuk-radios__item">
+                                <input class="nhsuk-radios__input" id="option-2" asp-for="@Model.ReorderCompetenciesOption" type="radio" value="2" aria-describedby="option-2-hint">
+                                <label class="nhsuk-label nhsuk-radios__label" for="option-2">
+                                    Apply changes to @Model.FrameworkVocabularySingular.ToLower() sequence
+                                </label>
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="option-2-hint">
+                                    The sequence of @Model.FrameworkVocabularyPlural.ToLower() in the framework will be changed to reflect the order in the sheet during processing.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </fieldset>
+                <a asp-controller="Frameworks" asp-action="ImportCompleted" asp-all-route-data="@cancelLinkData" role="button" class="nhsuk-button nhsuk-button--secondary">Back</a>
+                <button class="nhsuk-button" type="submit">Next</button>
+            </form>
+            <vc:cancel-link asp-controller="Frameworks" asp-action="CancelImport" asp-all-route-data="@cancelLinkData" link-text="Cancel" />
+        </div>
+    </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ImportCompleted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ImportCompleted.cshtml
@@ -32,23 +32,30 @@
         <div class="nhsuk-u-reading-width">
             <p class="nhsuk-body-l">@(Model.ErrorCount == 0 ? "Your file is error free and ready to be processed. Check the information below looks, correct before processing" : "Your file contains the following, including some errors:")</p>
             <ul>
-                <li>@Model.ToProcessCount @(Model.ToProcessCount == 1 ? "row" : "rows") to process</li>
-                <li>@Model.CompetenciesToAddCount new @(Model.CompetenciesToAddCount == 1 ? Model.FrameworkVocabularySingular.ToLower() : Model.FrameworkVocabularyPlural.ToLower()) to add</li>
-                <li>@Model.ToUpdateOrSkipCount @Model.FrameworkVocabularySingular.ToLower() @(Model.ToUpdateOrSkipCount == 1 ? "record" : "records") to update (or skip if unchanged)</li>
-                <li>In @Model.CompetencyGroupCount @Model.FrameworkVocabularySingular.ToLower() groups</li>
-                <li>With a total of @Model.FlagCount flags assigned to @Model.FrameworkVocabularyPlural.ToLower() (@Model.DistinctFlagsCount distinct flags)</li>
+                <li>@Model.ToProcessCount @(Model.ToProcessCount == 1 ? "row" : "rows") uploaded</li>
                 @if (Model.ErrorCount > 0)
                 {
                     <li>@Model.ErrorCount @(Model.ErrorCount == 1 ? "row" : "rows") containing errors that cannot be processed</li>
                 }
                 else
                 {
+                    <li>@Model.CompetenciesToAddCount new @(Model.CompetenciesToAddCount == 1 ? Model.FrameworkVocabularySingular.ToLower() : Model.FrameworkVocabularyPlural.ToLower()) to add</li>
+                    <li>@Model.ToUpdateOrSkipCount @Model.FrameworkVocabularySingular.ToLower() @(Model.ToUpdateOrSkipCount == 1 ? "record" : "records") to update (or skip if unchanged)</li>
+                    <li>In @Model.CompetencyGroupCount @Model.FrameworkVocabularySingular.ToLower() groups</li>
+                    <li>With @Model.FlagCount flags assigned to @Model.FrameworkVocabularyPlural.ToLower() (@Model.DistinctFlagsCount distinct flags)</li>
+                    @if (Model.CompetenciesToReorderCount > 0)
+                    {
+                        <text>
+                        <li>
+                                @Model.CompetenciesToReorderCount existing @Model.FrameworkVocabularySingular.ToLower() @(Model.CompetenciesToReorderCount == 1 ? "record" : "records") have changed sequence in your uploaded sheet. You can choose whether to fix them in the new order next.
+                        </li></text>
+                    }
                     <li>No errors</li>
                 }
             </ul>
             @if (Model.ErrorCount == 0)
             {
-                <a asp-controller="Frameworks" role="button" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure" asp-action="AddAssessmentQuestions" class="nhsuk-button">Continue</a>
+                <a asp-controller="Frameworks" role="button" asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]" asp-route-tabname="Structure" asp-action="ApplyCompetencyOrdering" class="nhsuk-button">Continue</a>
             }
             else
             {
@@ -85,7 +92,7 @@
                     <button class="nhsuk-button" type="submit">Upload file</button>
                 </form>
             }
-            <vc:back-link asp-controller="Frameworks" asp-action="Index" asp-all-route-data="@null" link-text="Cancel" />
+            <vc:cancel-link asp-controller="Frameworks" asp-action="CancelImport" asp-all-route-data="@cancelLinkData" link-text="Cancel" />
         </div>
     </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ImportCompleted.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ImportCompleted.cshtml
@@ -59,7 +59,7 @@
             }
             else
             {
-                <p class="nhsuk-body-l">Check the information below. You will need fix these errors before continuing or remove the rows with errors from your spreadsheet:</p>
+                <p class="nhsuk-body-l">Check the information below. You will need to fix these errors before continuing or remove the rows with errors from your spreadsheet:</p>
                 <div class="nhsuk-form-group nhsuk-form-group--error">
                     <span class="nhsuk-error-message" id="error-list">
                         <span class="nhsuk-u-visually-hidden">Error:</span> @Model.ErrorCount @Model.FrameworkVocabularySingular.ToLower() @(Model.ErrorCount == 1 ? "row" : "rows") contain errors and cannot be processed

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
@@ -110,7 +110,7 @@
                 <vc:file-input asp-for="@nameof(Model.ImportFile)" label="Excel file ready for import" hint-text="" css-class="nhsuk-u-width-one-half" />
                 <button class="nhsuk-button" type="submit">Start upload</button>
             </form>
-            <vc:cancel-link asp-controller="Frameworks" asp-action="ViewFramework" asp-all-route-data="@cancelLinkData" link-text="Cancel" />
+            <vc:cancel-link asp-controller="Frameworks" asp-action="CancelImport" asp-all-route-data="@cancelLinkData" link-text="Cancel" />
         </div>
     </div>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-5220](https://hee-tis.atlassian.net/browse/TD-5220)

### Description
Checks whether competency order for existing competencies has changed and prompts user to choose whether to store changes to the order or not.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5220]: https://hee-tis.atlassian.net/browse/TD-5220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ