### PR TITLE
TD-6108 Updating ServiceFilter Logic To Exclude Other Areas

### DIFF
--- a/DigitalLearningSolutions.Web/ServiceFilter/RequireProcessAgreementFilter .cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/RequireProcessAgreementFilter .cs
@@ -24,47 +24,50 @@
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            if (!(context.Controller is Controller controller))
+            if (context.HttpContext.Request.Path.ToString().Contains("/LearningPortal/SelfAssessment/"))
             {
-                return;
-            }
+                if (!(context.Controller is Controller controller))
+                {
+                    return;
+                }
 
-            if (!context.ActionArguments.ContainsKey("selfAssessmentId"))
-            {
-                return;
-            }
+                if (!context.ActionArguments.ContainsKey("selfAssessmentId"))
+                {
+                    return;
+                }
 
-            var selfAssessmentId = int.Parse(context.ActionArguments["selfAssessmentId"].ToString()!);
-            var delegateUserId = controller.User.GetUserIdKnownNotNull();
+                var selfAssessmentId = int.Parse(context.ActionArguments["selfAssessmentId"].ToString()!);
+                var delegateUserId = controller.User.GetUserIdKnownNotNull();
 
-            var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
+                var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(delegateUserId, selfAssessmentId);
 
-            if (selfAssessment == null)
-            {
-                logger.LogWarning(
-                    $"Attempt to access self assessment {selfAssessmentId} by user {delegateUserId}, but no such assessment found"
-                );
-                context.Result = new RedirectToActionResult("StatusCode", "LearningSolutions", new { code = 403 });
-                return;
-            }
+                if (selfAssessment == null)
+                {
+                    logger.LogWarning(
+                        $"Attempt to access self assessment {selfAssessmentId} by user {delegateUserId}, but no such assessment found"
+                    );
+                    context.Result = new RedirectToActionResult("StatusCode", "LearningSolutions", new { code = 403 });
+                    return;
+                }
 
-            var actionName = context.RouteData.Values["action"]?.ToString();
-            if (actionName == "AgreeSelfAssessmentProcess" || actionName == "ProcessAgreed")
-            {
-                return;
-            }
+                var actionName = context.RouteData.Values["action"]?.ToString();
+                if (actionName == "AgreeSelfAssessmentProcess" || actionName == "ProcessAgreed")
+                {
+                    return;
+                }
 
-            if (!selfAssessment.SelfAssessmentProcessAgreed && selfAssessment.IsSupervised)
-            {
-                logger.LogInformation(
-                    $"Redirecting user {delegateUserId} to agree process page for self assessment {selfAssessmentId}"
-                );
+                if (!selfAssessment.SelfAssessmentProcessAgreed && selfAssessment.IsSupervised)
+                {
+                    logger.LogInformation(
+                        $"Redirecting user {delegateUserId} to agree process page for self assessment {selfAssessmentId}"
+                    );
 
-                context.Result = new RedirectToActionResult(
-                    "AgreeSelfAssessmentProcess",
-                    "LearningPortal",
-                    new { selfAssessmentId }
-                );
+                    context.Result = new RedirectToActionResult(
+                        "AgreeSelfAssessmentProcess",
+                        "LearningPortal",
+                        new { selfAssessmentId }
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
### JIRA link
[TD-6108](https://hee-tis.atlassian.net/browse/TD-6108)

### Description
Updating servicefilter logic so that it works only on the self assessments and excludes other areas such as re-enrolment.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6108]: https://hee-tis.atlassian.net/browse/TD-6108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ