### PR TITLE
TD-5816 Issue clearing 'confirmation requests' of 'optional competencies' if removed/added some other 'optional' competencies

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CompetencyDataService.cs
@@ -639,15 +639,7 @@
                 new { selfAssessmentId, delegateUserId, competencyId }
             );
         }
-
-        public void RemoveReviewCandidateAssessmentOptionalCompetencies(int id)
-        {
-           
-            connection.Execute(
-                     @"delete from SelfAssessmentResultSupervisorVerifications WHERE SelfAssessmentResultId = @id", new { id });
-
-        }
-
+        
         private static string PrintResult(
             int competencyId,
             int selfAssessmentId,

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -174,7 +174,6 @@
         bool IsCentreSelfAssessment(int selfAssessmentId, int centreId);
         bool HasMinimumOptionalCompetencies(int selfAssessmentId, int delegateUserId);
         int GetSelfAssessmentCategoryId(int selfAssessmentId);
-        void RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
         public IEnumerable<SelfAssessmentResult> GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(
         int delegateUserId,
         int selfAssessmentId,

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1532,22 +1532,6 @@
                     );
                 }
             }
-            var optionalCompetency =
-            (selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId)).Where(x => !x.IncludedInSelfAssessment);
-            if (optionalCompetency.Any())
-            {
-                foreach (var optinal in optionalCompetency)
-                {
-                    var selfAssessmentResults = selfAssessmentService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, optinal.Id);
-                    if (selfAssessmentResults.Any())
-                    {
-                        foreach (var item in selfAssessmentResults)
-                        {
-                            selfAssessmentService.RemoveReviewCandidateAssessmentOptionalCompetencies(item.Id);
-                        }
-                    }
-                }
-            }
             if (model.GroupOptionalCompetenciesChecked != null)
             {
                 var optionalCompetencies =

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -605,6 +605,5 @@
         {
             return selfAssessmentDataService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, competencyId);
         }
-       
     }
 }

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -161,7 +161,6 @@
         int selfAssessmentId,
         int competencyId
     );
-        void RemoveReviewCandidateAssessmentOptionalCompetencies(int id);
     }
 
     public class SelfAssessmentService : ISelfAssessmentService
@@ -606,9 +605,6 @@
         {
             return selfAssessmentDataService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, competencyId);
         }
-        public void RemoveReviewCandidateAssessmentOptionalCompetencies(int id)
-        {
-            selfAssessmentDataService.RemoveReviewCandidateAssessmentOptionalCompetencies(id);
-        }
+       
     }
 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5816

### Description
Removed the logic in ManageOptionalCompetencies that deleted confirmation requests for optional competencies. Their confirmation status will now remain unchanged when optional competencies are added to or removed from a self-assessment

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/6b43a23e-5b20-4c94-aecf-3ca2247e1105" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
