### PR TITLE
TD-3713- Update LastAccessed Date For AdminAccounts And DelegateAccounts

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/LoginDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LoginDataService.cs
@@ -6,6 +6,10 @@
     public interface ILoginDataService
     {
         void UpdateLastAccessedForUsersTable(int Id);
+
+        void UpdateLastAccessedForDelegatesAccountsTable(int Id);
+
+        void UpdateLastAccessedForAdminAccountsTable(int Id);
     }
 
     public class LoginDataService : ILoginDataService
@@ -21,6 +25,32 @@
         {
             connection.Execute(
                 @"UPDATE Users SET
+                        LastAccessed = GetUtcDate()
+                WHERE ID = @Id",
+                new
+                {
+                    Id
+                }
+            );
+        }
+        
+        public void UpdateLastAccessedForDelegatesAccountsTable(int Id)
+        {
+            connection.Execute(
+                @"UPDATE DelegateAccounts SET
+                        LastAccessed = GetUtcDate()
+                WHERE ID = @Id",
+                new
+                {
+                    Id
+                }
+            );
+        }
+
+        public void UpdateLastAccessedForAdminAccountsTable(int Id)
+        {
+            connection.Execute(
+                @"UPDATE AdminAccounts SET
                         LastAccessed = GetUtcDate()
                 WHERE ID = @Id",
                 new

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -226,11 +226,13 @@
                 IsPersistent = rememberMe,
                 IssuedUtc = clockUtility.UtcNow,
             };
+            var centreAccountSet = userEntity?.GetCentreAccountSet(centreIdToLogInto);
+            loginService.UpdateLastAccessedForDelegatesAccountsTable(centreAccountSet.DelegateAccount.Id);
 
-            var adminAccount = userEntity!.GetCentreAccountSet(centreIdToLogInto)?.AdminAccount;
-
+            var adminAccount = centreAccountSet?.AdminAccount;
             if (adminAccount?.Active == true)
             {
+                loginService.UpdateLastAccessedForAdminAccountsTable(adminAccount.Id);
                 sessionService.StartAdminSession(adminAccount.Id);
             }
 

--- a/DigitalLearningSolutions.Web/Controllers/LoginController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LoginController.cs
@@ -227,7 +227,11 @@
                 IssuedUtc = clockUtility.UtcNow,
             };
             var centreAccountSet = userEntity?.GetCentreAccountSet(centreIdToLogInto);
-            loginService.UpdateLastAccessedForDelegatesAccountsTable(centreAccountSet.DelegateAccount.Id);
+
+            if (centreAccountSet?.DelegateAccount?.Id != null)
+            {
+                loginService.UpdateLastAccessedForDelegatesAccountsTable(centreAccountSet.DelegateAccount.Id);
+            }            
 
             var adminAccount = centreAccountSet?.AdminAccount;
             if (adminAccount?.Active == true)

--- a/DigitalLearningSolutions.Web/Services/LoginService.cs
+++ b/DigitalLearningSolutions.Web/Services/LoginService.cs
@@ -32,6 +32,10 @@
 
         void UpdateLastAccessedForUsersTable(int Id);
 
+        void UpdateLastAccessedForDelegatesAccountsTable(int Id);
+
+        void UpdateLastAccessedForAdminAccountsTable(int Id);
+
         Task<string> HandleLoginResult(
             LoginResult loginResult,
             TicketReceivedContext context,
@@ -57,6 +61,16 @@
         public void UpdateLastAccessedForUsersTable(int Id)
         {
            loginDataService.UpdateLastAccessedForUsersTable(Id);
+        }
+
+        public void UpdateLastAccessedForDelegatesAccountsTable(int Id)
+        {
+            loginDataService.UpdateLastAccessedForDelegatesAccountsTable(Id);
+        }
+
+        public void UpdateLastAccessedForAdminAccountsTable(int Id)
+        {
+            loginDataService.UpdateLastAccessedForAdminAccountsTable(Id);
         }
 
         public LoginResult AttemptLogin(string username, string password)


### PR DESCRIPTION
### JIRA link
[TD-3713](https://hee-tis.atlassian.net/browse/TD-3713)

### Description
Update LastAccessed Date For AdminAccounts And DelegateAccounts

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-3713]: https://hee-tis.atlassian.net/browse/TD-3713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ