### PR TITLE
TD-5568 Add 'Last accessed date' to 'sort' filter on 'Tracking system - Delegates' screen 

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -352,6 +352,8 @@
 
             if (sortBy == "SearchableName")
                 orderBy = " ORDER BY LTRIM(LastName) " + sortDirection + ", LTRIM(FirstName) ";
+            else if(sortBy == "LastAccessed")
+                orderBy = " ORDER BY LastAccessed " + sortDirection;
             else
                 orderBy = " ORDER BY DateRegistered " + sortDirection;
 

--- a/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
@@ -251,7 +251,7 @@
             ("Name", nameof(DelegateUserCard.SearchableName));
 
         public static readonly (string DisplayText, string PropertyName) LastAccessed =
-           ("Last Accessed Date", nameof(DelegateUserCard.LastAccessed));
+           ("Last accessed date", nameof(DelegateUserCard.LastAccessed));
 
         public static readonly (string DisplayText, string PropertyName) RegistrationDate =
             ("Registration Date", nameof(DelegateUserCard.DateRegistered));

--- a/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
+++ b/DigitalLearningSolutions.Data/Helpers/GenericSortingHelper.cs
@@ -250,6 +250,9 @@
         public static readonly (string DisplayText, string PropertyName) Name =
             ("Name", nameof(DelegateUserCard.SearchableName));
 
+        public static readonly (string DisplayText, string PropertyName) LastAccessed =
+           ("Last Accessed Date", nameof(DelegateUserCard.LastAccessed));
+
         public static readonly (string DisplayText, string PropertyName) RegistrationDate =
             ("Registration Date", nameof(DelegateUserCard.DateRegistered));
     }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/AllDelegates/AllDelegatesViewModel.cs
@@ -44,6 +44,7 @@
         public override IEnumerable<(string, string)> SortOptions { get; } = new[]
         {
             DelegateSortByOptions.Name,
+            DelegateSortByOptions.LastAccessed,
             DelegateSortByOptions.RegistrationDate,
         };
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5568

### Description
I added the Last Accessed Date and its corresponding property to the static class DelegateSortByOptions.

I also included LastAccessed in the overridden SortOptions within the AllDelegatesViewModel.

Additionally, I refactored the OrderBy condition to incorporate LastAccessed as a sorting option

### Screenshots

![image](https://github.com/user-attachments/assets/7479f747-e908-490c-bbdf-62d386db8ff4)
![image](https://github.com/user-attachments/assets/e06a1780-e8b6-41cb-892b-002daf9e16f9)
![image](https://github.com/user-attachments/assets/03b18869-4863-47c9-bc5d-aab9eb7e8d96)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
