### PR TITLE
TD-5361 Seperating the filter method of the leaner and supervisor

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -30,7 +30,7 @@ namespace DigitalLearningSolutions.Web.Helpers
             return filteredCompetencies;
         }
 
-        public static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
+        private static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
         {
             var appliedResponseStatusFilters = filters.Where(IsResponseStatusFilter).ToList();
 

--- a/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
@@ -17,7 +17,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                 var searchText = search.SearchText?.Trim() ?? string.Empty;
                 var filters = search.AppliedFilters?.Select(f => int.Parse(f.FilterValue)) ?? Enumerable.Empty<int>();
                 search.CompetencyFlags = competencyFlags.ToList();
-                CompetencyFilterHelper.ApplyResponseStatusFilters(ref filteredCompetencies, filters, searchText);
+                ApplyResponseStatusFilters(ref filteredCompetencies, filters, searchText);
                 UpdateRequirementsFilterDropdownOptionsVisibility(search, filteredCompetencies);
                 ApplyRequirementsFilters(ref filteredCompetencies, filters);
 
@@ -28,6 +28,39 @@ namespace DigitalLearningSolutions.Web.Helpers
             }
             return filteredCompetencies;
         }
+        private static void ApplyResponseStatusFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters, string searchText = "")
+        {
+            var appliedFilters = filters.Where(f => IsResponseStatusFilter(f)).ToList();
+            var wordsInSearchText = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            if (!appliedFilters.Any() && string.IsNullOrWhiteSpace(searchText))
+                return;
+
+            competencies = competencies.Where(c =>
+            {
+                // Search text match
+                bool searchTextMatches = !wordsInSearchText.Any() ||
+                    wordsInSearchText.All(w =>
+                        (c.CompetencyGroup?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false) ||
+                        (c.Description?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false) ||
+                        (c.Name?.Contains(w, StringComparison.CurrentCultureIgnoreCase) ?? false)
+                    );
+
+                // All filters must match (AND)
+                bool allFiltersMatch = appliedFilters.All(f =>
+                    (f == (int)SelfAssessmentCompetencyFilter.Verified && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff == true)) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.Optional && c.Optional) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.ConfirmationRejected && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true)) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.PendingConfirmation && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Verified == null && q.Requested != null && q.UserIsVerifier == false)) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.AwaitingConfirmation && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null && q.UserIsVerifier == true)) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment && c.AssessmentQuestions.Any(q => q.ResultId == null)) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.SelfAssessed && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
+                );
+
+                return searchTextMatches && allFiltersMatch;
+            }).ToList();
+        }
+
         private static void ApplyRequirementsFilters(ref IEnumerable<Competency> competencies, IEnumerable<int> filters)
         {
             var filteredCompetencies = competencies;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5361

### Description
I refactored the code to separate the filter logic for learners and supervisors.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/fa5c3604-239f-4969-aa8d-7a985bc0a90f" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/939d3f27-eecb-49a2-a80f-c8b936d26d68" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
