### PR TITLE
TD-5621 Align expander component on Review and Self-Assessment pages

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_OverviewTable.cshtml
@@ -33,7 +33,7 @@
     {
         <tbody class="nhsuk-table__body row-outer" id="comp-@competency.RowNo">
             <tr class="nhsuk-table__row first-row">
-                <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell nhsuk-u-text-align-left">
+                <td rowspan="@competency.AssessmentQuestions.Count()" class="nhsuk-table__cell">
                     <span class="nhsuk-table-responsive__heading">@Model.First().Vocabulary </span>
                   <div class="nhsuk-grid-row">
                         <div class="nhsuk-grid-column-full">
@@ -52,7 +52,7 @@
                             @if (!string.IsNullOrWhiteSpace(competency.Description) && !competency.AlwaysShowDescription)
                             {
                                 <details class="nhsuk-details">
-                                    <summary class="nhsuk-details__summary nhsuk-u-padding-0">
+                                    <summary class="nhsuk-details__summary">
                                         <span class="nhsuk-u-margin-bottom-0">
                                             <span class="nhsuk-details__summary-text">@competency.Name</span>
                                         </span>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -177,12 +177,10 @@
                                     @if (!string.IsNullOrWhiteSpace(competency.Description) && !competency.AlwaysShowDescription)
                                     {
                                         <details class="nhsuk-details">
-                                            <summary class="nhsuk-details__summary">
-                                                <h2 class="nhsuk-u-font-size-24 nhsuk-u-margin-bottom-0">
+                                            <summary class="nhsuk-details__summary"> 
                                                     <span class="nhsuk-details__summary-text">
                                                         @competency.Name
                                                     </span>
-                                                </h2>
                                             </summary>
                                             <div class="nhsuk-details__text">
                                                 @(Html.Raw(@competency.Description))


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5621

### Description
Adjusted markup by removing <h2> and nhsuk-u-padding-0 from <summary> to correct expander alignment on Review and Self-Assessment pages
Fixed expander alignment on Review and Self-Assessment pages by removing nhsuk-u-text-align-left from <td>
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/fcdd3673-e42e-44a5-a9f6-2737a813a7e7" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/2243ba41-f524-4021-8336-cb9cc2c319ec" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
