### PR TITLE
TD-5286 tweak table

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -52,6 +52,14 @@
                  WHERE (AdminID = sa.CreatedByAdminID)) AS Owner,
                  sa.Archived,
                  sa.LastEdit,
+                STUFF((
+                        SELECT 
+                            ', ' + f.FrameworkName
+                        FROM 
+                            Frameworks f
+                       WHERE 
+                            f.ID = saf.FrameworkId
+                        FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, '') AS LinkedFrameworks,
                  (SELECT ProfessionalGroup
                  FROM    NRPProfessionalGroups
                  WHERE (ID = sa.NRPProfessionalGroupID)) AS NRPProfessionalGroup,
@@ -68,7 +76,8 @@
 
         private const string SelfAssessmentTables =
             @" LEFT OUTER JOIN
-             SelfAssessmentReviews AS sar ON sac.ID = sar.SelfAssessmentCollaboratorID AND sar.Archived IS NULL AND sar.ReviewComplete IS NULL";
+             SelfAssessmentReviews AS sar ON sac.ID = sar.SelfAssessmentCollaboratorID AND sar.Archived IS NULL AND sar.ReviewComplete IS NULL
+                LEFT OUTER JOIN SelfAssessmentFrameworks AS saf ON sa.ID = saf.SelfAssessmentId";
 
         private readonly IDbConnection connection;
         private readonly ILogger<CompetencyAssessmentDataService> logger;

--- a/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessment.cs
@@ -14,6 +14,7 @@
         public string? Owner { get; set; }
         public DateTime? Archived { get; set; }
         public DateTime LastEdit { get; set; }
+        public string? LinkedFrameworks { get; set; }
         public string? NRPProfessionalGroup { get; set; }
         public string? NRPSubGroup { get; set; }
         public string? NRPRole { get; set; }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Shared/_AssessmentsGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Shared/_AssessmentsGrid.cshtml
@@ -10,7 +10,7 @@
         Competency Assessment
       </th>
       <th role="columnheader" class="" scope="col">
-        National Profile Link
+        Framework Links
       </th>
       <th role="columnheader" class="" scope="col">
         Created
@@ -41,11 +41,9 @@
           </span>
         </td>
         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-          <span class="nhsuk-table-responsive__heading">National Profile Link </span>
+          <span class="nhsuk-table-responsive__heading">Framework links </span>
           <span class="roleprofile-linkage">
-            @(competencyAssessment.NRPProfessionalGroup != null ? @competencyAssessment.NRPProfessionalGroup : "None/Generic")
-            @(competencyAssessment.NRPSubGroupID != null ? " / " + competencyAssessment.NRPSubGroup : "")
-            @(competencyAssessment.NRPRoleID != null ? " / " + competencyAssessment.NRPRole : "")
+            @competencyAssessment.LinkedFrameworks
           </span>
         </td>
         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
@@ -71,7 +69,7 @@
           @if (competencyAssessment.UserRole > 1)
           {
             <a asp-action="ViewCompetencyAssessment" asp-route-frameworkId="@competencyAssessment.ID" asp-route-tabname="Structure">
-              View/Edit
+              Manage
             </a>
           }
           else


### PR DESCRIPTION
### JIRA link
[TD-5286](https://hee-tis.atlassian.net/browse/TD-5286)

### Description
Reads linked frameworks into the competency assessments model and displays linked frameworks on the competency assessments table. Also changes View/Edit link to Manage.

### Screenshots
![image](https://github.com/user-attachments/assets/275aef34-ede5-4500-b4c8-11f204d99c55)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5286]: https://hee-tis.atlassian.net/browse/TD-5286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ