### PR TITLE
TD-5816-Moved competencies update code before competencies remove code

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -1532,22 +1532,6 @@
                     );
                 }
             }
-            var optionalCompetency =
-            (selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId)).Where(x => !x.IncludedInSelfAssessment);
-            if (optionalCompetency.Any())
-            {
-                foreach (var optinal in optionalCompetency)
-                {
-                    var selfAssessmentResults = selfAssessmentService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, optinal.Id);
-                    if (selfAssessmentResults.Any())
-                    {
-                        foreach (var item in selfAssessmentResults)
-                        {
-                            selfAssessmentService.RemoveReviewCandidateAssessmentOptionalCompetencies(item.Id);
-                        }
-                    }
-                }
-            }
             if (model.GroupOptionalCompetenciesChecked != null)
             {
                 var optionalCompetencies =
@@ -1564,6 +1548,23 @@
                     }
                 }
 
+            }
+
+            var optionalCompetency =
+            (selfAssessmentService.GetCandidateAssessmentOptionalCompetencies(selfAssessmentId, delegateUserId)).Where(x => !x.IncludedInSelfAssessment);
+            if (optionalCompetency.Any())
+            {
+                foreach (var optinal in optionalCompetency)
+                {
+                    var selfAssessmentResults = selfAssessmentService.GetSelfAssessmentResultswithSupervisorVerificationsForDelegateSelfAssessmentCompetency(delegateUserId, selfAssessmentId, optinal.Id);
+                    if (selfAssessmentResults.Any())
+                    {
+                        foreach (var item in selfAssessmentResults)
+                        {
+                            selfAssessmentService.RemoveReviewCandidateAssessmentOptionalCompetencies(item.Id);
+                        }
+                    }
+                }
             }
 
             var recentResults = selfAssessmentService.GetMostRecentResults(selfAssessmentId, User.GetCandidateIdKnownNotNull()).ToList();


### PR DESCRIPTION
### JIRA link
[TD-5816](https://hee-tis.atlassian.net/browse/TD-5816)

### Description
Swapped piece of code execution: Moved ‘competencies update’ code before ‘competencies remove’ code.

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5816]: https://hee-tis.atlassian.net/browse/TD-5816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ