### PR TITLE
TD-5333 Issue with optional proficiencies not retaining to previous State when removed and added them back

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -635,7 +635,7 @@
 				SelfAssessmentResultSupervisorVerifications sv ON s.ID = sv.SelfAssessmentResultId AND sv.Superceded = 0 
                     WHERE s.CompetencyID = @competencyId
                         AND s.SelfAssessmentID = @selfAssessmentId
-                        AND s.DelegateUserID = @delegateUserId",
+                        AND s.DelegateUserID = @delegateUserId AND sv.Verified IS NULL",
                 new { selfAssessmentId, delegateUserId, competencyId }
             );
         }
@@ -643,8 +643,6 @@
         public void RemoveReviewCandidateAssessmentOptionalCompetencies(int id)
         {
            
-            connection.Execute(@"UPDATE SelfAssessmentResults SET Result = NULL WHERE ID =  @id", new { id});
-
             connection.Execute(
                      @"delete from SelfAssessmentResultSupervisorVerifications WHERE SelfAssessmentResultId = @id", new { id });
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5333

### Description
I modified the RemoveReviewCandidateAssessmentOptionalCompetencies method, I removed the query that updates the Result field in SelfAssessmentResults  table 
I also modified the GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency method, I added the Verify is Null to the where clause 

### Screenshots
![image](https://github.com/user-attachments/assets/4d1d501f-3ce8-4c55-8efc-42876f7b5d2b)
![image](https://github.com/user-attachments/assets/ee223c41-f481-4888-b038-9aa35e1add13)
![image](https://github.com/user-attachments/assets/c6f5c42d-5d62-4f20-a3f1-dd9d712fe291)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
