### PR TITLE
TD-5327 Fix testing fails

### DIFF
--- a/DigitalLearningSolutions.Web/Views/ApplicationSelector/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/ApplicationSelector/Index.cshtml
@@ -17,20 +17,17 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content  beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <a class="nhsuk-card__link" asp-controller="LearningPortal" asp-action="Current">Learning Portal</a>
                     </h2>
                     <p class="nhsuk-card__description">Access to your current, available and completed learning courses.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>
@@ -41,7 +38,7 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <feature name="@(FeatureFlags.RefactoredTrackingSystem)">
                             <a class="nhsuk-card__link" asp-controller="Dashboard" asp-action="Index">Tracking System</a>
@@ -51,15 +48,12 @@
                         </feature>
                     </h2>
                     <p class="nhsuk-card__description">Manage and distribute learning to your organisation and access reports.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>
@@ -69,7 +63,7 @@
             <feature name="@(FeatureFlags.RefactoredTrackingSystem)">
                 <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
                     <div class="nhsuk-card nhsuk-card--clickable">
-                        <div class="nhsuk-card__content beta-card__content">
+                        <div class="nhsuk-card__content nhsuk-card__content--primary">
                             <h2 class="nhsuk-card__heading nhsuk-heading-m">
                                 <a class="nhsuk-card__link" href="@Configuration.GetCurrentSystemBaseUrl()/tracking/dashboard">Legacy Tracking System</a>
                             </h2>
@@ -77,18 +71,15 @@
                                 Access the old Tracking System if you can't find the functionality you need in the new one.
                                 Please raise a ticket to tell us about any missing functionality, too.
                             </p>
-                        </div>
-                        <div class="beta-hub-arrow">
-                            <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                             xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                                <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                                <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                               stroke-miterlimit="10" stroke-width="2.667">
-                                    <path d="M15.438 13l-3.771 3.771">
-                                    </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+                            <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                                <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                                <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                                    <path d="M15.438 13l-3.771 3.771" />
+                                    <path data-name="Path" d="M11.667 9.229L15.438 13" />
                                 </g>
                             </svg>
                         </div>
+
                     </div>
                 </div>
             </feature>
@@ -98,20 +89,16 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <a class="nhsuk-card__link" href="@Configuration.GetCurrentSystemBaseUrl()/cms/courses">Content Management System</a>
                     </h2>
                     <p class="nhsuk-card__description">Import and manage learning content that's delivered through the Digital Learning Solutions platform.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>
@@ -122,20 +109,16 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <a class="nhsuk-card__link" asp-controller="Supervisor" asp-action="Index">Supervise</a>
                     </h2>
                     <p class="nhsuk-card__description">Assign and review staff profile assessments and arrange supervision sessions.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>
@@ -146,20 +129,16 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <a class="nhsuk-card__link" href="@Configuration.GetCurrentSystemBaseUrl()/cms/contentcreator">Content Creator</a>
                     </h2>
                     <p class="nhsuk-card__description">Create interactive elearning and assessments.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>
@@ -170,20 +149,16 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <a class="nhsuk-card__link" asp-controller="Frameworks" asp-action="Index">Frameworks</a>
                     </h2>
                     <p class="nhsuk-card__description">Create and distribute competency frameworks and role profiles.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>
@@ -194,7 +169,7 @@
     {
         <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
             <div class="nhsuk-card nhsuk-card--clickable">
-                <div class="nhsuk-card__content beta-card__content">
+                <div class="nhsuk-card__content nhsuk-card__content--primary">
                     <h2 class="nhsuk-card__heading nhsuk-heading-m">
                         <feature name="@(FeatureFlags.RefactoredSuperAdminInterface)">
                             <a class="nhsuk-card__link" asp-controller="Users" asp-action="Index">Super Admin</a>
@@ -204,15 +179,11 @@
                         </feature>
                     </h2>
                     <p class="nhsuk-card__description">Manage content and settings across the whole system.</p>
-                </div>
-                <div class="beta-hub-arrow">
-                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle"
-                     xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true">
-                        <circle cx="13.333" cy="13.333" r="13.333" fill="#005eb8"></circle>
-                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round"
-                       stroke-miterlimit="10" stroke-width="2.667">
-                            <path d="M15.438 13l-3.771 3.771">
-                            </path><path data-name="Path" d="M11.667 9.229L15.438 13"></path>
+                    <svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" width="27" height="27" aria-hidden="true" focusable="false">
+                        <circle cx="13.333" cy="13.333" r="13.333" fill="" />
+                        <g data-name="Group 1" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.667">
+                            <path d="M15.438 13l-3.771 3.771" />
+                            <path data-name="Path" d="M11.667 9.229L15.438 13" />
                         </g>
                     </svg>
                 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -1,5 +1,6 @@
 ﻿@inject IConfiguration Configuration
 @using DigitalLearningSolutions.Data.Extensions
+@using DigitalLearningSolutions.Web.Helpers
 @using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
 @using Microsoft.Extensions.Configuration
 @model SelfAssessmentOverviewViewModel
@@ -113,7 +114,7 @@
                         </summary>
                         <div class="nhsuk-details__text">
                             <partial name="SelfAssessments/_CompetencySummary" view-data="@competencySummariesEnumerator.Current" />
-                            @if (!String.IsNullOrEmpty(groupDetails.CompetencyGroupDescription))
+                            @if (!String.IsNullOrEmpty(StringHelper.StripHtmlTags(groupDetails.CompetencyGroupDescription)))
                             {
                                 <p class="nhsuk-body-l nhsuk-u-margin-left-7">@Html.Raw(groupDetails.CompetencyGroupDescription)</p>
                             }

--- a/DigitalLearningSolutions.Web/Views/SuperAdmin/Users/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/SuperAdmin/Users/Index.cshtml
@@ -53,23 +53,23 @@
                         </div>
                         <div class="nhsuk-grid-row">
                             <div class="filter-container nhsuk-u-margin-top-5">
-                                <div class="nhsuk-grid-column-one-quarter nhsuk-u-margin-right-3">
+                                <div class="nhsuk-grid-column-one-quarter nhsuk-u-margin-right-4">
                                     <vc:select-list asp-for="@nameof(Model.UserStatus)"
                                                     label="User status"
                                                     value="@Model.UserStatus"
                                                     required="true"
                                                     hint-text=""
-                                                    css-class="nhsuk-grid-column-full nhsuk-u-width-full"
+                                                    css-class=""
                                                     default-option=""
                                                     select-list-options="@ViewBag.UserStatus" />
                                 </div>
-                                <div class="nhsuk-grid-column-one-quarter nhsuk-u-margin-right-3">
+                                <div class="nhsuk-grid-column-one-quarter nhsuk-u-margin-right-4">
                                     <vc:select-list asp-for="@nameof(Model.EmailStatus)"
                                                     label="Email status"
                                                     value="@Model.EmailStatus"
                                                     required="true"
                                                     hint-text=""
-                                                    css-class="nhsuk-grid-column-full nhsuk-u-width-full"
+                                                    css-class=""
                                                     default-option=""
                                                     select-list-options="@ViewBag.EmailStatus" />
                                 </div>
@@ -79,7 +79,7 @@
                                                     value="@Model.JobGroupId.ToString()"
                                                     hint-text=""
                                                     required="true"
-                                                    css-class="nhsuk-grid-column-full  nhsuk-u-width-full"
+                                                    css-class=""
                                                     default-option=""
                                                     select-list-options="@ViewBag.JobGroups" />
                                 </div>


### PR DESCRIPTION
### JIRA link
[TD-5327](https://hee-tis.atlassian.net/browse/TD-5327)

### Description
- Uses a string helper to check whether HTML stripped description string is empty before deciding whether to display a description expander.
- Fixes the styling of app selector cards and drop-down filters to ensure mouse interactivity.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5327]: https://hee-tis.atlassian.net/browse/TD-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ