### PR TITLE
TD-5339 Self Assessment Process Agreement

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202508190845_AddSelfAssessmentProcessAgreed .cs
+++ b/DigitalLearningSolutions.Data.Migrations/202508190845_AddSelfAssessmentProcessAgreed .cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202508190845)]
+    public class AddSelfAssessmentProcessAgreed : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("CandidateAssessments").AddColumn("SelfAssessmentProcessAgreed").AsDateTime().Nullable();
+        }
+
+        public override void Down()
+        {
+            Delete.Column("SelfAssessmentProcessAgreed").FromTable("CandidateAssessments");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -193,6 +193,7 @@
                         SA.LinearNavigation,
                         SA.UseDescriptionExpanders,
                         SA.ManageOptionalCompetenciesPrompt,
+                        CAST(CASE WHEN CA.SelfAssessmentProcessAgreed IS NOT NULL THEN 1 ELSE 0 END AS BIT) AS SelfAssessmentProcessAgreed,
                         CAST(CASE WHEN SA.SupervisorSelfAssessmentReview = 1 OR SA.SupervisorResultsReview = 1 THEN 1 ELSE 0 END AS BIT) AS IsSupervised,
                         CASE
                             WHEN (SELECT COUNT(*) FROM SelfAssessmentSupervisorRoles WHERE SelfAssessmentID = @selfAssessmentId AND AllowDelegateNomination = 1) > 0
@@ -241,7 +242,7 @@
                         CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders,
                         SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel,SA.EnforceRoleRequirementsForSignOff, SA.ManageSupervisorsDescription,CA.NonReportable,
-                        U.FirstName , U.LastName,SA.MinimumOptionalCompetencies",
+                        U.FirstName , U.LastName,SA.MinimumOptionalCompetencies, CA.SelfAssessmentProcessAgreed",
                 new { delegateUserId, selfAssessmentId }
             );
         }
@@ -321,6 +322,22 @@
                 logger.LogWarning(
                     "Not setting self assessment complete by date as db update failed. " +
                     $"Self assessment id: {selfAssessmentId}, Delegate User id: {delegateUserId}, complete by date: {completeByDate}"
+                );
+            }
+        }
+
+        public void MarkProgressAgreed(int selfAssessmentId, int delegateUserId)
+        {
+            var numberOfAffectedRows = connection.Execute(
+                @"UPDATE CandidateAssessments SET SelfAssessmentProcessAgreed = GETDATE()
+              WHERE SelfAssessmentID = @selfAssessmentId AND DelegateUserID = @delegateUserId",
+                new { selfAssessmentId, delegateUserId }
+            );
+            if (numberOfAffectedRows < 1)
+            {
+                logger.LogWarning(
+                    "SelfAssessmentProcessAgreed not set as db update failed. " +
+                    $"Self assessment id: {selfAssessmentId}, Delegate User id: {delegateUserId}"
                 );
             }
         }

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -89,6 +89,7 @@
 
         void SetBookmark(int selfAssessmentId, int delegateUserId, string bookmark);
 
+        void MarkProgressAgreed(int selfAssessmentId, int delegateUserId);
         IEnumerable<CandidateAssessment> GetCandidateAssessments(int delegateUserId, int selfAssessmentId);
 
         // SelfAssessmentSupervisorDataService

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/CurrentSelfAssessment.cs
@@ -24,5 +24,6 @@
         public int? DelegateUserId { get; set; }
         public string? DelegateName { get; set; }
         public string? EnrolledByFullName { get; set; }
+        public bool SelfAssessmentProcessAgreed { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -75,7 +75,43 @@
                 delegateUserId
             ).ToList();
             var model = new SelfAssessmentDescriptionViewModel(selfAssessment, supervisors);
+            var isProcessAgreed = model.SelfAssessmentProcessAgreed;
+            if (!isProcessAgreed && selfAssessment.IsSupervised)
+            {
+                var processmodel = new SelfAssessmentProcessViewModel()
+                {
+                    SelfAssessmentID = selfAssessmentId
+                };
+                return View("SelfAssessments/AgreeSelfAssessmentProcess", processmodel);
+            }
             return View("SelfAssessments/SelfAssessmentDescription", model);
+        }
+
+        [HttpPost]
+        public IActionResult ProcessAgreed(SelfAssessmentProcessViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View("SelfAssessments/AgreeSelfAssessmentProcess", model);
+            }
+            var delegateUserId = User.GetUserIdKnownNotNull();
+            int selfAssessmentId = model.SelfAssessmentID;
+            var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
+            if (selfAssessment == null)
+            {
+                logger.LogWarning(
+                    $"Attempt to display self assessment description for user {delegateUserId} with no self assessment"
+                );
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
+            }
+            var supervisors = selfAssessmentService.GetAllSupervisorsForSelfAssessmentId(
+                selfAssessmentId,
+                delegateUserId
+            ).ToList();
+            var selfAssessmentDescriptionViewModel = new SelfAssessmentDescriptionViewModel(selfAssessment, supervisors);
+            selfAssessmentService.MarkProgressAgreed(selfAssessmentId, delegateUserId);
+            return View("SelfAssessments/SelfAssessmentDescription", selfAssessmentDescriptionViewModel);
+
         }
 
         [ServiceFilter(typeof(IsCentreAuthorizedSelfAssessment))]

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -68,6 +68,17 @@
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
 
+            if (!selfAssessment.SelfAssessmentProcessAgreed && selfAssessment.IsSupervised)
+            {
+                var processmodel = new SelfAssessmentProcessViewModel()
+                {
+                    SelfAssessmentID = selfAssessmentId,
+                    Vocabulary = selfAssessment.Vocabulary,
+                    VocabPlural = FrameworkVocabularyHelper.VocabularyPlural(selfAssessment.Vocabulary)
+                };
+                return View("SelfAssessments/AgreeSelfAssessmentProcess", processmodel);
+            }
+
             selfAssessmentService.IncrementLaunchCount(selfAssessmentId, delegateUserId);
             selfAssessmentService.UpdateLastAccessed(selfAssessmentId, delegateUserId);
             var supervisors = selfAssessmentService.GetAllSupervisorsForSelfAssessmentId(
@@ -75,15 +86,7 @@
                 delegateUserId
             ).ToList();
             var model = new SelfAssessmentDescriptionViewModel(selfAssessment, supervisors);
-            var isProcessAgreed = model.SelfAssessmentProcessAgreed;
-            if (!isProcessAgreed && selfAssessment.IsSupervised)
-            {
-                var processmodel = new SelfAssessmentProcessViewModel()
-                {
-                    SelfAssessmentID = selfAssessmentId
-                };
-                return View("SelfAssessments/AgreeSelfAssessmentProcess", processmodel);
-            }
+            
             return View("SelfAssessments/SelfAssessmentDescription", model);
         }
 

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -32,6 +32,7 @@
 
         void SetCompleteByDate(int selfAssessmentId, int delegateUserId, DateTime? completeByDate);
 
+        void MarkProgressAgreed(int selfAssessmentId, int delegateUserId);
         bool CanDelegateAccessSelfAssessment(int delegateUserId, int selfAssessmentId, int centreId);
 
         // Competencies
@@ -214,6 +215,11 @@
         public void SetCompleteByDate(int selfAssessmentId, int delegateUserId, DateTime? completeByDate)
         {
             selfAssessmentDataService.SetCompleteByDate(selfAssessmentId, delegateUserId, completeByDate);
+        }
+
+        public void MarkProgressAgreed(int selfAssessmentId, int delegateUserId)
+        {
+            selfAssessmentDataService.MarkProgressAgreed(selfAssessmentId, delegateUserId);
         }
 
         public IEnumerable<Competency> GetCandidateAssessmentResultsById(int candidateAssessmentId, int adminId, int? selfAssessmentResultId = null)

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentDescriptionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentDescriptionViewModel.cs
@@ -18,6 +18,7 @@
         public readonly string VocabPlural;
         public readonly string? Vocabulary;
         public readonly bool NonReportable;
+        public bool SelfAssessmentProcessAgreed { get; set; }
 
         public SelfAssessmentDescriptionViewModel(
             CurrentSelfAssessment selfAssessment,
@@ -37,6 +38,7 @@
             Vocabulary = selfAssessment.Vocabulary;
             VocabPlural = FrameworkVocabularyHelper.VocabularyPlural(selfAssessment.Vocabulary);
             NonReportable = selfAssessment.NonReportable;
+            SelfAssessmentProcessAgreed = selfAssessment.SelfAssessmentProcessAgreed;
         }
 
         public List<SelfAssessmentSupervisor> Supervisors { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentProcessViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentProcessViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments
+{
+    using System.Collections.Generic;
+    using DigitalLearningSolutions.Data.Models.SelfAssessments;
+    using DigitalLearningSolutions.Web.Attributes;
+    using DigitalLearningSolutions.Web.Helpers;
+
+    public class SelfAssessmentProcessViewModel
+    {
+        public int SelfAssessmentID { get; set; }
+        [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm that you understand and agree to the self-assessment process")]
+        public bool ActionConfirmed { get; set; }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentProcessViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/LearningPortal/SelfAssessments/SelfAssessmentProcessViewModel.cs
@@ -10,5 +10,9 @@
         public int SelfAssessmentID { get; set; }
         [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm that you understand and agree to the self-assessment process")]
         public bool ActionConfirmed { get; set; }
+
+        public string? VocabPlural { get; set; }
+        public string? Vocabulary { get; set; }
+
     }
 }

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AgreeSelfAssessmentProcess.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AgreeSelfAssessmentProcess.cshtml
@@ -1,0 +1,55 @@
+﻿@using DigitalLearningSolutions.Web.Extensions
+@using DigitalLearningSolutions.Web.ViewModels.LearningPortal.SelfAssessments;
+@model SelfAssessmentProcessViewModel
+@{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "Agree To Process";
+    ViewData["Application"] = "LearningPortal";
+    ViewData["HeaderPathName"] = "LearningPortal";
+}
+
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full word-break">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
+        }
+        <h2>How are proficiencies and frameworks assessed?</h2>
+
+        <p>The process is learner-driven but you must be assessed by a supervisor before completing a self-assessment.</p>
+
+        <p>Once enrolled in a framework with at least 1 supervisor added, you can complete a digital self-assessment for any proficiency. However, before doing so, ensure that:</p>
+
+        <ol>
+            <li>Your supervisor can sign-off this proficiency based on their competence or department requirements.</li>
+            <li>You have been formally assessed, this could be through observation, discussion, or another agreed method with your supervisor.</li>
+            <li>You have reflected on the proficiency description and feel you meet the requirements.</li>
+            <li>If you don’t fully meet the requirements, you can still document your progress and next steps for future assessment.</li>
+        </ol>
+
+        <form method="post" asp-controller="LearningPortal" asp-action="ProcessAgreed">
+            <div class="nhsuk-checkboxes__item">
+                <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
+                                    label=" I understand and agree to the self-assessment process described above."
+                                    hint-text="" />
+            </div>
+            <button type="submit" class="nhsuk-button nhsuk-u-margin-top-4">
+                Continue
+            </button>
+            <input type="hidden" asp-for="SelfAssessmentID" />
+        </form>
+        <div class="nhsuk-back-link">
+            <a class="nhsuk-back-link__link" asp-controller="LearningPortal"
+               asp-action="Current">
+                <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+                </svg>
+                Cancel
+            </a>
+        </div>
+    </div>
+</div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AgreeSelfAssessmentProcess.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/AgreeSelfAssessmentProcess.cshtml
@@ -18,16 +18,16 @@
         {
             <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
         }
-        <h2>How are proficiencies and frameworks assessed?</h2>
+        <h2>How are @Model.VocabPlural?.ToLower() and frameworks assessed?</h2>
 
         <p>The process is learner-driven but you must be assessed by a supervisor before completing a self-assessment.</p>
 
-        <p>Once enrolled in a framework with at least 1 supervisor added, you can complete a digital self-assessment for any proficiency. However, before doing so, ensure that:</p>
+        <p>Once enrolled in a framework with at least 1 supervisor added, you can complete a digital self-assessment for any @Model.Vocabulary?.ToLower(). However, before doing so, ensure that:</p>
 
         <ol>
-            <li>Your supervisor can sign-off this proficiency based on their competence or department requirements.</li>
+            <li>Your supervisor can sign-off this @Model.Vocabulary?.ToLower() based on their competence or department requirements.</li>
             <li>You have been formally assessed, this could be through observation, discussion, or another agreed method with your supervisor.</li>
-            <li>You have reflected on the proficiency description and feel you meet the requirements.</li>
+            <li>You have reflected on the @Model.Vocabulary?.ToLower() description and feel you meet the requirements.</li>
             <li>If you don’t fully meet the requirements, you can still document your progress and next steps for future assessment.</li>
         </ol>
 
@@ -41,6 +41,8 @@
                 Continue
             </button>
             <input type="hidden" asp-for="SelfAssessmentID" />
+            <input type="hidden" asp-for="Vocabulary" />
+            <input type="hidden" asp-for="VocabPlural" />
         </form>
         <div class="nhsuk-back-link">
             <a class="nhsuk-back-link__link" asp-controller="LearningPortal"


### PR DESCRIPTION
### JIRA link
[TD-5339](https://hee-tis.atlassian.net/browse/TD-5339)

### Description
This PR introduces the "Self Assessment Process Agreement" functionality.

Key Changes
- **Added DB Column**:  
   SelfAssessmentProcessAgreed - nullable
- **Self Assessment Agreement Step**:  
  Added a new step in the self-assessment process where users must review and agree to the process agreement before continuing.
- **UI Updates**:  
  Introduced a new UI component/page/model for displaying the process agreement and capturing user consent.
- **Backend Support**:  
  Updated backend logic to track user agreement status and enforce the process agreement step as mandatory.
- **Validation**:  
  Users cannot proceed with their self assessment until they explicitly accept the agreement.
- **Unit/Integration Tests**:  
  Added/updated tests to cover the new agreement step and ensure robust validation.

### Screenshots
<img width="3106" height="1799" alt="image" src="https://github.com/user-attachments/assets/73a6a714-89a3-4287-aa94-4eeaa2393e14" />

<img width="2168" height="1867" alt="image" src="https://github.com/user-attachments/assets/4c59109c-3a92-44be-9c12-daf5d7f60ece" />

<img width="3806" height="2017" alt="image" src="https://github.com/user-attachments/assets/893e5096-4cfa-41fa-ab83-c30b6cf6894a" />

<img width="3804" height="2019" alt="image" src="https://github.com/user-attachments/assets/894c75d6-2ba8-48a6-a76d-249043226257" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [x] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [Self Assessment Process Agreement](https://hee-tis.atlassian.net/wiki/x/BIAmKAE)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5339]: https://hee-tis.atlassian.net/browse/TD-5339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ