### PR TITLE
TD-5771 Issue showing 'LearchingLaunched' field showing blank for all users on DSAT report

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/DCSAReportDataService.cs
@@ -48,7 +48,7 @@
                      WHERE (NOT (lli.LearningResourceReferenceID IS NULL)) AND (calli.CandidateAssessmentID = ca.ID)) +
                      (SELECT COUNT(*) AS FilteredLearning
                      FROM    FilteredLearningActivity AS fla
-                     WHERE (CandidateId = da.ID)) AS LearningCompleted,
+                     WHERE (CandidateId = da.ID)) AS LearningLaunched,
                          (SELECT COUNT(*) AS LearningLaunched
                      FROM    CandidateAssessmentLearningLogItems AS calli INNER JOIN
                                   LearningLogItems AS lli ON calli.LearningLogItemID = lli.LearningLogItemID


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5771

### Description
I replaced LearningCompleted with LearningLaunched in the subquery that counts records from the CandidateAssessmentLearningLogItems table joined with LearningLogItems. This way, LearningLaunched will not show blank in the report 
### Screenshots
![image](https://github.com/user-attachments/assets/d5688c2c-5a8a-4219-9196-a36680e254ce)
![image](https://github.com/user-attachments/assets/e3e64c94-cdb3-47d9-ab64-f39acfbcc93f)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
