### PR TITLE
TD-4624 Add regex validation of professional registration number field throughout the application

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/Register/RegisterDelegateByCentreControllerTests.cs
@@ -176,7 +176,7 @@
             const string answer4 = "answer4";
             const string answer5 = "answer5";
             const string answer6 = "answer6";
-            const string professionalRegistrationNumber = "PRN1234";
+            const string professionalRegistrationNumber = "PR123456";
             var model = new LearnerInformationViewModel
             {
                 JobGroup = jobGroupId,

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -175,9 +175,11 @@
                 result.As<ViewResult>().Model.Should().BeOfType<EditDelegateViewModel>();
                 AssertModelStateErrorIsExpected(
                     result,
-                    "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
-                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
-                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+                    "Invalid professional registration number format. " +
+        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
+        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
+        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
+        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
 
                 );
                 A.CallTo(() => userService.GetDelegateById(A<int>._)).MustNotHaveHappened();

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -175,7 +175,10 @@
                 result.As<ViewResult>().Model.Should().BeOfType<EditDelegateViewModel>();
                 AssertModelStateErrorIsExpected(
                     result,
-                    "Invalid professional registration number format - Only alphanumeric characters (a-z, A-Z and 0-9) and hyphens (-) allowed"
+                    "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
+                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
+                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+
                 );
                 A.CallTo(() => userService.GetDelegateById(A<int>._)).MustNotHaveHappened();
             }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EditDelegateControllerTests.cs
@@ -175,12 +175,7 @@
                 result.As<ViewResult>().Model.Should().BeOfType<EditDelegateViewModel>();
                 AssertModelStateErrorIsExpected(
                     result,
-                    "Invalid professional registration number format. " +
-        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
-        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
-        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
-        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
-
+                   ErrorMessagesTestHelper.InvalidFormatError
                 );
                 A.CallTo(() => userService.GetDelegateById(A<int>._)).MustNotHaveHappened();
             }

--- a/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
@@ -70,7 +70,7 @@
         {
             // Given
             var state = new ModelStateDictionary();
-            const string validPrn = "abc-123";
+            const string validPrn = "AB123456";
 
             // When
             ProfessionalRegistrationNumberHelper.ValidateProfessionalRegistrationNumber(

--- a/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
@@ -106,19 +106,28 @@
 
         [TestCase(null, "Enter a professional registration number")]
         [TestCase("", "Enter a professional registration number")]
-        [TestCase("123", "Professional registration number must be between 5 and 20 characters")]
-        [TestCase("0123456789-0123456789", "Professional registration number must be between 5 and 20 characters")]
+        [TestCase("1234", "Professional registration number must be between 5 and 20 characters")]
+        [TestCase("1234", "Professional registration number must be between 5 and 20 characters")]
         [TestCase(
             "01234_",
-            "Invalid professional registration number format - Only alphanumeric characters (a-z, A-Z and 0-9) and hyphens (-) allowed"
+          "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
+                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
+                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+
         )]
         [TestCase(
             "01234 ",
-            "Invalid professional registration number format - Only alphanumeric characters (a-z, A-Z and 0-9) and hyphens (-) allowed"
+           "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
+                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
+                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+
         )]
         [TestCase(
             "01234$",
-            "Invalid professional registration number format - Only alphanumeric characters (a-z, A-Z and 0-9) and hyphens (-) allowed"
+           "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
+                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
+                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+
         )]
         public void ValidateProfessionalRegistrationNumber_sets_error_when_prn_is_invalid(
             string prn,

--- a/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
@@ -110,23 +110,29 @@
         [TestCase("1234", "Professional registration number must be between 5 and 20 characters")]
         [TestCase(
             "01234_",
-          "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
-                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
-                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+         "Invalid professional registration number format. " +
+        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
+        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
+        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
+        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
 
         )]
         [TestCase(
             "01234 ",
-           "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
-                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
-                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+          "Invalid professional registration number format. " +
+        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
+        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
+        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
+        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
 
         )]
         [TestCase(
             "01234$",
-           "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)" +
-                    " 4–8 digits only " + "Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits " +
-                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+          "Invalid professional registration number format. " +
+        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
+        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
+        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
+        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
 
         )]
         public void ValidateProfessionalRegistrationNumber_sets_error_when_prn_is_invalid(

--- a/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
@@ -1,11 +1,12 @@
 ﻿namespace DigitalLearningSolutions.Web.Tests.Helpers
 {
-    using System.Linq;
     using DigitalLearningSolutions.Web.Helpers;
+    using DigitalLearningSolutions.Web.Tests.TestHelpers;
     using FluentAssertions;
     using FluentAssertions.Execution;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
     using NUnit.Framework;
+    using System.Linq;
 
     public class ProfessionalRegistrationNumberHelperTests
     {
@@ -104,37 +105,13 @@
             }
         }
 
-        [TestCase(null, "Enter a professional registration number")]
-        [TestCase("", "Enter a professional registration number")]
-        [TestCase("1234", "Professional registration number must be between 5 and 20 characters")]
-        [TestCase("1234", "Professional registration number must be between 5 and 20 characters")]
-        [TestCase(
-            "01234_",
-         "Invalid professional registration number format. " +
-        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
-        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
-        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
-        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
-
-        )]
-        [TestCase(
-            "01234 ",
-          "Invalid professional registration number format. " +
-        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
-        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
-        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
-        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
-
-        )]
-        [TestCase(
-            "01234$",
-          "Invalid professional registration number format. " +
-        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
-        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
-        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
-        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
-
-        )]
+        [TestCase(null, ErrorMessagesTestHelper.MissingNumberError)]
+        [TestCase("", ErrorMessagesTestHelper.MissingNumberError)]
+        [TestCase("1234", ErrorMessagesTestHelper.LengthError)]
+        [TestCase("1234", ErrorMessagesTestHelper.LengthError)]
+        [TestCase("01234_", ErrorMessagesTestHelper.InvalidFormatError)]
+        [TestCase("01234 ", ErrorMessagesTestHelper.InvalidFormatError)]
+        [TestCase("01234$", ErrorMessagesTestHelper.InvalidFormatError)]
         public void ValidateProfessionalRegistrationNumber_sets_error_when_prn_is_invalid(
             string prn,
             string expectedError

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/ErrorMessagesTestHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/ErrorMessagesTestHelper.cs
@@ -1,0 +1,17 @@
+﻿
+namespace DigitalLearningSolutions.Web.Tests.TestHelpers
+{
+    public static class ErrorMessagesTestHelper
+    {
+        public const string InvalidFormatError =
+           "Invalid professional registration number format. " +
+           "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
+           "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
+           "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
+           "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123).";
+
+        public const string MissingNumberError = "Enter a professional registration number";
+        public const string LengthError = "Professional registration number must be between 5 and 20 characters";
+
+    }
+}

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -58,9 +58,11 @@
             {
                 modelState.AddModelError(
                     "ProfessionalRegistrationNumber",
-                    "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)"+
-                    " 4–8 digits only "+"Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits "+
-                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
+                   "Invalid professional registration number format. " +
+        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
+        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
+        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
+        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -1,7 +1,11 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
-    using System.Text.RegularExpressions;
+    using DocumentFormat.OpenXml.ExtendedProperties;
+    using DocumentFormat.OpenXml.Spreadsheet;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using Microsoft.CodeAnalysis;
+    using System.Diagnostics.Metrics;
+    using System.Text.RegularExpressions;
 
     public class ProfessionalRegistrationNumberHelper
     {
@@ -40,11 +44,11 @@
                 return;
             }
 
-            if (prn.Length < 5 || prn.Length > 20)
+            if (prn.Length < 4 || prn.Length > 20)
             {
                 modelState.AddModelError(
                     "ProfessionalRegistrationNumber",
-                    "Professional registration number must be between 5 and 20 characters"
+                    "Professional registration number must be between 4 and 20 characters"
                 );
             }
 
@@ -54,7 +58,9 @@
             {
                 modelState.AddModelError(
                     "ProfessionalRegistrationNumber",
-                    "Invalid professional registration number format - Only alphanumeric characters (a-z, A-Z and 0-9) and hyphens (-) allowed"
+                    "Invalid professional registration number format. Accepted formats are: 1–2 letters followed by 6 digits (e.g., AB123456)"+
+                    " 4–8 digits only "+"Optional ‘P’ followed by 5–6 digits ‘C’ or ‘P’ followed by 6 digits "+
+                    "Optional letter followed by 5–6 digits ‘L’ followed by 4–6 digits 2 digits, hyphen, then 4–5 alphanumeric characters"
                 );
             }
         }

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -1,10 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
-    using DocumentFormat.OpenXml.ExtendedProperties;
-    using DocumentFormat.OpenXml.Spreadsheet;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
-    using Microsoft.CodeAnalysis;
-    using System.Diagnostics.Metrics;
     using System.Text.RegularExpressions;
 
     public class ProfessionalRegistrationNumberHelper

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -48,7 +48,7 @@
                 );
             }
 
-            const string pattern = @"^[a-z\d-]+$";
+           const string pattern = @"^(\d{7}|[A-Za-z]{1,2}\d{6}|\d{4,8}|P?\d{5,6}|[C|P]\d{6}|[A-Za-z]?\d{5,6}|L\d{4,6}|\d{2}-[A-Za-z\d]{4,5})$";
             var rg = new Regex(pattern, RegexOptions.IgnoreCase);
             if (!rg.Match(prn).Success)
             {

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -44,11 +44,11 @@
                 return;
             }
 
-            if (prn.Length < 4 || prn.Length > 20)
+            if (prn.Length < 5 || prn.Length > 20)
             {
                 modelState.AddModelError(
                     "ProfessionalRegistrationNumber",
-                    "Professional registration number must be between 4 and 20 characters"
+                    "Professional registration number must be between 5 and 20 characters"
                 );
             }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4624

### Description
I swapped out the pattern string for the .NET regex that validates professional registration numbers.
I updated the test data to match the new pattern so the tests pass, and I revised the error message to reflect the updated allowed format.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/500d8f4b-1e2a-4c86-a897-9ef49af4d5a0" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
