### PR TITLE
TD-5388 Deleting rejected delegate record from the USER table on rejection by ADMIN

### DIFF
--- a/DigitalLearningSolutions.Web/Services/DelegateApprovalsService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateApprovalsService.cs
@@ -127,7 +127,7 @@
             else
             {
                 userDataService.RemoveDelegateAccount(delegateId);
-                userDataService.DeleteUser(delegateEntity.UserAccount.Id);
+                userDataService.DeleteUserCentreDetail(delegateEntity.UserAccount.Id, centreId);
             }
 
             SendRejectionEmail(delegateEntity);

--- a/DigitalLearningSolutions.Web/Services/DelegateApprovalsService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateApprovalsService.cs
@@ -103,7 +103,7 @@
 
         public void RejectDelegate(int delegateId, int centreId)
         {
-            var delegateEntity = userDataService.GetDelegateById(delegateId);
+            var delegateEntity = userDataService.GetDelegateById(delegateId);         
 
             if (delegateEntity == null || delegateEntity.DelegateAccount.CentreId != centreId)
             {
@@ -127,6 +127,7 @@
             else
             {
                 userDataService.RemoveDelegateAccount(delegateId);
+                userDataService.DeleteUser(delegateEntity.UserAccount.Id);
             }
 
             SendRejectionEmail(delegateEntity);


### PR DESCRIPTION


### JIRA link
[TD-5388](https://hee-tis.atlassian.net/browse/TD-5388)

### Description
Once rejected by the centre admin, the delegate was not able to re register using the same email ID, so I added a logic to remove the specific record from the user table on delegate rejection.

### Screenshots
No screenshots

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5388]: https://hee-tis.atlassian.net/browse/TD-5388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ