### PR TITLE
TD-3711 Adding Last Accessed Columns To Tables

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202503111500_AddLastAccessedColumn.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202503111500_AddLastAccessedColumn.cs
@@ -1,0 +1,26 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202503111500)]
+    public class AddLastAccessedColumn : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("Users").AddColumn("LastAccessed").AsDateTime().Nullable();
+            Alter.Table("DelegateAccounts").AddColumn("LastAccessed").AsDateTime().Nullable();
+            Alter.Table("AdminAccounts").AddColumn("LastAccessed").AsDateTime().Nullable();
+
+            Execute.Sql("UPDATE u SET LastAccessed = (SELECT MAX(s.LoginTime) FROM DelegateAccounts da JOIN Sessions s ON da.ID = s.CandidateId WHERE da.UserID = u.ID) FROM users u;");
+            Execute.Sql("UPDATE da SET LastAccessed = (SELECT MAX(s.LoginTime) FROM Sessions s WHERE s.CandidateId = da.ID) FROM DelegateAccounts da;");
+            Execute.Sql("UPDATE da SET LastAccessed = (SELECT ca.LastAccessed FROM CandidateAssessments ca WHERE ca.ID = da.ID) FROM DelegateAccounts da where da.LastAccessed IS NULL;");
+            Execute.Sql("UPDATE AA SET LastAccessed = (SELECT MAX(AdS.LoginTime) FROM AdminSessions AdS WHERE AdS.AdminID = AA.ID) FROM AdminAccounts AA;");
+        }
+        public override void Down()
+        {
+            Delete.Column("LastAccessed").FromTable("Competencies");
+            Delete.Column("LastAccessed").FromTable("DelegateAccounts");
+            Delete.Column("LastAccessed").FromTable("AdminAccounts");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data.Migrations/202503111500_AddLastAccessedColumn.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202503111500_AddLastAccessedColumn.cs
@@ -18,7 +18,7 @@
         }
         public override void Down()
         {
-            Delete.Column("LastAccessed").FromTable("Competencies");
+            Delete.Column("LastAccessed").FromTable("Users");
             Delete.Column("LastAccessed").FromTable("DelegateAccounts");
             Delete.Column("LastAccessed").FromTable("AdminAccounts");
         }


### PR DESCRIPTION
### JIRA link
[TD-3711](https://hee-tis.atlassian.net/browse/TD-3711)

### Description
Fluent migration for adding LastAccessed column in Users, DelegateAccounts and AdminAccounts tables and populating values.

### Screenshots


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-3711]: https://hee-tis.atlassian.net/browse/TD-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ