### PR TITLE
TD-5683 Issue showing self assessment reports on Tracking system which are not published at the centre

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
@@ -16,6 +16,7 @@
     using Microsoft.FeatureManagement;
     using Microsoft.FeatureManagement.Mvc;
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
@@ -40,7 +41,7 @@
             IClockUtility clockUtility,
             IConfiguration config,
             ISelfAssessmentService selfAssessmentService,
-            ICentreSelfAssessmentsService centreSelfAssessmentsService
+            ICentreSelfAssessmentsService centreSelfAssessmentsService,
             IFeatureManager featureManager
         )
         {
@@ -63,11 +64,10 @@
             var categoryId = this.selfAssessmentService.GetSelfAssessmentCategoryId(1);
             var selfAssessments = centreSelfAssessmentsService.GetCentreSelfAssessments(centreId.Value);
             var dSATreportIsPublish = selfAssessments.Any(x => x.SelfAssessmentId == 1);
-            var model = new SelfAssessmentReportsViewModel(selfAssessmentReportService.GetSelfAssessmentsForReportList((int)centreId, adminCategoryId), adminCategoryId, categoryId, dSATreportIsPublish); return View(model);
             var tableauFlag = await featureManager.IsEnabledAsync(FeatureFlags.TableauSelfAssessmentDashboards);
             var tableauQueryOverride = string.Equals(Request.Query["tableaulink"], "true", StringComparison.OrdinalIgnoreCase);
             var showTableauLink = tableauFlag || tableauQueryOverride;
-            var model = new SelfAssessmentReportsViewModel(selfAssessmentReportService.GetSelfAssessmentsForReportList((int)centreId, adminCategoryId), adminCategoryId, categoryId, showTableauLink);
+            var model = new SelfAssessmentReportsViewModel(selfAssessmentReportService.GetSelfAssessmentsForReportList((int)centreId, adminCategoryId), adminCategoryId, categoryId, dSATreportIsPublish, showTableauLink);
             return View(model);
         }
         [HttpGet]

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/SelfAssessmentReportsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Centre/Reports/SelfAssessmentReportsViewModel.cs
@@ -6,8 +6,7 @@
     public class SelfAssessmentReportsViewModel
     {
         public SelfAssessmentReportsViewModel(
-            IEnumerable<SelfAssessmentSelect> selfAssessmentSelects, int? adminCategoryId, int categoryId, bool dSATreportIsPublish
-            IEnumerable<SelfAssessmentSelect> selfAssessmentSelects, int? adminCategoryId, int categoryId, bool showTableauLink
+            IEnumerable<SelfAssessmentSelect> selfAssessmentSelects, int? adminCategoryId, int categoryId, bool dSATreportIsPublish, bool showTableauLink
             )
         {
             SelfAssessmentSelects = selfAssessmentSelects;

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
@@ -33,10 +33,10 @@
         <h2>Excel learner activity reports</h2>
         <p class="nhsuk-lede-text">Download Excel competency self assessments activity reports for your centre.</p>
         <ul>
-          @if((Model.DSATreportIsPublish)  && ((Model.AdminCategoryId == null) || (Model.AdminCategoryId == Model.CategoryId)))
-          {
-            <li>
-                <a asp-controller="SelfAssessmentReports" asp-action="DownloadDigitalCapabilityToExcel">Digital Skills Assessment Tool - Download report</a>
+            @if ((Model.DSATreportIsPublish) && ((Model.AdminCategoryId == null) || (Model.AdminCategoryId == Model.CategoryId)))
+            {
+                <li>
+                    <a asp-controller="SelfAssessmentReports" asp-action="DownloadDigitalCapabilityToExcel">Digital Skills Assessment Tool - Download report</a>
 
                 </li>
             }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5683

### Description
Added GetCentreSelfAssessments method to the Index action:

This retrieves the Digital Skills Assessment Tool (DSAT) status for the centre the admin is logged into.

this is to confirm that DSAT is published for that centre or not.

Introduced DSATreportIsPublish property:

This boolean flag determines whether the DSAT report should be shown.

If the self-assessments are published for the centre, the report is visible; otherwise, it remains hidden

### Screenshots

![image](https://github.com/user-attachments/assets/fa155f36-d65e-4674-9d17-ad3b88dda4b8)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
