### PR TITLE
TD-5265 Issue showing 'confirmation requests/confirm self assessments link' when added optional proficiencies are removed

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -615,6 +615,41 @@
             );
         }
 
+        public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(
+          int delegateUserId,
+          int selfAssessmentId,
+          int competencyId
+      )
+        {
+            return connection.Query<SelfAssessmentResult>(
+                @"SELECT
+                         s.ID,
+                        s.SelfAssessmentID,
+                        s.CompetencyID,
+                        s.AssessmentQuestionID,
+                        s.Result,
+                        s.DateTime,
+                        s.SupportingComments,
+                        s.DelegateUserId
+                    FROM SelfAssessmentResults s inner join 
+				SelfAssessmentResultSupervisorVerifications sv ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0 
+                    WHERE s.CompetencyID = @competencyId
+                        AND s.SelfAssessmentID = @selfAssessmentId
+                        AND s.DelegateUserID = @delegateUserId",
+                new { selfAssessmentId, delegateUserId, competencyId }
+            );
+        }
+
+        public void RemoveReviewCandidateAssessmentOptionalCompetencies(int id)
+        {
+           
+            connection.Execute(@"UPDATE SelfAssessmentResults SET Result = NULL WHERE ID =  @id", new { id});
+
+            connection.Execute(
+                     @"delete from SelfAssessmentResultSupervisorVerifications WHERE SelfAssessmentResultId = @id", new { id });
+
+        }
+
         private static string PrintResult(
             int competencyId,
             int selfAssessmentId,

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -173,6 +173,12 @@
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
         int GetSelfAssessmentCategoryId(int selfAssessmentId);
+        void  RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
+        public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(
+        int delegateUserId,
+        int selfAssessmentId,
+        int competencyId
+    );
     }
     public partial class SelfAssessmentDataService : ISelfAssessmentDataService
     {

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1532,6 +1532,22 @@
                     );
                 }
             }
+            var optionalCompetency =
+            (selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId)).Where(x => !x.IncludedInSelfAssessment);
+            if (optionalCompetency.Any())
+            {
+                foreach (var optinal in optionalCompetency)
+                {
+                    var selfAssessmentResults = selfAssessmentService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, optinal.Id);
+                    if (selfAssessmentResults.Any())
+                    {
+                        foreach (var item in selfAssessmentResults)
+                        {
+                            selfAssessmentService.RemoveReviewCandidateAssessmentOptionalCompetencies(item.Id);
+                        }
+                    }
+                }
+            }
             if (model.GroupOptionalCompetenciesChecked != null)
             {
                 var optionalCompetencies =
@@ -1549,7 +1565,7 @@
                 }
 
             }
-
+           
             return RedirectToAction("SelfAssessmentOverview", new { selfAssessmentId, vocabulary });
         }
 

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -150,7 +150,17 @@
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
         public int GetSelfAssessmentCategoryId(int selfAssessmentId);
-
+        IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
+           int delegateUserId,
+           int selfAssessmentId,
+           int competencyId
+       );
+        public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(
+        int delegateUserId,
+        int selfAssessmentId,
+        int competencyId
+    );
+       void RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -574,6 +584,26 @@
         public int GetSelfAssessmentCategoryId(int selfAssessmentId)
         {
             return selfAssessmentDataService.GetSelfAssessmentCategoryId(selfAssessmentId);
+        }
+        public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(
+           int delegateUserId,
+           int selfAssessmentId,
+           int competencyId
+       )
+        {
+            return selfAssessmentDataService.GetSelfAssessmentResultsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, competencyId);
+        }
+        public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(
+        int delegateUserId,
+        int selfAssessmentId,
+        int competencyId
+    )
+        {
+            return selfAssessmentDataService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, competencyId);
+        }
+        public void RemoveReviewCandidateAssessmentOptionalCompetencies(int id)
+        {
+             selfAssessmentDataService.RemoveReviewCandidateAssessmentOptionalCompetencies(id);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5265

### Description
I added GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency method to get the optional proficiencies  added
I added RemoveReviewCandidateAssessmentOptionalCompetencies method to update and remove the optional proficiencies added 
I added GetCandidateAssessmentOptionalCompetencies method to the ManageOptionalCompetencies action method this method used get and  check OptionalCompetencies removed
### Screenshots
![image](https://github.com/user-attachments/assets/32241223-2b93-4a9a-ade1-2d25cefbda8f)
![image](https://github.com/user-attachments/assets/4a34d4b1-3058-4082-aaf8-40bc57639ef6)
![image](https://github.com/user-attachments/assets/38a2aada-2ab0-49ad-8f70-086d1cbbdbf9)
![image](https://github.com/user-attachments/assets/fc668aa1-74da-47ec-b3a7-bc3df71641ad)
![image](https://github.com/user-attachments/assets/15a94556-6cd0-4dce-850c-624f5f107853)
![image](https://github.com/user-attachments/assets/2b7efae8-f810-48d7-94ae-4ac924eee662)
![image](https://github.com/user-attachments/assets/a69f81da-4841-4fdf-9a1f-5689fd99699f)
![image](https://github.com/user-attachments/assets/6e7649aa-4b5b-402d-bdf5-915ae960cf17)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
