### PR TITLE
TD-5308 Implements assessment provider and category page

### DIFF
--- a/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessment.cs
@@ -9,6 +9,11 @@
             get => brand;
             set => brand = GetValidOrNull(value);
         }
+        public string? Category
+        {
+            get => category;
+            set => category = GetValidOrNull(value);
+        }
         public string? ParentCompetencyAssessment { get; set; }
         public string? Owner { get; set; }
         public DateTime? Archived { get; set; }
@@ -19,6 +24,7 @@
         public string? NRPRole { get; set; }
         public int? CompetencyAssessmentReviewID { get; set; }
         private string? brand;
+        private string? category;
         private static string? GetValidOrNull(string? toValidate)
         {
             return toValidate != null && toValidate.ToLower() == "undefined" ? null : toValidate;

--- a/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessmentBase.cs
+++ b/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessmentBase.cs
@@ -1,6 +1,5 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.CompetencyAssessments
 {
-    using System;
     using System.ComponentModel.DataAnnotations;
     public class CompetencyAssessmentBase
     {
@@ -10,6 +9,7 @@
         public string CompetencyAssessmentName { get; set; } = string.Empty;
         public string? Description { get; set; }
         public int BrandID { get; set; }
+        public int CategoryID { get; set; }
         public int? ParentCompetencyAssessmentID { get; set; }
         public bool National { get; set; }
         public bool Public { get; set; }

--- a/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
@@ -13,7 +13,8 @@ namespace DigitalLearningSolutions.Web.Services
 
         CompetencyAssessmentBase? GetCompetencyAssessmentBaseById(int competencyAssessmentId, int adminId);
 
-        CompetencyAssessmentBase? GetCompetencyAssessmentByName(string competencyAssessmentName, int adminId);
+        CompetencyAssessmentBase? GetCompetencyAssessmentBaseByName(string competencyAssessmentName, int adminId);
+        CompetencyAssessment? GetCompetencyAssessmentById(int competencyAssessmentId, int adminId);
 
         IEnumerable<NRPProfessionalGroups> GetNRPProfessionalGroups();
 
@@ -24,10 +25,13 @@ namespace DigitalLearningSolutions.Web.Services
 
         bool UpdateCompetencyAssessmentProfessionalGroup(int competencyAssessmentId, int adminId, int? nrpProfessionalGroupID);
         bool UpdateIntroductoryTextTaskStatus(int assessmentId, bool taskStatus);
+        bool UpdateCompetencyAssessmentDescription(int assessmentId, int adminId, string description);
+        bool UpdateCompetencyAssessmentBranding(int assessmentId, int adminId, int brandID, int categoryID);
+        bool UpdateBrandingTaskStatus(int assessmentId, bool taskStatus);
 
         //INSERT DATA
         int InsertCompetencyAssessment(int adminId, int centreId, string competencyAssessmentName, int? frameworkId);
-        bool UpdateCompetencyAssessmentDescription(int iD, int adminId, string description);
+       
     }
     public class CompetencyAssessmentService : ICompetencyAssessmentService
     {
@@ -53,9 +57,9 @@ namespace DigitalLearningSolutions.Web.Services
             return competencyAssessmentDataService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
         }
 
-        public CompetencyAssessmentBase? GetCompetencyAssessmentByName(string competencyAssessmentName, int adminId)
+        public CompetencyAssessmentBase? GetCompetencyAssessmentBaseByName(string competencyAssessmentName, int adminId)
         {
-            return competencyAssessmentDataService.GetCompetencyAssessmentByName(competencyAssessmentName, adminId);
+            return competencyAssessmentDataService.GetCompetencyAssessmentBaseByName(competencyAssessmentName, adminId);
         }
 
         public IEnumerable<CompetencyAssessment> GetCompetencyAssessmentsForAdminId(int adminId)
@@ -99,6 +103,21 @@ namespace DigitalLearningSolutions.Web.Services
         public bool UpdateIntroductoryTextTaskStatus(int assessmentId, bool taskStatus)
         {
             return competencyAssessmentDataService.UpdateIntroductoryTextTaskStatus(assessmentId, taskStatus);
+        }
+
+        public CompetencyAssessment? GetCompetencyAssessmentById(int competencyAssessmentId, int adminId)
+        {
+            return competencyAssessmentDataService.GetCompetencyAssessmentById(competencyAssessmentId, adminId);
+        }
+
+        public bool UpdateCompetencyAssessmentBranding(int assessmentId, int adminId, int brandID, int categoryID)
+        {
+            return competencyAssessmentDataService.UpdateCompetencyAssessmentBranding(assessmentId, adminId, brandID, categoryID);
+        }
+
+        public bool UpdateBrandingTaskStatus(int assessmentId, bool taskStatus)
+        {
+            return competencyAssessmentDataService.UpdateBrandingTaskStatus(assessmentId, taskStatus);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/EditBrandingViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/EditBrandingViewModel.cs
@@ -1,0 +1,33 @@
+﻿using DigitalLearningSolutions.Data.Models.CompetencyAssessments;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
+{
+    public class EditBrandingViewModel
+    {
+        public EditBrandingViewModel() { }
+        public EditBrandingViewModel(CompetencyAssessment competencyAssessment, SelectList brandSelectList, SelectList categorySelectList, bool? taskStatus)
+        {
+            ID = competencyAssessment.ID;
+            CompetencyAssessmentName = competencyAssessment.CompetencyAssessmentName;
+            BrandID = competencyAssessment.BrandID;
+            CategoryID = competencyAssessment.CategoryID;
+            Brand = competencyAssessment.Brand;
+            Category = competencyAssessment.Category;
+            UserRole = competencyAssessment.UserRole;
+            BrandSelectList = brandSelectList;
+            CategorySelectList = categorySelectList;
+            TaskStatus = taskStatus;
+        }
+        public int ID { get; set; }
+        public string CompetencyAssessmentName { get; set; }
+        public int BrandID { get; set; }
+        public int CategoryID { get; set; }
+        public string? Brand { get; set; }
+        public string? Category { get; set; }
+        public int UserRole { get; set; }
+        public bool? TaskStatus { get; set; }
+        public SelectList? BrandSelectList { get; set; }
+        public SelectList? CategorySelectList { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -1,0 +1,82 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
+@model EditBrandingViewModel
+@{
+    ViewData["Title"] = "Assessment Branding";
+    ViewData["Application"] = "Framework Service";
+    ViewData["HeaderPathName"] = "Framework Service";
+}
+
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Competency Assessments</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Manage Competency Assessment</a></li>
+                <li class="nhsuk-breadcrumb__item">Brand and category</li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Back to competency assessment detail</a></p>
+        </div>
+    </nav>
+}
+
+<h1>Edit @Model.CompetencyAssessmentName provider and category</h1>
+<p>This will be visible to users when they browse assessments. It wiull help them to identify where the assessment is from and what it contains.</p>
+<form method="post">
+    @if (!ViewData.ModelState.IsValid)
+    {
+        <partial name="_ErrorSummary" />
+    }
+    <nhs-form-group nhs-validation-for="BrandID">
+        <label class="nhsuk-label" for="brand-select">
+            Provider name
+        </label>
+        <select class="nhsuk-select" id="brand-select" name="BrandID" asp-for="BrandID" asp-items="Model.BrandSelectList">
+            <option value="0">* New provider *</option>
+        </select>
+        <div id="new-brand-field" class="non-js-only nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0">
+            <label class="nhsuk-label" for="brand-field">
+                New provider name
+            </label>
+            <input type="text" id="brand-field" name="Brand" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Brand" />
+        </div>
+    </nhs-form-group>
+    <nhs-form-group nhs-validation-for="CategoryID">
+        <label class="nhsuk-label" for="category-select">
+            Content category
+        </label>
+        <select class="nhsuk-select" id="category-select" name="CategoryID" asp-for="CategoryID" asp-items="Model.CategorySelectList">
+            <option value="0">* New category *</option>
+        </select>
+        <div id="new-category-field" class="non-js-only nhsuk-inset-text nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0">
+            <label class="nhsuk-label" for="category-field">
+                New category name
+            </label>
+            <input type="text" id="category-field" name="Category" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Category" />
+        </div>
+    </nhs-form-group>
+    <nhs-form-group>
+        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+    </nhs-form-group>
+    <input name="ID" type="hidden" asp-for="ID" />
+    <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
+    <input name="userRole" type="hidden" asp-for="UserRole" />
+    <input name="Category" type="hidden" asp-for="Category" />
+    <input name="Brand" type="hidden" asp-for="Brand" />
+    <button class="nhsuk-button" type="submit">
+        Save
+    </button>
+</form>
+<div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
+</div>
+@section scripts {
+    <script src="@Url.Content("~/js/frameworks/branding.js")" asp-append-version="true"></script>
+}

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -49,7 +49,7 @@
         Save
     </button>
     <div class="nhsuk-back-link">
-        <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-frameworkId="@Model.ID" asp-route-competencyAssessmentId="@Model.ID">
+        <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
             <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
             </svg>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
@@ -77,8 +77,8 @@
         </li>
         <li class="nhsuk-task-list__item nhsuk-task-list__item--with-link">
             <div class="nhsuk-task-list__name-and-hint" aria-describedby="brand-status">
-                <a class="nhsuk-link nhsuk-task-list__link" asp-action="SelectBranding" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                    Select assessment brand and category
+                <a class="nhsuk-link nhsuk-task-list__link" asp-action="EditBranding" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                    Specify assessment provider and category
                 </a>
             </div>
             <div class="nhsuk-task-list__status" id="brand-status">


### PR DESCRIPTION
### JIRA link
[TD-5308](https://hee-tis.atlassian.net/browse/TD-5308)

### Description
Implements the assessment provider and category MVC page with new provider and category handling and mark task complete checkbox.

### Screenshots
![image](https://github.com/user-attachments/assets/c4c8a53b-091f-4e52-b7a9-7db27b7f3cfb)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5308]: https://hee-tis.atlassian.net/browse/TD-5308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ