### PR TITLE
TD_5434 Move the Centre Name to the top of footer across all Learning Portal Pages.

### DIFF
--- a/DigitalLearningSolutions.Web/ViewComponents/DlsFooterBannerTextViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/DlsFooterBannerTextViewComponent.cs
@@ -1,0 +1,14 @@
+﻿using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DigitalLearningSolutions.Web.ViewComponents
+{
+    public class DlsFooterBannerTextViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(string centreName)
+        {
+            var model = new DlsFooterBannerTextViewModel(centreName);
+            return View(model);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewComponents/DlsFooterBannerTextViewComponent.cs
+++ b/DigitalLearningSolutions.Web/ViewComponents/DlsFooterBannerTextViewComponent.cs
@@ -1,13 +1,33 @@
-﻿using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+﻿using System.Security.Claims;
+using DigitalLearningSolutions.Data.DataServices;
+using DigitalLearningSolutions.Web.Helpers;
 using Microsoft.AspNetCore.Mvc;
+using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents;
+using DigitalLearningSolutions.Web.Services;
+using System;
+using System.Threading.Tasks;
 
 namespace DigitalLearningSolutions.Web.ViewComponents
 {
     public class DlsFooterBannerTextViewComponent : ViewComponent
     {
-        public IViewComponentResult Invoke(string centreName)
+        private readonly ICentresService centresService;
+
+        public DlsFooterBannerTextViewComponent(ICentresService centresService)
         {
-            var model = new DlsFooterBannerTextViewModel(centreName);
+            this.centresService = centresService;
+        }
+
+        public  IViewComponentResult Invoke()
+        {
+            var centreId = ((ClaimsPrincipal)User).GetCustomClaimAsInt(CustomClaimTypes.UserCentreId);
+            if (centreId == null)
+            {
+                return View(new DlsFooterBannerTextViewModel(null));
+            }
+
+            var bannerText = centresService.GetBannerText(Convert.ToInt32(centreId));
+            var model = new DlsFooterBannerTextViewModel(bannerText);
             return View(model);
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DlsFooterBannerTextViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DlsFooterBannerTextViewModel.cs
@@ -1,0 +1,13 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+{
+    public class DlsFooterBannerTextViewModel
+    {
+        public  readonly string? CentreName;
+
+        public DlsFooterBannerTextViewModel(string centreName)
+        {
+            CentreName = centreName;
+        }
+
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DlsFooterBannerTextViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/ViewComponents/DlsFooterBannerTextViewModel.cs
@@ -2,11 +2,11 @@
 {
     public class DlsFooterBannerTextViewModel
     {
-        public  readonly string? CentreName;
+        public  readonly string? BannerText;
 
-        public DlsFooterBannerTextViewModel(string centreName)
+        public DlsFooterBannerTextViewModel(string bannerText)
         {
-            CentreName = centreName;
+            BannerText = bannerText;
         }
 
     }

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
@@ -12,6 +12,7 @@
   ViewData["CustomisationId"] = Model.Id;
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.Id}/Password";
   ViewData["HeaderPathName"] = Model.Title;
+  ViewData["BannerText"] = Model.BannerText;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
@@ -36,7 +37,6 @@
     <div class="nhsuk-grid-column-full">
       <h1 id="page-heading" class="nhsuk-heading-xl">@Model.Title</h1>
       <p class="nhsuk-u-font-size-24">@Model.Description</p>
-      <p class="nhsuk-u-secondary-text-color nhsuk-heading-s">@Model.BannerText</p>
     </div>
   </div>
 

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/CoursePassword.cshtml
@@ -12,7 +12,6 @@
   ViewData["CustomisationId"] = Model.Id;
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.Id}/Password";
   ViewData["HeaderPathName"] = Model.Title;
-  ViewData["BannerText"] = Model.BannerText;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -12,6 +12,7 @@
   ViewData["CustomisationId"] = Model.Id;
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.Id}";
   ViewData["HeaderPathName"] = Model.Title;
+  ViewData["BannerText"] = Model.BannerText;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />
@@ -42,7 +43,6 @@
     }
 
     <p class="nhsuk-u-margin-bottom-0 nhsuk-heading-m">@Model.CentreName</p>
-    <p class="nhsuk-u-secondary-text-color nhsuk-heading-s">@Model.BannerText</p>
   </div>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningMenu/Index.cshtml
@@ -12,7 +12,6 @@
   ViewData["CustomisationId"] = Model.Id;
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningMenu/{Model.Id}";
   ViewData["HeaderPathName"] = Model.Title;
-  ViewData["BannerText"] = Model.BannerText;
 }
 @section NavMenuItems {
   <partial name="Shared/_NavMenuItems" />

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -14,47 +14,47 @@
 }
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  @if (Model.JavascriptSearchSortFilterPaginateEnabled)
+@if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  <vc:loading-spinner page-has-side-nav-menu="false" />
+    <vc:loading-spinner page-has-side-nav-menu="false" />
 }
 <div class="nhsuk-grid-row" id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
 
-  <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">Available Activities</h1>
+    <div class="nhsuk-grid-column-full">
+        <h1 id="page-heading">Available Activities</h1>
 
-    <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
+        <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
 
-    <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
-    @if (Model.NoDataFound)
-    {
-      <p class="nhsuk-u-margin-top-4" role="alert">
-        <b>No data to display</b>
-      </p>
-    }
-    else
-    {
-      <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-      <partial name="SearchablePage/_TopPagination" model="Model" />
-      <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
-
-      <div id="searchable-elements">
-        @foreach (var availableCourse in Model.AvailableCourses)
+        <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
+        @if (Model.NoDataFound)
         {
-          <partial name="Available/_AvailableCourseCard" model="availableCourse" />
+            <p class="nhsuk-u-margin-top-4" role="alert">
+                <b>No data to display</b>
+            </p>
         }
-      </div>
-    }
-    <partial name="SearchablePage/_BottomPagination" model="Model" />
-  </div>
+        else
+        {
+            <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+            <partial name="SearchablePage/_TopPagination" model="Model" />
+            <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
+
+            <div id="searchable-elements">
+                @foreach (var availableCourse in Model.AvailableCourses)
+                {
+                    <partial name="Available/_AvailableCourseCard" model="availableCourse" />
+                }
+            </div>
+        }
+        <partial name="SearchablePage/_BottomPagination" model="Model" />
+    </div>
 </div>
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  @section scripts {
-  <script src="@Url.Content("~/js/learningPortal/available.js")" asp-append-version="true"></script>
-}
+    @section scripts {
+    <script src="@Url.Content("~/js/learningPortal/available.js")" asp-append-version="true"></script>
+    }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -6,10 +6,11 @@
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/courses.css")" asp-append-version="true">
 
 @{
-  ViewData["Application"] = "Learning Portal";
-  ViewData["Title"] = "Available Activities";
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Available";
-  ViewData["HeaderPathName"] = "Learning Portal";
+    ViewData["Application"] = "Learning Portal";
+    ViewData["Title"] = "Available Activities";
+    ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Available";
+    ViewData["HeaderPathName"] = "Learning Portal";
+    ViewData["BannerText"] = Model.BannerText;
 }
 
 @section NavMenuItems {
@@ -24,10 +25,6 @@
 
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">Available Activities</h1>
-    @if (Model.BannerText != null)
-    {
-      <h2 class="page-subheading">@Model.BannerText</h2>
-    }
 
     <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/Available.cshtml
@@ -10,7 +10,6 @@
     ViewData["Title"] = "Available Activities";
     ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Available";
     ViewData["HeaderPathName"] = "Learning Portal";
-    ViewData["BannerText"] = Model.BannerText;
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -6,64 +6,64 @@
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/completed.css")" asp-append-version="true">
 
 @{
-  ViewData["Application"] = "Learning Portal";
-  ViewData["Title"] = "My Completed Activities";
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Completed";
-  ViewData["HeaderPathName"] = "Learning Portal";
-  ViewData["BannerText"] = Model.BannerText;
+    ViewData["Application"] = "Learning Portal";
+    ViewData["Title"] = "My Completed Activities";
+    ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Completed";
+    ViewData["HeaderPathName"] = "Learning Portal";
+    ViewData["BannerText"] = Model.BannerText;
 }
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  <vc:loading-spinner page-has-side-nav-menu="false" />
+    <vc:loading-spinner page-has-side-nav-menu="false" />
 }
 <div class="nhsuk-grid-row" id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
-  <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">My Completed Activities</h1>
-    
-    @if (!Model.ApiIsAccessible)
-    {
-      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"
-                                  text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
-    }
+    <div class="nhsuk-grid-column-full">
+        <h1 id="page-heading">My Completed Activities</h1>
 
-    <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
-
-    <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
-    @if (Model.NoDataFound)
-    {
-      <p class="nhsuk-u-margin-top-4" role="alert">
-        <b>No data to display</b>
-      </p>
-    }
-    else
-    {
-      <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-      <partial name="SearchablePage/_TopPagination" model="Model" />
-      <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
-
-      <div id="searchable-elements">
-        @foreach (var completedLearningItem in Model.CompletedActivities)
+        @if (!Model.ApiIsAccessible)
         {
-          if (completedLearningItem is CompletedCourseViewModel)
-          {
-            <partial name="Completed/CompletedCourseCard/_CompletedCourseCard" model="completedLearningItem" />
-          }
-          else
-          {
-            <partial name="Completed/CompletedActionPlanResourceCard/_CompletedActionPlanResourceCard" model="completedLearningItem" />
-          }
+            <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"
+                                          text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
         }
-      </div>
-    }
 
-    <partial name="SearchablePage/_BottomPagination" model="Model" />
-  </div>
+        <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
+
+        <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
+        @if (Model.NoDataFound)
+        {
+            <p class="nhsuk-u-margin-top-4" role="alert">
+                <b>No data to display</b>
+            </p>
+        }
+        else
+        {
+            <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+            <partial name="SearchablePage/_TopPagination" model="Model" />
+            <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
+
+            <div id="searchable-elements">
+                @foreach (var completedLearningItem in Model.CompletedActivities)
+                {
+                    if (completedLearningItem is CompletedCourseViewModel)
+                    {
+                        <partial name="Completed/CompletedCourseCard/_CompletedCourseCard" model="completedLearningItem" />
+                    }
+                    else
+                    {
+                        <partial name="Completed/CompletedActionPlanResourceCard/_CompletedActionPlanResourceCard" model="completedLearningItem" />
+                    }
+                }
+            </div>
+        }
+
+        <partial name="SearchablePage/_BottomPagination" model="Model" />
+    </div>
 </div>
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  @section scripts {
-  <script src="@Url.Content("~/js/learningPortal/completed.js")" asp-append-version="true"></script>
-}
+    @section scripts {
+    <script src="@Url.Content("~/js/learningPortal/completed.js")" asp-append-version="true"></script>
+    }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -10,6 +10,7 @@
   ViewData["Title"] = "My Completed Activities";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Completed";
   ViewData["HeaderPathName"] = "Learning Portal";
+  ViewData["BannerText"] = Model.BannerText;
 }
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)
@@ -19,11 +20,7 @@
 <div class="nhsuk-grid-row" id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">My Completed Activities</h1>
-    @if (Model.BannerText != null)
-    {
-      <h2 class="page-subheading">@Model.BannerText</h2>
-    }
-
+    
     @if (!Model.ApiIsAccessible)
     {
       <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Completed/Completed.cshtml
@@ -10,7 +10,6 @@
     ViewData["Title"] = "My Completed Activities";
     ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Completed";
     ViewData["HeaderPathName"] = "Learning Portal";
-    ViewData["BannerText"] = Model.BannerText;
 }
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -8,72 +8,72 @@
 <link rel="stylesheet" href="@Url.Content("~/css/learningPortal/current.css")" asp-append-version="true">
 
 @{
-  ViewData["Application"] = "Learning Portal";
-  ViewData["Title"] = "My Current Activities";
-  ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Current";
-  ViewData["HeaderPathName"] = "Learning Portal";
+    ViewData["Application"] = "Learning Portal";
+    ViewData["Title"] = "My Current Activities";
+    ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Current";
+    ViewData["HeaderPathName"] = "Learning Portal";
     ViewData["BannerText"] = Model.BannerText;
 }
 
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
 
-  @if (Model.JavascriptSearchSortFilterPaginateEnabled)
+@if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  <vc:loading-spinner page-has-side-nav-menu="false" />
+    <vc:loading-spinner page-has-side-nav-menu="false" />
 }
 <div class="nhsuk-grid-row" id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
-  <div class="nhsuk-grid-column-full">
-    <h1 id="page-heading">My Current Activities</h1>
-    
-    @if (!Model.ApiIsAccessible)
-    {
-      <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"
-                                  text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
-    }
+    <div class="nhsuk-grid-column-full">
+        <h1 id="page-heading">My Current Activities</h1>
 
-    <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
-
-    @if (Model.NoDataFound)
-    {
-      <p class="nhsuk-u-margin-top-4" role="alert">
-        <b>You are not enrolled on anything.</b> View <a asp-action="Available">Available activities</a>.
-      </p>
-    }
-    else
-    {
-      <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
-      <partial name="SearchablePage/_SearchResultsCount" model="Model" />
-      <partial name="SearchablePage/_TopPagination" model="Model" />
-      <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
-
-      <div id="searchable-elements">
-        @foreach (var currentLearningItem in Model.CurrentActivities)
+        @if (!Model.ApiIsAccessible)
         {
-          if (currentLearningItem is SelfAssessmentCardViewModel)
-          {
-            <partial name="SelfAssessments/_SelfAssessmentCard" model="currentLearningItem" />
-          }
-          else if (currentLearningItem is CurrentLearningResourceViewModel)
-          {
-            <partial name="Current/_CurrentLearningResourceCard" model="currentLearningItem" />
-          }
-          else
-          {
-            <partial name="Current/CurrentCourseCard/_CurrentCourseCard" model="currentLearningItem" />
-          }
+            <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"
+                                          text="@LearningHubWarningTextHelper.ResourceDetailsMayBeOutOfDate" />
         }
-      </div>
-    }
 
-    <partial name="SearchablePage/_BottomPagination" model="Model" />
-  </div>
+        <partial name="SearchablePage/Configurations/_FullWidthSearchSortAndFilter" model="Model" />
+
+        @if (Model.NoDataFound)
+        {
+            <p class="nhsuk-u-margin-top-4" role="alert">
+                <b>You are not enrolled on anything.</b> View <a asp-action="Available">Available activities</a>.
+            </p>
+        }
+        else
+        {
+            <hr class="nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4" />
+            <partial name="SearchablePage/_SearchResultsCount" model="Model" />
+            <partial name="SearchablePage/_TopPagination" model="Model" />
+            <partial name="SearchablePage/_ResultCountAndPageAlerts" model="Model" />
+
+            <div id="searchable-elements">
+                @foreach (var currentLearningItem in Model.CurrentActivities)
+                {
+                    if (currentLearningItem is SelfAssessmentCardViewModel)
+                    {
+                        <partial name="SelfAssessments/_SelfAssessmentCard" model="currentLearningItem" />
+                    }
+                    else if (currentLearningItem is CurrentLearningResourceViewModel)
+                    {
+                        <partial name="Current/_CurrentLearningResourceCard" model="currentLearningItem" />
+                    }
+                    else
+                    {
+                        <partial name="Current/CurrentCourseCard/_CurrentCourseCard" model="currentLearningItem" />
+                    }
+                }
+            </div>
+        }
+
+        <partial name="SearchablePage/_BottomPagination" model="Model" />
+    </div>
 </div>
 
 @if (Model.JavascriptSearchSortFilterPaginateEnabled)
 {
-  @section scripts {
-  <script src="@Url.Content("~/js/learningPortal/current.js")" asp-append-version="true"></script>
-}
+    @section scripts {
+    <script src="@Url.Content("~/js/learningPortal/current.js")" asp-append-version="true"></script>
+    }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -12,6 +12,7 @@
   ViewData["Title"] = "My Current Activities";
   ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Current";
   ViewData["HeaderPathName"] = "Learning Portal";
+    ViewData["BannerText"] = Model.BannerText;
 }
 
 @section NavMenuItems {
@@ -25,11 +26,7 @@
 <div class="nhsuk-grid-row" id="@(Model.JavascriptSearchSortFilterPaginateEnabled ? "js-styling-hidden-area-while-loading" : "no-js-styling")">
   <div class="nhsuk-grid-column-full">
     <h1 id="page-heading">My Current Activities</h1>
-    @if (Model.BannerText != null)
-    {
-      <h2 class="page-subheading word-break">@Model.BannerText</h2>
-    }
-
+    
     @if (!Model.ApiIsAccessible)
     {
       <vc:learning-resource-warning css-class="nhsuk-u-margin-bottom-4 nhsuk-u-margin-top-4"

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Current/Current.cshtml
@@ -12,7 +12,6 @@
     ViewData["Title"] = "My Current Activities";
     ViewData["HeaderPath"] = $"{Configuration["AppRootPath"]}/LearningPortal/Current";
     ViewData["HeaderPathName"] = "Learning Portal";
-    ViewData["BannerText"] = Model.BannerText;
 }
 
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
@@ -14,15 +14,6 @@
                 </li>
             </ul>
         </div>
-        // <hr class="nhsuk-footer-centre-banner-separator" />
     }
 }
 
-@* <style type="text/css">
-    .nhsuk-footer-centre-banner-separator {
-        display: block;
-        border: 0;
-        border-bottom: 1px solid black;
-        margin-top: 1%;
-    }
-</style> *@

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
@@ -1,13 +1,13 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
 @model DlsFooterBannerTextViewModel
 @{
-    if (!String.IsNullOrEmpty(Model.CentreName))
+    if (!String.IsNullOrEmpty(Model.BannerText))
     {
         <h2 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color">Need help?</h2>
         <div class="nhsuk-footer nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">
             <ul class="nhsuk-footer__list">
                 <li class="nhsuk-footer__list-item">
-                    <span>Centre contact information:</span> <span>@Model.CentreName</span>
+                    <span>Centre contact information:</span> <span>@Model.BannerText</span>
                 </li>
             </ul>
         </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
@@ -1,0 +1,28 @@
+﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
+@model DlsFooterBannerTextViewModel
+@{
+    var currentApplication = ViewData["Application"]?.ToString();
+}
+@{
+    if (!String.IsNullOrEmpty(currentApplication) && (currentApplication.Contains("Learning Portal") || currentApplication.Contains("Supervisor")))
+    {
+        <h2 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color">Need help?</h2>
+        <div class="nhsuk-footer nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">
+            <ul class="nhsuk-footer__list">
+                <li class="nhsuk-footer__list-item">
+                    <span>Centre contact information:</span> <span>@Model.CentreName</span>
+                </li>
+            </ul>
+        </div>
+        // <hr class="nhsuk-footer-centre-banner-separator" />
+    }
+}
+
+@* <style type="text/css">
+    .nhsuk-footer-centre-banner-separator {
+        display: block;
+        border: 0;
+        border-bottom: 1px solid black;
+        margin-top: 1%;
+    }
+</style> *@

--- a/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/Components/DlsFooterBannerText/Default.cshtml
@@ -1,10 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Common.ViewComponents
 @model DlsFooterBannerTextViewModel
 @{
-    var currentApplication = ViewData["Application"]?.ToString();
-}
-@{
-    if (!String.IsNullOrEmpty(currentApplication) && (currentApplication.Contains("Learning Portal") || currentApplication.Contains("Supervisor")))
+    if (!String.IsNullOrEmpty(Model.CentreName))
     {
         <h2 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color">Need help?</h2>
         <div class="nhsuk-footer nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">

--- a/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
@@ -7,11 +7,11 @@
             @{
                 if (currentPath.Contains("/LearningPortal/Current") || currentPath.Contains("/LearningPortal/Completed") || currentPath.Contains("/LearningPortal/Available"))
                 {
-                    <h2 class="nhsuk-u-visually-hidden">Centre Information</h2>
+                    <h2 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color">Need help?</h2>
                     <div class="nhsuk-footer">
                         <ul class="nhsuk-footer__list">
                             <li class="nhsuk-footer__list-item">
-                                <span>Centre contact information:</span> <span>@ViewData["BannerText"]</span>
+                                <span class="nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">Centre contact information:</span> <span>@ViewData["BannerText"]</span>
                             </li>
                         </ul>
                     </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
@@ -1,24 +1,10 @@
 @{
-    var currentPath = Context.Request.Path.ToString();
+
 }
 <footer role="contentinfo">
     <div class="nhsuk-footer-container">
         <div class="nhsuk-width-container">
-            @{
-                if (currentPath.Contains("/LearningPortal/Current") || currentPath.Contains("/LearningPortal/Completed") || currentPath.Contains("/LearningPortal/Available"))
-                {
-                    <h2 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color">Need help?</h2>
-                    <div class="nhsuk-footer nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">
-                        <ul class="nhsuk-footer__list">
-                            <li class="nhsuk-footer__list-item">
-                                <span>Centre contact information:</span> <span>@ViewData["BannerText"]</span>
-                            </li>
-                        </ul>
-                    </div>
-                }
-            }
-        </div>
-        <div class="nhsuk-width-container">
+            @await Component.InvokeAsync("DlsFooterBannerText", new { centreName = ViewData["BannerText"] })
             <h2 class="nhsuk-u-visually-hidden">Support links</h2>
             <div class="nhsuk-footer">
                 <ul class="nhsuk-footer__list">

--- a/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
@@ -8,10 +8,10 @@
                 if (currentPath.Contains("/LearningPortal/Current") || currentPath.Contains("/LearningPortal/Completed") || currentPath.Contains("/LearningPortal/Available"))
                 {
                     <h2 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color">Need help?</h2>
-                    <div class="nhsuk-footer">
+                    <div class="nhsuk-footer nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">
                         <ul class="nhsuk-footer__list">
                             <li class="nhsuk-footer__list-item">
-                                <span class="nhsuk-u-font-size-16 nhsuk-u-secondary-text-color">Centre contact information:</span> <span>@ViewData["BannerText"]</span>
+                                <span>Centre contact information:</span> <span>@ViewData["BannerText"]</span>
                             </li>
                         </ul>
                     </div>

--- a/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
@@ -1,5 +1,23 @@
+@{
+    var currentPath = Context.Request.Path.ToString();
+}
 <footer role="contentinfo">
     <div class="nhsuk-footer-container">
+        <div class="nhsuk-width-container">
+            @{
+                if (currentPath.Contains("/LearningPortal/Current") || currentPath.Contains("/LearningPortal/Completed") || currentPath.Contains("/LearningPortal/Available"))
+                {
+                    <h2 class="nhsuk-u-visually-hidden">Centre Information</h2>
+                    <div class="nhsuk-footer">
+                        <ul class="nhsuk-footer__list">
+                            <li class="nhsuk-footer__list-item">
+                                <span>Centre contact information:</span> <span>@ViewData["BannerText"]</span>
+                            </li>
+                        </ul>
+                    </div>
+                }
+            }
+        </div>
         <div class="nhsuk-width-container">
             <h2 class="nhsuk-u-visually-hidden">Support links</h2>
             <div class="nhsuk-footer">

--- a/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_DlsFooter.cshtml
@@ -1,10 +1,7 @@
-@{
-
-}
 <footer role="contentinfo">
     <div class="nhsuk-footer-container">
         <div class="nhsuk-width-container">
-            @await Component.InvokeAsync("DlsFooterBannerText", new { centreName = ViewData["BannerText"] })
+            @await Component.InvokeAsync("DlsFooterBannerText")
             <h2 class="nhsuk-u-visually-hidden">Support links</h2>
             <div class="nhsuk-footer">
                 <ul class="nhsuk-footer__list">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
@@ -6,7 +6,6 @@
     ViewData["Title"] = "Dashboard";
     ViewData["Application"] = "Supervisor";
     ViewData["HeaderPathName"] = "Supervisor";
-    ViewData["BannerText"] = Model.BannerText;
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
@@ -51,10 +51,7 @@ else
 {
     <p>There are no tasks requiring your attention.</p>
 }
-@if (Model.BannerText != null)
-{
-    <h2 class="page-subheading word-break">@Model.BannerText</h2>
-}
+
 <ul class="nhsuk-grid-row nhsuk-card-group">
 
     <feature name="@(FeatureFlags.SupervisorProfileAssessmentInterface)">

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Index.cshtml
@@ -6,6 +6,7 @@
     ViewData["Title"] = "Dashboard";
     ViewData["Application"] = "Supervisor";
     ViewData["HeaderPathName"] = "Supervisor";
+    ViewData["BannerText"] = Model.BannerText;
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {


### PR DESCRIPTION
### JIRA link
[TD-5434](https://hee-tis.atlassian.net/browse/TD-5434)

### Description
I added the centre name to the footer and accessed it as a ViewData across the footer partial after making changes to three Learning Hub pages i.e. Current, Available and Completed.

### Screenshots
![image](https://github.com/user-attachments/assets/3658130f-4880-4e55-a789-25f573114a0c)


Wave tool screenshot
![image](https://github.com/user-attachments/assets/871a4c20-b2ab-4225-9f52-3e81312dbbc9)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5434]: https://hee-tis.atlassian.net/browse/TD-5434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ