### PR TITLE
TD-5438-Moved the 'View Proficiencies' button to the top.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
@@ -29,23 +29,6 @@
 {
     <partial name="_NonReportableSelfAssessment" />
 }
-@if (Model.IsSupervised)
-{
-    <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-two-thirds">
-            @(Html.Raw(Model.Description))
-        </div>
-        <div class="nhsuk-grid-column-one-third">
-            <partial name="Shared/_SupervisorsCard"
-                     model="@Model.Supervisors" />
-        </div>
-    </div>
-}
-else
-{
-    <div class="nhsuk-u-reading-width">@(Html.Raw(Model.Description))</div>
-}
-
 @if (Model.LinearNavigation)
 {
     <a role="button" class="nhsuk-button @(Model.UserBookmark != null || bookmarkIsRelevant ? "nhsuk-button--secondary" : "") trigger-loader" asp-action="AddOptionalCompetencies" asp-route-selfAssessmentId="@Model.Id" asp-route-vocabulary="@Model.VocabPlural">View @Model.VocabPlural</a>
@@ -72,6 +55,19 @@ else
         <a role="button" class="nhsuk-button nhsuk-button--secondary trigger-loader" href="@Configuration["AppRootPath"]@Model.UserBookmark">Continue where I left off</a>
     }
 }
-
-
-
+@if (Model.IsSupervised)
+{
+    <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+            @(Html.Raw(Model.Description))
+        </div>
+        <div class="nhsuk-grid-column-one-third">
+            <partial name="Shared/_SupervisorsCard"
+                     model="@Model.Supervisors" />
+        </div>
+    </div>
+}
+else
+{
+    <div class="nhsuk-u-reading-width">@(Html.Raw(Model.Description))</div>
+}


### PR DESCRIPTION
### JIRA link
[TD-5438](https://hee-tis.atlassian.net/browse/TD-5438)

### Description
Moved the 'View Proficiencies' button to the top.

### Screenshots
<img width="808" alt="image" src="https://github.com/user-attachments/assets/3eb25c4c-35f3-4a99-9dab-822bfea4fdb5" />


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5438]: https://hee-tis.atlassian.net/browse/TD-5438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ