### PR TITLE
TD-4435 Mismatch of 'Enrolment method' showing on 'Tracking system' & 'Delegate activities' screen for 'Digital skills assessment tool' assessment

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -537,16 +537,16 @@ namespace DigitalLearningSolutions.Data.DataServices
             if (candidateAssessmentId > 1 && supervisorDelegateId == 0)
             {
                 connection.Execute(
-                        @"UPDATE CandidateAssessments SET RemovedDate = NULL, EnrolmentMethodId = @enrolmentMethodId, CompleteByDate = @completeByDateDynamic
+                        @"UPDATE CandidateAssessments SET RemovedDate = NULL, EnrolmentMethodId = @enrolmentMethodId, CompleteByDate = @completeByDateDynamic, EnrolledByAdminId = @enrolledByAdminId
                   WHERE ID = @candidateAssessmentId",
-                        new { candidateAssessmentId, enrolmentMethodId, completeByDateDynamic }
+                        new { candidateAssessmentId, enrolmentMethodId, completeByDateDynamic, enrolledByAdminId }
                     );
             }
             if (candidateAssessmentId > 1 && supervisorDelegateId != 0)
             {
                 string sqlQuery = $@"
                 BEGIN TRANSACTION
-                UPDATE CandidateAssessments SET RemovedDate = NULL, EnrolmentMethodId = @enrolmentMethodId, CompleteByDate = @completeByDateDynamic
+                UPDATE CandidateAssessments SET RemovedDate = NULL, EnrolmentMethodId = @enrolmentMethodId, CompleteByDate = @completeByDateDynamic, EnrolledByAdminId = @enrolledByAdminId
                   WHERE ID = @candidateAssessmentId
 
                 UPDATE CandidateAssessmentSupervisors SET Removed = NULL
@@ -556,7 +556,7 @@ namespace DigitalLearningSolutions.Data.DataServices
                 COMMIT TRANSACTION";
 
                 connection.Execute(sqlQuery
-                , new { candidateAssessmentId, selfAssessmentSupervisorRoleId, enrolmentMethodId, completeByDateDynamic, supervisorDelegateId });
+                , new { candidateAssessmentId, selfAssessmentSupervisorRoleId, enrolmentMethodId, completeByDateDynamic, supervisorDelegateId, enrolledByAdminId });
             }
 
             if (supervisorId > 0)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4435

### Description
I added EnrolledByAdminId field  to the update query of EnrolOnActivitySelfAssessment method so that enrolledadminid can be part of the updated field

### Screenshots
![image](https://github.com/user-attachments/assets/4e195909-5fff-4bf5-b6f6-333fa3b34a2d)
![image](https://github.com/user-attachments/assets/fb4c8399-e7ef-4505-bb03-84f242b40726)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
