### PR TITLE
TD-5397-Removed pending sign-off request when supervisor delegate was removed

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -547,6 +547,13 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                     WHERE cas.SupervisorDelegateId = @supervisorDelegateId AND cas.Removed IS NULL AND sarsv.Verified IS NULL", new { supervisorDelegateId }
             );
 
+            connection.Execute(
+                @"DELETE FROM casv FROM CandidateAssessmentSupervisorVerifications casv INNER JOIN
+			                CandidateAssessmentSupervisors cas ON casv.CandidateAssessmentSupervisorID = cas.ID
+                    WHERE cas.SupervisorDelegateId = @supervisorDelegateId
+			                AND casv.Verified IS NULL AND casv.SignedOff = 0", new { supervisorDelegateId }
+            );
+
             var numberOfAffectedRows = connection.Execute(
          @"UPDATE SupervisorDelegates SET Removed = getUTCDate()
             WHERE ID = @supervisorDelegateId AND Removed IS NULL AND (DelegateUserID = @delegateUserId OR SupervisorAdminID = @adminId)",


### PR DESCRIPTION
### JIRA link
[TD-5397](https://hee-tis.atlassian.net/browse/TD-5397)

### Description
Removed pending request from CandidateAssessmentSupervisorVerifications table when supervisor delegate was removed.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5397]: https://hee-tis.atlassian.net/browse/TD-5397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ