### PR TITLE
TD-5153 Reapplies new logic to cope with only empty competency groups

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Structure.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Structure.cshtml
@@ -9,7 +9,7 @@
         {
             <a class="nhsuk-button" asp-action="AddEditFrameworkCompetencyGroup" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Add @Model.VocabSingular().ToLower() group</a>
             <a class="nhsuk-button nhsuk-button--secondary" asp-action="AddEditFrameworkCompetency" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])">Add ungrouped @Model.VocabSingular().ToLower()</a>
-            <a class="nhsuk-button nhsuk-button--secondary" asp-action="ImportCompetencies" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-isNotBlank="@(Model.FrameworkCompetencies.Any()|Model.FrameworkCompetencyGroups.Any())" asp-route-tabname="@(ViewContext.RouteData.Values["tabname"])">Bulk upload/update @Model.VocabPlural().ToLower()</a>
+            <a class="nhsuk-button nhsuk-button--secondary" asp-action="ImportCompetencies" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-isNotBlank="@((Model.FrameworkCompetencies?.Any() ?? false) || (Model.FrameworkCompetencyGroups?.Any(group=> group.FrameworkCompetencies.Any()) ?? false))" asp-route-tabname="@(ViewContext.RouteData.Values["tabname"])">Bulk upload/update @Model.VocabPlural().ToLower()</a>
         }
         @if ((Model.FrameworkCompetencies?.Any() ?? false) || (Model.FrameworkCompetencyGroups?.Any(group => group.FrameworkCompetencies.Any()) ?? false))
         {


### PR DESCRIPTION
### JIRA link
[TD-5153](https://hee-tis.atlassian.net/browse/TD-5153)

### Description
Reinstates logic to show only the download template option if the framework only contained empty groups. This was overwritten when resolving merge conflicts in the past.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5153]: https://hee-tis.atlassian.net/browse/TD-5153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ