### PR TITLE
TD- 5263 fix empty description

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/StringHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/StringHelper.cs
@@ -1,6 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
     using System;
+    using System.Text.RegularExpressions;
     using DigitalLearningSolutions.Data.Extensions;
     using Microsoft.Extensions.Configuration;
 
@@ -15,6 +16,18 @@
         {
             var applicationPath = new Uri(config.GetAppRootPath()).AbsolutePath.TrimEnd('/');
             return applicationPath + basicUrl;
+        }
+        public static string StripHtmlTags(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return string.Empty;
+            }
+
+            // Remove HTML tags
+            string result = Regex.Replace(input, "<.*?>", string.Empty).Trim();
+
+            return string.IsNullOrEmpty(result) ? string.Empty : result;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/FrameworkService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkService.cs
@@ -5,6 +5,7 @@ using DigitalLearningSolutions.Data.Models.Frameworks;
 using DigitalLearningSolutions.Data.Models.Frameworks.Import;
 using DigitalLearningSolutions.Data.Models.SelfAssessments;
 using System.Collections.Generic;
+using DigitalLearningSolutions.Web.Helpers;
 using AssessmentQuestion = DigitalLearningSolutions.Data.Models.Frameworks.AssessmentQuestion;
 using CompetencyResourceAssessmentQuestionParameter =
     DigitalLearningSolutions.Data.Models.Frameworks.CompetencyResourceAssessmentQuestionParameter;
@@ -516,7 +517,12 @@ namespace DigitalLearningSolutions.Web.Services
 
         public DetailFramework? GetFrameworkDetailByFrameworkId(int frameworkId, int adminId)
         {
-            return frameworkDataService.GetFrameworkDetailByFrameworkId(frameworkId, adminId);
+            var detailFramework = frameworkDataService.GetFrameworkDetailByFrameworkId(frameworkId, adminId);
+            if (StringHelper.StripHtmlTags(detailFramework.Description) == string.Empty)
+            {
+                detailFramework.Description = string.Empty;
+            }
+            return detailFramework;
         }
 
         public FrameworkReview? GetFrameworkReview(int frameworkId, int adminId, int reviewId)


### PR DESCRIPTION
### JIRA link
[TD-5263](https://hee-tis.atlassian.net/browse/TD-5263)

### Description
When a description is edited and left blank, a spurious <br/> tag is stored to the description field. This was causing an empty box to be displayed for framework description. This change uses a string helper to strip HTML tags and set the description to empty if the string is empty after tags have been stripped.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5263]: https://hee-tis.atlassian.net/browse/TD-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ