### PR TITLE
TD-5439 - A competency description is added to competency when it exists.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
@@ -130,9 +130,25 @@
                                     <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
                                     <div class="nhsuk-checkboxes__item">
                                         <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.SelfAssessmentResultSupervisorVerificationId" name="resultChecked" type="checkbox" value="@question.SelfAssessmentResultSupervisorVerificationId">
-                                        <label class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
-                                            @competency.Name
+                                        <label aria-label="Competency.Name" class="@(string.IsNullOrEmpty(competency.Description) ? "nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" : "nhsuk-label nhsuk-checkboxes__label nhsuk-u-padding-0 nhsuk-u-display-block")" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
+                                            @if (competency.Description == null)
+                                            {
+                                                @competency.Name
+                                            }
                                         </label>
+                                        @if (!string.IsNullOrEmpty(competency.Description))
+                                        {
+                                            <details class="nhsuk-details nhsuk-u-padding-left-2 ">
+                                                <summary class="nhsuk-details__summary nhsuk-u-padding-left-2">
+                                                    <span class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16 " for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
+                                                        @competency.Name
+                                                    </span>
+                                                </summary>
+                                                <div class="nhsuk-details__text nhsuk-u-margin-left-6 nhsuk-u-margin-top-2">
+                                                    @(Html.Raw(@competency.Description))
+                                                </div>
+                                            </details>
+                                        }
                                     </div>
                                 </td>
                                 <partial name="Shared/_AssessmentQuestionCells" model="question" />


### PR DESCRIPTION
### JIRA link
[TD-5439](https://hee-tis.atlassian.net/browse/TD-5439)

### Description
When a competency description exists, it is shown to the competency in the view.

### Screenshots

![image](https://github.com/user-attachments/assets/91321ee4-1f22-4bb7-af39-30d5005b16ea)

![image](https://github.com/user-attachments/assets/38e15c88-15e8-40ea-bb06-d365e6a339ab)


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5439]: https://hee-tis.atlassian.net/browse/TD-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ