### PR TITLE
TD-5220 fix warning messages on reorder competency confirmation

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
@@ -39,7 +39,7 @@
                     <div class="nhsuk-inset-text">
                         <span class="nhsuk-u-visually-hidden">Information: </span>
                         <p>We strongly recommend including all framework @Model.FrameworkVocabularyPlural.ToLower() in your uploaded sheet if reordering @Model.FrameworkVocabularyPlural.ToLower() to ensure that the correct sequence is applied.</p>
-                        <p>Note that if you split competency groups in your uploaded sheet, they will not be split in your framework but the order of groups may be affected.</p>
+                        <p>Note that if you split @Model.FrameworkVocabularySingular.ToLower() groups in your uploaded sheet, they will not be split in your framework but the order of groups may be affected.</p>
                     </div>
                     <div class="nhsuk-hint nhsuk-u-margin-bottom-2">
                         Your uploaded file includes changes to the order of existing @Model.FrameworkVocabularyPlural.ToLower(). Choose whether to store the changes to @Model.FrameworkVocabularySingular.ToLower() order during update.

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Import/ApplyCompetencyOrdering.cshtml
@@ -38,7 +38,8 @@
                     </legend>
                     <div class="nhsuk-inset-text">
                         <span class="nhsuk-u-visually-hidden">Information: </span>
-                        <p>We strongly recommend including all framework competencies in your uploaded sheet if reordering competencies to ensure that the correct sequence is applied.</p>
+                        <p>We strongly recommend including all framework @Model.FrameworkVocabularyPlural.ToLower() in your uploaded sheet if reordering @Model.FrameworkVocabularyPlural.ToLower() to ensure that the correct sequence is applied.</p>
+                        <p>Note that if you split competency groups in your uploaded sheet, they will not be split in your framework but the order of groups may be affected.</p>
                     </div>
                     <div class="nhsuk-hint nhsuk-u-margin-bottom-2">
                         Your uploaded file includes changes to the order of existing @Model.FrameworkVocabularyPlural.ToLower(). Choose whether to store the changes to @Model.FrameworkVocabularySingular.ToLower() order during update.


### PR DESCRIPTION
### JIRA link
[TD-5220](https://hee-tis.atlassian.net/browse/TD-5220)

### Description
Uses competency vocabulary in competency reordering screen and adds note about split competency groups in upload.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
