### PR TITLE
TD-5234 Issue with few proficiencies on copy2 self assessments not sh…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -307,7 +307,7 @@
                     SELECT {CompetencyFields}
                     FROM {CompetencyTables} INNER JOIN SelfAssessments AS SA ON CA.SelfAssessmentID = SA.ID
                     WHERE ((LAR.Requested IS NULL) OR (LAR.Requested < DATEADD(week, -1, getUTCDate()))) AND (LAR.Verified IS NULL) AND ((LAR.Result IS NOT NULL)
-                        OR (LAR.SupportingComments IS NOT NULL)) AND ((CAOC.IncludedInSelfAssessment = 1) OR (SAS.Optional = 0)) AND ((SA.EnforceRoleRequirementsForSignOff = 0) OR (CAQ.Required = 0))
+                        OR (LAR.SupportingComments IS NOT NULL)) AND ((CAOC.IncludedInSelfAssessment = 1) OR (SAS.Optional = 0)) AND ((SA.EnforceRoleRequirementsForSignOff = 1) OR (CAQ.Required = 0))
 						OR ((LAR.Requested IS NULL) OR (LAR.Requested < DATEADD(week, -1, getUTCDate()))) AND (LAR.Verified IS NULL) AND (LAR.ResultRAG = 3) AND ((CAOC.IncludedInSelfAssessment = 1) 
 						OR (SAS.Optional = 0)) AND (SA.EnforceRoleRequirementsForSignOff = 1)
                     ORDER BY SAS.Ordering, CAQ.Ordering",


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5234

### Description
After testing the issue, I found that proficiencies were not appearing on the Manage Confirmation Request page because the WHERE condition for EnforceRoleRequirementsForSignOff was set to false. However, in the SelfAssessments table, assessments requiring sign-off have EnforceRoleRequirementsForSignOff set to true.

To resolve this, I modified the query in the GetCandidateAssessmentResultsToVerifyById method, changing the WHERE clause to filter for EnforceRoleRequirementsForSignOff = true instead of false. This adjustment successfully fixed the issue, ensuring that proficiencies now display correctly.

### Screenshots
![image](https://github.com/user-attachments/assets/f8f7b19e-ba87-4c9a-89fe-9d93f50ed98e)
![image](https://github.com/user-attachments/assets/296421f8-22a2-4204-a3de-1ec298b1a49f)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
