### PR TITLE
TD-5481-Added a Details view component to show supervisor list.

### DIFF
--- a/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/courseDelegates.scss
+++ b/DigitalLearningSolutions.Web/Styles/trackingSystem/delegates/courseDelegates.scss
@@ -26,3 +26,31 @@
     }
   }
 }
+
+.nhsuk-expander[open] details.nhsuk-details[open] .nhsuk-details__summary-text::before {
+  display: block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+  border-width: 12.124px 7px 0 7px;
+  border-top-color: inherit;
+}
+
+.nhsuk-details[open] .nhsuk-details .nhsuk-details__summary-text::before {
+  bottom: 0;
+  content: "";
+  left: 0;
+  margin: auto;
+  position: absolute;
+  top: 0;
+  display: block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+  border-width: 7px 0 7px 12.124px;
+  border-left-color: inherit;
+}

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -45,14 +45,28 @@
             <dd class="nhsuk-summary-list__value" data-name-for-sorting="complete-by-date">
                 @if (Model.Supervisors.Any())
                 {
-                    @foreach (var supervisor in Model.Supervisors.Take(3))
-                    {
-                        <p>@supervisor.SupervisorName, @supervisor.RoleName (@supervisor.CentreName)</p>
-                    }
-                    @if (Model.Supervisors.Count() > 3)
-                    {
-                        <p>+@(Model.Supervisors.Count() - 3) more</p>
-                    }
+                    <details class="nhsuk-details">
+                        <summary class="nhsuk-details__summary nhsuk-u-padding-0">
+                            @{
+                                var supervisors = string.Join(", ", new[] {
+                                    new { Role = "Educator/Manager", Count = Model.Supervisors.Count(x => x.RoleName == "Educator/Manager") },
+                                    new { Role = "Assessor", Count = Model.Supervisors.Count(x => x.RoleName == "Assessor") },
+                                    new { Role = "Supervisor", Count = Model.Supervisors.Count(x => x.RoleName == "Supervisor") }
+                                    }
+                                .Where(x => x.Count > 0)
+                                .Select(x => $"{x.Count} {x.Role}{(x.Count > 1 ? "s" : "")}"));
+                            }
+                            <span class="nhsuk-details__summary-text nhsuk-u-padding-left-4">@supervisors</span>
+                        </summary>
+                        <div class="nhsuk-details__text nhsuk-u-margin-top-2">
+                            <ul>
+                                @foreach (var supervisor in Model.Supervisors)
+                                {
+                                    <li>@supervisor.SupervisorName, @supervisor.RoleName (@supervisor.CentreName)</li>
+                                }
+                            </ul>
+                        </div>
+                    </details>
                 }
                 else
                 {


### PR DESCRIPTION
### JIRA link
[TD-5481](https://hee-tis.atlassian.net/browse/TD-5481)

### Description
Added a Details view component in the view to show the supervisor list.
Note: As per discussion with @rshrirohit, decided to show a comma-separated Details heading.


### Screenshots
![image](https://github.com/user-attachments/assets/bd57796d-d943-4fe9-a1d1-88e5f3c5c1fd)

![image](https://github.com/user-attachments/assets/9aee6345-880a-4428-81dd-42ae4a5e4d08)

![image](https://github.com/user-attachments/assets/677ec315-c90e-48c2-bc1e-3a19a2f8a374)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5481]: https://hee-tis.atlassian.net/browse/TD-5481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ