### PR TITLE
TD-3223 Showing console '404' error when removing the delegate from activity and clicking browser back button

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/DelegateProgressController.cs
@@ -275,10 +275,8 @@
         )
         {
             var progress = progressService.GetDetailedCourseProgress(progressId);
-            if (progress == null)
-            {
-                return StatusCode((int)HttpStatusCode.Gone);
-            }
+            if (!courseService.DelegateHasCurrentProgress(progressId) || progress == null)
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
 
             var model = new RemoveFromCourseViewModel(
                 progress,
@@ -305,9 +303,7 @@
 
             var progress = progressService.GetDetailedCourseProgress(progressId);
             if (!courseService.DelegateHasCurrentProgress(progressId) || progress == null)
-            {
-                return new NotFoundResult();
-            }
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
 
             courseService.RemoveDelegateFromCourse(
                 progress.DelegateId,


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3223

### Description
I replaced the direct check for a null progress object and HTTP 410 Gone status code response with a conditional that also verifies whether the delegate still has current progress for the given progressId. If not, it redirects to a StatusCode action in the LearningSolutions controller with a 410 code parameter

### Screenshots
![image](https://github.com/user-attachments/assets/e522d99c-c613-450e-aea3-4be52c5ba8f9)
![image](https://github.com/user-attachments/assets/b8e3353e-e4fd-4d1f-9ab5-d0051dcfee34)
![image](https://github.com/user-attachments/assets/e6a324f9-fe80-4588-b671-8c8568c2f8ef)
![image](https://github.com/user-attachments/assets/5f5e3eb3-a2bd-470f-b772-755adc703e53)
![image](https://github.com/user-attachments/assets/c44d1931-2f0d-4e84-8a5b-f2ccd69aad78)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
