### PR TITLE
TD-6149-Tracking System - Enrol on activity should display Warning message for retiring self-assessment

### DIFF
--- a/DigitalLearningSolutions.Data/Models/SessionData/Tracking/Delegate/Enrol/SessionEnrolDelegate.cs
+++ b/DigitalLearningSolutions.Data/Models/SessionData/Tracking/Delegate/Enrol/SessionEnrolDelegate.cs
@@ -17,5 +17,6 @@
         public bool IsSelfAssessment { get; set; }
         public int AssessmentVersion { get; set; }
         public int? AssessmentCategoryID { get; set; }
+        public bool ActionConfirmed { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EnrolControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/EnrolControllerTests.cs
@@ -22,6 +22,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
         private ISupervisorService supervisorService = null!;
         private ICourseService courseService = null!;
         private IEnrolService enrolService = null!;
+        private ISelfAssessmentService selfAssessmentService = null!;
         private HttpRequest httpRequest = null!;
         private HttpResponse httpResponse = null!;
         private HttpContext httpContext = null!;
@@ -35,6 +36,7 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
             supervisorService = A.Fake<ISupervisorService>();
             enrolService = A.Fake<IEnrolService>();
             courseService = A.Fake<ICourseService>();
+            selfAssessmentService = A.Fake<ISelfAssessmentService>();
             sessionEnrolDelegate = A.Fake<SessionEnrolDelegate>();
 
             httpRequest = A.Fake<HttpRequest>();
@@ -46,7 +48,8 @@ namespace DigitalLearningSolutions.Web.Tests.Controllers.TrackingSystem.Delegate
                 multiPageFormService,
                 supervisorService,
                 enrolService,
-                courseService)
+                courseService,
+                selfAssessmentService)
                 .WithMockHttpContext(httpRequest, null, null, httpResponse)
                 .WithMockTempData()
                 .WithDefaultContext()

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -12,6 +12,7 @@
     using DigitalLearningSolutions.Web.Extensions;
     using DigitalLearningSolutions.Web.Helpers;
     using DigitalLearningSolutions.Web.ServiceFilter;
+    using DigitalLearningSolutions.Web.ViewModels.Common;
     using DigitalLearningSolutions.Web.ViewModels.Common.SearchablePage;
     using DigitalLearningSolutions.Web.ViewModels.Supervisor;
     using GDS.MultiPageFormData.Enums;
@@ -796,7 +797,7 @@
             );
 
             var retirementDate = selfAssessmentService.GetSelfAssessmentById(selfAssessmentID).RetirementDate;
-            if (CheckRetirementDate(retirementDate))
+            if (SelfAssessmentHelper.CheckRetirementDate(retirementDate))
             {
                 return RedirectToAction("ConfirmRetiringSelfAssessment", "Supervisor", new { supervisorDelegateId });
             }
@@ -817,14 +818,14 @@
                    ).GetAwaiter().GetResult();
 
             var retirementDate = selfAssessmentService.GetSelfAssessmentById((int)sessionEnrolOnRoleProfile.SelfAssessmentID).RetirementDate;
-            if (!CheckRetirementDate((retirementDate)))
+            if (!SelfAssessmentHelper.CheckRetirementDate((retirementDate)))
             {
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             }
             var model = new RetiringSelfAssessmentViewModel()
             {
                 SelfAssessmentID = (int)sessionEnrolOnRoleProfile.SelfAssessmentID,
-                SupervisorDelegateID = supervisorDelegateId,
+                RouteID = supervisorDelegateId,
                 RetirementDate = retirementDate,
                 ActionConfirmed = sessionEnrolOnRoleProfile.ActionConfirmed
             };
@@ -853,7 +854,7 @@
                 return RedirectToAction(
                     "EnrolDelegateCompleteBy",
                     "Supervisor",
-                    new { supervisorDelegateId = retiringSelfAssessment.SupervisorDelegateID }
+                    new { supervisorDelegateId = retiringSelfAssessment.RouteID }
                 );
             }
             else
@@ -876,7 +877,7 @@
             ).GetAwaiter().GetResult();
 
             var retirementDate = selfAssessmentService.GetSelfAssessmentById((int)sessionEnrolOnRoleProfile.SelfAssessmentID).RetirementDate;
-            if (CheckRetirementDate(retirementDate) && !sessionEnrolOnRoleProfile.ActionConfirmed)
+            if (SelfAssessmentHelper.CheckRetirementDate(retirementDate) && !sessionEnrolOnRoleProfile.ActionConfirmed)
             {
                 return RedirectToAction("ConfirmRetiringSelfAssessment", "Supervisor", new { supervisorDelegateId });
             }
@@ -1030,7 +1031,7 @@
             );
 
             var retirementDate = selfAssessmentService.GetSelfAssessmentById((int)sessionEnrolOnRoleProfile.SelfAssessmentID).RetirementDate;
-            if (CheckRetirementDate(retirementDate) && !sessionEnrolOnRoleProfile.ActionConfirmed)
+            if (SelfAssessmentHelper.CheckRetirementDate(retirementDate) && !sessionEnrolOnRoleProfile.ActionConfirmed)
             {
                 return RedirectToAction("ConfirmRetiringSelfAssessment", "Supervisor", new { supervisorDelegateId });
             }
@@ -1585,16 +1586,6 @@
                 viewResult.View.RenderAsync(viewContext);
                 return sw.GetStringBuilder().ToString();
             }
-        }
-
-        private bool CheckRetirementDate(DateTime? date)
-        {
-            if (date == null)
-                return false;
-
-            DateTime retirementOffsetDate = DateTime.Today.AddDays(14);
-            DateTime today = DateTime.Today;
-            return (date >= today && date <= retirementOffsetDate);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/EnrolController.cs
@@ -16,8 +16,12 @@ using GDS.MultiPageFormData.Enums;
 
 namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 {
+    using DigitalLearningSolutions.Data.Models.SessionData.Supervisor;
+    using DigitalLearningSolutions.Data.Models.Supervisor;
     using DigitalLearningSolutions.Data.Utilities;
     using DigitalLearningSolutions.Web.ServiceFilter;
+    using DigitalLearningSolutions.Web.ViewModels.Common;
+    using Pipelines.Sockets.Unofficial;
 
     [FeatureGate(FeatureFlags.RefactoredTrackingSystem)]
     [Authorize(Policy = CustomPolicies.UserCentreAdmin)]
@@ -29,18 +33,21 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         private readonly ISupervisorService supervisorService;
         private readonly IEnrolService enrolService;
         private readonly ICourseService courseService;
+        private readonly ISelfAssessmentService selfAssessmentService;
 
         public EnrolController(
             IMultiPageFormService multiPageFormService,
             ISupervisorService supervisorService,
             IEnrolService enrolService,
-            ICourseService courseService
+            ICourseService courseService,
+            ISelfAssessmentService selfAssessmentService
         )
         {
             this.multiPageFormService = multiPageFormService;
             this.supervisorService = supervisorService;
             this.enrolService = enrolService;
             this.courseService = courseService;
+            this.selfAssessmentService = selfAssessmentService;
         }
 
         public IActionResult StartEnrolProcess(int delegateId, int delegateUserId, string delegateName)
@@ -116,6 +123,15 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
                 return View(model);
             }
 
+            if (sessionEnrol.AssessmentID.HasValue && sessionEnrol.AssessmentID != enrolCurrentLearningViewModel.SelectedActivity)
+            {
+                var delegateUserID = sessionEnrol.DelegateUserID;
+                var userName = sessionEnrol.DelegateName;
+                sessionEnrol = new SessionEnrolDelegate();
+                sessionEnrol.DelegateID = delegateId;
+                sessionEnrol.DelegateName = userName;
+                sessionEnrol.DelegateUserID = delegateUserID;
+            }
             sessionEnrol.AssessmentID = enrolCurrentLearningViewModel.SelectedActivity;
             var availableCourse = selfAssessments as List<AvailableCourse>;
             var selectedCourse = availableCourse.Find(x => x.Id == enrolCurrentLearningViewModel.SelectedActivity);
@@ -126,15 +142,72 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
 
             multiPageFormService.SetMultiPageFormData(
                 sessionEnrol,
-                MultiPageFormDataFeature.EnrolDelegateInActivity,
+            MultiPageFormDataFeature.EnrolDelegateInActivity,
                 TempData
             );
+
+            if (HasNotConfirmedRetiring(sessionEnrol.IsSelfAssessment, (int)sessionEnrol.AssessmentID, delegateId, sessionEnrol.ActionConfirmed))
+            {
+                return RedirectToAction("ConfirmRetiring", "Enrol", new { delegateId });
+            }
 
             return RedirectToAction(
                "EnrolCompleteBy",
                "Enrol",
                new { delegateId }
            );
+        }
+
+        public IActionResult ConfirmRetiring(int delegateId)
+        {
+            var sessionEnrol = multiPageFormService.GetMultiPageFormData<SessionEnrolDelegate>(
+                   MultiPageFormDataFeature.EnrolDelegateInActivity,
+                   TempData
+                   ).GetAwaiter().GetResult();
+
+            var retirementDate = selfAssessmentService.GetSelfAssessmentById((int)sessionEnrol.AssessmentID).RetirementDate;
+            if (!SelfAssessmentHelper.CheckRetirementDate((retirementDate)))
+            {
+                return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
+            }
+            var model = new RetiringSelfAssessmentViewModel()
+            {
+                SelfAssessmentID = (int)sessionEnrol.AssessmentID,
+                RouteID = (int)sessionEnrol.DelegateID,
+                RetirementDate = retirementDate,
+                ActionConfirmed = sessionEnrol.ActionConfirmed
+            };
+            return View("ConfirmRetiring", model);
+        }
+
+        [HttpPost]
+        public IActionResult ConfirmRetiring(RetiringSelfAssessmentViewModel retiringSelfAssessment)
+        {
+            var sessionEnrol = multiPageFormService.GetMultiPageFormData<SessionEnrolDelegate>(
+                    MultiPageFormDataFeature.EnrolDelegateInActivity,
+                    TempData
+                    ).GetAwaiter().GetResult();
+
+            sessionEnrol.AssessmentID = retiringSelfAssessment.SelfAssessmentID;
+            sessionEnrol.ActionConfirmed = retiringSelfAssessment.ActionConfirmed;
+            multiPageFormService.SetMultiPageFormData(
+                sessionEnrol,
+                MultiPageFormDataFeature.EnrolDelegateInActivity,
+                TempData
+            );
+
+            if (ModelState.IsValid && retiringSelfAssessment.ActionConfirmed)
+            {
+                return RedirectToAction(
+                    "EnrolCompleteBy",
+                    "Enrol",
+                    new { delegateId = retiringSelfAssessment.RouteID }
+                );
+            }
+            else
+            {
+                return View("ConfirmRetiring", retiringSelfAssessment);
+            }
         }
 
         [HttpGet]
@@ -145,9 +218,15 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         public IActionResult EnrolCompleteBy(int delegateId)
         {
             var sessionEnrol = multiPageFormService.GetMultiPageFormData<SessionEnrolDelegate>(
-               MultiPageFormDataFeature.EnrolDelegateInActivity,
-               TempData
-           ).GetAwaiter().GetResult();
+            MultiPageFormDataFeature.EnrolDelegateInActivity,
+            TempData
+            ).GetAwaiter().GetResult();
+
+            if (HasNotConfirmedRetiring(sessionEnrol.IsSelfAssessment, (int)sessionEnrol.AssessmentID, delegateId, sessionEnrol.ActionConfirmed))
+            {
+                return RedirectToAction("ConfirmRetiring", "Enrol", new { delegateId });
+            }
+
             multiPageFormService.SetMultiPageFormData(
                 sessionEnrol,
                 MultiPageFormDataFeature.EnrolDelegateInActivity,
@@ -202,6 +281,12 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             var sessionEnrol = multiPageFormService.GetMultiPageFormData<SessionEnrolDelegate>(
               MultiPageFormDataFeature.EnrolDelegateInActivity,
               TempData).GetAwaiter().GetResult();
+
+            if (HasNotConfirmedRetiring(sessionEnrol.IsSelfAssessment, (int)sessionEnrol.AssessmentID, delegateId, sessionEnrol.ActionConfirmed))
+            {
+                return RedirectToAction("ConfirmRetiring", "Enrol", new { delegateId });
+            }
+
             var supervisorList = supervisorService.GetSupervisorForEnrolDelegate(centreId.Value, sessionEnrol.AssessmentCategoryID.Value);
             if (!sessionEnrol.IsSelfAssessment)
             {
@@ -283,6 +368,12 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         public IActionResult EnrolDelegateSummary(int delegateId)
         {
             var sessionEnrol = multiPageFormService.GetMultiPageFormData<SessionEnrolDelegate>(MultiPageFormDataFeature.EnrolDelegateInActivity, TempData).GetAwaiter().GetResult();
+
+            if (HasNotConfirmedRetiring(sessionEnrol.IsSelfAssessment, (int)sessionEnrol.AssessmentID, delegateId, sessionEnrol.ActionConfirmed))
+            {
+                return RedirectToAction("ConfirmRetiring", "Enrol", new { delegateId });
+            }
+
             var roles = supervisorService.GetSupervisorRolesBySelfAssessmentIdForSupervisor(sessionEnrol.AssessmentID.GetValueOrDefault()).ToArray();
             var clockUtility = new ClockUtility();
             var monthDiffrence = "";
@@ -303,6 +394,7 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
             model.IsSelfAssessment = sessionEnrol.IsSelfAssessment;
             model.SupervisorRoleName = sessionEnrol.SelfAssessmentSupervisorRoleName;
             model.RoleCount = roles.Count();
+            ViewBag.actionConfirmed = sessionEnrol.ActionConfirmed;
             return View(model);
         }
 
@@ -344,6 +436,16 @@ namespace DigitalLearningSolutions.Web.Controllers.TrackingSystem.Delegates
         private int GetAdminID()
         {
             return User.GetCustomClaimAsRequiredInt(CustomClaimTypes.UserAdminId);
+        }
+
+        private bool HasNotConfirmedRetiring(bool IsSelfAssessment, int selfAssessmentId, int delegateId, bool actionConfirmed)
+        {
+            if (IsSelfAssessment)
+            {
+                var retirementDate = selfAssessmentService.GetSelfAssessmentById(selfAssessmentId).RetirementDate;
+                return SelfAssessmentHelper.CheckRetirementDate(retirementDate) && !actionConfirmed;
+            }
+            return false;
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/SelfAssessmentHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SelfAssessmentHelper.cs
@@ -1,0 +1,17 @@
+﻿namespace DigitalLearningSolutions.Web.Helpers
+{
+    using System;
+
+    public static class SelfAssessmentHelper
+    {
+        public static bool CheckRetirementDate(DateTime? date)
+        {
+            if (date == null)
+                return false;
+
+            DateTime retirementOffsetDate = DateTime.Today.AddDays(14);
+            DateTime today = DateTime.Today;
+            return (date >= today && date <= retirementOffsetDate);
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/ViewModels/Common/RetiringSelfAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Common/RetiringSelfAssessmentViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
+﻿namespace DigitalLearningSolutions.Web.ViewModels.Common
 {
     using DigitalLearningSolutions.Web.Attributes;
     using System;
@@ -6,7 +6,7 @@
     public class RetiringSelfAssessmentViewModel
     {
         public int SelfAssessmentID { get; set; }
-        public int SupervisorDelegateID { get; set; }
+        public int RouteID { get; set; }
         public DateTime? RetirementDate { get; set; }
         [BooleanMustBeTrue(ErrorMessage = "Please tick the checkbox to confirm you wish to perform this action")]
         public bool ActionConfirmed { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Enrol/ConfirmRetiring.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Enrol/ConfirmRetiring.cshtml
@@ -5,9 +5,7 @@
 @inject IConfiguration Configuration;
 @{
     var errorHasOccurred = !ViewData.ModelState.IsValid;
-    ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "Enrol on Profile Assessment";
-    ViewData["Application"] = "Supervisor";
-    ViewData["HeaderPathName"] = "Supervisor";
+    ViewData["Title"] = (errorHasOccurred ? "Error: " : "") + "Enrol on Activity - Confirm Retiring";
 }
 
 @section NavMenuItems {
@@ -30,13 +28,13 @@
             <li>You may wish to consider enrolling them on an updated version, if available</li>
         </ul>
         <p class="nhsuk-body-m">To continue, you must acknowledge that you understand the self-assessment is being retired and you still wish to proceed.</p>
-        <form method="post" asp-controller="Supervisor">
+        <form method="post" asp-controller="Enrol">
             <div class="nhsuk-checkboxes__item">
                 <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
                                     label=" I understand this self-assessment is being retired and I still want to enrol learners."
                                     hint-text="" />
             </div>
-            <button type="submit" class="nhsuk-button nhsuk-button nhsuk-u-margin-top-4" asp-action="ConfirmRetiringSelfAssessment">
+            <button type="submit" class="nhsuk-button nhsuk-button nhsuk-u-margin-top-4" asp-action="ConfirmRetiring">
                 Continue
             </button>
             @Html.HiddenFor(m => m.SelfAssessmentID)
@@ -44,8 +42,8 @@
             @Html.HiddenFor(m => m.RetirementDate)
         </form>
         <div class="nhsuk-back-link">
-            <a class="nhsuk-back-link__link" asp-controller="Supervisor"
-               asp-action="DelegateProfileAssessments" asp-route-supervisorDelegateId="@Model.RouteID">
+            <a class="nhsuk-back-link__link" asp-controller="ViewDelegate"
+               asp-action="Index" asp-route-DelegateId="@Model.RouteID">
                 <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                     <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
                 </svg>

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Enrol/EnrolDelegateSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Enrol/EnrolDelegateSummary.cshtml
@@ -40,6 +40,19 @@
                         </a>
                     </dd>
                 </div>
+                @if (ViewBag.actionConfirmed)
+                {
+                    <div class="nhsuk-summary-list__row">
+                        <dt class="nhsuk-summary-list__key">
+                            Retiring confirmed
+                        </dt>
+                        <dd class="nhsuk-summary-list__value">
+                            Yes
+                        </dd>
+                        <dd class="nhsuk-summary-list__actions">
+                        </dd>
+                    </div>
+                }
                 <div class="nhsuk-summary-list__row">
                     <dt class="nhsuk-summary-list__key">
                         Complete by date
@@ -101,7 +114,7 @@
                                 <text>Not Set</text>
                             }
                         </dd>
-                        @if (Model.RoleCount>1)
+                        @if (Model.RoleCount > 1)
                         {
                             <dd class="nhsuk-summary-list__actions">
                                 <a asp-action="EnrolDelegateSupervisor" asp-route-delegateId="@Model.DelegateId"


### PR DESCRIPTION
### JIRA link
[TD-6149](https://hee-tis.atlassian.net/browse/TD-6149)

### Description
Created a common view model - RetiringSelfAssessmentViewModel
Moved the retiring self-assessment check into a helper class
Made corresponding changes to the supervisor and Enrol controllers


### Screenshots

<img width="1733" height="921" alt="image" src="https://github.com/user-attachments/assets/f88cfe17-8eee-41f6-a07a-4421427c96cc" />

<img width="1287" height="922" alt="image" src="https://github.com/user-attachments/assets/636f0380-ad1b-45ca-9697-1f44344da5a2" />


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6149]: https://hee-tis.atlassian.net/browse/TD-6149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ