### PR TITLE
TD-5345 Fixes header styling issue

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -32,14 +32,8 @@ footer {
 }
 
 .nhsuk-header__navigation-item.selected {
-  @include mq($from: large-desktop) {
-    box-shadow: inset 0 -4px 0 #d8dde0;
-  }
-
-  @include mq($until: large-desktop) {
-    a {
-      font-weight: bold;
-    }
+  a {
+    font-weight: bold;
   }
 }
 

--- a/DigitalLearningSolutions.Web/Styles/layout.scss
+++ b/DigitalLearningSolutions.Web/Styles/layout.scss
@@ -37,6 +37,30 @@ footer {
   }
 }
 
+.nhsuk-header__logo {
+  @include mq($until: large-desktop) {
+    max-width: unset;
+
+    .nhsuk-header__link--service {
+      align-items: center;
+      display: flex;
+      -ms-flex-align: center;
+      margin-bottom: 0;
+      width: auto;
+    }
+
+    .nhsuk-header__service-name {
+      padding-left: nhsuk-spacing(3);
+      max-width: unset;
+    }
+  }
+}
+.nhsuk-navigation-container {
+  @include mq($until: tablet) {
+    margin-top: unset;
+  }
+}
+
 body:not(.js-enabled) {
   .nhsuk-header__menu {
     display: none;

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -65,11 +65,11 @@
     {
         @await Html.PartialAsync("~/Views/Shared/_GoogleTagManagerBodyTagJs.cshtml")
     }
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
     <div id="pagewrapper">
         <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white" role="banner">
-            <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
             <partial name="_CookieConsentPartial" />
-            <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
             @if (Configuration["ShowAlertBanner"] == "True")
             {
                 <div class="dls-alert-banner no-print">

--- a/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_Layout.cshtml
@@ -153,7 +153,6 @@
             @{
                 var visualSeparatorNoNavBar = (bool?)ViewData[LayoutViewDataKeys.DoNotDisplayNavBar] == true ? "visual-separator-no-nav-bar" : string.Empty;
             }
-            <div class="visual-separator @visualSeparatorNoNavBar"></div>
 
             <feature name="@(FeatureFlags.UserFeedbackBar)">
                 <partial name="_UserFeedbackBarPartial" model=@(userResearchUrl) />


### PR DESCRIPTION
### JIRA link
[TD-5345](https://hee-tis.atlassian.net/browse/TD-5345)

### Description
Fixes header styling issues:
- max width and flex box layout of service name
- removal of active nav item border indicator

### Screenshots
![image](https://github.com/user-attachments/assets/a650a714-bc2d-4467-a9fd-bfe68030b8e7)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5345]: https://hee-tis.atlassian.net/browse/TD-5345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ