### PR TITLE
TD-5367-Issue showing duplicate self assessments on 'Supervisor Dashboard - My staff' screen

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -173,7 +173,7 @@
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
         int GetSelfAssessmentCategoryId(int selfAssessmentId);
-        void  RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
+        void RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
         public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(
         int delegateUserId,
         int selfAssessmentId,
@@ -682,9 +682,6 @@
                     BEGIN TRANSACTION
                         UPDATE CandidateAssessments SET RemovedDate = GETUTCDATE(), RemovalMethodID = 2
                             WHERE ID = @candidateAssessmentsId AND RemovedDate IS NULL
-
-                        UPDATE CandidateAssessmentSupervisors SET Removed = GETUTCDATE()
-                            WHERE CandidateAssessmentID = @candidateAssessmentsId AND Removed IS NULL
 
                         COMMIT TRANSACTION
                 END TRY


### PR DESCRIPTION
### JIRA link
[TD-5367](https://hee-tis.atlassian.net/browse/TD-5367)

### Description

Removed 'Update CandidateAssessmentSupervisors..' when removing self assessment which helps to preserve previously selected supervisors. Updated CandidateAssessmentSupervisor during self-assessment enrolment so that only one supervisor role is active for a candidate assessment. This solves the current problem.

### Screenshots


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [x] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [DLS self assessment enrolment business rules](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/4627398657/DLS+self+assessment+enrolment+business+rules)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5367]: https://hee-tis.atlassian.net/browse/TD-5367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ