### PR TITLE
TD-5443-Validation summary field name corrected

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Frameworks.cs
@@ -583,9 +583,9 @@ namespace DigitalLearningSolutions.Web.Controllers.FrameworksController
             if (ModelState.IsValid)
             {
                 var flags = frameworkService.GetCustomFlagsByFrameworkId(frameworkId, null)
-                    .Where(fn => fn.FlagName == model.FlagName).ToList();
+                    .Where(fn => fn.FlagName.ToLower() == model.FlagName.ToLower()).ToList();
 
-                bool nameExists = flags.Any(x => x.FlagName == model.FlagName);
+                bool nameExists = flags.Any(x => x.FlagName.ToLower() == model.FlagName.ToLower());
                 bool idExists = flags.Any(x => x.FlagId == flagId);
 
                 if (actionname == "Edit")

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/EditCustomFlag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/EditCustomFlag.cshtml
@@ -1,65 +1,65 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks
 @model CustomFlagViewModel
 @{
-  var addOrEdit = Model.Id == 0 ? "Add" : "Edit";
-  var frameworkId = ViewContext.RouteData.Values["frameworkId"];
-  ViewData["Title"] = "Framework Custom Flags";
-  ViewData["Application"] = "Framework Service";
-  ViewData["HeaderPathName"] = "Framework Service";
+    var addOrEdit = Model.Id == 0 ? "Add" : "Edit";
+    var frameworkId = ViewContext.RouteData.Values["frameworkId"];
+    ViewData["Title"] = "Framework Custom Flags";
+    ViewData["Application"] = "Framework Service";
+    ViewData["HeaderPathName"] = "Framework Service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
-  <partial name="Shared/_NavMenuItems" />
+    <partial name="Shared/_NavMenuItems" />
 }
-  @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@frameworkId" asp-route-tabname="Details">Framework Details</a></li>
-        <li class="nhsuk-breadcrumb__item">@addOrEdit Custom Flags</li>
-      </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@frameworkId" asp-route-tabname="Details">Back to framework detail</a></p>
-    </div>
-  </nav>
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@frameworkId" asp-route-tabname="Details">Framework Details</a></li>
+                <li class="nhsuk-breadcrumb__item">@addOrEdit Custom Flags</li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@frameworkId" asp-route-tabname="Details">Back to framework detail</a></p>
+        </div>
+    </nav>
 }
-  <h1>@addOrEdit custom flag</h1>
-  <form method="post">
+<h1>@addOrEdit custom flag</h1>
+<form method="post">
     @if (!ViewData.ModelState.IsValid)
-  {
-    <partial name="_ErrorSummary" />
-  }
-  <nhs-form-group nhs-validation-for="FlagName">
-    <label class="nhsuk-label" id="flag-name-label" for="flag-name">Name</label>
-    <span nhs-validation-for="FlagName"></span>
-    <input class="nhsuk-input nhsuk-input--width-30" asp-for="FlagName" id="flag-name" name="FlagName" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="flag-name-label">
-  </nhs-form-group>
-  <nhs-form-group nhs-validation-for="FlagGroup">
-    <label class="nhsuk-label" id="flag-group-label" for="flag-group">Group</label>
-    <span nhs-validation-for="FlagGroup"></span>
-    <input class="nhsuk-input nhsuk-input--width-30" asp-for="FlagGroup" id="flag-group" name="FlagGroup" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="flag-group-label">
-  </nhs-form-group>
-  <nhs-form-group nhs-validation-for="FlagTagClass">
-    <div class="nhsuk-hint" id="framework-name-hint">
-      Tag colour
+    {
+        <partial name="_ErrorSummary" />
+    }
+    <nhs-form-group nhs-validation-for="FlagName">
+        <label class="nhsuk-label" id="flag-name-label" for="FlagName">Name</label>
+        <span nhs-validation-for="FlagName"></span>
+        <input class="nhsuk-input nhsuk-input--width-30" asp-for="FlagName" id="FlagName" name="FlagName" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="flag-name-label">
+    </nhs-form-group>
+    <nhs-form-group nhs-validation-for="FlagGroup">
+        <label class="nhsuk-label" id="flag-group-label" for="FlagGroup">Group</label>
+        <span nhs-validation-for="FlagGroup"></span>
+        <input class="nhsuk-input nhsuk-input--width-30" asp-for="FlagGroup" id="FlagGroup" name="FlagGroup" type="text" error-class-toggle="nhsuk-input--error" aria-describedby="flag-group-label">
+    </nhs-form-group>
+    <nhs-form-group nhs-validation-for="FlagTagClass">
+        <div class="nhsuk-hint" id="framework-name-hint">
+            Tag colour
+        </div>
+        <select class="nhsuk-select" asp-for="FlagTagClass" name="FlagTagClass">
+            @foreach (var tagColor in Model.TagColors)
+            {
+                var selected = tagColor.Key == Model.FlagTagClass ? @"selected=""selected""" : "";
+                <!option value="@tagColor.Key" @selected>@tagColor.Value</!option>
+            }
+        </select>
+        <span nhs-validation-for="FlagTagClass"></span>
+    </nhs-form-group>
+    <button class="nhsuk-button nhsuk-u-margin-top-3" type="submit">Submit</button>
+    <div class="nhsuk-back-link nhsuk-u-margin-left-1">
+        <a class="nhsuk-back-link__link" asp-action="EditFrameworkFlags" asp-route-frameworkId="@frameworkId">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
+        </a>
     </div>
-    <select class="nhsuk-select" asp-for="FlagTagClass" name="FlagTagClass">
-      @foreach (var tagColor in Model.TagColors)
-      {
-        var selected = tagColor.Key == Model.FlagTagClass ? @"selected=""selected""" : "";
-        <!option value="@tagColor.Key" @selected>@tagColor.Value</!option>
-      }
-    </select>
-    <span nhs-validation-for="FlagTagClass"></span>
-  </nhs-form-group>
-  <button class="nhsuk-button nhsuk-u-margin-top-3" type="submit">Submit</button>
-  <div class="nhsuk-back-link nhsuk-u-margin-left-1">
-    <a class="nhsuk-back-link__link" asp-action="EditFrameworkFlags" asp-route-frameworkId="@frameworkId">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-      </svg>
-      Cancel
-    </a>
-  </div>
-  <input type="hidden" asp-for="@Model.Id" />
+    <input type="hidden" asp-for="@Model.Id" />
 </form>


### PR DESCRIPTION
### JIRA link
[TD-5443](https://hee-tis.atlassian.net/browse/TD-5443)

### Description
The name of the validation summary field has been corrected. This places focus on the input field when clicking on the summary error message.
The names of the flags have been compared by converting them to lowercase letters.

### Screenshots
![image](https://github.com/user-attachments/assets/47acd7da-e5bd-4f58-a37c-56211a1c71ce)

![image](https://github.com/user-attachments/assets/c663be20-7fdc-4085-9c91-3ab9be7d8ed8)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5443]: https://hee-tis.atlassian.net/browse/TD-5443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ