### PR TITLE
TD-6295 When creating a self assessment from a framework, the logged in admin user should become the owner of the self assessment not the framework owner

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -822,9 +822,7 @@
                     SET 
                     [Description] = COALESCE(F.[Description], 'No description provided'),
                     BrandID = F.BrandID,
-                    CategoryID = F.CategoryID,
-                    CreatedByCentreID = AU.CentreID,
-                    CreatedByAdminID = F.OwnerAdminID
+                    CategoryID = F.CategoryID
                     FROM SelfAssessments s
                     INNER JOIN Frameworks F ON F.ID = @frameworkId
                     INNER JOIN AdminUsers AU ON F.OwnerAdminID = AU.AdminID


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6295

### Description
I removed these two assignments from the SET clause to avoid overwriting the self-assessment’s creator details with the framework owner’s information, ensuring that the logged-in admin’s ID remains intact

### Screenshots


<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/5d3c21bf-3a19-4f9e-89c1-f51c7258c748" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/bceaf656-a205-438f-a417-d2ffe93c7c6e" />

<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/0493356d-8466-43b2-b87c-bb240d2db3b9" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
