### PR TITLE
TD-5433-Manage Supervisor link removed

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/RequestSignOff.cshtml
@@ -12,7 +12,7 @@
     <li class="nhsuk-breadcrumb__item">Request Sign Off</li>
 }
 @section mobilebacklink
-  {
+{
     <p class="nhsuk-breadcrumb__back">
         <a class="nhsuk-breadcrumb__backlink" asp-action="SelfAssessmentOverview"
            asp-route-vocabulary="@Model.VocabPlural()"
@@ -66,10 +66,10 @@
                     <div class="nhsuk-checkboxes__item">
                         <input class="nhsuk-checkboxes__input" id="optional-ompetencies" name="OptionalCompetenciesChecked" asp-for="OptionalCompetenciesChecked" type="checkbox">
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="optional-competencies">
-                        I have reviewed the optional competencies available for this self assessment and included those that are appropriate to my role.
-                    </label>
-                </div>
-            </nhs-form-group>
+                            I have reviewed the optional competencies available for this self assessment and included those that are appropriate to my role.
+                        </label>
+                    </div>
+                </nhs-form-group>
             }
         </fieldset>
 
@@ -78,7 +78,6 @@
         </button>
     </form>
 
-    <p>Can't see the supervisor you need? <a asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Click here</a> to manage supervisors.</p>
     <div class="nhsuk-back-link">
         <a class="nhsuk-back-link__link"
            asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()"
@@ -93,7 +92,6 @@
 else
 {
     <p>No supervisors are identified who can sign-off the activity <strong>@Model.SelfAssessment.Name</strong> who don't have an outstanding sign-off request.</p>
-    <p><a asp-action="ManageSupervisors" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">Click here</a> to manage supervisors.</p>
     <div class="nhsuk-action-link">
         <a class="nhsuk-back-link__link"
            asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()"


### PR DESCRIPTION
### JIRA link
[TD-5433](https://hee-tis.atlassian.net/browse/TD-5433)

### Description
Manage Supervisor link removed from RequestSignOff page.

### Screenshots

![image](https://github.com/user-attachments/assets/8561a252-6a7d-48fe-a1c8-dfd841de6e11)


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
