### PR TITLE
TD-5482-Related supervisor role added to view.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
@@ -12,7 +12,7 @@
                 Self Assessment
             </th>
             <th role="columnheader" class="" scope="col">
-                Role links
+                Role
             </th>
             <th role="columnheader" class="" scope="col">
                 Last activity
@@ -36,9 +36,7 @@
                     <span class="nhsuk-table-responsive__heading">Self Assessment </span>@delegateSelfAssessment.RoleName
                 </td>
                 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                    <span class="nhsuk-table-responsive__heading">Role links </span>@(delegateSelfAssessment.ProfessionalGroup != null ? delegateSelfAssessment.ProfessionalGroup : "None/Generic")
-                    @(delegateSelfAssessment.SubGroup != null ? " / " + delegateSelfAssessment.SubGroup : "")
-                    @(delegateSelfAssessment.RoleProfile != null ? " / " + delegateSelfAssessment.RoleProfile : "")
+                    <span class="nhsuk-table-responsive__heading">Role</span>@(delegateSelfAssessment.SupervisorRoleTitle)
                 </td>
                 <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
                     <span class="nhsuk-table-responsive__heading">Last activity </span>@delegateSelfAssessment.LastAccessed.ToShortDateString()<br /> (@delegateSelfAssessment.LaunchCount launches)


### PR DESCRIPTION
### JIRA link
[TD-5482](https://hee-tis.atlassian.net/browse/TD-5482)

### Description
Related supervisor role added to view.

### Screenshots

![image](https://github.com/user-attachments/assets/0d7c7ecc-8a61-4d40-a79b-26373202e684)

![image](https://github.com/user-attachments/assets/7713bc2b-49bf-4b49-a15e-4913805600b9)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5482]: https://hee-tis.atlassian.net/browse/TD-5482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ