### PR TITLE
TD-5451-Empty competency description check added in the Supervise section.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -174,7 +174,7 @@
                                 </div>
                                 <div class="nhsuk-grid-column-full">
 
-                                    @if (competency.Description != null && !competency.AlwaysShowDescription)
+                                    @if (!string.IsNullOrWhiteSpace(competency.Description) && !competency.AlwaysShowDescription)
                                     {
                                         <details class="nhsuk-details">
                                             <summary class="nhsuk-details__summary">
@@ -194,7 +194,7 @@
                                         <h2 class="nhsuk-u-margin-bottom-0 nhsuk-u-font-size-24">
                                             @competency.Name
                                         </h2>
-                                        @if (competency.Description != null)
+                                        @if (!string.IsNullOrWhiteSpace(competency.Description))
                                         {
                                             <p class="nhsuk-body-l">
                                                 @(Html.Raw(competency.Description))


### PR DESCRIPTION
### JIRA link
[TD-5451](https://hee-tis.atlassian.net/browse/TD-5451)

### Description
Empty competency description check added for competencies in the Supervise section.

### Screenshots

![image](https://github.com/user-attachments/assets/3055ccd2-e822-45d7-aa2d-7bc215408644)

![image](https://github.com/user-attachments/assets/65adcfbe-398b-4ac2-864c-a80dbf0851ad)


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5451]: https://hee-tis.atlassian.net/browse/TD-5451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ