### PR TITLE
TD-5390-Jodit editor validation added

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/Support/RequestSupportTicketController.cs
@@ -137,7 +137,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
             // Check if RequestDescription is null or contains any default empty tags ("<p><br></p>").  
             // This ensures that when a user navigates to the submit page and returns to SetRequestSummary,  
             // removing the description completely results in an actual empty value rather than leftover HTML tags.
-            if (requestDetailsmodel.RequestDescription == "<p><br></p>")
+            if (string.IsNullOrEmpty(StringHelper.StripHtmlTags(requestDetailsmodel.RequestDescription)))
             {
                 ModelState.AddModelError("RequestDescription", "Please enter request description");
             }
@@ -246,7 +246,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
             var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
                 MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
                 TempData
-            ).GetAwaiter().GetResult(); 
+            ).GetAwaiter().GetResult();
             var model = new SupportSummaryViewModel(data);
             return View("SupportTicketSummaryPage", model);
         }
@@ -262,7 +262,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
             var data = multiPageFormService.GetMultiPageFormData<RequestSupportTicketData>(
                 MultiPageFormDataFeature.AddCustomWebForm("RequestSupportTicketCWF"),
                 TempData
-            ).GetAwaiter().GetResult(); 
+            ).GetAwaiter().GetResult();
             data.GroupId = configuration.GetFreshdeskCreateTicketGroupId();
             data.ProductId = configuration.GetFreshdeskCreateTicketProductId();
             List<RequestAttachment> RequestAttachmentList = new List<RequestAttachment>();
@@ -354,7 +354,7 @@ namespace DigitalLearningSolutions.Web.Controllers.Support
             {
                 foreach (var item in requestAttachmentmodel.RequestAttachment)
                 {
-                    totalFileSize = totalFileSize + item.SizeMb??0;
+                    totalFileSize = totalFileSize + item.SizeMb ?? 0;
                 }
             }
             foreach (var item in requestAttachmentmodel.ImageFiles)

--- a/DigitalLearningSolutions.Web/Helpers/StringHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/StringHelper.cs
@@ -26,8 +26,8 @@
 
             // Remove HTML tags
             string result = Regex.Replace(input, "<.*?>", string.Empty).Trim();
-
-            return string.IsNullOrEmpty(result) ? string.Empty : result;
+            result = System.Net.WebUtility.HtmlDecode(result);
+            return string.IsNullOrEmpty(result.Trim()) ? string.Empty : result;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/htmleditor.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/htmleditor.ts
@@ -1,4 +1,4 @@
-import { Jodit } from 'jodit';
+﻿import { Jodit } from 'jodit';
 import DOMPurify from 'dompurify';
 
 let jodited = false;
@@ -70,5 +70,31 @@ if (jodited === false) {
       const clean = DOMPurify.sanitize(editor.editor.innerHTML);
       editor.editor.innerHTML = clean;
     });
+    const textarea = document.querySelector('.nhsuk-textarea.html-editor.nhsuk-input--error') as HTMLTextAreaElement | null;
+    if (textarea) {
+      const editorDiv = document.querySelector('.jodit-container.jodit.jodit_theme_default.jodit-wysiwyg_mode') as HTMLDivElement | null;
+      editorDiv?.classList.add('jodit-container', 'jodit', 'jodit_theme_default', 'jodit-wysiwyg_mode', 'jodit-error');
+    }
+
+    const summary = document.querySelector('.nhsuk-list.nhsuk-error-summary__list') as HTMLDivElement | null;
+
+    if (summary) {
+      summary.addEventListener('click', (e: Event) => {
+        if (textarea) {
+          const textareaId = textarea.id.toString();
+          const target = e.target as HTMLElement;
+          if (target.tagName.toLowerCase() === 'a') {
+            const href = (target as HTMLAnchorElement).getAttribute('href');
+
+            if (href && href.includes(textareaId)) {
+              const editorArea = document.querySelector('.jodit-wysiwyg') as HTMLDivElement | null;
+              editorArea?.focus();
+              editorArea?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              e.preventDefault();
+            }
+          }
+        }
+      });
+    }
   }
 }

--- a/DigitalLearningSolutions.Web/Styles/jodit.scss
+++ b/DigitalLearningSolutions.Web/Styles/jodit.scss
@@ -1,1 +1,6 @@
 ﻿@use "jodit/build/jodit.min";
+
+.jodit-error {
+  border: 2px solid red !important;
+  border-radius: 4px;
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Support/RequestSupportTicket/RequestSummaryViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Support/RequestSupportTicket/RequestSummaryViewModel.cs
@@ -21,7 +21,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.Support.RequestSupportTicket
         [Required(ErrorMessage = "Please enter request summary")]
         public string? RequestSubject { get; set; }
 
-        [Required(ErrorMessage = "Please enter request description")]
         public string? RequestDescription { get; set; }
 
         public int? RequestTypeId { get; set; }

--- a/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Support/RequestSupportTicket/RequestSummary.cshtml
@@ -40,17 +40,15 @@
                                autocomplete="given-name"
                                css-class=""
                                required="true" />
-                <nhs-form-group nhs-validation-for="RequestDescription">
-                    <vc:text-area asp-for="RequestDescription"
-                                  label="Describe your problem or request"
-                                  populate-with-current-value="true"
-                                  rows="5"
-                                  spell-check="false"
-                                  hint-text="If you are reporting a problem, please tell us exactly where it occurs and steps to recreate it. If you need to add screenshots, you will be able to do this in the next step."
-                                  css-class=""
-                                  character-count="null">
-                    </vc:text-area>
-                </nhs-form-group>
+                <vc:text-area asp-for="RequestDescription"
+                              label="Describe your problem or request"
+                              populate-with-current-value="true"
+                              rows="5"
+                              spell-check="false"
+                              hint-text="If you are reporting a problem, please tell us exactly where it occurs and steps to recreate it. If you need to add screenshots, you will be able to do this in the next step."
+                              css-class="html-editor"
+                              character-count="null">
+                </vc:text-area>
                 <button class="nhsuk-button" type="submit">Next</button>
             </form>
 


### PR DESCRIPTION
### JIRA link
[TD-5390](https://hee-tis.atlassian.net/browse/TD-5390)

### Description
1. validation code added to htmleditor.ts.
2. Removed [Required] attribute from view model as there is code in controller to validate and add model error.

Note: Wave errors exist for the Jodit editor that have been noticed in the application.

### Screenshots

![image](https://github.com/user-attachments/assets/8c9f15eb-8954-4872-8a84-78ab960fe331)

![image](https://github.com/user-attachments/assets/8164c285-49e3-4c2b-8c11-2c2762b68010)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5390]: https://hee-tis.atlassian.net/browse/TD-5390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ