### PR TITLE
TD-5361 Refactor the learners Response Status Filters method

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -18,7 +18,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                 var searchText = search.SearchText?.Trim() ?? string.Empty;
                 var filters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)) ?? Enumerable.Empty<int>();
                 search.CompetencyFlags = competencyFlags.ToList();
-                ApplyResponseStatusFilters(ref filteredCompetencies, filters, searchText);
+                ResponseStatusFilters(ref filteredCompetencies, filters, searchText);
                 UpdateRequirementsFilterDropdownOptionsVisibility(search, filteredCompetencies);
                 ApplyRequirementsFilters(ref filteredCompetencies, filters);
 
@@ -30,6 +30,48 @@ namespace DigitalLearningSolutions.Web.Helpers
             return filteredCompetencies;
         }
 
+        public static void ResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
+        {
+            var appliedResponseStatusFilters = filters.Where(IsResponseStatusFilter).ToList();
+
+            if (!appliedResponseStatusFilters.Any() && string.IsNullOrWhiteSpace(searchText))
+            {
+                return;
+            }
+
+            // Break search text into words
+            var wordsInSearchText = searchText?
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                ?? Array.Empty<string>();
+
+            bool MatchesSearch(Competency c) =>
+                wordsInSearchText.Length == 0
+                || wordsInSearchText.All(w =>
+                       (c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                    || (c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                    || (c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false));
+
+            // Define reusable filter checks
+            var filterChecks = new Dictionary<SelfAssessmentCompetencyFilter, Func<Competency, bool>>
+            {
+                [SelfAssessmentCompetencyFilter.RequiresSelfAssessment] = c => c.AssessmentQuestions.Any(q => q.ResultId == null),
+                [SelfAssessmentCompetencyFilter.SelfAssessed] = c => c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null),
+                [SelfAssessmentCompetencyFilter.ConfirmationRequested] = c => c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null),
+                [SelfAssessmentCompetencyFilter.ConfirmationRejected] = c => c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true),
+                [SelfAssessmentCompetencyFilter.Verified] = c => c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true),
+                [SelfAssessmentCompetencyFilter.AwaitingConfirmation] = c => c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null && q.UserIsVerifier == true),
+                [SelfAssessmentCompetencyFilter.PendingConfirmation] = c => c.AssessmentQuestions.Any(q => q.ResultId != null && q.Verified == null && q.Requested != null && q.UserIsVerifier == false),
+                [SelfAssessmentCompetencyFilter.Optional] = c => c.Optional
+            };
+
+            // Require ALL applied filters to match
+            bool MatchesFilters(Competency c) =>
+                !appliedResponseStatusFilters.Any()
+                || appliedResponseStatusFilters.All(f => filterChecks[(SelfAssessmentCompetencyFilter)f](c));
+
+            // Final filtering
+            competencies = competencies.Where(c => MatchesSearch(c) && MatchesFilters(c));
+        }
         private static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
         {
             var filteredCompetencies = competencies;
@@ -38,20 +80,21 @@ namespace DigitalLearningSolutions.Web.Helpers
             if (appliedResponseStatusFilters.Any() || searchText.Length > 0)
             {
                 var wordsInSearchText = searchText.Split().Where(w => w != string.Empty);
-                filteredCompetencies = from c in competencies
-                                       let searchTextMatchesGroup = wordsInSearchText.All(w => c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                                       let searchTextMatchesCompetencyDescription = wordsInSearchText.All(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                                       let searchTextMatchesCompetencyName = wordsInSearchText.All(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                                       let responseStatusFilterMatchesAll =
-                                          (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
-                                       || (filters.Contains((int)SelfAssessmentCompetencyFilter.Optional) && c.Optional)
-                                       where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
-                                           && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAll)
-                                       select c;
+                                    filteredCompetencies = from c in competencies
+                                           let searchTextMatchesGroup = wordsInSearchText.All(w => c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                                           let searchTextMatchesCompetencyDescription = wordsInSearchText.All(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                                           let searchTextMatchesCompetencyName = wordsInSearchText.All(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                                           let responseStatusFilterMatchesAll =
+                                              (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
+                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.Optional) && c.Optional)
+                                           where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
+                                               && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAll)
+                                           select c;
+               
             }
             competencies = filteredCompetencies;
         }

--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -18,7 +18,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                 var searchText = search.SearchText?.Trim() ?? string.Empty;
                 var filters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)) ?? Enumerable.Empty<int>();
                 search.CompetencyFlags = competencyFlags.ToList();
-                ResponseStatusFilters(ref filteredCompetencies, filters, searchText);
+                ApplyResponseStatusFilters(ref filteredCompetencies, filters, searchText);
                 UpdateRequirementsFilterDropdownOptionsVisibility(search, filteredCompetencies);
                 ApplyRequirementsFilters(ref filteredCompetencies, filters);
 
@@ -30,7 +30,7 @@ namespace DigitalLearningSolutions.Web.Helpers
             return filteredCompetencies;
         }
 
-        public static void ResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
+        private static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
         {
             var appliedResponseStatusFilters = filters.Where(IsResponseStatusFilter).ToList();
 
@@ -72,33 +72,6 @@ namespace DigitalLearningSolutions.Web.Helpers
             // Final filtering
             competencies = competencies.Where(c => MatchesSearch(c) && MatchesFilters(c));
         }
-        private static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
-        {
-            var filteredCompetencies = competencies;
-            var appliedResponseStatusFilters = filters.Where(f => IsResponseStatusFilter(f));
-
-            if (appliedResponseStatusFilters.Any() || searchText.Length > 0)
-            {
-                var wordsInSearchText = searchText.Split().Where(w => w != string.Empty);
-                                    filteredCompetencies = from c in competencies
-                                           let searchTextMatchesGroup = wordsInSearchText.All(w => c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                                           let searchTextMatchesCompetencyDescription = wordsInSearchText.All(w => c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                                           let searchTextMatchesCompetencyName = wordsInSearchText.All(w => c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                                           let responseStatusFilterMatchesAll =
-                                              (filters.Contains((int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment) && c.AssessmentQuestions.Any(q => q.ResultId == null))
-                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.SelfAssessed) && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
-                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRequested) && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null))
-                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.ConfirmationRejected) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true))
-                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.Verified) && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true))
-                                           || (filters.Contains((int)SelfAssessmentCompetencyFilter.Optional) && c.Optional)
-                                           where (wordsInSearchText.Count() == 0 || searchTextMatchesGroup || searchTextMatchesCompetencyDescription || searchTextMatchesCompetencyName)
-                                               && (!appliedResponseStatusFilters.Any() || responseStatusFilterMatchesAll)
-                                           select c;
-               
-            }
-            competencies = filteredCompetencies;
-        }
-
         private static void ApplyRequirementsFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters)
         {
             var filteredCompetencies = competencies;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5361

### Description
I checked the search text to ensure is not null
I extracted the search text matching into a reusable function.
I extracted filter condition checks into reusable lambdas/dictionary mappings.
I combined filter logic dynamically rather than hardcoding every possible pair of filters.

### Screenshots
filtering confirmed competency
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/531d1e09-65bc-4f95-9a0e-9b7dc062acde" />
filtering confirmed and optional competency
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b56051f7-4be4-4aef-a9ad-0675645ca7f1" />
filtering confirmed, confirmation rejected and optional competency
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/61b69341-124e-424d-b59f-b4d4091a1625" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
