### PR TITLE
TD-5443-Added check for existing flag names prior to add or edit custom flags.

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
@@ -582,14 +582,33 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         {
             if (ModelState.IsValid)
             {
+                var flags = frameworkService.GetCustomFlagsByFrameworkId(frameworkId, null)
+                    .Where(fn => fn.FlagName == model.FlagName).ToList();
+
+                bool nameExists = flags.Any(x => x.FlagName == model.FlagName);
+                bool idExists = flags.Any(x => x.FlagId == flagId);
+
                 if (actionname == "Edit")
                 {
-                    frameworkService.UpdateFrameworkCustomFlag(frameworkId, model.Id, model.FlagName, model.FlagGroup, model.FlagTagClass);
+                    if (nameExists && !idExists)
+                    {
+                        ModelState.AddModelError(nameof(model.FlagName), "A custom flag already exists.");
+                        return View("Developer/EditCustomFlag", model);
+                    }
+                    else
+                        frameworkService.UpdateFrameworkCustomFlag(frameworkId, model.Id, model.FlagName, model.FlagGroup, model.FlagTagClass);
                 }
                 else
                 {
-                    frameworkService.AddCustomFlagToFramework(frameworkId, model.FlagName, model.FlagGroup, model.FlagTagClass);
+                    if (nameExists)
+                    {
+                        ModelState.AddModelError(nameof(model.FlagName), "A custom flag already exists.");
+                        return View("Developer/EditCustomFlag", model);
+                    }
+                    else
+                        frameworkService.AddCustomFlagToFramework(frameworkId, model.FlagName, model.FlagGroup, model.FlagTagClass);
                 }
+
                 return RedirectToAction("EditFrameworkFlags", "Frameworks", new { frameworkId });
             }
             return View("Developer/EditCustomFlag", model);


### PR DESCRIPTION
### JIRA link
[TD-5443](https://hee-tis.atlassian.net/browse/TD-5443)

### Description
Added check for existing flag name prior to add or edit custom flags.

### Screenshots

![image](https://github.com/user-attachments/assets/1734e572-235c-4402-b3cb-ab3d5254e7e7)

![image](https://github.com/user-attachments/assets/ee12340e-f233-472a-95ea-473e87cd436e)

![image](https://github.com/user-attachments/assets/aad6e10e-5929-4027-a070-55dae0ec032e)

-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5443]: https://hee-tis.atlassian.net/browse/TD-5443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ