### PR TITLE
TD-5390 Solved validation issue

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
@@ -124,12 +124,20 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
         [Route("/{dlsSubApplication}/RequestSupport/SetRequestSummary")]
         public IActionResult SetRequestSummary(DlsSubApplication dlsSubApplication, RequestSummaryViewModel requestDetailsmodel)
         {
+            var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
+                MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
+                TempData
+            ).GetAwaiter().GetResult(); ;
+            requestDetailsmodel.RequestType = data.RequestType;
             if (requestDetailsmodel.RequestSubject == null)
             {
                 ModelState.AddModelError("RequestSubject", "Please enter request summary");
                 return View("RequestSummary", requestDetailsmodel);
             }
-            if (requestDetailsmodel.RequestDescription == null)
+            // Check if RequestDescription is null or contains any default empty tags ("<p><br></p>").  
+            // This ensures that when a user navigates to the submit page and returns to SetRequestSummary,  
+            // removing the description completely results in an actual empty value rather than leftover HTML tags.
+            if (requestDetailsmodel.RequestDescription == null || requestDetailsmodel.RequestDescription == "<p><br></p>")
             {
                 ModelState.AddModelError("RequestDescription", "Please enter request description");
                 return View("RequestSummary", requestDetailsmodel);
@@ -138,10 +146,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
             {
                 return View("RequestSummary", requestDetailsmodel);
             }
-            var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
-                MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
-                TempData
-            ).GetAwaiter().GetResult(); ;
+            
             data.setRequestSubjectDetails(requestDetailsmodel);
             setRequestSupportTicketData(data);
             return RedirectToAction("RequestAttachment", new { dlsSubApplication });

--- a/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestSummary.cshtml
@@ -5,7 +5,7 @@
 @model RequestSummaryViewModel;
 @{
     bool errorHasOccurred = false;
-    @if (Model.RequestSubject == null && !ViewData.ModelState.IsValid)
+    @if (!ViewData.ModelState.IsValid)
     {
         errorHasOccurred = true;
     }


### PR DESCRIPTION
### JIRA link
[TD-5390](https://hee-tis.atlassian.net/browse/TD-5390)

### Description
Solved validation issue on create FreshDesk ticket.
RequestSubject property was not being set from multipage form data on page load after validation, and hence it was not loading on the screen.

### Screenshots
![image](https://github.com/user-attachments/assets/1f602ad3-2e67-4555-acba-08b301ffc1e1)

**Wave screenshot -** 
The two errors showing are those of the Jodit rich text editor. We are going to find a solution for this in the coming sprints; hence, we are ignoring this for now.

![image](https://github.com/user-attachments/assets/e82ea01e-0882-49d0-8a35-3b47c77171c6)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5390]: https://hee-tis.atlassian.net/browse/TD-5390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ