### PR TITLE
TD-5263 Fix framework view for print fails

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/FrameworkPrintLayout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/FrameworkPrintLayout.cshtml
@@ -50,51 +50,54 @@
             {
                 @foreach (var frameworkCompetencyGroup in Model.FrameworkCompetencyGroups)
                 {
-                    groupNum++;
-                    <h3>@frameworkCompetencyGroup.Name</h3>
-                    if (frameworkCompetencyGroup.Description != null)
+                    if (frameworkCompetencyGroup.FrameworkCompetencies.Count() > 0)
                     {
-                        <p class="nhsuk-lede-text">
-                            @frameworkCompetencyGroup.Description
-                        </p>
-                    }
+                        groupNum++;
+                        <h3>@frameworkCompetencyGroup.Name</h3>
+                        if (frameworkCompetencyGroup.Description != null)
+                        {
+                            <p class="nhsuk-lede-text">
+                                @frameworkCompetencyGroup.Description
+                            </p>
+                        }
 
-                    int compNum = 0;
-                    if (frameworkCompetencyGroup.FrameworkCompetencies[0] != null)
-                    {
-                        <table class="nhsuk-table">
-                            <thead role="rowgroup" class="nhsuk-table__head">
-                                <tr role="row">
-                                    <th role="columnheader" class="" scope="col">
-                                        @Model.VocabSingular()
-                                    </th>
-                                    <th role="columnheader" class="status-tag" scope="col">
-                                        Date and Signature
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody class="nhsuk-table__body">
-                                @foreach (var frameworkCompetency in frameworkCompetencyGroup.FrameworkCompetencies)
-                                {
-                                    compNum++;
-                                    <tr role="row" class="nhsuk-table__row">
-                                        <td>
-                                            <strong>@frameworkCompetency.Name</strong>
-
-                                            <partial name="_CompetencyFlags" model="Model.CompetencyFlags.Where(c => c.CompetencyId == frameworkCompetency.CompetencyID)" />
-                                            @if (frameworkCompetency.Description != null)
-                                            {
-                                                <p class="nhsuk-lede-text--small">
-                                                    @Html.Raw(frameworkCompetency.Description)
-                                                </p>
-                                            }
-                                        </td>
-                                        <td>
-                                        </td>
+                        int compNum = 0;
+                        if (frameworkCompetencyGroup.FrameworkCompetencies[0] != null)
+                        {
+                            <table class="nhsuk-table">
+                                <thead role="rowgroup" class="nhsuk-table__head">
+                                    <tr role="row">
+                                        <th role="columnheader" class="" scope="col">
+                                            @Model.VocabSingular()
+                                        </th>
+                                        <th role="columnheader" class="status-tag" scope="col">
+                                            Date and Signature
+                                        </th>
                                     </tr>
-                                }
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody class="nhsuk-table__body">
+                                    @foreach (var frameworkCompetency in frameworkCompetencyGroup.FrameworkCompetencies)
+                                    {
+                                        compNum++;
+                                        <tr role="row" class="nhsuk-table__row">
+                                            <td>
+                                                <strong>@frameworkCompetency.Name</strong>
+
+                                                <partial name="_CompetencyFlags" model="Model.CompetencyFlags.Where(c => c.CompetencyId == frameworkCompetency.CompetencyID)" />
+                                                @if (frameworkCompetency.Description != null)
+                                                {
+                                                    <p class="nhsuk-lede-text--small">
+                                                        @Html.Raw(frameworkCompetency.Description)
+                                                    </p>
+                                                }
+                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        }
                     }
                 }
             }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/FrameworkPrintLayout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/FrameworkPrintLayout.cshtml
@@ -28,7 +28,7 @@
         <h1>
             @Model.DetailFramework.FrameworkName
         </h1>
-        @if (!String.IsNullOrEmpty(Model.DetailFramework.Description))
+        @if (!String.IsNullOrEmpty(Model.DetailFramework.Description.Trim()))
         {
             <div class="nhsuk-card">
                 <div class="nhsuk-card__content">

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/FrameworkPrintLayout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/FrameworkPrintLayout.cshtml
@@ -28,41 +28,41 @@
         <h1>
             @Model.DetailFramework.FrameworkName
         </h1>
-            @if (!String.IsNullOrEmpty(Model.DetailFramework.Description))
-            {
-                <div class="nhsuk-card">
-                    <div class="nhsuk-card__content">
-                        <h2 class="nhsuk-card__heading">
-                            Framework description
+        @if (!String.IsNullOrEmpty(Model.DetailFramework.Description))
+        {
+            <div class="nhsuk-card">
+                <div class="nhsuk-card__content">
+                    <h2 class="nhsuk-card__heading">
+                        Framework description
 
-                        </h2>
-                        <p class="nhsuk-card__description">
-                            @(Html.Raw(Model.DetailFramework.Description))
-                        </p>
-                    </div>
+                    </h2>
+                    <p class="nhsuk-card__description">
+                        @(Html.Raw(Model.DetailFramework.Description))
+                    </p>
                 </div>
-            }
-            <h2>Framework @Model.VocabPlural().ToLower()</h2>
+            </div>
+        }
+        <h2>Framework @Model.VocabPlural().ToLower()</h2>
 
-            @if (Model.FrameworkCompetencyGroups != null)
+        @if (Model.FrameworkCompetencyGroups != null)
+        {
+            if (Model.FrameworkCompetencyGroups.Any())
             {
-                if (Model.FrameworkCompetencyGroups.Any())
+                @foreach (var frameworkCompetencyGroup in Model.FrameworkCompetencyGroups)
                 {
-                    @foreach (var frameworkCompetencyGroup in Model.FrameworkCompetencyGroups)
+                    groupNum++;
+                    <h3>@frameworkCompetencyGroup.Name</h3>
+                    if (frameworkCompetencyGroup.Description != null)
                     {
-                        groupNum++;
-                        <h3>@frameworkCompetencyGroup.Name</h3>
-                        if (frameworkCompetencyGroup.Description != null)
-                        {
-                            <p class="nhsuk-lede-text">
-                                @frameworkCompetencyGroup.Description
-                            </p>
-                        }
-                        
-                        int compNum = 0;
-                        if (frameworkCompetencyGroup.FrameworkCompetencies[0] != null)
-                        {
-                          <table class="nhsuk-table">
+                        <p class="nhsuk-lede-text">
+                            @frameworkCompetencyGroup.Description
+                        </p>
+                    }
+
+                    int compNum = 0;
+                    if (frameworkCompetencyGroup.FrameworkCompetencies[0] != null)
+                    {
+                        <table class="nhsuk-table">
                             <thead role="rowgroup" class="nhsuk-table__head">
                                 <tr role="row">
                                     <th role="columnheader" class="" scope="col">
@@ -74,54 +74,53 @@
                                 </tr>
                             </thead>
                             <tbody class="nhsuk-table__body">
-                            @foreach (var frameworkCompetency in frameworkCompetencyGroup.FrameworkCompetencies)
-                            {
-                                compNum++;
+                                @foreach (var frameworkCompetency in frameworkCompetencyGroup.FrameworkCompetencies)
+                                {
+                                    compNum++;
                                     <tr role="row" class="nhsuk-table__row">
-                                <td>
-                                    <strong>@frameworkCompetency.Name</strong>
+                                        <td>
+                                            <strong>@frameworkCompetency.Name</strong>
 
-                                    <partial name="_CompetencyFlags" model="Model.CompetencyFlags.Where(c => c.CompetencyId == frameworkCompetency.CompetencyID)" />
-                                    @if (frameworkCompetency.Description != null)
-                                    {
-                                        <p class="nhsuk-lede-text--small">
-                                            @Html.Raw(frameworkCompetency.Description)
-                                        </p>
-                                    }
-                                    </td>
-                                    <td>
-
-                                    </td>
-                                        </tr>
-                            }
-                                </tbody>
-                            </table>
-                        }
+                                            <partial name="_CompetencyFlags" model="Model.CompetencyFlags.Where(c => c.CompetencyId == frameworkCompetency.CompetencyID)" />
+                                            @if (frameworkCompetency.Description != null)
+                                            {
+                                                <p class="nhsuk-lede-text--small">
+                                                    @Html.Raw(frameworkCompetency.Description)
+                                                </p>
+                                            }
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
                     }
                 }
             }
-            @if (Model.FrameworkCompetencies != null)
+        }
+        @if (Model.FrameworkCompetencies != null)
+        {
+            if (Model.FrameworkCompetencies.Any())
             {
-                if (Model.FrameworkCompetencies.Any())
+                groupNum++;
+                int compNum = 0;
+                <h2>Ungrouped competencies</h2>
+                foreach (var frameworkCompetency in Model.FrameworkCompetencies)
                 {
-                    groupNum++;
-                    int compNum = 0;
-                    <h2>Ungrouped competencies</h2>
-                    foreach (var frameworkCompetency in Model.FrameworkCompetencies)
-                    {
-                        compNum++;
-                        <div class="nhsuk-u-margin-left-8">
-                            <h3>@frameworkCompetency.Name</h3>
-                            <partial name="_CompetencyFlags" model="Model.CompetencyFlags.Where(c => c.CompetencyId == frameworkCompetency.CompetencyID)" />
-                            @if (frameworkCompetency.Description != null)
-                            {
-                                <p class="nhsuk-lede-text--small">
-                                    @frameworkCompetency.Description
-                                </p>
-                            }
-                        </div>
-                    }
+                    compNum++;
+                    <div class="nhsuk-u-margin-left-8">
+                        <h3>@frameworkCompetency.Name</h3>
+                        <partial name="_CompetencyFlags" model="Model.CompetencyFlags.Where(c => c.CompetencyId == frameworkCompetency.CompetencyID)" />
+                        @if (frameworkCompetency.Description != null)
+                        {
+                            <p class="nhsuk-lede-text--small">
+                                @Html.Raw(frameworkCompetency.Description)
+                            </p>
+                        }
+                    </div>
                 }
             }
-        </div>
+        }
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Structure.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Structure.cshtml
@@ -9,7 +9,10 @@
             <a class="nhsuk-button" asp-action="AddEditFrameworkCompetencyGroup" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Add @Model.VocabSingular().ToLower() group</a>
             <a class="nhsuk-button nhsuk-button--secondary" asp-action="AddEditFrameworkCompetency" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Add ungrouped @Model.VocabSingular().ToLower()</a>
             <a class="nhsuk-button nhsuk-button--secondary" asp-action="ImportCompetencies" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-isNotBlank="@(Model.FrameworkCompetencies.Any()|Model.FrameworkCompetencyGroups.Any())" asp-route-tabname="@(ViewContext.RouteData.Values["tabname"])">Bulk upload/update @Model.VocabPlural().ToLower()</a>
-            <a class="nhsuk-button nhsuk-button--secondary" asp-action="PrintLayout" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">View for print</a>
+            @if ((Model.FrameworkCompetencies?.Any() ?? false) || (Model.FrameworkCompetencyGroups?.Any(group => group.FrameworkCompetencies.Any()) ?? false) )
+            {
+              <a class="nhsuk-button nhsuk-button--secondary" asp-action="PrintLayout" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">View for print</a>
+            }
         </div>
     </div>
 }


### PR DESCRIPTION
### JIRA link
[TD-5263](https://hee-tis.atlassian.net/browse/TD-5263)

### Description
Fixes issues identified by testers with the view for print page:
- Renders descriptions as HTML instead of text in ungrouped proficiencies
- Hides the View for print button for empty frameworks
- Adds Razor C# check to make sure competency group isn't empty before rendering

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5263]: https://hee-tis.atlassian.net/browse/TD-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ