### PR TITLE
TD-5658-Issue allowing the empty framework to 'Send for review'/'Publish'

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Framework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Framework.cshtml
@@ -4,6 +4,8 @@
     ViewData["Title"] = Model.DetailFramework.FrameworkName;
     ViewData["Application"] = "Framework Service";
     ViewData["HeaderPathName"] = "Framework Service";
+    bool isGroupCompetenciesNotEmpty = Model.FrameworkCompetencyGroups != null &&
+                  Model.FrameworkCompetencyGroups.Any(g => g.FrameworkCompetencies != null && g.FrameworkCompetencies.Any());
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
@@ -44,7 +46,7 @@
     </div>
     <div class="nhsuk-grid-column-one-third">
         @*<a class="nhsuk-button nhsuk-button--secondary">Preview</a>*@
-        @if ((Model.FrameworkCompetencyGroups?.Any() == true || Model.FrameworkCompetencies?.Any() == true) && Model.DetailFramework.UserRole > 1)
+        @if ((isGroupCompetenciesNotEmpty || Model.FrameworkCompetencies?.Any() == true) && Model.DetailFramework.UserRole > 1)
         {
             if (Model.DetailFramework.PublishStatusID == 2)
             {

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Framework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Framework.cshtml
@@ -44,7 +44,7 @@
     </div>
     <div class="nhsuk-grid-column-one-third">
         @*<a class="nhsuk-button nhsuk-button--secondary">Preview</a>*@
-        @if (Model.DetailFramework.UserRole > 1)
+        @if ((Model.FrameworkCompetencyGroups?.Any() == true || Model.FrameworkCompetencies?.Any() == true) && Model.DetailFramework.UserRole > 1)
         {
             if (Model.DetailFramework.PublishStatusID == 2)
             {


### PR DESCRIPTION
### JIRA link
[TD-5658](https://hee-tis.atlassian.net/browse/TD-5658)

### Description
Empty framework/group validation added to show/hide buttons

### Screenshots

![image](https://github.com/user-attachments/assets/6dd8893b-c405-48f3-a1c5-06b8efd59a6d)

![image](https://github.com/user-attachments/assets/ff3404c9-15e4-4d80-a13d-00d78f2ca40a)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5658]: https://hee-tis.atlassian.net/browse/TD-5658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ