### PR TITLE
TD-4340 Issue with the 'Course content' change link when creating a course from 'Course set up' screen

### DIFF
--- a/DigitalLearningSolutions.Data/Models/MultiPageFormData/AddNewCentreCourse/AddNewCentreCourseTempData.cs
+++ b/DigitalLearningSolutions.Data/Models/MultiPageFormData/AddNewCentreCourse/AddNewCentreCourseTempData.cs
@@ -17,7 +17,7 @@
         public CourseOptionsTempData? CourseOptionsData { get; set; }
         public CourseContentTempData? CourseContentData { get; set; }
         public List<SectionContentTempData>? SectionContentData { get; set; }
-
+        public bool EditCourseContent { get; set; }
         public void SetApplicationAndResetModels(ApplicationDetails application)
         {
             if (Application == application)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -365,7 +365,7 @@
             data!.CourseOptionsData = model.ToCourseOptionsTempData();
             multiPageFormService.SetMultiPageFormData(data, MultiPageFormDataFeature.AddNewCourse, TempData);
 
-            return RedirectToAction("SetCourseContent");
+            return RedirectToAction("SetCourseContent", false);
         }
 
         [HttpGet("AddCourse/SetCourseContent")]
@@ -373,7 +373,7 @@
             typeof(RedirectMissingMultiPageFormData),
             Arguments = new object[] { nameof(MultiPageFormDataFeature.AddNewCourse) }
         )]
-        public IActionResult SetCourseContent()
+        public IActionResult SetCourseContent(bool editCourseContent)
         {
             var data = multiPageFormService.GetMultiPageFormData<AddNewCentreCourseTempData>(MultiPageFormDataFeature.AddNewCourse, TempData).GetAwaiter().GetResult();
 
@@ -381,6 +381,8 @@
             {
                 return RedirectToAction("Summary");
             }
+            data.EditCourseContent = editCourseContent;
+            multiPageFormService.SetMultiPageFormData(data, MultiPageFormDataFeature.AddNewCourse, TempData);
 
             var model = data!.CourseContentData != null
                 ? new SetCourseContentViewModel(data.CourseContentData)
@@ -457,7 +459,7 @@
             }
 
             var showDiagnostic = data.Application!.DiagAssess;
-            if (data.SectionContentData != null && data.SectionContentData.Count >=3 )
+            if (data.EditCourseContent)
             {
                 var tutorial = GetTutorialsFromSectionContentData(data.SectionContentData, tutorials);
                 var model = new SetSectionContentViewModel(section, sectionIndex, showDiagnostic, tutorial);
@@ -649,20 +651,19 @@
             {
                 data.SectionContentData = new List<SectionContentTempData>();
             }
-            if (data.SectionContentData != null && data.SectionContentData.Count >= 3)
+            if (data.EditCourseContent)
             {
                 return RedirectToNextSectionOrSummary(
                model.Index,
-               new SetCourseContentViewModel(data.CourseContentData!)
-           );
+               new SetCourseContentViewModel(data.CourseContentData!));
             }
-                data!.SectionContentData!.Add(
-                new SectionContentTempData(
-                    model.Tutorials != null
-                        ? model.Tutorials.Select(GetCourseTutorialData)
-                        : new List<CourseTutorialTempData>()
-                )
-            );
+            data!.SectionContentData!.Add(
+            new SectionContentTempData(
+                model.Tutorials != null
+                    ? model.Tutorials.Select(GetCourseTutorialData)
+                    : new List<CourseTutorialTempData>()
+            )
+        );
             multiPageFormService.SetMultiPageFormData(data, MultiPageFormDataFeature.AddNewCourse, TempData);
 
             return RedirectToNextSectionOrSummary(

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AddNewCentreCourse/_CourseContentSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/CourseSetup/AddNewCentreCourse/_CourseContentSummary.cshtml
@@ -26,7 +26,8 @@
   <dd class="nhsuk-summary-list__actions">
     @if (!Model.NoContent)
     {
-      <a asp-action="SetCourseContent">
+      <a asp-action="SetCourseContent"
+               asp-route-EditCourseContent="true">
         Change<span class="nhsuk-u-visually-hidden"> course content</span>
       </a>
     }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4340

### Description
I added EditCourseContent  properties AddNewCentreCourseTempData class 
I added editCourseContent parameter to the SetCourseContent action method CourseSetupController
I added editCourseContent  to the route parameter on the _CourseContentSummary.cshtml partial view
I added EditCourseContent   to the multiPageFormService 
I replaced the data.SectionContentData with data.editCourseContent   in the if statement
### Screenshots
![image](https://github.com/user-attachments/assets/6696c660-10a4-486e-bce2-0be9fcee0774)
when I click the change from the summary page 
![image](https://github.com/user-attachments/assets/88e2ba08-f24a-49b2-994f-af97568669cd)
![image](https://github.com/user-attachments/assets/f4f5a5c6-313e-48b1-8b6d-60d3d82f75af)
![image](https://github.com/user-attachments/assets/e28aa53c-f518-47ba-a634-21f7701625a0)
![image](https://github.com/user-attachments/assets/ab178fbc-5681-44b3-945b-77aa936e49bc)
![image](https://github.com/user-attachments/assets/7d4ec950-918a-4b10-9fe7-5078ad8ef9ba)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
