### PR TITLE
TD-5435-'To Do' section has been moved above the 'Staff' section.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
@@ -3,99 +3,99 @@
 
 @model SupervisorDashboardViewModel;
 @{
-  ViewData["Title"] = "Dashboard";
-  ViewData["Application"] = "Supervisor";
-  ViewData["HeaderPathName"] = "Supervisor";
+    ViewData["Title"] = "Dashboard";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item">Supervisor</li>
-      </ol>
-    </div>
-  </nav>
-}
-  <h1>Supervisor Dashboard</h1>
-  @if (Model.BannerText != null)
-{
-  <h2 class="page-subheading word-break">@Model.BannerText</h2>
-}
-<ul class="nhsuk-grid-row nhsuk-card-group">
-
-  <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)">
-    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-  </feature>
-  <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)" negate="true">
-    <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-  </feature>
-  <div class="nhsuk-card">
-    <div class="nhsuk-card__content">
-      <p class="nhsuk-heading-xl nhsuk-u-font-size-32 nhsuk-u-margin-bottom-3">
-        @Model.DashboardData.StaffCount Staff  @if (Model.DashboardData.StaffUnregisteredCount > 0)
-        {
-          <span class="nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal">
-            (@Model.DashboardData.StaffUnregisteredCount not registered)
-          </span>
-        }
-      </p>
-      <ul class="nhsuk-contents-list__list">
-
-        <li class="nhsuk-contents-list__item"><a asp-controller="Supervisor" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="MyStaffList">View My Staff List</a></li>
-      </ul>
-    </div>
-  </div>
-  </li>
-  <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)">
-    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-      <div class="nhsuk-card">
-        <div class="nhsuk-card__content">
-          <p class="nhsuk-heading-xl nhsuk-u-font-size-32 nhsuk-u-margin-bottom-3">
-            @Model.DashboardData.ProfileCount Role Profiles
-          </p>
-          <ul class="nhsuk-contents-list__list">
-            @if (Model.DashboardData.AwaitingReviewCount > 0)
-            {
-              <li class="nhsuk-contents-list__item"><a asp-controller="Supervisor" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="RoleProfileReviewRequests" asp-route-tabname="Mine">Profile Assessment Sign-off Requests (@Model.DashboardData.AwaitingReviewCount)</a></li>
-            }
-            <li class="nhsuk-contents-list__item"><a asp-controller="Supervisor" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="ViewRoleProfileAssessments" asp-route-tabname="All">View Profile Assessments (@Model.DashboardData.ProfileSelfAssessmentCount)</a></li>
-          </ul>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">Supervisor</li>
+            </ol>
         </div>
-      </div>
-    </li>
-  </feature>
-</ul>
+    </nav>
+}
+<h1>Supervisor Dashboard</h1>
 <h2>Your to do list</h2>
 @if (Model.SupervisorDashboardToDoItems.Count() > 0)
 {
-  <ul class="nhsuk-contents-list__list">
-    @foreach (var toDoItem in Model.SupervisorDashboardToDoItems)
-    {
+    <ul class="nhsuk-contents-list__list">
+        @foreach (var toDoItem in Model.SupervisorDashboardToDoItems)
+        {
 
-      if (toDoItem.SignOffRequest)
-      {
-        <li class="nhsuk-contents-list__item">
-          <a class="nhsuk-link--no-visited-state" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@toDoItem.SupervisorDelegateId" asp-route-candidateAssessmentId="@toDoItem.ID">
-            Review and sign-off @toDoItem.DelegateName's @toDoItem.ProfileName
-          </a>. Requested @toDoItem.Requested.ToShortDateString()
-        </li>
-      }
-      else if (toDoItem.ResultsReviewRequest)
-      {
-        <li class="nhsuk-contents-list__item">
-          <a class="nhsuk-link--no-visited-state" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@toDoItem.SupervisorDelegateId" asp-route-candidateAssessmentId="@toDoItem.ID">
-            Confirm self-assessment results for @toDoItem.DelegateName's @toDoItem.ProfileName
-          </a>. Requested @toDoItem.Requested.ToShortDateString()
-        </li>
-      }
-    }
-  </ul>
+            if (toDoItem.SignOffRequest)
+            {
+                <li class="nhsuk-contents-list__item">
+                    <a class="nhsuk-link--no-visited-state" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@toDoItem.SupervisorDelegateId" asp-route-candidateAssessmentId="@toDoItem.ID">
+                        Review and sign-off @toDoItem.DelegateName's @toDoItem.ProfileName
+                    </a>. Requested @toDoItem.Requested.ToShortDateString()
+                </li>
+            }
+            else if (toDoItem.ResultsReviewRequest)
+            {
+                <li class="nhsuk-contents-list__item">
+                    <a class="nhsuk-link--no-visited-state" asp-action="ReviewDelegateSelfAssessment" asp-route-supervisorDelegateId="@toDoItem.SupervisorDelegateId" asp-route-candidateAssessmentId="@toDoItem.ID">
+                        Confirm self-assessment results for @toDoItem.DelegateName's @toDoItem.ProfileName
+                    </a>. Requested @toDoItem.Requested.ToShortDateString()
+                </li>
+            }
+        }
+    </ul>
 }
 else
 {
-  <p>There are no tasks requiring your attention.</p>
+    <p>There are no tasks requiring your attention.</p>
 }
+@if (Model.BannerText != null)
+{
+    <h2 class="page-subheading word-break">@Model.BannerText</h2>
+}
+<ul class="nhsuk-grid-row nhsuk-card-group">
+
+    <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)">
+        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+    </feature>
+    <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)" negate="true">
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+    </feature>
+    <div class="nhsuk-card">
+        <div class="nhsuk-card__content">
+            <p class="nhsuk-heading-xl nhsuk-u-font-size-32 nhsuk-u-margin-bottom-3">
+                @Model.DashboardData.StaffCount Staff  @if (Model.DashboardData.StaffUnregisteredCount > 0)
+                {
+                    <span class="nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal">
+                        (@Model.DashboardData.StaffUnregisteredCount not registered)
+                    </span>
+                }
+            </p>
+            <ul class="nhsuk-contents-list__list">
+
+                <li class="nhsuk-contents-list__item"><a asp-controller="Supervisor" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="MyStaffList">View My Staff List</a></li>
+            </ul>
+        </div>
+    </div>
+    </li>
+    <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)">
+        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+            <div class="nhsuk-card">
+                <div class="nhsuk-card__content">
+                    <p class="nhsuk-heading-xl nhsuk-u-font-size-32 nhsuk-u-margin-bottom-3">
+                        @Model.DashboardData.ProfileCount Role Profiles
+                    </p>
+                    <ul class="nhsuk-contents-list__list">
+                        @if (Model.DashboardData.AwaitingReviewCount > 0)
+                        {
+                            <li class="nhsuk-contents-list__item"><a asp-controller="Supervisor" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="RoleProfileReviewRequests" asp-route-tabname="Mine">Profile Assessment Sign-off Requests (@Model.DashboardData.AwaitingReviewCount)</a></li>
+                        }
+                        <li class="nhsuk-contents-list__item"><a asp-controller="Supervisor" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="ViewRoleProfileAssessments" asp-route-tabname="All">View Profile Assessments (@Model.DashboardData.ProfileSelfAssessmentCount)</a></li>
+                    </ul>
+                </div>
+            </div>
+        </li>
+    </feature>
+</ul>


### PR DESCRIPTION
### JIRA link
[TD-5435](https://hee-tis.atlassian.net/browse/TD-5435)

### Description
The 'To Do' section has been moved above the 'Staff' section.

### Screenshots
![image](https://github.com/user-attachments/assets/35b7387c-8c62-4055-8b5f-d963827e98b0)

![image](https://github.com/user-attachments/assets/835c0c2a-debc-46b5-bab7-4091368a52cb)


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5435]: https://hee-tis.atlassian.net/browse/TD-5435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ