### PR TITLE
TD-5233 bulk import tidy up tasks

### DIFF
--- a/DigitalLearningSolutions.Data/Models/Frameworks/Import/CompetencyTableRow.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/Import/CompetencyTableRow.cs
@@ -9,7 +9,6 @@
         CompetencyGroupAndCompetencyInserted,
         CompetencyInserted,
         CompetencyUpdated,
-        CompetencyUpdatedAndReordered,
         CompetencyGroupInserted,
         CompetencyGroupUpdated,
         CompetencyGroupAndCompetencyUpdated,
@@ -42,6 +41,7 @@
         public string? AlwaysShowDescriptionRaw { get; set; }
         public ImportCompetenciesResult.ErrorReason? Error { get; set; }
         public RowStatus RowStatus { get; set; }
+        public bool Reordered { get; set; } = false;
         public bool Validate()
         {
             if (string.IsNullOrEmpty(Competency))

--- a/DigitalLearningSolutions.Data/Models/Frameworks/Import/ImportCompetenciesResult.cs
+++ b/DigitalLearningSolutions.Data/Models/Frameworks/Import/ImportCompetenciesResult.cs
@@ -22,10 +22,10 @@
         {
             ProcessedCount = competencyTableRows.Count;
             CompetencyAddedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyInserted | dr.RowStatus == RowStatus.CompetencyGroupAndCompetencyInserted);
-            CompetencyUpdatedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyUpdated | dr.RowStatus == RowStatus.CompetencyUpdatedAndReordered);
-            CompetencyReorderedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyUpdatedAndReordered);
+            CompetencyUpdatedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyUpdated | dr.RowStatus == RowStatus.CompetencyGroupAndCompetencyUpdated);
             GroupAddedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.CompetencyGroupInserted | dr.RowStatus == RowStatus.CompetencyGroupAndCompetencyInserted);
-            SkippedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.Skipped);
+            SkippedCount = competencyTableRows.Count(dr => dr.RowStatus == RowStatus.Skipped && dr.Reordered == false);
+            CompetencyReorderedCount = competencyTableRows.Count(dr => dr.Reordered == true);
             Errors = competencyTableRows.Where(dr => dr.Error.HasValue).Select(dr => (dr.RowNumber, dr.Error!.Value));
             FlagCount = competencyTableRows
                 .Where(row => !string.IsNullOrWhiteSpace(row.FlagsCsv))

--- a/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
@@ -143,11 +143,11 @@ namespace DigitalLearningSolutions.Web.Services
                         for (int p = 0; p < placesToMove; p++)
                         {
                             frameworkService.MoveFrameworkCompetencyGroup(thisGroup.ID, true, direction);
-                            competenciesRows
+                        }
+                        competenciesRows
                                 .Where(row => row.CompetencyGroup == thisGroup.Name)
                                 .ToList()
                                 .ForEach(row => row.Reordered = true);
-                        }
                     }
                 }
             }

--- a/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
@@ -61,13 +61,10 @@ namespace DigitalLearningSolutions.Web.Services
                 {
                     int originalIndex = existingIds.IndexOf(id);
                     int newIndex = newIds.IndexOf(id);
-                    if (originalIndex == newIndex)
+                    competencyRow.RowStatus = RowStatus.CompetencyUpdated;
+                    if (originalIndex != newIndex)
                     {
-                        competencyRow.RowStatus = RowStatus.CompetencyUpdated;
-                    }
-                    else
-                    {
-                        competencyRow.RowStatus = RowStatus.CompetencyUpdatedAndReordered;
+                        competencyRow.Reordered = true;
                     }
                 }
             }
@@ -125,7 +122,7 @@ namespace DigitalLearningSolutions.Web.Services
             {
                 maxFrameworkCompetencyGroupId = ProcessCompetencyRow(adminUserId, frameworkId, maxFrameworkCompetencyId, maxFrameworkCompetencyGroupId, addAssessmentQuestionsOption, reorderCompetenciesOption, customAssessmentQuestionID, defaultQuestionIds, competencyRow);
             }
-            // TO DO: Check for changes to competency group order and apply them if appropriate:
+            // Check for changes to competency group order and apply them if appropriate:
             if (reorderCompetenciesOption == 2)
             {
                 var distinctCompetencyGroups = competenciesRows
@@ -146,6 +143,10 @@ namespace DigitalLearningSolutions.Web.Services
                         for (int p = 0; p < placesToMove; p++)
                         {
                             frameworkService.MoveFrameworkCompetencyGroup(thisGroup.ID, true, direction);
+                            competenciesRows
+                                .Where(row => row.CompetencyGroup == thisGroup.Name)
+                                .ToList()
+                                .ForEach(row => row.Reordered = true);
                         }
                     }
                 }
@@ -274,10 +275,7 @@ namespace DigitalLearningSolutions.Web.Services
                         frameworkService.MoveFrameworkCompetency(frameworkCompetencyId, true, direction);
                     }
 
-                    if (competencyRow.RowStatus == RowStatus.Skipped)
-                    {
-                        competencyRow.RowStatus = RowStatus.CompetencyUpdated;
-                    }
+                    competencyRow.Reordered = true;
                 }
             }
 

--- a/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ImportCompetenciesResultsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Frameworks/Import/ImportCompetenciesResultsViewModel.cs
@@ -14,6 +14,7 @@
             CompetenciesUpdatedCount = importCompetenciesResult.CompetencyUpdatedCount;
             CompetencyGroupsInsertedCount = importCompetenciesResult.GroupAddedCount;
             CompetencyGroupsUpdatedCount = importCompetenciesResult.GroupUpdatedCount;
+            CompetenciesReorderedCount = importCompetenciesResult.CompetencyReorderedCount;
             SkippedCount = importCompetenciesResult.SkippedCount;
             Errors = importCompetenciesResult.Errors.Select(x => (x.RowNumber, MapReasonToErrorMessage(x.Reason)));
             FrameworkID = frameworkId;
@@ -26,6 +27,7 @@
         public int ProcessedCount { get; set; }
         public int CompetenciesInsertedCount { get; set; }
         public int CompetenciesUpdatedCount { get; set; }
+        public int CompetenciesReorderedCount { get; set; }
         public int CompetencyGroupsInsertedCount { get; set; }
         public int CompetencyGroupsUpdatedCount { get; set; }
         public int SkippedCount { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
@@ -63,7 +63,7 @@
                                     Apply changes to @Model.FrameworkVocabularySingular.ToLower() order
                                 </label>
                                 <div class="nhsuk-hint nhsuk-radios__hint" id="option-2-hint">
-                                    The sequence of @Model.FrameworkVocabularyPlural.ToLower() in the framework will be changed to reflect the order in the sheet during processing.
+                                    The oder of @Model.FrameworkVocabularyPlural.ToLower() in the framework will be changed to reflect the order in the sheet during processing.
                                 </div>
                             </div>
                         </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
@@ -41,7 +41,7 @@
                         <p>We strongly recommend including all framework competencies in your uploaded sheet if reordering competencies to ensure that the correct sequence is applied.</p>
                     </div>
                     <div class="nhsuk-hint nhsuk-u-margin-bottom-2">
-                        Your uploaded file includes changes to the sequence of existing @Model.FrameworkVocabularyPlural.ToLower(). Choose whether to store the changes to @Model.FrameworkVocabularySingular.ToLower() sequence during update.
+                        Your uploaded file includes changes to the order of existing @Model.FrameworkVocabularyPlural.ToLower(). Choose whether to store the changes to @Model.FrameworkVocabularySingular.ToLower() order during update.
                     </div>
                     <div class="nhsuk-hint">
                         Select an option
@@ -51,7 +51,7 @@
                             <div class="nhsuk-radios__item">
                                 <input class="nhsuk-radios__input" id="option-1" asp-for="@Model.ReorderCompetenciesOption" type="radio" value="1" aria-describedby="option-1-hint">
                                 <label class="nhsuk-label nhsuk-radios__label" for="option-1">
-                                    Ignore changes to @Model.FrameworkVocabularySingular.ToLower() sequence
+                                    Ignore changes to @Model.FrameworkVocabularySingular.ToLower() order
                                 </label>
                                 <div class="nhsuk-hint nhsuk-radios__hint" id="option-1-hint">
                                     @Model.FrameworkVocabularyPlural will be updated if they have changed but there sequence/order in the framework will not change.
@@ -60,7 +60,7 @@
                             <div class="nhsuk-radios__item">
                                 <input class="nhsuk-radios__input" id="option-2" asp-for="@Model.ReorderCompetenciesOption" type="radio" value="2" aria-describedby="option-2-hint">
                                 <label class="nhsuk-label nhsuk-radios__label" for="option-2">
-                                    Apply changes to @Model.FrameworkVocabularySingular.ToLower() sequence
+                                    Apply changes to @Model.FrameworkVocabularySingular.ToLower() order
                                 </label>
                                 <div class="nhsuk-hint nhsuk-radios__hint" id="option-2-hint">
                                     The sequence of @Model.FrameworkVocabularyPlural.ToLower() in the framework will be changed to reflect the order in the sheet during processing.

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ImportSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ImportSummary.cshtml
@@ -31,6 +31,10 @@
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
         <h1 class="nhsuk-heading-xl">@Model.FrameworkVocabularyPlural import summary</h1>
+        @if (Model.PublishStatusID == 3)
+        {
+            <partial name="Shared/_PublishedWarning" />
+        }
         <p class="nhsuk-body-l nhsuk-u-reading-width">Your @Model.FrameworkVocabularySingular.ToLower() sheet is ready to be processed. Please check the details below are correct before proceeding to @process @Model.FrameworkVocabularyPlural.ToLower() in the framework @Model.FrameworkName.</p>
         <h2>Upload summary</h2>
         <dl class="nhsuk-summary-list">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
@@ -46,9 +46,10 @@
                             Bulk upload <strong>cannot</strong> be used to:
                         </p>
                             <ul>
-                                <li>Delete competencies or competency groups</li>
-                                <li>Remove assessment questions from existing competencies</li>
-                                <li>Add more than one custom assessment question to uploaded competencies</li>
+                            <li>Delete @Model.FrameworkVocabularyPlural.ToLower() or @Model.FrameworkVocabularySingular.ToLower() groups</li>
+                            <li>Remove assessment questions from existing @Model.FrameworkVocabularyPlural.ToLower()</li>
+                            <li>Add more than one custom assessment question to uploaded @Model.FrameworkVocabularyPlural.ToLower()</li>
+                            <li>Remove flags from @Model.FrameworkVocabularyPlural.ToLower()</li>
                             </ul>
                         
                     </div>
@@ -102,7 +103,7 @@
                 }
                 else
                 {
-                    <vc:inset-text css-class="" text="Bulk upload cannot be used to add more than one custom assessment question to uploaded competencies."></vc:inset-text>
+                    <vc:inset-text css-class="" text="Bulk upload cannot be used to add more than one custom assessment question to uploaded @Model.FrameworkVocabularyPlural.ToLower()."></vc:inset-text>
                     <p class="nhsuk-body-m">
                         Download a blank template for bulk adding @Model.FrameworkVocabularyPlural.ToLower() to your framework, <strong>@Model.FrameworkName</strong>. This Excel file will be empty. New @Model.FrameworkVocabularyPlural.ToLower() can be added by including their details on a blank row.
                     </p>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
@@ -43,7 +43,7 @@
                     <div class="nhsuk-inset-text">
                         <span class="nhsuk-u-visually-hidden">Note: </span>
                         <p>
-                            Bulk upload cannot be used to:
+                            Bulk upload <strong>cannot</strong> be used to:
                         </p>
                             <ul>
                                 <li>Delete competencies or competency groups</li>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
@@ -36,7 +36,7 @@
             {
                 <partial name="Shared/_PublishedWarning" />
             }
-            @* <vc:inset-text css-class="" text="The building blocks for your framework will be referred to as 'competencies' for the purpose of importing. Once they have been imported, they will be referred to using your chosen vocabulary."></vc:inset-text> *@
+            
             <div class="nhsuk-form-group">
                 @if (Model.IsNotBlank)
                 {
@@ -102,12 +102,7 @@
                 }
                 else
                 {
-                    <div class="nhsuk-inset-text">
-                        <span class="nhsuk-u-visually-hidden">Note: </span>
-                        <p>
-                            Bulk upload cannot be used to add more than one custom assessment question to uploaded competencies.
-                        </p>
-                    </div>
+                    <vc:inset-text css-class="" text="Bulk upload cannot be used to add more than one custom assessment question to uploaded competencies."></vc:inset-text>
                     <p class="nhsuk-body-m">
                         Download a blank template for bulk adding @Model.FrameworkVocabularyPlural.ToLower() to your framework, <strong>@Model.FrameworkName</strong>. This Excel file will be empty. New @Model.FrameworkVocabularyPlural.ToLower() can be added by including their details on a blank row.
                     </p>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/Index.cshtml
@@ -40,7 +40,18 @@
             <div class="nhsuk-form-group">
                 @if (Model.IsNotBlank)
                 {
-
+                    <div class="nhsuk-inset-text">
+                        <span class="nhsuk-u-visually-hidden">Note: </span>
+                        <p>
+                            Bulk upload cannot be used to:
+                        </p>
+                            <ul>
+                                <li>Delete competencies or competency groups</li>
+                                <li>Remove assessment questions from existing competencies</li>
+                                <li>Add more than one custom assessment question to uploaded competencies</li>
+                            </ul>
+                        
+                    </div>
                     <p class="nhsuk-body-m">
                         To bulk add and/or update @Model.FrameworkVocabularyPlural.ToLower() in the framework, <strong>@Model.FrameworkName</strong>, download an Excel workbook using one of the options below.
                     </p>
@@ -91,6 +102,12 @@
                 }
                 else
                 {
+                    <div class="nhsuk-inset-text">
+                        <span class="nhsuk-u-visually-hidden">Note: </span>
+                        <p>
+                            Bulk upload cannot be used to add more than one custom assessment question to uploaded competencies.
+                        </p>
+                    </div>
                     <p class="nhsuk-body-m">
                         Download a blank template for bulk adding @Model.FrameworkVocabularyPlural.ToLower() to your framework, <strong>@Model.FrameworkName</strong>. This Excel file will be empty. New @Model.FrameworkVocabularyPlural.ToLower() can be added by including their details on a blank row.
                     </p>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/UploadResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/UploadResults.cshtml
@@ -37,6 +37,7 @@
                 <li>@Model.CompetencyGroupsInsertedCount new @(Model.CompetencyGroupsInsertedCount == 1 ? $"{Model.FrameworkVocabularySingular.ToLower()} group" : $"{Model.FrameworkVocabularySingular.ToLower()} groups") inserted</li>
                 <li>@Model.CompetenciesInsertedCount new @(Model.CompetenciesInsertedCount == 1 ? Model.FrameworkVocabularySingular.ToLower() : Model.FrameworkVocabularyPlural.ToLower()) inserted</li>
                 <li>@Model.CompetenciesUpdatedCount existing @(Model.CompetenciesUpdatedCount == 1 ? Model.FrameworkVocabularySingular.ToLower() : Model.FrameworkVocabularyPlural.ToLower()) updated</li>
+                <li>@Model.CompetenciesReorderedCount existing @(Model.CompetenciesReorderedCount == 1 ? Model.FrameworkVocabularySingular.ToLower() : Model.FrameworkVocabularyPlural.ToLower()) reordered</li>
                 <li>@Model.SkippedCount rows @(Model.SkippedCount == 1 ? "line" : "lines") skipped (nothing inserted or updated but no errors)</li>
                 <li>@Model.ErrorCount @(Model.ErrorCount == 1 ? "line" : "lines") skipped due to errors</li>
             </ul>


### PR DESCRIPTION
### JIRA link
[TD-5233](https://hee-tis.atlassian.net/browse/TD-5233)

### Description
These changes tidy up the bulk upload/download competencies flow to:
- provide a count of competencies reordered
- warn users about the limitations of the import process
- warn users uploading proficiencies to a published framework before processing starts

### Screenshots
![image](https://github.com/user-attachments/assets/6a37149a-759c-495e-8ada-e282c75cdeff)
![image](https://github.com/user-attachments/assets/05ad343a-70e5-4fe8-9d98-d1718fba9a2f)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5233]: https://hee-tis.atlassian.net/browse/TD-5233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ