### PR TITLE
TD-4475-Count of matching proficiencies should be shown on 'Supervisor' section same as on 'Learning Portal' for the self assessments

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -620,20 +620,21 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         {
             return connection.Query<DelegateSelfAssessment>(
                @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.QuestionLabel, sa.DescriptionLabel, sa.ReviewerCommentsLabel,
-                sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, ca.StartedDate,
-                COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed,
-                ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate,
-                 (SELECT COUNT(*) AS Expr1
-                 FROM    CandidateAssessmentSupervisorVerifications AS casv
-                 WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-                {signedOffFields}
-                 (SELECT COUNT(*) AS Expr1
-                    FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
-                    WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (sarsv.Superceded = 0)) AS ResultsVerificationRequests
-                FROM CandidateAssessmentSupervisors AS cas INNER JOIN
-                         CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-                SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID
-                WHERE (ca.ID = @candidateAssessmentId) AND (ISNULL(@adminIdCategoryID, 0) = 0 OR sa.CategoryID = @adminIdCategoryId)", new { candidateAssessmentId, adminIdCategoryId }
+                            sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, ca.StartedDate,
+                            COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed,
+                            ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate,
+                            (SELECT COUNT(*) AS Expr1
+                                FROM    CandidateAssessmentSupervisorVerifications AS casv
+                                WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
+                            {signedOffFields}
+                            (SELECT COUNT(*) AS Expr1
+                                FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
+                                WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (sarsv.Superceded = 0)) AS ResultsVerificationRequests,
+                            sa.Vocabulary
+                    FROM CandidateAssessmentSupervisors AS cas INNER JOIN
+                            CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
+                            SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID
+                    WHERE (ca.ID = @candidateAssessmentId) AND (ISNULL(@adminIdCategoryID, 0) = 0 OR sa.CategoryID = @adminIdCategoryId)", new { candidateAssessmentId, adminIdCategoryId }
                ).FirstOrDefault();
         }
         public DelegateSelfAssessment? GetSelfAssessmentBySupervisorDelegateCandidateAssessmentId(int candidateAssessmentId, int supervisorDelegateId)
@@ -696,23 +697,24 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         {
             return connection.Query<DelegateSelfAssessment>(
                 @$"SELECT ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, sa.ReviewerCommentsLabel, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup, sa.SupervisorResultsReview AS IsSupervisorResultsReviewed,
-                 (SELECT COUNT(*) AS Expr1
-                 FROM    CandidateAssessmentSupervisorVerifications AS casv
-                 WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
-               {signedOffFields}
-                 (SELECT COUNT(*) AS Expr1
-                    FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
-                    WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (Superceded = 0)) AS ResultsVerificationRequests,
-                    ca.NonReportable,ca.DelegateUserID
+                            (SELECT COUNT(*) AS Expr1
+                            FROM    CandidateAssessmentSupervisorVerifications AS casv
+                            WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
+                            {signedOffFields}
+                            (SELECT COUNT(*) AS Expr1
+                            FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
+                            WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Verified IS NULL) AND (Superceded = 0)) AS ResultsVerificationRequests,
+                            ca.NonReportable,ca.DelegateUserID,
+                            sa.Vocabulary
                     FROM   CandidateAssessmentSupervisors AS cas INNER JOIN
-                         CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
-                           SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID INNER JOIN
-                             SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID LEFT OUTER JOIN
-                             NRPProfessionalGroups AS pg ON sa.NRPProfessionalGroupID = pg.ID LEFT OUTER JOIN
-                             NRPSubGroups AS sg ON sa.NRPSubGroupID = sg.ID LEFT OUTER JOIN
-                             NRPRoles AS r ON sa.NRPRoleID = r.ID
-                             LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
-                WHERE (ca.ID = @candidateAssessmentId) AND (cas.Removed IS NULL) AND (sd.SupervisorAdminID = @adminId) AND (ISNULL(@adminIdCategoryID, 0) = 0 OR sa.CategoryID = @adminIdCategoryId)",
+                            CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID INNER JOIN
+                            SelfAssessments AS sa ON sa.ID = ca.SelfAssessmentID INNER JOIN
+                            SupervisorDelegates AS sd ON cas.SupervisorDelegateId = sd.ID LEFT OUTER JOIN
+                            NRPProfessionalGroups AS pg ON sa.NRPProfessionalGroupID = pg.ID LEFT OUTER JOIN
+                            NRPSubGroups AS sg ON sa.NRPSubGroupID = sg.ID LEFT OUTER JOIN
+                            NRPRoles AS r ON sa.NRPRoleID = r.ID
+                            LEFT OUTER JOIN SelfAssessmentSupervisorRoles AS sasr ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
+                    WHERE (ca.ID = @candidateAssessmentId) AND (cas.Removed IS NULL) AND (sd.SupervisorAdminID = @adminId) AND (ISNULL(@adminIdCategoryID, 0) = 0 OR sa.CategoryID = @adminIdCategoryId)",
                 new { candidateAssessmentId, adminId, adminIdCategoryId }
                 ).FirstOrDefault();
         }

--- a/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
@@ -28,5 +28,6 @@
         public bool IsSupervisorResultsReviewed { get; set; }
         public bool IsAssignedToSupervisor { get; set; }
         public bool NonReportable { get; set; }
+        public string? Vocabulary { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/ReviewSelfAssessmentViewModel.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
 {
-    using DigitalLearningSolutions.Data.Models.Frameworks;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
     using DigitalLearningSolutions.Data.Models.Supervisor;
     using DigitalLearningSolutions.Web.Helpers;
@@ -15,9 +14,9 @@
         public IEnumerable<SupervisorSignOff>? SupervisorSignOffs { get; set; }
         public bool IsSupervisorResultsReviewed { get; set; }
         public SearchSupervisorCompetencyViewModel SearchViewModel { get; set; }
-        public string VocabPlural(string vocabulary)
+        public string VocabPlural()
         {
-            return FrameworkVocabularyHelper.VocabularyPlural(vocabulary);
+            return FrameworkVocabularyHelper.VocabularyPlural(DelegateSelfAssessment.Vocabulary);
         }
         public int CandidateAssessmentId { get; set; }
         public bool ExportToExcelHide { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -96,7 +96,7 @@
             </a>
         }
 
-        @if(Model.CompetencySummaries.CanViewCertificate)
+        @if (Model.CompetencySummaries.CanViewCertificate)
         {
             <a class="nhsuk-button"
                asp-route-candidateAssessmentId="@Model.CandidateAssessmentId"
@@ -106,11 +106,11 @@
                 Certificate
             </a>
         }
-        @if(Model.DelegateSelfAssessment.SignOffRequested > 0 && Model.CompetencySummaries.VerifiedCount == Model.CompetencySummaries.QuestionsCount)
+        @if (Model.DelegateSelfAssessment.SignOffRequested > 0 && Model.CompetencySummaries.VerifiedCount == Model.CompetencySummaries.QuestionsCount)
         {
             <a role="button" asp-action="SignOffProfileAssessment" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Sign-off self assessment</a>
         }
-        @if((Model.DelegateSelfAssessment.ResultsVerificationRequests > 1) && Model.CompetencySummaries.VerifiedCount < Model.CompetencySummaries.QuestionsCount)
+        @if ((Model.DelegateSelfAssessment.ResultsVerificationRequests > 1) && Model.CompetencySummaries.VerifiedCount < Model.CompetencySummaries.QuestionsCount)
         {
             <a role="button" asp-action="VerifyMultipleResults" asp-route-candidateAssessmentId="@Model.DelegateSelfAssessment.ID" asp-route-supervisorDelegateId="@Model.SupervisorDelegateDetail.ID" class="nhsuk-button">Confirm multiple results</a>
         }
@@ -119,6 +119,7 @@
 <partial name="../../Supervisor/Shared/_SearchSupervisorCompetency"
          model="@Model.SearchViewModel"
          view-data="@(new ViewDataDictionary(ViewData) { { "parent", Model } })" />
+<p><span role="alert">@Model.CompetencyGroups.Sum(g => g.Count()) matching @Model.VocabPlural().ToLower()</span></p>
 @if (Model.CompetencyGroups.Any())
 {
     foreach (var competencyGroup in Model.CompetencyGroups)

--- a/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
@@ -1,56 +1,56 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Supervisor;
 @model ReviewSelfAssessmentViewModel;
 @{
-  ViewData["Title"] = "Review Self Assessment";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    ViewData["Title"] = "Review Self Assessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 <link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
-           asp-action="DelegateProfileAssessments"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
-            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-          </a>
-        </li>
-        <li class="nhsuk-breadcrumb__item">
-          <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment"
-           asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-           asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-            @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
-          </a>
-        </li>
-        <li>
-          Confirm results
-        </li>
-      </ol>
-    </div>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
-       asp-action="ReviewDelegateSelfAssessment"
-       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
-       asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
-        Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
-      Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
-      </a>
-    </p>
-  </nav>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor"
+                       asp-action="DelegateProfileAssessments"
+                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]">
+                        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+                    </a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment"
+                       asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+                       asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+                        @(Model.DelegateSelfAssessment.RoleName.Length > 35 ? Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
+                    </a>
+                </li>
+                <li>
+                    Confirm results
+                </li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor"
+               asp-action="ReviewDelegateSelfAssessment"
+               asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]"
+               asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">
+                Back to @(Model.DelegateSelfAssessment.RoleName.Length > 35 ?
+            Model.DelegateSelfAssessment.RoleName.Substring(0, 32) + "..." : Model.DelegateSelfAssessment.RoleName)
+            </a>
+        </p>
+    </nav>
 }
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
@@ -72,92 +72,92 @@
         </div>
     </div>
 }
-  <details class="nhsuk-details nhsuk-expander">
+<details class="nhsuk-details nhsuk-expander">
     <summary class="nhsuk-details__summary">
-      <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
-        @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
-      </h1>
+        <h1 class="nhsuk-details__summary-text nhsuk-u-margin-bottom-0">
+            @Model.SupervisorDelegateDetail.FirstName @Model.SupervisorDelegateDetail.LastName
+        </h1>
     </summary>
     <div class="nhsuk-details__text">
-      <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
+        <partial name="Shared/_StaffDetails" model="Model.SupervisorDelegateDetail" />
     </div>
-  </details>
-  <h2>Confirm Multiple Results for @Model.DelegateSelfAssessment.RoleName</h2>
-  @if (Model.CompetencyGroups.Any())
+</details>
+<h2>Confirm Multiple Results for @Model.DelegateSelfAssessment.RoleName</h2>
+@if (Model.CompetencyGroups.Any())
 {
-  <h3>Tick each self assessment result that you wish to confirm and then click Submit</h3>
-  <form method="post">
-    @foreach (var competencyGroup in Model.CompetencyGroups)
-    {
-      var vocabulary = competencyGroup.First().Vocabulary;
-      <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
-        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-          <span class="nhsuk-fieldset__heading">
-            @competencyGroup.Key
-          </span>
-        </legend>
-      </fieldset>
-      @if (competencyGroup.Count() > 1)
-      {
-        <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
-          <div class="nhsuk-grid-column-full">
-            <a class="nhsuk-button select-all-button select-all status-tag nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural(vocabulary).ToLower()</a>
-            <a class="nhsuk-button select-all-button deselect-all status-tag nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural(vocabulary).ToLower()</a>
-          </div>
-        </div>
-      }
-      <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
-        <thead role="rowgroup" class="nhsuk-table__head">
-          <tr role="row">
-            <th role="columnheader" class="" scope="col">
-              @vocabulary
-            </th>
-            <th role="columnheader" class="" scope="col">
-              Question
-            </th>
-            <th role="columnheader" class="" scope="col">
-              Response
-            </th>
-          </tr>
-        </thead>
-        <tbody class="nhsuk-table__body">
-          @foreach (var competency in competencyGroup)
-          {
-            @foreach (var question in competency.AssessmentQuestions)
+    <h3>Tick each self assessment result that you wish to confirm and then click Submit</h3>
+    <form method="post">
+        @foreach (var competencyGroup in Model.CompetencyGroups)
+        {
+            var vocabulary = competencyGroup.First().Vocabulary;
+            <fieldset class="nhsuk-fieldset nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
+                <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                    <span class="nhsuk-fieldset__heading">
+                        @competencyGroup.Key
+                    </span>
+                </legend>
+            </fieldset>
+            @if (competencyGroup.Count() > 1)
             {
-              <tr role="row" class="nhsuk-table__row">
-                <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                  <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
-                  <div class="nhsuk-checkboxes__item">
-                    <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.SelfAssessmentResultSupervisorVerificationId" name="resultChecked" type="checkbox" value="@question.SelfAssessmentResultSupervisorVerificationId">
-                    <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
-                      @competency.Name
-                    </label>
-                  </div>
-                </td>
-                <partial name="Shared/_AssessmentQuestionCells" model="question" />
-              </tr>
+                <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">
+                    <div class="nhsuk-grid-column-full">
+                        <a class="nhsuk-button select-all-button select-all status-tag nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" name="selectAll" value="true">Select all @Model.VocabPlural().ToLower()</a>
+                        <a class="nhsuk-button select-all-button deselect-all status-tag nhsuk-u-margin-bottom-1" role="button" data-group="@competencyGroup.Key" id="" name="selectAll" value="false">Deselect all @Model.VocabPlural().ToLower()</a>
+                    </div>
+                </div>
             }
-          }
-        </tbody>
-      </table>
-    }
-    <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
-      <div class="nhsuk-grid-column-full">
-        <button class="nhsuk-button" type="submit">Submit</button>
-        <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">Cancel</a>
-      </div>
-    </div>
-  </form>
+            <table role="table" class="nhsuk-table-responsive nhsuk-u-margin-top-4">
+                <thead role="rowgroup" class="nhsuk-table__head">
+                    <tr role="row">
+                        <th role="columnheader" class="" scope="col">
+                            @vocabulary
+                        </th>
+                        <th role="columnheader" class="" scope="col">
+                            Question
+                        </th>
+                        <th role="columnheader" class="" scope="col">
+                            Response
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="nhsuk-table__body">
+                    @foreach (var competency in competencyGroup)
+                    {
+                        @foreach (var question in competency.AssessmentQuestions)
+                        {
+                            <tr role="row" class="nhsuk-table__row">
+                                <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                    <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
+                                    <div class="nhsuk-checkboxes__item">
+                                        <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.SelfAssessmentResultSupervisorVerificationId" name="resultChecked" type="checkbox" value="@question.SelfAssessmentResultSupervisorVerificationId">
+                                        <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
+                                            @competency.Name
+                                        </label>
+                                    </div>
+                                </td>
+                                <partial name="Shared/_AssessmentQuestionCells" model="question" />
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        }
+        <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+            <div class="nhsuk-grid-column-full">
+                <button class="nhsuk-button" type="submit">Submit</button>
+                <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">Cancel</a>
+            </div>
+        </div>
+    </form>
 }
 else
 {
-  <p>
-    Oops. There are no results awaiting confirmation.
-  </p>
-  <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">Cancel</a>
+    <p>
+        Oops. There are no results awaiting confirmation.
+    </p>
+    <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-controller="Supervisor" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@ViewContext.RouteData.Values["candidateAssessmentId"]">Cancel</a>
 }
 
 @section scripts {
-  <script src="@Url.Content("~/js/Supervisor/verifyMultipleResults.js")" asp-append-version="true"></script>
+    <script src="@Url.Content("~/js/Supervisor/verifyMultipleResults.js")" asp-append-version="true"></script>
 }


### PR DESCRIPTION
### JIRA link
[TD-4475](https://hee-tis.atlassian.net/browse/TD-4475)

### Description
Matching proficiencies count added to screen.
VocabPlural method updated to get vocabulary.

### Screenshots

![image](https://github.com/user-attachments/assets/ebc6daa1-9e25-4c17-944f-ed366ea3ad46)

![image](https://github.com/user-attachments/assets/78dc7521-42b3-4d29-b985-df8a6747c1e0)

![image](https://github.com/user-attachments/assets/1f73a8e1-419d-49a9-b25e-ff24cd372b5d)

![image](https://github.com/user-attachments/assets/bf93380b-803b-4224-9a3d-26bb596cba84)


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-4475]: https://hee-tis.atlassian.net/browse/TD-4475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ