### PR TITLE
TD-3542 Console '500' error is seeing on the 'My staff' screen when clicked 'Supervise' link for 'Version_2_Data_Professions framework' assessment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -1061,8 +1061,8 @@
 
                 var sessionEnrolOnRoleProfile = new SessionEnrolOnRoleProfile()
                 {
-                    SelfAssessmentID = supervisorRoles.FirstOrDefault().SelfAssessmentID,
-                    SelfAssessmentSupervisorRoleId = supervisorRoles.FirstOrDefault().ID
+                    SelfAssessmentID = supervisorRoles.FirstOrDefault() != null ? supervisorRoles.FirstOrDefault().SelfAssessmentID : selfAssessmentId,
+                    SelfAssessmentSupervisorRoleId = supervisorRoles.FirstOrDefault() != null ? supervisorRoles.FirstOrDefault().ID : 0
                 };
 
                 multiPageFormService.SetMultiPageFormData(
@@ -1070,7 +1070,7 @@
                     MultiPageFormDataFeature.EnrolDelegateOnProfileAssessment,
                     TempData
                 );
-                var supervisorRoleName = supervisorRoles.FirstOrDefault().RoleName;
+                var supervisorRoleName = supervisorRoles.FirstOrDefault() != null ? supervisorRoles.FirstOrDefault().RoleName : "";
                 var model = new EnrolDelegateSummaryViewModel
                 {
                     RoleProfile = roleProfile,

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/EnrolDelegateSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/EnrolDelegateSummaryViewModel.cs
@@ -12,5 +12,6 @@
         public string SupervisorRoleName { get; set; }
         public int SupervisorRoleCount { get; set; }
         public bool AllowSupervisorRoleSelection { get; set; }
+        public bool HasSupervisorRoles => !string.IsNullOrWhiteSpace(SupervisorRoleName);
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRoleSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRoleSummary.cshtml
@@ -47,7 +47,15 @@
             <partial name="Shared/_StaffDetails" model="Model.Item1.SupervisorDelegateDetail" />
         </div>
     </details>
-    <h2>Supervision Summary</h2>
+@if (string.IsNullOrWhiteSpace(Model.Item1.SupervisorRoleName))
+{
+    <p>No supervisor roles have been configured for this self assessment.</p>
+}
+else
+{
+    
+
+<h2>Supervision Summary</h2>
     <dl class="nhsuk-summary-list">
 
         <div class="nhsuk-summary-list__row">
@@ -115,3 +123,4 @@
         Cancel
     </a>
 </div>
+}

--- a/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRoleSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/SelectDelegateSupervisorRoleSummary.cshtml
@@ -47,7 +47,7 @@
             <partial name="Shared/_StaffDetails" model="Model.Item1.SupervisorDelegateDetail" />
         </div>
     </details>
-@if (string.IsNullOrWhiteSpace(Model.Item1.SupervisorRoleName))
+@if (!Model.Item1.HasSupervisorRoles)
 {
     <p>No supervisor roles have been configured for this self assessment.</p>
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3542

### Description
I added validation to supervisorRoles  to take care of NullReferenceException that is causing error 500
I also added validation SelectDelegateSupervisorRoleSummary.cshtml page to show if  no supervisor roles is configured for the self assessment 

### Screenshots
![image](https://github.com/user-attachments/assets/1aaa2f49-24ea-41d5-a5fc-f0ab7620ecc4)
![image](https://github.com/user-attachments/assets/3aafd89f-ea6e-41c4-94eb-896ac89c4729)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
