### PR TITLE
TD-5439-Added empty competency description check

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/VerifyMultipleResults.cshtml
@@ -130,17 +130,17 @@
                                     <span class="nhsuk-table-responsive__heading">@competency.Vocabulary </span>
                                     <div class="nhsuk-checkboxes__item">
                                         <input data-group="@competencyGroup.Key" class="nhsuk-checkboxes__input select-all-checkbox" id="result-check-@question.SelfAssessmentResultSupervisorVerificationId" name="resultChecked" type="checkbox" value="@question.SelfAssessmentResultSupervisorVerificationId">
-                                        <label aria-label="Competency.Name" class="@(string.IsNullOrEmpty(competency.Description) ? "nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16" : "nhsuk-label nhsuk-checkboxes__label nhsuk-u-padding-0 nhsuk-u-display-block")" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
-                                            @if (competency.Description == null)
+                                        <label aria-label="Competency.Name" class="@(string.IsNullOrWhiteSpace(competency.Description) ? "nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-19" : "nhsuk-label nhsuk-checkboxes__label nhsuk-u-padding-0 nhsuk-u-display-block")" for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
+                                            @if (string.IsNullOrWhiteSpace(competency.Description))
                                             {
                                                 @competency.Name
                                             }
                                         </label>
-                                        @if (!string.IsNullOrEmpty(competency.Description))
+                                        @if (!string.IsNullOrWhiteSpace(competency.Description))
                                         {
                                             <details class="nhsuk-details nhsuk-u-padding-left-2 ">
                                                 <summary class="nhsuk-details__summary nhsuk-u-padding-left-2">
-                                                    <span class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16 " for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
+                                                    <span class="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-19 " for="result-check-@question.SelfAssessmentResultSupervisorVerificationId">
                                                         @competency.Name
                                                     </span>
                                                 </summary>


### PR DESCRIPTION

### JIRA link
[TD-5439](https://hee-tis.atlassian.net/browse/TD-5439)

### Description
Added empty competency description check. 
Increased competency text font to 19.


### Screenshots
![image](https://github.com/user-attachments/assets/58154582-21ae-4619-9ce7-3cd209a13366)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5439]: https://hee-tis.atlassian.net/browse/TD-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ