### PR TITLE
TD-5657-Issue when submitting the review on frameworks section

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/FrameworksController/Review.cs
+++ b/DigitalLearningSolutions.Web/Controllers/FrameworksController/Review.cs
@@ -85,7 +85,24 @@
             var framework = frameworkService.GetBaseFrameworkByFrameworkId(frameworkId, adminId);
             if (framework.FrameworkReviewID == 0 || framework.FrameworkReviewID == null) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             int? commentId = null;
-            if (!string.IsNullOrWhiteSpace(comment)) commentId = frameworkService.InsertComment(frameworkId, adminId, comment, null);
+            if (string.IsNullOrWhiteSpace(comment))
+            {
+                ModelState.AddModelError("comment", "Please enter comment");
+                var frameworkReview = frameworkService.GetFrameworkReview(frameworkId, adminId, reviewId);
+                frameworkReview.SignedOff = signedOff;
+                var model = new SubmitReviewViewModel()
+                {
+                    FrameworkId = frameworkId,
+                    FrameworkName = framework.FrameworkName,
+                    FrameworkReview = frameworkReview
+                };
+                return View("Developer/SubmitReview", model);
+            }
+            else
+            {
+                commentId = frameworkService.InsertComment(frameworkId, adminId, comment, null);
+            }
+
             frameworkService.SubmitFrameworkReview(frameworkId, reviewId, signedOff, commentId);
             frameworkNotificationService.SendReviewOutcomeNotification(reviewId, User.GetCentreIdKnownNotNull());
             return RedirectToAction("ViewFramework", "Frameworks", new { frameworkId, tabname = "Structure" });

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SubmitReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/SubmitReview.cshtml
@@ -1,55 +1,60 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.Frameworks;
 @model SubmitReviewViewModel;
 @{
-  ViewData["Title"] = Model.FrameworkName;
-  ViewData["Application"] = "Framework Service";
-  ViewData["HeaderPathName"] = "Framework Service";
+    ViewData["Title"] = Model.FrameworkName;
+    ViewData["Application"] = "Framework Service";
+    ViewData["HeaderPathName"] = "Framework Service";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
 }
 @section NavBreadcrumbs {
-  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-      <ol class="nhsuk-breadcrumb__list">
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
-        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Framework Structure</a></li>
-        <li class="nhsuk-breadcrumb__item">Send for Review</li>
-      </ol>
-      <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Back to framework structure</a></p>
-    </div>
-  </nav>
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFrameworks" asp-route-tabname="Mine">Frameworks</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewFramework" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Framework Structure</a></li>
+                <li class="nhsuk-breadcrumb__item">Send for Review</li>
+            </ol>
+            <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ViewFramework" asp-route-frameworkId="@Model.FrameworkId" asp-route-tabname="Structure">Back to framework structure</a></p>
+        </div>
+    </nav>
 }
-  <h1>Submit review</h1>
-  @if (Model.FrameworkReview.SignOffRequired)
+<h1>Submit review</h1>
+@if (Model.FrameworkReview.SignOffRequired)
 {
-  <div class="nhsuk-warning-callout">
-    <h2 class="nhsuk-warning-callout__label">
-      <span role="text">
-        <span class="nhsuk-u-visually-hidden">Important: </span>
-        Approval required
-      </span>
-    </h2>
-    <p>Your approval is required before this framework can be published.</p>
-  </div>
+    <div class="nhsuk-warning-callout">
+        <h2 class="nhsuk-warning-callout__label">
+            <span role="text">
+                <span class="nhsuk-u-visually-hidden">Important: </span>
+                Approval required
+            </span>
+        </h2>
+        <p>Your approval is required before this framework can be published.</p>
+    </div>
 }
 <form method="post">
-  <div class="nhsuk-form-group">
-    <label class="nhsuk-label" for="new-comment">
-      Review comments
-    </label>
-    <input type="hidden" value="@Model.FrameworkReview.Comment" name="parentComment" />
-    <textarea class="nhsuk-textarea" id="new-comment" asp-for="FrameworkReview.Comment" name="Comment" rows="3"></textarea>
-  </div>
-  <div class="nhsuk-form-group">
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" id="signOff" name="SignedOff" asp-for="FrameworkReview.SignedOff" type="checkbox" aria-describedby="sign-off-hint">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="signOff">
-        Approve for publishing?
-      </label>
-      <div class="nhsuk-hint nhsuk-checkboxes__hint" id="sign-off-hint">
-        I give my approval to publish this framework for use in its current state
-      </div>
+    @if (errorHasOccurred)
+    {
+        <vc:error-summary order-of-property-names="@(new[] { nameof(Model.FrameworkReview.Comment)})" />
+    }
+    <div class="nhsuk-form-group">
+        <label class="nhsuk-label" for="comment">
+            Review comments
+        </label>
+        <input type="hidden" value="@Model.FrameworkReview.Comment" name="parentComment" />
+        <textarea class="nhsuk-textarea" id="comment" asp-for="FrameworkReview.Comment" name="Comment" rows="3"></textarea>
     </div>
-  </div>
-  <button class="nhsuk-button" type="submit">
-    Submit
-  </button>
+    <div class="nhsuk-form-group">
+        <div class="nhsuk-checkboxes__item">
+            <input class="nhsuk-checkboxes__input" id="signOff" name="SignedOff" asp-for="FrameworkReview.SignedOff" type="checkbox" aria-describedby="sign-off-hint">
+            <label class="nhsuk-label nhsuk-checkboxes__label" for="signOff">
+                Approve for publishing?
+            </label>
+            <div class="nhsuk-hint nhsuk-checkboxes__hint" id="sign-off-hint">
+                I give my approval to publish this framework for use in its current state
+            </div>
+        </div>
+    </div>
+    <button class="nhsuk-button" type="submit">
+        Submit
+    </button>
 </form>


### PR DESCRIPTION
### JIRA link
[TD-5657](https://hee-tis.atlassian.net/browse/TD-5657)

### Description
Review comment empty check validation added.

### Screenshots

![image](https://github.com/user-attachments/assets/5d53aecb-0693-46e9-9865-d79805de2f35)

![image](https://github.com/user-attachments/assets/1722e5fa-8874-4b8a-af98-971a289c0305)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5657]: https://hee-tis.atlassian.net/browse/TD-5657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ