### PR TITLE
TD- 3714 Display the DelegateAccounts.LastAccessed date on the Tracking System -> Delegates cards

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
@@ -52,7 +52,7 @@
 
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
                     <dt class="nhsuk-summary-list__key">
-                        Last Accessed date
+                        Last accessed date
                     </dt>
                     <partial name="_SummaryFieldValue" model="@Model.DelegateInfo.LastAccessed" />
                 </div>


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-3714

### Description
I updated the Last accessed date label in the delegate cards to use a lowercase "a" in "accessed" for consistency

### Screenshots
![image](https://github.com/user-attachments/assets/6944d47e-a2e7-48ff-a12e-16840f6746fe)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
