### PR TITLE
TD-5487 Issue showing multiple comments when clicked the back link after submitted the review on Frameworks section

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Review.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Review.cs
@@ -81,6 +81,8 @@
         public IActionResult SubmitFrameworkReview(int frameworkId, int reviewId, string? comment, bool signedOff)
         {
             var adminId = GetAdminId();
+            var framework = frameworkService.GetBaseFrameworkByFrameworkId(frameworkId, adminId);
+            if (framework.FrameworkReviewID == 0 || framework.FrameworkReviewID == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             int? commentId = null;
             if (!string.IsNullOrWhiteSpace(comment)) commentId = frameworkService.InsertComment(frameworkId, adminId, comment, null);
             frameworkService.SubmitFrameworkReview(frameworkId, reviewId, signedOff, commentId);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5487

### Description
There was no validation to prevent multiple submissions of a review comment. If users clicked the back button after submitting a review, they could unintentionally resubmit it.
I added a check using the FrameworkReviewID property. Since this property is not null until the review is submitted, we now verify its value before allowing any further submissions. This prevents duplicate posting of review comments.
### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
![image](https://github.com/user-attachments/assets/b482edc3-8006-4f70-9d65-c692a17080fb)
![image](https://github.com/user-attachments/assets/c8b4db83-3fab-444b-8e8b-189782501220)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
