### PR TITLE
TD-5220 fix order comparison for ungrouped competencies

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
@@ -2435,7 +2435,7 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
                          CompetencyGroups AS cg ON fcg.CompetencyGroupID = cg.ID
                     WHERE (fc.FrameworkID = @frameworkId)
                     GROUP BY fc.ID, c.ID, cg.Name, cg.Description, c.Name, c.Description, c.AlwaysShowDescription, fcg.Ordering, fc.Ordering
-                    ORDER BY COALESCE(fcg.Ordering,99999), fc.Ordering",
+                    ORDER BY COALESCE(fcg.Ordering,99999), fc.Ordering, fc.ID",
                                 new { frameworkId }
                             );
             }
@@ -2448,7 +2448,7 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
                     FROM   FrameworkCompetencies AS fc LEFT JOIN
                                  FrameworkCompetencyGroups AS fcg ON fc.FrameworkCompetencyGroupID = fcg.ID
                     WHERE (fc.FrameworkID = @frameworkId) AND (fc.ID IN @frameworkCompetencyIds)
-                    ORDER BY COALESCE(fcg.Ordering,99999), fc.Ordering",
+                    ORDER BY COALESCE(fcg.Ordering,99999), fc.Ordering, fc.ID",
                                 new { frameworkId, frameworkCompetencyIds }
                             ).ToList();
         }


### PR DESCRIPTION
### JIRA link
[TD-5220](https://hee-tis.atlassian.net/browse/TD-5220)

### Description
Because ungrouped competency ordering is broken (order is 1 for all competencies) the preprocess is still reporting a competency order change for frameworks with ungrouped competencies that haven't been reordered. Adding FC.ID to the ORDER BY clause for the download and preprocess get competency order queries ensures like a like-for-like comparison to avoid this problem. 


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
