### PR TITLE
TD-6139-Retrieved only those accessors who have verified the assessment results

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -513,11 +513,13 @@
         {
             return connection.Query<Accessor>(
                 @"SELECT CASE  WHEN AccessorPRN IS NOT NULL THEN AccessorName+', '+AccessorPRN ELSE AccessorName END AS AccessorList,AccessorName,AccessorPRN   
-                   FROM (SELECT COALESCE(au.Forename + ' ' + au.Surname + (CASE WHEN au.Active = 1 THEN '' ELSE ' (Inactive)' END), sd.SupervisorEmail) AS AccessorName,
+                   FROM (SELECT DISTINCT COALESCE(au.Forename + ' ' + au.Surname + (CASE WHEN au.Active = 1 THEN '' ELSE ' (Inactive)' END), sd.SupervisorEmail) AS AccessorName,
                			u.ProfessionalRegistrationNumber AS AccessorPRN
             FROM SupervisorDelegates AS sd
             INNER JOIN CandidateAssessmentSupervisors AS cas
                 ON sd.ID = cas.SupervisorDelegateId
+            INNER JOIN SelfAssessmentResultSupervisorVerifications AS srsv
+			    ON cas.ID = srsv.CandidateAssessmentSupervisorID
             INNER JOIN CandidateAssessments AS ca
                 ON cas.CandidateAssessmentID = ca.ID
             LEFT OUTER JOIN AdminUsers AS au
@@ -527,7 +529,8 @@
                 ON cas.SelfAssessmentSupervisorRoleID = sasr.ID
 				INNER JOIN Users AS u ON U.PrimaryEmail =  au.Email 
              WHERE
-              (sd.Removed IS NULL) AND (cas.Removed IS NULL) AND (ca.DelegateUserID = @DelegateUserID) AND (ca.SelfAssessmentID = @selfAssessmentId)) Accessor
+                (ca.DelegateUserID = @DelegateUserID) AND (ca.SelfAssessmentID = @selfAssessmentId)
+                    AND (srsv.Verified IS NOT NULL)) Accessor
                 ORDER BY AccessorName, AccessorPRN DESC",
                 new { selfAssessmentId, delegateUserID }
             );


### PR DESCRIPTION
### JIRA link
[TD-6139](https://hee-tis.atlassian.net/browse/TD-6139)

### Description
GetAccessor(+) SQL modified to retrieve only those accessors who have verified the assessment results.

### Screenshots

Assigned accessors:
<img width="990" height="926" alt="image" src="https://github.com/user-attachments/assets/42702f6c-d392-4ace-9a1a-bfcbb522a121" />

Only accessors who have verified the assessment results.
<img width="783" height="814" alt="image" src="https://github.com/user-attachments/assets/f68d5db9-cef6-45b6-bd74-c042d9828404" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6139]: https://hee-tis.atlassian.net/browse/TD-6139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ