### PR TITLE
TD-5291 Issue on 'Course set up' screen when selected Few course content first time and changed to 'All' of them clicking 'change link'

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/CourseSetup/CourseSetupController.cs
@@ -461,14 +461,14 @@
 
             var showDiagnostic = data.Application!.DiagAssess;
             var tutorial = GetTutorialsFromSectionContentData(data.SectionContentData, tutorials);
-            if(tutorial.Count() == 0)
+            if (tutorial.Count() == 0)
             {
                 var models = new SetSectionContentViewModel(section, sectionIndex, showDiagnostic, tutorials);
                 return View("AddNewCentreCourse/SetSectionContent", models);
             }
-                var model = new SetSectionContentViewModel(section, sectionIndex, showDiagnostic, tutorial);
-                return View("AddNewCentreCourse/SetSectionContent", model);
-           
+            var model = new SetSectionContentViewModel(section, sectionIndex, showDiagnostic, tutorial);
+            return View("AddNewCentreCourse/SetSectionContent", model);
+
 
         }
 
@@ -510,7 +510,7 @@
 
                 updatedSections.AddRange(matchingSections);
             }
-            
+
             updatedSections = updatedSections.Distinct().ToList();
             data.SectionContentData = updatedSections;
             multiPageFormService.SetMultiPageFormData(data, MultiPageFormDataFeature.AddNewCourse, TempData);
@@ -677,11 +677,11 @@
                 }
             }
             if (sectionsToRemove.Count > 0)
-            { 
-            foreach (var section in sectionsToRemove)
             {
-                data.SectionContentData.Remove(section);
-            }
+                foreach (var section in sectionsToRemove)
+                {
+                    data.SectionContentData.Remove(section);
+                }
             }
             data!.SectionContentData!.Add(
             new SectionContentTempData(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5291

### Description
At the point of opening the summary page, I compared the SectionContentTempData and CourseContentData and removed the section that was not added but still in the memory this fixed the issue mentioned in the TD-5290
I also fixed the goto issue by checking if the SectionContentData already selected, I load the selected section if not I return section 
### Screenshots

![image](https://github.com/user-attachments/assets/d6d74969-1960-4f0a-b2b2-c6a27ff65fef)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
