### PR TITLE
TD-5548 Issue showing 'some existing competency records changed order' on 'competency file uploaded' screen when even modified the competency names

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
@@ -80,13 +80,13 @@
 
         IEnumerable<GenericSelectList> GetAssessmentQuestions(int frameworkId, int adminId);
 
-        FrameworkDefaultQuestionUsage GetFrameworkDefaultQuestionUsage(int frameworkId, int assessmentQuestionId);
+        FrameworkDefaultQuestionUsage? GetFrameworkDefaultQuestionUsage(int frameworkId, int assessmentQuestionId);
 
         IEnumerable<GenericSelectList> GetAssessmentQuestionsForCompetency(int frameworkCompetencyId, int adminId);
 
-        AssessmentQuestionDetail GetAssessmentQuestionDetailById(int assessmentQuestionId, int adminId);
+        AssessmentQuestionDetail? GetAssessmentQuestionDetailById(int assessmentQuestionId, int adminId);
 
-        LevelDescriptor GetLevelDescriptorForAssessmentQuestionId(int assessmentQuestionId, int adminId, int level);
+        LevelDescriptor? GetLevelDescriptorForAssessmentQuestionId(int assessmentQuestionId, int adminId, int level);
 
         IEnumerable<CompetencyResourceAssessmentQuestionParameter>
             GetSignpostingResourceParametersByFrameworkAndCompetencyId(int frameworkId, int competencyId);
@@ -122,7 +122,7 @@
         FrameworkReviewOutcomeNotification? GetFrameworkReviewNotification(int reviewId);
 
         //INSERT DATA
-        BrandedFramework CreateFramework(DetailFramework detailFramework, int adminId);
+        BrandedFramework? CreateFramework(DetailFramework detailFramework, int adminId);
 
         int InsertCompetencyGroup(string groupName, string? groupDescription, int adminId, int? frameworkId);
 
@@ -366,7 +366,7 @@
             );
         }
 
-        public BaseFramework GetBaseFrameworkByFrameworkId(int frameworkId, int adminId)
+        public BaseFramework? GetBaseFrameworkByFrameworkId(int frameworkId, int adminId)
         {
             return connection.QueryFirstOrDefault<BaseFramework>(
                 $@"SELECT {BaseFrameworkFields}
@@ -376,7 +376,7 @@
             );
         }
 
-        public BrandedFramework GetBrandedFrameworkByFrameworkId(int frameworkId, int adminId)
+        public BrandedFramework? GetBrandedFrameworkByFrameworkId(int frameworkId, int adminId)
         {
             return connection.QueryFirstOrDefault<BrandedFramework>(
                 $@"SELECT {BaseFrameworkFields} {BrandedFrameworkFields}
@@ -483,7 +483,7 @@
             );
         }
 
-        public BrandedFramework CreateFramework(DetailFramework detailFramework, int adminId)
+        public BrandedFramework? CreateFramework(DetailFramework detailFramework, int adminId)
         {
             string frameworkName = detailFramework.FrameworkName;
             var description = detailFramework.Description;
@@ -531,7 +531,7 @@
                 return new BrandedFramework();
             }
 
-            return connection.QueryFirstOrDefault<BrandedFramework>(
+            return connection.QueryFirstOrDefault<BrandedFramework?>(
                 $@"SELECT {BaseFrameworkFields}
                       FROM {FrameworkTables}
                       WHERE FrameworkName = @frameworkName AND OwnerAdminID = @adminId",
@@ -866,7 +866,7 @@
                 @"SELECT fcg.ID, fcg.CompetencyGroupID, cg.Name, fcg.Ordering, fc.ID, c.ID AS CompetencyID, c.Name, c.Description, fc.Ordering, COUNT(caq.AssessmentQuestionID) AS AssessmentQuestions
                     ,(SELECT COUNT(*) FROM CompetencyLearningResources clr WHERE clr.CompetencyID = c.ID AND clr.RemovedDate IS NULL) AS CompetencyLearningResourcesCount
                     FROM   FrameworkCompetencyGroups AS fcg INNER JOIN
-                      CompetencyGroups AS cg ON fcg.CompetencyGroupID = cg.ID LEFT OUTER JOIN
+                      CompetencyGroups AS cg ON fcg.CompetencyGroupID = cg.ID INNER JOIN
                        FrameworkCompetencies AS fc ON fcg.ID = fc.FrameworkCompetencyGroupID LEFT OUTER JOIN
                        Competencies AS c ON fc.CompetencyID = c.ID LEFT OUTER JOIN
                       CompetencyAssessmentQuestions AS caq ON c.ID = caq.CompetencyID
@@ -1518,7 +1518,7 @@ GROUP BY fc.ID, c.ID, c.Name, c.Description, fc.Ordering
             );
         }
 
-        public FrameworkDefaultQuestionUsage GetFrameworkDefaultQuestionUsage(int frameworkId, int assessmentQuestionId)
+        public FrameworkDefaultQuestionUsage? GetFrameworkDefaultQuestionUsage(int frameworkId, int assessmentQuestionId)
         {
             return connection.QueryFirstOrDefault<FrameworkDefaultQuestionUsage>(
                 @"SELECT @assessmentQuestionId AS ID,
@@ -1619,7 +1619,7 @@ WHERE (FrameworkID = @frameworkId)",
             }
         }
 
-        public AssessmentQuestionDetail GetAssessmentQuestionDetailById(int assessmentQuestionId, int adminId)
+        public AssessmentQuestionDetail? GetAssessmentQuestionDetailById(int assessmentQuestionId, int adminId)
         {
             return connection.QueryFirstOrDefault<AssessmentQuestionDetail>(
                 $@"{AssessmentQuestionFields}{AssessmentQuestionDetailFields}
@@ -1629,7 +1629,7 @@ WHERE (FrameworkID = @frameworkId)",
             );
         }
 
-        public LevelDescriptor GetLevelDescriptorForAssessmentQuestionId(
+        public LevelDescriptor? GetLevelDescriptorForAssessmentQuestionId(
             int assessmentQuestionId,
             int adminId,
             int level
@@ -2500,7 +2500,7 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
                         FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, '') AS FlagsCsv
                     FROM 
                          Competencies AS c INNER JOIN
-                         FrameworkCompetencies AS fc ON c.ID = fc.CompetencyID LEFT JOIN
+                         FrameworkCompetencies AS fc ON c.ID = fc.CompetencyID INNER JOIN
                          FrameworkCompetencyGroups AS fcg ON fc.FrameworkCompetencyGroupID = fcg.ID LEFT JOIN
                          CompetencyGroups AS cg ON fcg.CompetencyGroupID = cg.ID
                     WHERE (fc.FrameworkID = @frameworkId)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5548

### Description
Updated the query to change the join between FrameworkCompetencyGroups (fcg) and FrameworkCompetencies (fc) from LEFT OUTER JOIN to INNER JOIN.
This ensures that only competency groups with at least one matching framework competency are returned.
The change resolves the reordering sequence issue when downloading the template by excluding competency groups that have no competencies assigned
Fixed a “Unboxing a possibly null value” warning in FrameworkDataService.cs
### Screenshots
![image](https://github.com/user-attachments/assets/ae2a5412-9bde-4ad9-a715-4d24c237195e)
![image](https://github.com/user-attachments/assets/75612943-28a0-40f9-917a-3abf55ebfce4)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
