### PR TITLE
TD-5334 Pulls breadcrumb out of header

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -159,8 +159,11 @@
                 <partial name="_UserFeedbackBarPartial" model=@(userResearchUrl) />
             </feature>
 
-            @RenderSection("NavBreadcrumbs", false)
+
         </header>
+        <div class="nhsuk-grid-row">
+            @RenderSection("NavBreadcrumbs", false)
+        </div>
         <div class="nhsuk-width-container" id="maincontentwrapper">
             <main class="nhsuk-main-wrapper" id="maincontent" tabindex="-1">
                 @RenderBody()


### PR DESCRIPTION
### JIRA link
[TD-5334](https://hee-tis.atlassian.net/browse/TD-5334)

### Description
Pulls the breadcrumb out of the header and into the body to reflect the example usage in the NHS design system.

### Screenshots
![image](https://github.com/user-attachments/assets/3d6bfc59-f4b8-46e4-bf96-8ed0babf3d29)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5334]: https://hee-tis.atlassian.net/browse/TD-5334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ