### PR TITLE
TD-4624 Add regex validation of professional registration number field throughout the application

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Helpers/ProfessionalRegistrationNumberHelperTests.cs
@@ -107,8 +107,6 @@
 
         [TestCase(null, ErrorMessagesTestHelper.MissingNumberError)]
         [TestCase("", ErrorMessagesTestHelper.MissingNumberError)]
-        [TestCase("1234", ErrorMessagesTestHelper.LengthError)]
-        [TestCase("1234", ErrorMessagesTestHelper.LengthError)]
         [TestCase("01234_", ErrorMessagesTestHelper.InvalidFormatError)]
         [TestCase("01234 ", ErrorMessagesTestHelper.InvalidFormatError)]
         [TestCase("01234$", ErrorMessagesTestHelper.InvalidFormatError)]

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/ErrorMessagesTestHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/ErrorMessagesTestHelper.cs
@@ -5,14 +5,16 @@ namespace DigitalLearningSolutions.Web.Tests.TestHelpers
     {
         public const string InvalidFormatError =
             @"The format you entered isn’t recognised. Please check and try again.
-            Valid formats include
-            7 digits - example, 1234567
-            1-2 letters followed by 6 digits - example, AB123456
-            ‘P’ followed by 5-6 digits - example, P12345, P123456
-            ‘C’ or ‘P’ followed by 6 digits - example, C123456, P123456
-            Optional letter followed by 5-6 digits - example, A12345, B123456
-            ‘L’ followed by 4-6 digits - example, L1234, L123456
-            2 digits, hyphen, then 4-5 alphanumeric characters - example, 12-AB123";
+            <br>Valid formats include:
+            <ul>
+                <li>7 digits - example, 1234567</li>
+                <li>1–2 letters followed by 6 digits - example, AB123456</li>
+                <li>‘P’ followed by 5–6 digits - example, P12345, P123456</li>
+                <li>‘C’ or ‘P’ followed by 6 digits - example, C123456, P123456</li>
+                <li>Optional letter followed by 5–6 digits - example, A12345, B123456</li>
+                <li>‘L’ followed by 4–6 digits - example, L1234, L123456</li>
+                <li>2 digits, hyphen, then 4–5 alphanumeric characters - example, 12-AB123</li>
+            </ul>";
 
         public const string MissingNumberError = "Enter a professional registration number";
         public const string LengthError = "Professional registration number must be between 4 and 8 characters";

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/ErrorMessagesTestHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/ErrorMessagesTestHelper.cs
@@ -4,14 +4,18 @@ namespace DigitalLearningSolutions.Web.Tests.TestHelpers
     public static class ErrorMessagesTestHelper
     {
         public const string InvalidFormatError =
-           "Invalid professional registration number format. " +
-           "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
-           "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
-           "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
-           "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123).";
+            @"The format you entered isn’t recognised. Please check and try again.
+            Valid formats include
+            7 digits - example, 1234567
+            1-2 letters followed by 6 digits - example, AB123456
+            ‘P’ followed by 5-6 digits - example, P12345, P123456
+            ‘C’ or ‘P’ followed by 6 digits - example, C123456, P123456
+            Optional letter followed by 5-6 digits - example, A12345, B123456
+            ‘L’ followed by 4-6 digits - example, L1234, L123456
+            2 digits, hyphen, then 4-5 alphanumeric characters - example, 12-AB123";
 
         public const string MissingNumberError = "Enter a professional registration number";
-        public const string LengthError = "Professional registration number must be between 5 and 20 characters";
+        public const string LengthError = "Professional registration number must be between 4 and 8 characters";
 
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -1,6 +1,9 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
+    using DocumentFormat.OpenXml.Spreadsheet;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using MimeKit;
+    using System;
     using System.Text.RegularExpressions;
 
     public class ProfessionalRegistrationNumberHelper
@@ -39,28 +42,27 @@
                 modelState.AddModelError("ProfessionalRegistrationNumber", "Enter a professional registration number");
                 return;
             }
-
-            if (prn.Length < 5 || prn.Length > 20)
-            {
-                modelState.AddModelError(
-                    "ProfessionalRegistrationNumber",
-                    "Professional registration number must be between 5 and 20 characters"
-                );
-            }
-
-           const string pattern = @"^(\d{7}|[A-Za-z]{1,2}\d{6}|\d{4,8}|P?\d{5,6}|[C|P]\d{6}|[A-Za-z]?\d{5,6}|L\d{4,6}|\d{2}-[A-Za-z\d]{4,5})$";
+            const string pattern = @"^(\d{7}|[A-Za-z]{1,2}\d{6}|\d{4,8}|P?\d{5,6}|[C|P]\d{6}|[A-Za-z]?\d{5,6}|L\d{4,6}|\d{2}-[A-Za-z\d]{4,5})$";
             var rg = new Regex(pattern, RegexOptions.IgnoreCase);
             if (!rg.Match(prn).Success)
             {
                 modelState.AddModelError(
                     "ProfessionalRegistrationNumber",
-                   "Invalid professional registration number format. " +
-        "Valid formats include: 7 digits (e.g., 1234567), 1–2 letters followed by 6 digits (e.g., AB123456), " +
-        "4–8 digits, an optional 'P' plus 5–6 digits, 'C' or 'P' plus 6 digits, " +
-        "an optional letter plus 5–6 digits, 'L' plus 4–6 digits, " +
-        "or 2 digits followed by a hyphen and 4–5 alphanumeric characters (e.g., 12-AB123)."
+                 GetProfessionalRegistrationNumberErrorMessage()
                 );
             }
+        }
+        public static string GetProfessionalRegistrationNumberErrorMessage()
+        {
+            return @"The format you entered isn’t recognised. Please check and try again.
+            Valid formats include
+            7 digits - example, 1234567
+            1-2 letters followed by 6 digits - example, AB123456
+            ‘P’ followed by 5-6 digits - example, P12345, P123456
+            ‘C’ or ‘P’ followed by 6 digits - example, C123456, P123456
+            Optional letter followed by 5-6 digits - example, A12345, B123456
+            ‘L’ followed by 4-6 digits - example, L1234, L123456
+            2 digits, hyphen, then 4-5 alphanumeric characters - example, 12-AB123";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -2,6 +2,7 @@
 {
 
     using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using System.Text;
     using System.Text.RegularExpressions;
 
     public class ProfessionalRegistrationNumberHelper
@@ -53,14 +54,16 @@
         public static string GetProfessionalRegistrationNumberErrorMessage()
         {
             return @"The format you entered isn’t recognised. Please check and try again.
-            Valid formats include
-            7 digits - example, 1234567
-            1-2 letters followed by 6 digits - example, AB123456
-            ‘P’ followed by 5-6 digits - example, P12345, P123456
-            ‘C’ or ‘P’ followed by 6 digits - example, C123456, P123456
-            Optional letter followed by 5-6 digits - example, A12345, B123456
-            ‘L’ followed by 4-6 digits - example, L1234, L123456
-            2 digits, hyphen, then 4-5 alphanumeric characters - example, 12-AB123";
+            <br>Valid formats include:
+            <ul>
+                <li>7 digits - example, 1234567</li>
+                <li>1–2 letters followed by 6 digits - example, AB123456</li>
+                <li>‘P’ followed by 5–6 digits - example, P12345, P123456</li>
+                <li>‘C’ or ‘P’ followed by 6 digits - example, C123456, P123456</li>
+                <li>Optional letter followed by 5–6 digits - example, A12345, B123456</li>
+                <li>‘L’ followed by 4–6 digits - example, L1234, L123456</li>
+                <li>2 digits, hyphen, then 4–5 alphanumeric characters - example, 12-AB123</li>
+            </ul>";
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/ProfessionalRegistrationNumberHelper.cs
@@ -1,9 +1,7 @@
 ﻿namespace DigitalLearningSolutions.Web.Helpers
 {
-    using DocumentFormat.OpenXml.Spreadsheet;
+
     using Microsoft.AspNetCore.Mvc.ModelBinding;
-    using MimeKit;
-    using System;
     using System.Text.RegularExpressions;
 
     public class ProfessionalRegistrationNumberHelper

--- a/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
@@ -71,7 +71,7 @@
           Yes
         </label>
       </div>
-            <div class="nhsuk-radios__conditional @(optionYesSelected ? " " : " nhsuk-radios__conditional--hidden") @(professionalRegNumberErrorHasOccurred ? "form-group-wrapper--error" : "")"
+      <div class="nhsuk-radios__conditional"
            id="@professionalRegConditionalId">
                 @if (professionalRegistrationNumberError != null)
                 {

--- a/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_EditRegistrationNumber.cshtml
@@ -17,6 +17,11 @@
 
   var subject = Model.IsSelfRegistrationOrEdit ? "you" : "they";
   var capitalisedSubject = Model.IsSelfRegistrationOrEdit ? "You" : "They";
+    var professionalRegistrationNumberError = ViewData.ModelState["ProfessionalRegistrationNumber"]?.Errors.FirstOrDefault()?.ErrorMessage;
+    if (ViewData.ModelState.ContainsKey("ProfessionalRegistrationNumber"))
+    {
+        ViewData.ModelState["ProfessionalRegistrationNumber"].Errors.Clear();
+    }
 }
 
 <input type="hidden" asp-for="IsSelfRegistrationOrEdit" />
@@ -53,7 +58,7 @@
           No
         </label>
       </div>
-
+           
       <div class="nhsuk-radios__item">
         <input name="@nameof(Model.HasProfessionalRegistrationNumber)"
                class="nhsuk-radios__input"
@@ -66,9 +71,16 @@
           Yes
         </label>
       </div>
-      <div class="nhsuk-radios__conditional @(optionYesSelected ? " " : " nhsuk-radios__conditional--hidden") @(professionalRegNumberErrorHasOccurred ? "form-group-wrapper--error" : "" )"
+            <div class="nhsuk-radios__conditional @(optionYesSelected ? " " : " nhsuk-radios__conditional--hidden") @(professionalRegNumberErrorHasOccurred ? "form-group-wrapper--error" : "")"
            id="@professionalRegConditionalId">
-        <vc:text-input asp-for="@nameof(Model.ProfessionalRegistrationNumber)"
+                @if (professionalRegistrationNumberError != null)
+                {
+                    <span class="nhsuk-error-message" id="ProfessionalRegistrationNumber-error">
+                        <span class="nhsuk-u-visually-hidden">Error:</span>
+                        @Html.Raw(professionalRegistrationNumberError)
+                    </span>
+                }
+                      <vc:text-input asp-for="@nameof(Model.ProfessionalRegistrationNumber)"
                        label="Professional Registration Number"
                        populate-with-current-value="true"
                        type="text"

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EditDelegate/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/EditDelegate/Index.cshtml
@@ -15,7 +15,10 @@
   <div class="nhsuk-grid-column-full">
     @if (errorHasOccurred)
     {
-      <vc:error-summary order-of-property-names="@(new[] {
+            var professionalRegistrationNumberError = ViewData.ModelState["ProfessionalRegistrationNumber"]?.Errors.FirstOrDefault();
+            if (professionalRegistrationNumberError == null)
+            {
+                <vc:error-summary order-of-property-names="@(new[] {
                                                    nameof(Model.FirstName),
                                                    nameof(Model.LastName),
                                                    nameof(Model.CentreSpecificEmail),
@@ -28,6 +31,23 @@
                                                    nameof(Model.Answer4),
                                                    nameof(Model.Answer5),
                                                    nameof(Model.Answer6) })" />
+            }
+            if (professionalRegistrationNumberError != null)
+            {
+                <div class="nhsuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+                    <h2 class="nhsuk-error-summary__title" id="error-summary-title">
+                        There is a problem
+                    </h2>
+                    <div class="nhsuk-error-summary__body">
+                        <span class="nhsuk-error-message" id="ProfessionalRegistrationNumber-error">
+                            <span class="nhsuk-u-visually-hidden">Error:</span> <span class="nhsuk-error-message" id="ProfessionalRegistrationNumber-error">
+                                <span class="nhsuk-u-visually-hidden">Error:</span>
+                                @Html.Raw(professionalRegistrationNumberError.ErrorMessage)
+                            </span>
+                        </span>
+                    </div>
+                </div>
+            }
     }
 
     <h1 class="nhsuk-heading-xl">Edit delegate details</h1>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4624

### Description
I created a reusable helper method that returns a formatted error message for invalid professional registration numbers.
 I removed the explicit length check since the regex validation already covers it.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/c75af93a-7af1-4b57-b8ec-058fababe6fd" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/733a4e1a-942d-4fee-972d-703fd135e61c" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
