### PR TITLE
TD-5511-Sql modified to show FrameworkReviewID for admin logged in from different centre.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_MyFrameworks.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/_MyFrameworks.cshtml
@@ -73,7 +73,7 @@ else
                                 @if (framework.UserRole > 1)
                                 {
                                     <a asp-action="ViewFramework" asp-route-frameworkId="@framework.ID" asp-route-tabname="Structure">
-                                        View/Edit
+                                        @(framework.FrameworkReviewID == null ? "View/Edit" : "Review/Edit")
                                         <span class="visually-hidden">@framework.FrameworkName</span>
                                     </a>
                                 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_BrandedFrameworkTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_BrandedFrameworkTable.cshtml
@@ -67,7 +67,7 @@
                         @if (framework.UserRole > 1)
                         {
                             <a asp-action="ViewFramework" asp-route-frameworkId="@framework.ID" asp-route-tabname="Structure">
-                                View/Edit
+                                @(framework.FrameworkReviewID == null ? "View/Edit" : "Review/Edit")
                                 <span class="visually-hidden">@framework.FrameworkName</span>
                             </a>
                         }


### PR DESCRIPTION
### JIRA link
[TD-5511](https://hee-tis.atlassian.net/browse/TD-5511)

### Description
SQL modified to show FrameworkReviewID for admin logged in from different centre.
This fix covers following:
1. Show Review link when reviewer is logged in to another centre
2. Show Review/Edit link when contributor is logged in to another centre.
3. Submit review when reviewer/contributor is logged in to another centre.


### Screenshots

![image](https://github.com/user-attachments/assets/ac0e1cb7-2df8-4577-8aea-2d6ab609f879)

![image](https://github.com/user-attachments/assets/ec9bb1ae-0061-42d7-964d-43dc87be549c)

Framework owner log in - same centre
![image](https://github.com/user-attachments/assets/a217fd8a-31f6-4edb-a400-07d2231ae903)

Framework contributor log in - same centre
![image](https://github.com/user-attachments/assets/0b389046-daba-41ad-9603-0b580e25d388)

Framework contributor log in - other centre
![image](https://github.com/user-attachments/assets/7276c108-bd18-4d3c-9d12-da7ecb8798c5)

Framework reviewer log in - same centre
![image](https://github.com/user-attachments/assets/ff755273-091e-4c06-a6d2-afed57fce403)

Framework reviewer log in - other centre
![image](https://github.com/user-attachments/assets/44d4be92-342f-41fb-b561-45d867962db7)

Framework contributor log in - without review request
![image](https://github.com/user-attachments/assets/fa6c6b28-7f0a-447e-b6db-3f34738af421)

Framework reviewer log in - without review request
![image](https://github.com/user-attachments/assets/1f3377a7-522c-4a7a-80bd-dcedf23b6751)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
