### PR TITLE
Issue showing multiple comments on 'Frameworks' - 'Comments' section when clicked browser back link

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Comments.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_Comments.cshtml
@@ -31,7 +31,7 @@ else
         Add a comment
       </label>
       <span nhs-validation-for="Comment"></span>
-      <textarea class="nhsuk-textarea" id="new-comment" name="Comment" rows="3"></textarea>
+            <textarea class="nhsuk-textarea" id="new-comment" name="Comment" autocomplete="off" rows="3"></textarea>
     </nhs-form-group>
     <button class="nhsuk-button" type="submit">
       Post


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5581

### Description
I added autocomplete="off" to the <textarea> to prevent the browser from remembering and repopulating the <textarea> when a user clicks the Back button and the page reloads


### Screenshots
![image](https://github.com/user-attachments/assets/46ff350b-4fad-40ce-82f4-b5215b67853e)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
