### PR TITLE
TD-5327 update nhs design system

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -95,7 +95,6 @@
             <partial name="/Views/LearningPortal/Shared/_LoadingSpinner.cshtml" />
         </div>
         <partial name="_DlsFooter" />
-        <script src="@Url.Content("~/js/nhsuk.js")" asp-append-version="true"></script>>
         @await RenderSectionAsync("scripts", false)
     </div>
 </body>

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -102,22 +102,13 @@
                         }
                     </a>
                 </div>
-
-                @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true)
-                {
-                    <div class="nhsuk-header__content" id="content-header">
-                        <div class="nhsuk-header__menu">
-                            <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
-                        </div>
-                    </div>
-                }
                 <vc:logo customisation-id="@((int?)ViewData[LayoutViewDataKeys.CustomisationIdForHeaderLogo])" />
             </div>
 
             @if ((bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] != true)
             {
                 <div class="nhsuk-navigation-container">
-                    <nav class="nhsuk-header__navigation" id="header-navigation" aria-label="Primary navigation" role="navigation">
+                    <nav class="nhsuk-navigation" id="header-navigation" aria-label="Primary navigation" role="navigation">
                         <ul class="nhsuk-header__navigation-list">
                             @if (IsSectionDefined("NavMenuItems"))
                             {
@@ -180,7 +171,6 @@
         @await RenderSectionAsync("scripts", false)
         <script src="@Url.Content("~/js/learningPortal/dlscommon.js")" asp-append-version="true"></script>
         <script src="@Url.Content("~/js/cookiesbanner.js")" asp-append-version="true"></script>
-        <script src="@Url.Content("~/js/nhsuk.js")" asp-append-version="true"></script>>
         <input type="hidden" id="keepAlivePingPath" value="@Url.Action("ping","keepSessionAlive")" />
 
     </div>


### PR DESCRIPTION
### JIRA link
[TD-5327](https://hee-tis.atlassian.net/browse/TD-5327)

### Description
Fixes errors with markup and js referencing that were preventing the more button from collapsing properly.

### Screenshots
![localhost_44363_Home_Welcome(iPhone SE)](https://github.com/user-attachments/assets/b7102e93-e4a6-4b3e-a731-0f1b261c7362)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5327]: https://hee-tis.atlassian.net/browse/TD-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ