### PR TITLE
TD-5222 Error when enrolling a staff on self assessment from the tracking system

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -551,7 +551,7 @@ namespace DigitalLearningSolutions.Data.DataServices
 
                 UPDATE CandidateAssessmentSupervisors SET Removed = NULL
                  {((selfAssessmentSupervisorRoleId > 0) ? " ,SelfAssessmentSupervisorRoleID = @selfAssessmentSupervisorRoleID" : string.Empty)}
-                WHERE CandidateAssessmentID = @candidateAssessmentId AND SupervisorDelegateId = @supervisorDelegateId 
+                WHERE CandidateAssessmentID = @candidateAssessmentId AND SupervisorDelegateId = @supervisorDelegateId AND SelfAssessmentSupervisorRoleID = @selfAssessmentSupervisorRoleID
 
                 COMMIT TRANSACTION";
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5222

### Description
I added SelfAssessmentSupervisorRoleID to the where clause of the query that is updating CandidateAssessmentSupervisors table

### Screenshots
![image](https://github.com/user-attachments/assets/97b15338-03e1-4db0-a4ac-96bd4a5bb058)
![image](https://github.com/user-attachments/assets/ba7ac5e9-4bc9-45f1-9a34-0554293a9e25)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
