### PR TITLE
TD-5544 Formatting issue for the links showing on the 'preview' screen on Frameworks section

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyPreview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/CompetencyPreview.cshtml
@@ -87,9 +87,11 @@
     </span>
   </div>
 </div>
+<div class=" nhsuk-u-padding-top-6">
 <a class="nhsuk-button" role="button" asp-action="ViewFramework" asp-route-frameworkCompetencyGroupId="@ViewContext.RouteData.Values["frameworkCompetencyGroupId"]" asp-fragment="fc-@(ViewContext.RouteData.Values["frameworkCompetencyId"])" asp-route-frameworkId="@(ViewContext.RouteData.Values["frameworkId"])" asp-route-tabname="Structure">
   Done
 </a>
+</div>
 @section scripts {
   <script src="@Url.Content("~/js/learningPortal/selfAssessment.js")" asp-append-version="true"></script>
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5544

### Description
I resolved the issue by adding top padding to the Done button, creating space between the 'Previous question' and 'Skip' link , and the buttons

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

![image](https://github.com/user-attachments/assets/271e0c33-412c-4471-8338-4377dd4e0d37)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
