### PR TITLE
TD-3718 Adding LastAccessed Date in SuperAdmin Administrators Card

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/AdminUserDataService.cs
@@ -370,7 +370,7 @@
             }
 
             string BaseSelectQuery = $@"SELECT aa.ID, aa.UserID, aa.CentreID, aa.Active, aa.IsCentreAdmin, aa.IsReportsViewer, aa.IsSuperAdmin, aa.IsCentreManager, 
-		                                aa.IsContentManager, aa.IsContentCreator, aa.IsSupervisor, aa.IsTrainer, aa.CategoryID, aa.IsFrameworkDeveloper, aa.IsFrameworkContributor,aa.ImportOnly,
+		                                aa.LastAccessed, aa.IsContentManager, aa.IsContentCreator, aa.IsSupervisor, aa.IsTrainer, aa.CategoryID, aa.IsFrameworkDeveloper, aa.IsFrameworkContributor,aa.ImportOnly,
 		                                aa.IsWorkforceManager, aa.IsWorkforceContributor, aa.IsLocalWorkforceManager, aa.IsNominatedSupervisor,
 		                                u.ID, u.PrimaryEmail, u.FirstName, u.LastName, u.Active, u.FailedLoginCount,
 		                                c.CentreID, c.CentreName,

--- a/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Administrators/SearchableAdminAccountsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/SuperAdmin/Administrators/SearchableAdminAccountsViewModel.cs
@@ -5,7 +5,7 @@
     using DigitalLearningSolutions.Data.Models.User;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
-
+    using DateHelper = Helpers.DateHelper;
     public class SearchableAdminAccountsViewModel : BaseFilterableViewModel
     {
         public readonly bool CanShowDeleteAdminButton;
@@ -28,7 +28,10 @@
             IsLocked = admin.UserAccount?.FailedLoginCount >= AuthHelper.FailedLoginThreshold;
             IsAdminActive = admin.AdminAccount.Active;
             IsUserActive = admin.UserAccount.Active;
-
+            if (admin.LastAccessed.HasValue)
+            {
+                LastAccessed = admin.LastAccessed.Value.ToString(DateHelper.StandardDateFormat);
+            }
             CanShowDeactivateAdminButton = IsAdminActive && admin.AdminIdReferenceCount > 0;
             CanShowDeleteAdminButton = admin.AdminIdReferenceCount == 0;
 
@@ -47,6 +50,7 @@
         public bool IsLocked { get; set; }
         public bool IsAdminActive { get; set; }
         public bool IsUserActive { get; set; }
+        public string? LastAccessed { get; set; }
         public ReturnPageQuery ReturnPageQuery { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/AdminAccounts/_SearchableAdminAccountsCard.cshtml
@@ -74,6 +74,14 @@
                     <dd class="nhsuk-summary-list__actions">
                     </dd>
                 </div>
+                <div class="nhsuk-summary-list__row">
+                    <dt class="nhsuk-summary-list__key">
+                        Last Accessed
+                    </dt>
+                    <partial name="_SummaryFieldValue" model="@Model.LastAccessed" />
+                    <dd class="nhsuk-summary-list__actions">
+                    </dd>
+                </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
                     <dt class="nhsuk-summary-list__key">
                         User Account


### PR DESCRIPTION
### JIRA link
[TD-3718](https://hee-tis.atlassian.net/browse/TD-3718)

### Description
Adding LastAccessed Date in SuperAdmin Administrators Card

### Screenshots
![image](https://github.com/user-attachments/assets/fad80401-8158-42e0-a7f2-c1cfb3f03b74)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-3718]: https://hee-tis.atlassian.net/browse/TD-3718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ