### PR TITLE
TD-3712 Update LastAccessed Date For Users During Login

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/LoginDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LoginDataService.cs
@@ -21,7 +21,7 @@
         {
             connection.Execute(
                 @"UPDATE Users SET
-                        LastAccessed = GETDATE()
+                        LastAccessed = GetUtcDate()
                 WHERE ID = @Id",
                 new
                 {

--- a/DigitalLearningSolutions.Data/DataServices/LoginDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LoginDataService.cs
@@ -1,0 +1,33 @@
+﻿namespace DigitalLearningSolutions.Data.DataServices
+{
+    using Dapper;
+    using System.Data;
+
+    public interface ILoginDataService
+    {
+        void UpdateLastAccessedForUsersTable(int Id);
+    }
+
+    public class LoginDataService : ILoginDataService
+    {
+        private readonly IDbConnection connection;
+
+        public LoginDataService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public void UpdateLastAccessedForUsersTable(int Id)
+        {
+            connection.Execute(
+                @"UPDATE Users SET
+                        LastAccessed = GETDATE()
+                WHERE ID = @Id",
+                new
+                {
+                    Id
+                }
+            );
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web.Tests/Services/LoginServiceTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/LoginServiceTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models;
@@ -32,6 +33,7 @@
         private LoginService loginService = null!;
         private IUserService userService = null!;
         private IUserVerificationService userVerificationService = null!;
+        private ILoginDataService loginDataService = null!;
 
         [SetUp]
         public void Setup()
@@ -39,7 +41,7 @@
             userVerificationService = A.Fake<IUserVerificationService>(x => x.Strict());
             userService = A.Fake<IUserService>(x => x.Strict());
 
-            loginService = new LoginService(userService, userVerificationService);
+            loginService = new LoginService(userService, userVerificationService, loginDataService);
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -82,6 +82,13 @@
 
             var loginResult = loginService.AttemptLogin(model.Username!.Trim(), model.Password!);
 
+            if (loginResult.LoginAttemptResult == LoginAttemptResult.LogIntoSingleCentre ||
+                loginResult.LoginAttemptResult == LoginAttemptResult.ChooseACentre)
+            {
+                loginService.UpdateLastAccessedForUsersTable(loginResult.UserEntity.UserAccount.Id);
+            }
+
+
             switch (loginResult.LoginAttemptResult)
             {
                 case LoginAttemptResult.InvalidCredentials:

--- a/DigitalLearningSolutions.Web/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Web/Services/LoginService.cs
@@ -5,10 +5,12 @@
     using System.Linq;
     using System.Security.Claims;
     using System.Threading.Tasks;
+    using DigitalLearningSolutions.Data.DataServices;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
     using DigitalLearningSolutions.Data.Models;
     using DigitalLearningSolutions.Data.Models.User;
+    using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Data.ViewModels;
     using DigitalLearningSolutions.Web.Helpers;
     using Microsoft.AspNetCore.Authentication;
@@ -28,6 +30,8 @@
 
         bool CentreEmailIsVerified(int userId, int centreIdIfLoggingIntoSingleCentre);
 
+        void UpdateLastAccessedForUsersTable(int Id);
+
         Task<string> HandleLoginResult(
             LoginResult loginResult,
             TicketReceivedContext context,
@@ -41,11 +45,18 @@
     {
         private readonly IUserService userService;
         private readonly IUserVerificationService userVerificationService;
+        private readonly ILoginDataService loginDataService;
 
-        public LoginService(IUserService userService, IUserVerificationService userVerificationService)
+        public LoginService(IUserService userService, IUserVerificationService userVerificationService, ILoginDataService loginDataService)
         {
             this.userService = userService;
             this.userVerificationService = userVerificationService;
+            this.loginDataService = loginDataService;
+        }
+
+        public void UpdateLastAccessedForUsersTable(int Id)
+        {
+           loginDataService.UpdateLastAccessedForUsersTable(Id);
         }
 
         public LoginResult AttemptLogin(string username, string password)

--- a/DigitalLearningSolutions.Web/Startup.cs
+++ b/DigitalLearningSolutions.Web/Startup.cs
@@ -534,6 +534,7 @@ namespace DigitalLearningSolutions.Web
             services.AddScoped<IRequestSupportTicketDataService, RequestSupportTicketDataService>();
             services.AddScoped<ICentreApplicationsDataService, CentreApplicationsDataService>();
             services.AddScoped<ICentreSelfAssessmentsDataService, CentreSelfAssessmentsDataService>();
+            services.AddScoped<ILoginDataService, LoginDataService>();
         }
 
         private static void RegisterHelpers(IServiceCollection services)


### PR DESCRIPTION
### JIRA link
[TD-3712](https://hee-tis.atlassian.net/browse/TD-3712)

### Description
Update LastAccessed Date For Users During Login

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-3712]: https://hee-tis.atlassian.net/browse/TD-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ