### PR TITLE
TD-5290- Issue on 'Course set up' screen when selected All course content first time and changed to few of them clicking 'change link'

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -674,9 +674,12 @@
                 data.SectionContentData = new List<SectionContentTempData>();
             }
 
-            var tutorialId = model.Tutorials.Select(x => x.TutorialId).FirstOrDefault();
-            var tutorialExist = data.SectionContentData!.SelectMany(x => x.Tutorials).Select(y => y.TutorialId).Contains(tutorialId);
-
+            bool tutorialExist = false;
+            if (model.Tutorials != null)
+            {
+                var tutorialId = model.Tutorials.Select(x => x.TutorialId).FirstOrDefault();
+                tutorialExist = data.SectionContentData!.SelectMany(x => x.Tutorials).Select(y => y.TutorialId).Contains(tutorialId);
+            }
 
             if (data.EditCourseContent && tutorialExist) // Edit only for existing sections else add
             {


### PR DESCRIPTION
### JIRA link
[TD-5290](https://hee-tis.atlassian.net/browse/TD-5290)

### Description
SectionContentData is updated in edit mode according to existing and newly selected sections.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5290]: https://hee-tis.atlassian.net/browse/TD-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ