### PR TITLE
TD-5542 Issue not focussing to the respective fields when clicked the error links on the frameworks section

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Competencies.cs
@@ -158,6 +158,7 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
                     FrameworkCompetency = frameworkCompetency,
                     CompetencyFlags = competencyFlags
                 };
+                ModelState.Remove("SearchableName");
                 return View("Developer/Competency", model);
             }
             var adminId = GetAdminId();

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Competency.cshtml
@@ -51,7 +51,7 @@
           @Model.VocabSingular() statement
         </label>
         <span nhs-validation-for="FrameworkCompetency.Name"></span>
-        <input class="nhsuk-input" asp-for="FrameworkCompetency.Name" id="competency-name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-name-label">
+        <input class="nhsuk-input" asp-for="FrameworkCompetency.Name" id="Name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-name-label">
       </nhs-form-group>
       <div class="nhsuk-form-group">
         <vc:text-area asp-for="FrameworkCompetency.Description"

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyGroup.cshtml
@@ -47,11 +47,11 @@
         <partial name="_ErrorSummary" />
       }
       <nhs-form-group nhs-validation-for="CompetencyGroupBase.Name">
-        <label class="nhsuk-label" id="competency-group-name-label" for="competency-group-name">
+        <label class="nhsuk-label" id="competency-group-name-label" for="Name">
           @Model.VocabSingular() group name
         </label>
         <span nhs-validation-for="CompetencyGroupBase.Name"></span>
-        <input class="nhsuk-input" asp-for="CompetencyGroupBase.Name" id="competency-group-name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-group-name-label">
+        <input class="nhsuk-input" asp-for="CompetencyGroupBase.Name" id="Name" name="Name" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="competency-group-name-label">
       </nhs-form-group>
       <nhs-form-group nhs-validation-for="CompetencyGroupBase.Description">
         <span nhs-validation-for="CompetencyGroupBase.Description"></span>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5542

### Description
I resolved a validation UI issue where the clickable error summary wasn't scrolling to the correct form field due to mismatched id attributes. Changing the field name from competency-group-name to Name ensures the error summary link now correctly targets the form field, since the generated id now matches.

I also removed SearchableName from ModelState because it's not required, and it is not necessary to show on validation errors or interfere with model binding.
### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet, and desktop, wave analyser showing no errors._
![image](https://github.com/user-attachments/assets/ce0d9989-9782-44a6-b843-bae394ef46ca)
![image](https://github.com/user-attachments/assets/20fd71a5-c37e-44b8-84a9-3257a3f978d9)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
