### PR TITLE
TD-5361 Switch filter logic from AND to OR to match any selected filter

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -43,12 +43,12 @@ namespace DigitalLearningSolutions.Web.Helpers
                                        let searchTextMatchesCompetencyDescription = wordsInSearchText.All(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
                                        let searchTextMatchesCompetencyName = wordsInSearchText.All(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
                                        let responseStatusFilterMatchesAll =
-                                           (!filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) || c.AssessmentQuestions.Any(q => q.ResultId == null))
-                                       && (!filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) || c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
-                                       && (!filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) || c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
-                                       && (!filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) || c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
-                                       && (!filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) || c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
-                                       && (!filters.Contains((int)SelfAssessmentCompetencyFilter.Optional) || c.Optional)
+                                          (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
+                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.Optional) && c.Optional)
                                        where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
                                            && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAll)
                                        select c;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5361

### Description
I updated the filter logic to use OR instead of AND, so that if multiple filters are selected, a competency will be included in the results as long as it matches at least one of the selected filters.
I removed the negation (!) in front of the filter checks and replaced the OR operators with AND operators, so now the query only returns competencies that satisfy all of the selected filters.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b95b319f-7918-4edc-8575-61a4c2fb4fa0" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/e9c7d50e-905f-40f0-be3a-a89b577fffef" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
