### PR TITLE
TD-5291 Issue on 'Course set up' screen when selected Few course content first time and changed to 'All' of them clicking 'change link'

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -651,11 +651,20 @@
             {
                 data.SectionContentData = new List<SectionContentTempData>();
             }
-            if (data.EditCourseContent)
+            var sectionsToRemove = new List<SectionContentTempData>();
+            foreach (var section in data.SectionContentData)
             {
-                return RedirectToNextSectionOrSummary(
-               model.Index,
-               new SetCourseContentViewModel(data.CourseContentData!));
+                section.Tutorials = section.Tutorials
+                    .Where(t => !model.Tutorials.Any(newT => newT.TutorialId == t.TutorialId))
+                    .ToList();
+                if (!section.Tutorials.Any())
+                {
+                    sectionsToRemove.Add(section);
+                }
+            }
+            foreach (var section in sectionsToRemove)
+            {
+                data.SectionContentData.Remove(section);
             }
             data!.SectionContentData!.Add(
             new SectionContentTempData(

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -662,9 +662,12 @@
                     sectionsToRemove.Add(section);
                 }
             }
+            if (sectionsToRemove.Count > 0)
+            { 
             foreach (var section in sectionsToRemove)
             {
                 data.SectionContentData.Remove(section);
+            }
             }
             data!.SectionContentData!.Add(
             new SectionContentTempData(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5291

### Description
I loop through each section inside data.SectionContentData
I Filters out only the tutorials that exist in setCourseContentViewModelNew.Tutorials
I remove the tutorials that does not exist in setCourseContentViewModelNew.Tutorials
I save SectionContentData back into multiPageFormService

### Screenshots
![image](https://github.com/user-attachments/assets/419ddeee-a2d8-44d8-9dc1-96bdf0946540)
![image](https://github.com/user-attachments/assets/366e6d00-97dd-43d3-9f50-078cdcef3bae)
![image](https://github.com/user-attachments/assets/4220e618-1e02-4533-a0e7-2bb9bbb785cd)
![image](https://github.com/user-attachments/assets/d969cbf7-d93d-411f-b8a6-f244167e31d4)
![image](https://github.com/user-attachments/assets/9d2910b1-fd91-4359-9ef7-39302d3cad59)
![image](https://github.com/user-attachments/assets/e3159fbb-3808-4b74-a342-080cded91d32)
![image](https://github.com/user-attachments/assets/c2e74707-51dc-40fe-b46f-d5b1312ee295)
![image](https://github.com/user-attachments/assets/bc77247f-7c5d-4b72-881c-995601b18762)
![image](https://github.com/user-attachments/assets/e7ee7944-6c07-4385-992e-51fc7aacd789)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
