### PR TITLE
TD-5548- Competency groups that have any competencies, were selected for old/new group comparison.

### DIFF
--- a/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/ImportCompetenciesFromFileService.cs
@@ -37,11 +37,13 @@ namespace DigitalLearningSolutions.Web.Services
             var newCompetencyIds = competencyRows.Select(row => row.ID ?? 0).ToList();
             var existingIds = frameworkService.GetFrameworkCompetencyOrder(frameworkId, newCompetencyIds);
             var existingGroups = frameworkService
-                .GetFrameworkCompetencyGroups(frameworkId)
+                .GetFrameworkCompetencyGroups(frameworkId).Where(x => x.FrameworkCompetencies.Any()).ToList()
                 .Select(row => row.Name)
                 .Distinct()
                 .ToList();
-            var newGroups = competencyRows.Select(row => row.CompetencyGroup ?? "").Distinct().ToList();
+            var newGroups = competencyRows.Select(row => row.CompetencyGroup)
+                .Where(g => !string.IsNullOrEmpty(g))
+                .Distinct().ToList();
             foreach (var competencyRow in competencyRows)
             {
                 PreProcessCompetencyRow(competencyRow, newCompetencyIds, existingIds, existingGroups, newGroups);


### PR DESCRIPTION
### JIRA link
[TD-5548](https://hee-tis.atlassian.net/browse/TD-5548)

### Description
Only those competency/proficiencies groups that have any competencies/proficiencies, were selected for old/new group comparison.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5548]: https://hee-tis.atlassian.net/browse/TD-5548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ