### PR TITLE
TD_5410_Adding config to the rate limiter so that we can environment, and add production logic to it.

### DIFF
--- a/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
+++ b/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
@@ -16,7 +16,6 @@ namespace DigitalLearningSolutions.Web.Middleware
             RequestDelegate next,
             IProcessingStrategy processingStrategy,
             IOptions<IpRateLimitOptions> options,
-            IConfiguration configuration,
             IIpPolicyStore policyStore,
             IRateLimitConfiguration config,
             ILogger<IpRateLimitMiddleware> logger)
@@ -27,7 +26,6 @@ namespace DigitalLearningSolutions.Web.Middleware
                   config,
                   logger)
         {
-            _configuration = configuration;
         }
 
         public override Task ReturnQuotaExceededResponse(

--- a/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
+++ b/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
@@ -1,6 +1,5 @@
 namespace DigitalLearningSolutions.Web.Middleware
 {
-    using System;
     using System.Threading.Tasks;
     using AspNetCoreRateLimit;
     using Microsoft.AspNetCore.Http;

--- a/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
+++ b/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
@@ -35,14 +35,9 @@ namespace DigitalLearningSolutions.Web.Middleware
             RateLimitRule rule,
             string retryAfter)
         {
-            if (_configuration["ASPNETCORE_ENVIRONMENT"] == "PRODUCTION")
-            {
-                httpContext.Response.Headers["Location"] = "/toomanyrequests";
-                httpContext.Response.StatusCode = 302;
-                
-            }
+            httpContext.Response.Headers["Location"] = "/toomanyrequests";
+            httpContext.Response.StatusCode = 302;
             return httpContext.Response.WriteAsync("");
-
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
+++ b/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
@@ -1,17 +1,22 @@
 namespace DigitalLearningSolutions.Web.Middleware
 {
+    using System;
     using System.Threading.Tasks;
     using AspNetCoreRateLimit;
     using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
+    using static Org.BouncyCastle.Math.EC.ECCurve;
 
     public class DLSIPRateLimitMiddleware : IpRateLimitMiddleware
     {
+        private readonly IConfiguration _configuration;
         public DLSIPRateLimitMiddleware(
             RequestDelegate next,
             IProcessingStrategy processingStrategy,
             IOptions<IpRateLimitOptions> options,
+            IConfiguration configuration,
             IIpPolicyStore policyStore,
             IRateLimitConfiguration config,
             ILogger<IpRateLimitMiddleware> logger)
@@ -21,16 +26,23 @@ namespace DigitalLearningSolutions.Web.Middleware
                   policyStore,
                   config,
                   logger)
-        { }
+        {
+            _configuration = configuration;
+        }
 
         public override Task ReturnQuotaExceededResponse(
             HttpContext httpContext,
             RateLimitRule rule,
             string retryAfter)
         {
-            httpContext.Response.Headers["Location"] = "/toomanyrequests";
-            httpContext.Response.StatusCode = 302;
+            if (_configuration["ASPNETCORE_ENVIRONMENT"] == "PRODUCTION")
+            {
+                httpContext.Response.Headers["Location"] = "/toomanyrequests";
+                httpContext.Response.StatusCode = 302;
+                
+            }
             return httpContext.Response.WriteAsync("");
+
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
+++ b/DigitalLearningSolutions.Web/Middleware/DLSIPRateLimitMiddleware.cs
@@ -4,14 +4,11 @@ namespace DigitalLearningSolutions.Web.Middleware
     using System.Threading.Tasks;
     using AspNetCoreRateLimit;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
-    using static Org.BouncyCastle.Math.EC.ECCurve;
 
     public class DLSIPRateLimitMiddleware : IpRateLimitMiddleware
     {
-        private readonly IConfiguration _configuration;
         public DLSIPRateLimitMiddleware(
             RequestDelegate next,
             IProcessingStrategy processingStrategy,
@@ -25,8 +22,7 @@ namespace DigitalLearningSolutions.Web.Middleware
                   policyStore,
                   config,
                   logger)
-        {
-        }
+        { }
 
         public override Task ReturnQuotaExceededResponse(
             HttpContext httpContext,

--- a/DigitalLearningSolutions.Web/appSettings.UAT.json
+++ b/DigitalLearningSolutions.Web/appSettings.UAT.json
@@ -25,22 +25,7 @@
     "LoginWithLearningHub": true
   },
   "IpRateLimiting": {
-    "EnableEndpointRateLimiting": false,
-    "StackBlockedRequests": false,
-    "RealIpHeader": "X-Real-IP",
-    "HttpStatusCode": 429,
-    "GeneralRules": [
-      {
-        "Endpoint": "post:/ForgotPassword",
-        "Period": "1m",
-        "Limit": 5
-      },
-      {
-        "Endpoint": "post:/Login",
-        "Period": "1m",
-        "Limit": 5
-      }
-    ]
+    "EnableEndpointRateLimiting": false
   },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "FreshdeskAPIConfig": {

--- a/DigitalLearningSolutions.Web/appSettings.UAT.json
+++ b/DigitalLearningSolutions.Web/appSettings.UAT.json
@@ -24,6 +24,24 @@
     "MaxBulkUploadRows": 200,
     "LoginWithLearningHub": true
   },
+  "IpRateLimiting": {
+    "EnableEndpointRateLimiting": false,
+    "StackBlockedRequests": false,
+    "RealIpHeader": "X-Real-IP",
+    "HttpStatusCode": 429,
+    "GeneralRules": [
+      {
+        "Endpoint": "post:/ForgotPassword",
+        "Period": "1m",
+        "Limit": 5
+      },
+      {
+        "Endpoint": "post:/Login",
+        "Period": "1m",
+        "Limit": 5
+      }
+    ]
+  },
   "LearningHubOpenAPIBaseUrl": "https://uks-learninghubnhsuk-openapi-test.azurewebsites.net",
   "FreshdeskAPIConfig": {
     "GroupId": "80000650208",


### PR DESCRIPTION


### JIRA link
[TD-5410](https://hee-tis.atlassian.net/browse/TD-5410)

### Description
Using Iconfiguration interface fetching the environment value and adding the rate limiter for request logic only on the Production level.

### Screenshots
No Screenshots

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5410]: https://hee-tis.atlassian.net/browse/TD-5410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ