### PR TITLE
TD-5581 Issue showing multiple comments on 'Frameworks' - 'Comments' section when clicked browser back link

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CommentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CommentCard.cshtml
@@ -71,7 +71,7 @@
                     else
                     {
                         <hr />
-                        <form method="post" >
+                        <form method="post">
                             <div class="nhsuk-form-group">
                                 <label class="nhsuk-label" for="new-comment">
                                     Post a reply

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CommentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CommentCard.cshtml
@@ -1,92 +1,92 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Frameworks;
 @model CommentReplies;
 <div class="@(Model.UserIsCommenter ? "nhsuk-card comment comment-mine nhsuk-u-margin-bottom-2" : "nhsuk-card comment comment-other nhsuk-u-margin-bottom-3")">
-  <div class="nhsuk-card__content nhsuk-u-padding-4">
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
+    <div class="nhsuk-card__content nhsuk-u-padding-4">
         <div class="nhsuk-grid-row">
-          <div class="nhsuk-grid-column-full">
-            <h3 class="nhsuk-card__heading nhsuk-heading-xs heading-xxs" id="@Model.ID-header">
-              @Model.Commenter <span class="heading-light">@Model.AddedDate.ToString("dddd dd MMMM yyyy h:mm tt")</span>
-            </h3>
-            <p class="nhsuk-body-s">
-              @Html.Raw(Model.Comments)
-            </p>
-          </div>
-        </div>
-        <div class="grid-column-ninety">
-          @if (Model.Replies.Any())
-          {
-            if (@ViewContext.RouteData.Values["commentId"] == null)
-            {
-              <details class="nhsuk-details">
-                <summary class="nhsuk-details__summary">
-                  <span class="nhsuk-details__summary-text">
-                    @Model.Replies.Count() @(Model.Replies.Count() > 1 ? "Replies" : "Reply")
-                  </span>
-                </summary>
-                <div class="nhsuk-details__text">
-                  @foreach (var item in Model.Replies.Select((value, i) => new { i, value }))
-                  {
-                    <partial name="_ReplyCard.cshtml" model="item.value" view-data="@(new ViewDataDictionary(ViewData) { { "isLast", (item.i == Model.Replies.Count-1 ? true :false)} })" />
-                  }
+            <div class="nhsuk-grid-column-full">
+                <div class="nhsuk-grid-row">
+                    <div class="nhsuk-grid-column-full">
+                        <h3 class="nhsuk-card__heading nhsuk-heading-xs heading-xxs" id="@Model.ID-header">
+                            @Model.Commenter <span class="heading-light">@Model.AddedDate.ToString("dddd dd MMMM yyyy h:mm tt")</span>
+                        </h3>
+                        <p class="nhsuk-body-s">
+                            @Html.Raw(Model.Comments)
+                        </p>
+                    </div>
                 </div>
-              </details>
-            }
-            else
-            {
-              @foreach (var item in Model.Replies.Select((value, i) => new { i, value }))
-              {
-                <partial name="_ReplyCard.cshtml" model="item.value" view-data="@(new ViewDataDictionary(ViewData) { { "isLast", (item.i == Model.Replies.Count-1 ? true :false)} })" />
-              }
-            }
-          }
-        </div>
-        <div class="nhsuk-grid-column-full">
-          @if (@ViewContext.RouteData.Values["commentId"] == null)
-          {
+                <div class="grid-column-ninety">
+                    @if (Model.Replies.Any())
+                    {
+                        if (@ViewContext.RouteData.Values["commentId"] == null)
+                        {
+                            <details class="nhsuk-details">
+                                <summary class="nhsuk-details__summary">
+                                    <span class="nhsuk-details__summary-text">
+                                        @Model.Replies.Count() @(Model.Replies.Count() > 1 ? "Replies" : "Reply")
+                                    </span>
+                                </summary>
+                                <div class="nhsuk-details__text">
+                                    @foreach (var item in Model.Replies.Select((value, i) => new { i, value }))
+                                    {
+                                        <partial name="_ReplyCard.cshtml" model="item.value" view-data="@(new ViewDataDictionary(ViewData) { { "isLast", (item.i == Model.Replies.Count - 1 ? true : false) } })" />
+                                    }
+                                </div>
+                            </details>
+                        }
+                        else
+                        {
+                            @foreach (var item in Model.Replies.Select((value, i) => new { i, value }))
+                            {
+                                <partial name="_ReplyCard.cshtml" model="item.value" view-data="@(new ViewDataDictionary(ViewData) { { "isLast", (item.i == Model.Replies.Count - 1 ? true : false) } })" />
+                            }
+                        }
+                    }
+                </div>
+                <div class="nhsuk-grid-column-full">
+                    @if (@ViewContext.RouteData.Values["commentId"] == null)
+                    {
 
-            <a class="nhsuk-button button-small nhsuk-button--secondary nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"
-             role="button"
-             aria-describedby="@Model.ID-header"
-             asp-action="ViewThread"
-             asp-controller="Frameworks"
-             asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]"
-             asp-route-commentId="@Model.ID">
-              Reply
-            </a>
-            @if (!Model.Replies.Any() && Model.UserIsCommenter)
-            {
-              <a class="nhsuk-button button-small delete-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"
-             role="button"
-             aria-describedby="@Model.ID-header"
-             asp-action="ArchiveComment"
-             asp-controller="Frameworks"
-             asp-route-commentId="@Model.ID"
-             asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">
-                Delete
-              </a>
-            }
-          }
-          else
-          {
-            <hr />
-            <form method="post">
-              <div class="nhsuk-form-group">
-                <label class="nhsuk-label" for="new-comment">
-                  Post a reply
-                </label>
-                <input type="hidden" value="@Model.Comments" name="parentComment" />
-                <textarea class="nhsuk-textarea" id="new-comment" name="Comment" rows="3"></textarea>
-              </div>
-              <button class="nhsuk-button" type="submit">
-                Post
-              </button>
-            </form>
-          }
+                        <a class="nhsuk-button button-small nhsuk-button--secondary nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"
+                           role="button"
+                           aria-describedby="@Model.ID-header"
+                           asp-action="ViewThread"
+                           asp-controller="Frameworks"
+                           asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]"
+                           asp-route-commentId="@Model.ID">
+                            Reply
+                        </a>
+                        @if (!Model.Replies.Any() && Model.UserIsCommenter)
+                        {
+                            <a class="nhsuk-button button-small delete-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0"
+                               role="button"
+                               aria-describedby="@Model.ID-header"
+                               asp-action="ArchiveComment"
+                               asp-controller="Frameworks"
+                               asp-route-commentId="@Model.ID"
+                               asp-route-frameworkId="@ViewContext.RouteData.Values["frameworkId"]">
+                                Delete
+                            </a>
+                        }
+                    }
+                    else
+                    {
+                        <hr />
+                        <form method="post" autocomplete="off">
+                            <div class="nhsuk-form-group">
+                                <label class="nhsuk-label" for="new-comment">
+                                    Post a reply
+                                </label>
+                                <input type="hidden" value="@Model.Comments" name="parentComment" />
+                                <textarea class="nhsuk-textarea" id="new-comment" name="Comment" rows="3"></textarea>
+                            </div>
+                            <button class="nhsuk-button" type="submit">
+                                Post
+                            </button>
+                        </form>
+                    }
 
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CommentCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_CommentCard.cshtml
@@ -71,13 +71,13 @@
                     else
                     {
                         <hr />
-                        <form method="post" autocomplete="off">
+                        <form method="post" >
                             <div class="nhsuk-form-group">
                                 <label class="nhsuk-label" for="new-comment">
                                     Post a reply
                                 </label>
                                 <input type="hidden" value="@Model.Comments" name="parentComment" />
-                                <textarea class="nhsuk-textarea" id="new-comment" name="Comment" rows="3"></textarea>
+                                <textarea class="nhsuk-textarea" id="new-comment" name="Comment" autocomplete="off" rows="3"></textarea>
                             </div>
                             <button class="nhsuk-button" type="submit">
                                 Post


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5581

### Description
I added autocomplete="off" to the <textarea> to prevent the browser from remembering and repopulating the <textarea>  when a user clicks the Back button and the page reloads

### Screenshots
![image](https://github.com/user-attachments/assets/d24f23c4-2d1c-413b-9131-b74613127868)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
