### PR TITLE
TD-5528 Issue showing console '500' error on the screen when clicked browser back link on 'Import competencies complete' screen

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/ImportCompetencies.cs
@@ -246,6 +246,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
         [Route("/Framework/{frameworkId}/{tabname}/Import/Summary")]
         public IActionResult ImportSummary()
         {
+            if (!TempData.Any()) return  RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             var data = GetBulkUploadData();
             var model = new ImportSummaryViewModel(data);
             return View("Developer/Import/ImportSummary", model);


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5528

### Description
A 500 error occurs when the user clicks the browser's back button because GetMultiPageFormData returns null and triggers an exception.
To handle this, I added a validation step to check whether the required value exists in TempData before calling GetMultiPageFormData.
If the value is missing, the application now returns a 410 (Gone) status page to indicate that the session data is no longer available.page

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
![image](https://github.com/user-attachments/assets/d5343fc2-4ec6-4b0b-9214-99d8a2113330)
![image](https://github.com/user-attachments/assets/fb7a9750-40f9-438c-b251-590368dd2e56)
![image](https://github.com/user-attachments/assets/8a6eda63-e92f-4d4d-b69e-857d3d0d27fc)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
