### PR TITLE
TD-5096 Hide the link to the DSAT report if the admin user is in a category that doesn't match

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
@@ -15,6 +15,7 @@
     using System.Threading.Tasks;
     using Microsoft.Extensions.Configuration;
     using DigitalLearningSolutions.Data.Extensions;
+    using DigitalLearningSolutions.Web.Services;
 
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
@@ -30,11 +31,13 @@
         private readonly string tableauSiteName;
         private readonly string workbookName;
         private readonly string viewName;
+        private readonly ISelfAssessmentService selfAssessmentService;
         public SelfAssessmentReportsController(
             ISelfAssessmentReportService selfAssessmentReportService,
             ITableauConnectionHelperService tableauConnectionHelper,
             IClockUtility clockUtility,
-            IConfiguration config
+            IConfiguration config,
+            ISelfAssessmentService selfAssessmentService
         )
         {
             this.selfAssessmentReportService = selfAssessmentReportService;
@@ -44,12 +47,14 @@
             tableauSiteName = config.GetTableauSiteName();
             workbookName = config.GetTableauWorkbookName();
             viewName = config.GetTableauViewName();
+            this.selfAssessmentService = selfAssessmentService;
         }
         public IActionResult Index()
         {
             var centreId = User.GetCentreId();
-            var categoryId = User.GetAdminCategoryId();
-            var model = new SelfAssessmentReportsViewModel(selfAssessmentReportService.GetSelfAssessmentsForReportList((int)centreId, categoryId));
+            var adminCategoryId = User.GetAdminCategoryId();
+            var categoryId = this.selfAssessmentService.GetSelfAssessmentCategoryId(1);
+            var model = new SelfAssessmentReportsViewModel(selfAssessmentReportService.GetSelfAssessmentsForReportList((int)centreId, adminCategoryId), adminCategoryId, categoryId);
             return View(model);
         }
         [HttpGet]

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/SelfAssessmentReportsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/SelfAssessmentReportsViewModel.cs
@@ -6,11 +6,15 @@
     public class SelfAssessmentReportsViewModel
     {
         public SelfAssessmentReportsViewModel(
-            IEnumerable<SelfAssessmentSelect> selfAssessmentSelects
+            IEnumerable<SelfAssessmentSelect> selfAssessmentSelects, int? adminCategoryId, int categoryId
             )
         {
             SelfAssessmentSelects = selfAssessmentSelects;
+            AdminCategoryId = adminCategoryId;
+            CategoryId = categoryId;
         }
         public IEnumerable<SelfAssessmentSelect> SelfAssessmentSelects { get; set; }
+        public int? AdminCategoryId { get; set; }
+        public int CategoryId { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
@@ -28,10 +28,13 @@
         <h2>Excel learner activity reports</h2>
         <p class="nhsuk-lede-text">Download Excel competency self assessments activity reports for your centre.</p>
         <ul>
+          @if((Model.AdminCategoryId == null) || (Model.AdminCategoryId == Model.CategoryId))
+          {
             <li>
                 <a asp-controller="SelfAssessmentReports" asp-action="DownloadDigitalCapabilityToExcel">Digital Skills Assessment Tool - Download report</a>
 
             </li>
+          }
             @if (Model.SelfAssessmentSelects.Any())
             {
                 @foreach (var report in Model.SelfAssessmentSelects)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5096

### Description
I added the AdminCategoryId and CategoryId properties  to the SelfAssessmentReportsViewModel class
I added the GetSelfAssessmentCategoryId to the index action method of the SelfAssessmentReportsController to get the DSAT CategoryId 
I added a check to the index view to hide the link to the DSAT report if the AdminCategoryId did not match the CategoryId and the AdminCategoryId is not NULL

### Screenshots
When the adminCategoryId is set to 4
![image](https://github.com/user-attachments/assets/d31873fb-6518-4420-a41f-f0f4aa81757c)
When the adminCategoryId is set to 1
![image](https://github.com/user-attachments/assets/4ee7f627-c495-4806-9c7b-0eecb2894a45)
When the adminCategoryId is set to Null
![image](https://github.com/user-attachments/assets/3a05fdd9-4384-49bb-b4a6-d4239f8ad043)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
