### PR TITLE
TD-6106- SelfAssessmentProcessAgreed set to null upon removal of candidate assessment

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -423,7 +423,7 @@
         public void RemoveEnrolment(int selfAssessmentId, int delegateUserId)
         {
             connection.Execute(
-                @"UPDATE CandidateAssessments SET RemovedDate = GETDATE()
+                @"UPDATE CandidateAssessments SET RemovedDate = GETDATE(), SelfAssessmentProcessAgreed = NULL
                       WHERE SelfAssessmentID = @selfAssessmentId AND DelegateUserID = @delegateUserId",
                 new { selfAssessmentId, delegateUserId }
             );

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -745,7 +745,8 @@
             connection.Execute(
                 @"BEGIN TRY
                     BEGIN TRANSACTION
-                        UPDATE CandidateAssessments SET RemovedDate = GETUTCDATE(), RemovalMethodID = 2
+                        UPDATE CandidateAssessments SET RemovedDate = GETUTCDATE(), RemovalMethodID = 2,
+                                                        SelfAssessmentProcessAgreed = NULL
                             WHERE ID = @candidateAssessmentsId AND RemovedDate IS NULL
 
                         COMMIT TRANSACTION

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -1000,7 +1000,8 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
          @"
                 BEGIN TRY
                     BEGIN TRANSACTION
-                        UPDATE CandidateAssessments SET RemovedDate = getUTCDate(), RemovalMethodID = 2
+                        UPDATE CandidateAssessments SET RemovedDate = getUTCDate(), RemovalMethodID = 2,
+                                                        SelfAssessmentProcessAgreed = NULL
                             WHERE ID = @candidateAssessmentId AND RemovedDate IS NULL
 
                         COMMIT TRANSACTION


### PR DESCRIPTION
### JIRA link
[TD-6106](https://hee-tis.atlassian.net/browse/TD-6106)

### Description
SelfAssessmentProcessAgreed set to null upon removal of candidate assessment

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6106]: https://hee-tis.atlassian.net/browse/TD-6106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ