### PR TITLE
TD-5325 Updating Freshdesk Api Nuget Package

### DIFF
--- a/DigitalLearningSolutions.Data/DigitalLearningSolutions.Data.csproj
+++ b/DigitalLearningSolutions.Data/DigitalLearningSolutions.Data.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Dapper" Version="2.1.24" />
     <PackageReference Include="Dapper.FluentMap" Version="2.0.0" />
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
-    <PackageReference Include="Freshdesk.Api" Version="0.13.6" />
+    <PackageReference Include="Freshdesk.Api" Version="0.17.2" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="MailKit" Version="4.3.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.0.0" />


### PR DESCRIPTION
### JIRA link
[TD-5325](https://hee-tis.atlassian.net/browse/TD-5325)

### Description
While investigating we found out that the API call was successful and the Freshdesk ticket was being created in Freshdesk. The response mapping was failing because the 'due_by' date sent in the API response was null, and the response model contained a property 'due_by' that was non-nullable. This resulted in the datatype mismatch during deserialization. 

I did some research and found out that recently, Freshdesk addressed this issue in their latest version, PR for this change- 
https://github.com/DaveTCode/FreshdeskApiDotnet/pull/272

Hence updating Freshdesk Api Nuget Package in this PR solves our issue.

### Screenshots
![image](https://github.com/user-attachments/assets/9b8702d4-04b1-41bc-9703-06698af461f4)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5325]: https://hee-tis.atlassian.net/browse/TD-5325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ