### PR TITLE
TD-3715 Fix for initial test fail scenario changed Last Accessed column name to Last accessed date in delegate excel reports

### DIFF
--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -39,7 +39,7 @@
         private const string ProfessionalRegistrationNumber = "Professional Registration Number";
         private const string JobGroup = "Job group";
         private const string RegisteredDate = "Registered";
-        private const string LastAccessed = "Last Accessed";
+        private const string LastAccessed = "Last Accessed Date";
         private const string RegistrationComplete = "Registration complete";
         private const string Active = "Active";
         private const string Approved = "Approved";


### PR DESCRIPTION
### JIRA link
[TD-3715](https://hee-tis.atlassian.net/browse/TD-3715)

### Description
Changed the excel report column name to 'Last accessed date' from 'Last Accessed'.

### Screenshots
![image](https://github.com/user-attachments/assets/9cbfe4f8-e323-4499-9649-580ae40ca25a)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-3715]: https://hee-tis.atlassian.net/browse/TD-3715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ