### PR TITLE
TD-5621 Issue with the font/size showing for the headings/sub headings on self assessment screens

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -191,9 +191,9 @@
                                     }
                                     else
                                     {
-                                        <h2 class="nhsuk-u-margin-bottom-0 nhsuk-u-font-size-24">
+                                        <p class="@(!string.IsNullOrWhiteSpace(competency.Description) ? "nhsuk-u-font-weight-bold" : "") nhsuk-u-margin-bottom-0">
                                             @competency.Name
-                                        </h2>
+                                        </p>
                                         @if (!string.IsNullOrWhiteSpace(competency.Description))
                                         {
                                             <p class="nhsuk-body-l">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5621

### Description
I replaced the heading element heading element with a paragraph tag for @competency.Name to align the visual styling of the Supervisor Dashboard self-assessment with the Learning Portal version. This ensures consistent formatting across both views.

### Screenshots
‘Supervisor Dashboard’ self assessment screens 
![image](https://github.com/user-attachments/assets/da1d4972-72af-45e7-b1b1-c9f454ae030c)
![image](https://github.com/user-attachments/assets/1fcfe9b2-7604-4fc1-9b4d-5e787c7dfc4d)

 ‘Learning Portal’ self assessment screens
![image](https://github.com/user-attachments/assets/7c17bf1a-6e8f-41f3-9773-54d24a4b90fd)
![image](https://github.com/user-attachments/assets/aed86de6-55ea-477d-a0b2-1e8527a7b499)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
