### PR TITLE
TD-5561 Issue showing mismatch of colouring of buttons on Learning Portal - Self assessments screen

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentDescription.cshtml
@@ -31,12 +31,12 @@
 }
 @if (Model.LinearNavigation)
 {
-    <a role="button" class="nhsuk-button @(Model.UserBookmark != null || bookmarkIsRelevant ? "nhsuk-button--secondary" : "") trigger-loader" asp-action="AddOptionalCompetencies" asp-route-selfAssessmentId="@Model.Id" asp-route-vocabulary="@Model.VocabPlural">View @Model.VocabPlural</a>
+    <a role="button" class="nhsuk-button  trigger-loader" asp-action="AddOptionalCompetencies" asp-route-selfAssessmentId="@Model.Id" asp-route-vocabulary="@Model.VocabPlural">View @Model.VocabPlural</a>
     @if (Model.UserBookmark != null)
     {
         if (bookmarkIsRelevant)
         {
-            <a class="nhsuk-button trigger-loader" role="button" href="@Configuration["AppRootPath"]@Model.UserBookmark">
+            <a class="nhsuk-button nhsuk-button--secondary trigger-loader" role="button" href="@Configuration["AppRootPath"]@Model.UserBookmark">
                 Continue where I left off
             </a>
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5561

### Description
To resolve the issue, the primary button for "View Proficiencies" should appear in green, while the "Continue where I left off" button should be displayed in grey.
To achieve this, I need to remove the current if condition and swap the button colors accordingly.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
![image](https://github.com/user-attachments/assets/018defdc-86a7-4b22-aed9-4a1110d53d54)
![image](https://github.com/user-attachments/assets/930b65dd-5712-426c-aaf2-992857a287ae)
![image](https://github.com/user-attachments/assets/9624add6-361f-403f-90ca-bec1d74fe6f6)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
