### PR TITLE
TD-5370- Added code to remove a pending sign-off request if the self-assessment does not include the minimum optional competencies.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -298,6 +298,13 @@
             }
         }
 
+        public void RemoveSignoffRequestById(int candidateAssessmentSupervisorVerificationsId)
+        {
+            var numberOfAffectedRows = connection.Execute(
+              @" DELETE FROM CandidateAssessmentSupervisorVerifications WHERE ID = @candidateAssessmentSupervisorVerificationsId ",
+            new { candidateAssessmentSupervisorVerificationsId });
+        }
+
 
         public void SetCompleteByDate(int selfAssessmentId, int delegateUserId, DateTime? completeByDate)
         {

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -78,6 +78,7 @@
 
         void UpdateLastAccessed(int selfAssessmentId, int delegateUserId);
         void RemoveSignoffRequests(int selfAssessmentId, int delegateUserId, int competencyGroupsId);
+        void RemoveSignoffRequestById(int candidateAssessmentSupervisorVerificationsId);
         void SetCompleteByDate(int selfAssessmentId, int delegateUserId, DateTime? completeByDate);
 
         void SetSubmittedDateNow(int selfAssessmentId, int delegateUserId);

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1565,7 +1565,18 @@
                 }
 
             }
-           
+
+            if (!selfAssessmentService.HasMinimumOptionalCompetencies(selfAssessmentId, delegateUserId))
+            {
+                var supervisorsSignOffs = selfAssessmentService.GetSupervisorSignOffsForCandidateAssessment(selfAssessmentId, delegateUserId);
+
+                if (supervisorsSignOffs.FirstOrDefault() is { Verified: null, Removed: null })
+                {
+                    selfAssessmentService.RemoveSignoffRequestById(supervisorsSignOffs.FirstOrDefault().ID);
+                }
+            }
+
+
             return RedirectToAction("SelfAssessmentOverview", new { selfAssessmentId, vocabulary });
         }
 
@@ -1577,9 +1588,9 @@
             var delegateId = User.GetCandidateIdKnownNotNull();
             var recentResults = selfAssessmentService.GetMostRecentResults(selfAssessmentId, delegateId).ToList();
             var competencySummaries = CertificateHelper.CompetencySummation(recentResults);
-           
-            if (competencySummaries.QuestionsCount != competencySummaries.VerifiedCount)  return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
-            
+
+            if (competencySummaries.QuestionsCount != competencySummaries.VerifiedCount) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+
             var assessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
             var supervisors =
                 selfAssessmentService.GetSignOffSupervisorsForSelfAssessmentId(selfAssessmentId, delegateUserId);
@@ -1591,7 +1602,7 @@
                 NumberOfSelfAssessedOptionalCompetencies = optionalCompetencies.Count(x => x.IncludedInSelfAssessment)
             };
             if (model.NumberOfSelfAssessedOptionalCompetencies < model.SelfAssessment.MinimumOptionalCompetencies) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
-            
+
             return View("SelfAssessments/RequestSignOff", model);
         }
 

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -27,6 +27,7 @@
 
         void UpdateLastAccessed(int selfAssessmentId, int delegateUserId);
         void RemoveSignoffRequests(int selfAssessmentId, int delegateUserId, int competencyGroupsId);
+        void RemoveSignoffRequestById(int candidateAssessmentSupervisorVerificationsId);
         void IncrementLaunchCount(int selfAssessmentId, int delegateUserId);
 
         void SetCompleteByDate(int selfAssessmentId, int delegateUserId, DateTime? completeByDate);
@@ -160,7 +161,7 @@
         int selfAssessmentId,
         int competencyId
     );
-       void RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
+        void RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -200,6 +201,10 @@
         public void RemoveSignoffRequests(int selfAssessmentId, int delegateUserId, int competencyGroupId)
         {
             selfAssessmentDataService.RemoveSignoffRequests(selfAssessmentId, delegateUserId, competencyGroupId);
+        }
+        public void RemoveSignoffRequestById(int candidateAssessmentSupervisorVerificationsId)
+        {
+            selfAssessmentDataService.RemoveSignoffRequestById(candidateAssessmentSupervisorVerificationsId);
         }
         public void IncrementLaunchCount(int selfAssessmentId, int delegateUserId)
         {
@@ -467,10 +472,10 @@
 
             var selfAssessmentCategoryId = selfAssessmentDataService.GetSelfAssessmentCategoryId((int)selfAssessmentId);
 
-            if (adminCategoryId > 0  && adminCategoryId != selfAssessmentCategoryId)
+            if (adminCategoryId > 0 && adminCategoryId != selfAssessmentCategoryId)
             {
                 // return null variants of the object when the categoryID mismatches 
-                return (new SelfAssessmentDelegatesData(), null);      
+                return (new SelfAssessmentDelegatesData(), null);
             }
 
             (var delegateselfAssessments, int resultCount) = selfAssessmentDataService.GetSelfAssessmentDelegates(searchString, offSet, itemsPerPage, sortBy, sortDirection,
@@ -603,7 +608,7 @@
         }
         public void RemoveReviewCandidateAssessmentOptionalCompetencies(int id)
         {
-             selfAssessmentDataService.RemoveReviewCandidateAssessmentOptionalCompetencies(id);
+            selfAssessmentDataService.RemoveReviewCandidateAssessmentOptionalCompetencies(id);
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-5370](https://hee-tis.atlassian.net/browse/TD-5370)

### Description
Added code to remove a pending sign-off request if the self-assessment does not include the minimum optional competencies.

### Screenshots

-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5370]: https://hee-tis.atlassian.net/browse/TD-5370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ