### PR TITLE
TD-5859 url flag override persist to dashboard page and handle

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Centre/SelfAssessmentReports/SelfAssessmentReportsController.cs
@@ -93,11 +93,14 @@
         }
         [HttpGet]
         [Route("TableauCompetencyDashboard")]
-        public IActionResult TableauCompetencyDashboard()
+        public async Task<IActionResult> TableauCompetencyDashboardAsync()
         {
             var userEmail = User.GetUserPrimaryEmail();
             var adminId = User.GetAdminId();
             var jwt = tableauConnectionHelper.GetTableauJwt();
+            var tableauFlag = await featureManager.IsEnabledAsync(FeatureFlags.TableauSelfAssessmentDashboards);
+            var tableauQueryOverride = string.Equals(Request.Query["tableaulink"], "true", StringComparison.OrdinalIgnoreCase);
+            var showTableauLink = tableauFlag || tableauQueryOverride;
             ViewBag.Email = userEmail;
             ViewBag.AdminId = adminId;
             ViewBag.SiteName = tableauSiteName;
@@ -105,7 +108,7 @@
             ViewBag.WorkbookName = workbookName;
             ViewBag.ViewName = viewName;
             ViewBag.JwtToken = jwt;
-
+            ViewBag.ShowTableauLink = showTableauLink;
             return View();
         }
     }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
@@ -4,6 +4,12 @@
 @model SelfAssessmentReportsViewModel
 @{
     ViewData["Title"] = "Self assessment reports";
+    var routeData = new Dictionary<string, string>();
+
+    if (string.Equals(Context.Request.Query["tableaulink"], "true", StringComparison.OrdinalIgnoreCase))
+    {
+        routeData["tableaulink"] = "true";
+    }
 }
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-one-quarter">
@@ -21,7 +27,8 @@
         </h1>
         @if (Model.ShowTableauLink && Model.SelfAssessmentSelects.Any())
         {
-            <vc:action-link asp-controller="SelfAssessmentReports" asp-action="TableauCompetencyDashboard" asp-all-route-data="@new Dictionary<string, string>();" link-text="View Tableau supervised self assessments dashboard" />
+            <vc:action-link asp-controller="SelfAssessmentReports"
+                            asp-all-route-data="routeData" asp-action="TableauCompetencyDashboard" link-text="View Tableau supervised self assessments dashboard" />
         }
         <h2>Excel learner activity reports</h2>
         <p class="nhsuk-lede-text">Download Excel competency self assessments activity reports for your centre.</p>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/TableauCompetencyDashboard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/TableauCompetencyDashboard.cshtml
@@ -20,8 +20,9 @@
 </div>
 <h1>@ViewData["Title"]</h1>
 <vc:inset-text css-class="" text="Use the full screen button below the Tableau dashboard (next to 'Share') for the best experience." />
-<feature name="@(FeatureFlags.TableauSelfAssessmentDashboards)">
-    <tableau-viz id='tableau-viz'
+@if (ViewBag.ShowTableauLink)
+{
+<tableau-viz id='tableau-viz'
                  src='@srcUrl' token='@jwtToken' toolbar='bottom'>
         If the dashboard doesn't appear after a few seconds, <a href="#">reload the page</a>
     </tableau-viz>
@@ -32,8 +33,10 @@
         <script type="module" src="@tableauServerUrl/javascripts/api/tableau.embedding.3.latest.min.js"></script>
         <script src="@Url.Content("~/js/trackingSystem/tableaureports.js")" asp-append-version="true"></script>
     }
-</feature>
-<feature name="@(FeatureFlags.TableauSelfAssessmentDashboards)" negate="true">
+}
+else
+{
     <h2>Oops! We are still working on this area of the site</h2>
     <p class="nhsuk-lede-text">This feature is under development and should be available soon.</p>
-</feature>
+}
+

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/TableauCompetencyDashboard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/TableauCompetencyDashboard.cshtml
@@ -22,7 +22,7 @@
 <vc:inset-text css-class="" text="Use the full screen button below the Tableau dashboard (next to 'Share') for the best experience." />
 @if (ViewBag.ShowTableauLink)
 {
-<tableau-viz id='tableau-viz'
+    <tableau-viz id='tableau-viz'
                  src='@srcUrl' token='@jwtToken' toolbar='bottom'>
         If the dashboard doesn't appear after a few seconds, <a href="#">reload the page</a>
     </tableau-viz>


### PR DESCRIPTION
### JIRA link
[TD-5859](https://hee-tis.atlassian.net/browse/TD-5859)

### Description
Persists the tableaulink url parameter to the dashboard page and handles in feature flagging on that page.


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
