### PR TITLE
TD-3714 Adding LastAccessed Date To Delegates Card In Tracking System

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -87,6 +87,7 @@
 				c.CentreName,
 				da.CentreID,
 				da.DateRegistered,
+                da.LastAccessed,
 				da.RegistrationConfirmationHash,
 				c.Active AS CentreActive,
 				COALESCE(ucd.Email, u.PrimaryEmail) AS EmailAddress,

--- a/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
@@ -12,7 +12,7 @@
         public bool CentreActive { get; set; }
         public string CandidateNumber { get; set; } = string.Empty;
         public DateTime DateRegistered { get; set; }
-        public DateTime LastAccessed { get; set; }
+        public DateTime? LastAccessed { get; set; }
         public string? Answer1 { get; set; }
         public string? Answer2 { get; set; }
         public string? Answer3 { get; set; }

--- a/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateAccount.cs
@@ -12,6 +12,7 @@
         public bool CentreActive { get; set; }
         public string CandidateNumber { get; set; } = string.Empty;
         public DateTime DateRegistered { get; set; }
+        public DateTime LastAccessed { get; set; }
         public string? Answer1 { get; set; }
         public string? Answer2 { get; set; }
         public string? Answer3 { get; set; }

--- a/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUser.cs
@@ -9,6 +9,7 @@
         public int UserId { get; set; }
         public string CandidateNumber { get; set; } = string.Empty;
         public DateTime? DateRegistered { get; set; }
+        public DateTime? LastAccessed { get; set; }
         public int JobGroupId { get; set; }
         public string? JobGroupName { get; set; }
         public string? Answer1 { get; set; }

--- a/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
@@ -23,6 +23,7 @@
             Password = delegateEntity.UserAccount.PasswordHash;
             CandidateNumber = delegateEntity.DelegateAccount.CandidateNumber;
             DateRegistered = delegateEntity.DelegateAccount.DateRegistered;
+            LastAccessed = delegateEntity.DelegateAccount.LastAccessed;
             JobGroupId = delegateEntity.UserAccount.JobGroupId;
             JobGroupName = delegateEntity.UserAccount.JobGroupName;
             Answer1 = delegateEntity.DelegateAccount.Answer1;

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -41,6 +41,10 @@
             {
                 RegistrationDate = delegateUser.DateRegistered.Value.ToString(DateHelper.StandardDateFormat);
             }
+            if (delegateUser.LastAccessed.HasValue)
+            {
+                LastAccessed = delegateUser.LastAccessed.Value.ToString(DateHelper.StandardDateFormat);
+            }
 
             DelegateRegistrationPrompts = delegateRegistrationPrompts;
             RegistrationConfirmationHash = delegateUser.RegistrationConfirmationHash;
@@ -61,6 +65,7 @@
         public int JobGroupId { get; set; }
         public string? JobGroup { get; set; }
         public string? RegistrationDate { get; set; }
+        public string? LastAccessed { get; set; }
         public string ProfessionalRegistrationNumber { get; set; }
         public string? RegistrationConfirmationHash { get; set; }
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
@@ -4,91 +4,98 @@
 
 <div class="searchable-element nhsuk-expander-group word-break" id="@Model.DelegateInfo.Id-card">
 
-  <details class="nhsuk-details nhsuk-expander">
-    <summary class="nhsuk-details__summary">
-      <span class="nhsuk-details__summary-text" id="@Model.DelegateInfo.Id-name">
-        <span class="searchable-element-title" name="name">@Model.DelegateInfo.TitleName</span>
-        @if (Model.DelegateInfo.Email == null)
-          @("(Email address not set)")
-        else
-          @DisplayStringHelper.GetEmailDisplayString(Model.DelegateInfo.Email)
+    <details class="nhsuk-details nhsuk-expander">
+        <summary class="nhsuk-details__summary">
+            <span class="nhsuk-details__summary-text" id="@Model.DelegateInfo.Id-name">
+                <span class="searchable-element-title" name="name">@Model.DelegateInfo.TitleName</span>
+                @if (Model.DelegateInfo.Email == null)
+                    @("(Email address not set)")
+                else
+                    @DisplayStringHelper.GetEmailDisplayString(Model.DelegateInfo.Email)
 
-        </span>
-      </summary>
+            </span>
+        </summary>
 
-      <div class="nhsuk-details__text">
+        <div class="nhsuk-details__text">
 
-        <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
+            <partial name="SearchablePage/_FilterableTags" model="@Model.Tags" />
 
-        <dl class="nhsuk-summary-list details-list-with-button">
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key">
-              Name
-            </dt>
-            <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.Name" />
-          </div>
+            <dl class="nhsuk-summary-list details-list-with-button">
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Name
+                    </dt>
+                    <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.Name" />
+                </div>
 
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key ">
-              Email
-            </dt>
-            <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.Email, "email") />
-          </div>
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key ">
+                        Email
+                    </dt>
+                    <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.Email, "email") />
+                </div>
 
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key">
-              ID
-            </dt>
-            <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.CandidateNumber, "candidate-number") />
-          </div>
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key">
+                        ID
+                    </dt>
+                    <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.CandidateNumber, "candidate-number") />
+                </div>
 
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key">
-              Registration date
-            </dt>
-            <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.RegistrationDate" />
-            <div hidden name="registration-date">@Model.DelegateInfo.RegistrationDate</div>
-          </div>
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Registration date
+                    </dt>
+                    <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.RegistrationDate" />
+                    <div hidden name="registration-date">@Model.DelegateInfo.RegistrationDate</div>
+                </div>
 
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key">
-              Job group
-            </dt>
-            <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.JobGroup" />
-            <div hidden data-filter-value="@Model.JobGroupFilter"></div>
-          </div>
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Last Accessed date
+                    </dt>
+                    <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.LastAccessed" />
+                </div>
 
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key">
-              Professional Registration Number
-            </dt>
-            <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
-          </div>
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Job group
+                    </dt>
+                    <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.JobGroup" />
+                    <div hidden data-filter-value="@Model.JobGroupFilter"></div>
+                </div>
 
-          @foreach (var delegateRegistrationPrompt in Model.DelegateInfo.DelegateRegistrationPrompts)
-        {
-          <div class="nhsuk-summary-list__row details-list-with-button__row">
-            <dt class="nhsuk-summary-list__key">@delegateRegistrationPrompt.Prompt</dt>
-            <partial name="_SummaryFieldValue" model="@delegateRegistrationPrompt.Answer" />
-            @if (Model.RegistrationPromptFilters.ContainsKey(delegateRegistrationPrompt.PromptNumber))
-            {
-              <div hidden data-filter-value="@Model.RegistrationPromptFilters[delegateRegistrationPrompt.PromptNumber]"></div>
-            }
-          </div>
-        }
-      </dl>
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Professional Registration Number
+                    </dt>
+                    <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.ProfessionalRegistrationNumber" />
+                </div>
 
-      <a class="nhsuk-button" asp-controller="ViewDelegate" asp-action="Index" asp-route-delegateId="@Model.DelegateInfo.Id" role="button">Manage delegate</a>
-      <a class="nhsuk-button nhsuk-button--secondary"
-         role="button"
-         data-return-page-enabled="true"
-         asp-controller="SetDelegatePassword"
-         asp-action="Index"
-         asp-route-delegateId="@Model.DelegateInfo.Id"
-         asp-route-isFromViewDelegatePage="false"
-         asp-route-returnPageQuery="@Model.ReturnPageQuery?.ToString()">
-        Set password
-      </a>
-    </div>
-  </details>
+                @foreach (var delegateRegistrationPrompt in Model.DelegateInfo.DelegateRegistrationPrompts)
+                {
+                    <div class="nhsuk-summary-list__row details-list-with-button__row">
+                        <dt class="nhsuk-summary-list__key">@delegateRegistrationPrompt.Prompt</dt>
+                        <partial name="_SummaryFieldValue" model="@delegateRegistrationPrompt.Answer" />
+                        @if (Model.RegistrationPromptFilters.ContainsKey(delegateRegistrationPrompt.PromptNumber))
+                        {
+                            <div hidden data-filter-value="@Model.RegistrationPromptFilters[delegateRegistrationPrompt.PromptNumber]"></div>
+                        }
+                    </div>
+                }
+            </dl>
+
+            <a class="nhsuk-button" asp-controller="ViewDelegate" asp-action="Index" asp-route-delegateId="@Model.DelegateInfo.Id" role="button">Manage delegate</a>
+            <a class="nhsuk-button nhsuk-button--secondary"
+               role="button"
+               data-return-page-enabled="true"
+               asp-controller="SetDelegatePassword"
+               asp-action="Index"
+               asp-route-delegateId="@Model.DelegateInfo.Id"
+               asp-route-isFromViewDelegatePage="false"
+               asp-route-returnPageQuery="@Model.ReturnPageQuery?.ToString()">
+                Set password
+            </a>
+        </div>
+    </details>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-3714](https://hee-tis.atlassian.net/browse/TD-3714)

### Description
Adding LastAccessed Date To Delegates Card In Tracking System

### Screenshots
![image](https://github.com/user-attachments/assets/53d14106-b146-4e13-ae62-46370802b481)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-3714]: https://hee-tis.atlassian.net/browse/TD-3714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ