### PR TITLE
TD-6313-Sql queries have been modified to return sign-off value based on on the current status of the self-assessment.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -296,7 +296,12 @@
                 COALESCE(ucd.Email, u.PrimaryEmail) AS DelegateEmail,
                 da.Active AS IsDelegateActive,
                 sa.Name AS [Name],
-                MAX(casv.Verified) as SignedOff,
+                CASE 
+					WHEN MAX(sar.[DateTime]) >= MAX(casv.Verified) THEN NULL
+					ELSE (
+							MAX(casv.Verified)
+						)
+					END AS SignedOff,
 				sa.SupervisorSelfAssessmentReview,
 				sa.SupervisorResultsReview";
 
@@ -311,6 +316,8 @@
                 LEFT JOIN dbo.CandidateAssessmentSupervisors AS cas WITH (NOLOCK) ON ca.ID = cas.CandidateAssessmentID
                 LEFT JOIN dbo.CandidateAssessmentSupervisorVerifications AS casv WITH (NOLOCK) ON cas.ID = casv.CandidateAssessmentSupervisorID AND
                 (casv.Verified IS NOT NULL AND casv.SignedOff = 1)
+                LEFT JOIN SelfAssessmentResults AS sar ON ca.SelfAssessmentID = sar.SelfAssessmentID AND
+                        ca.DelegateUserID = sar.DelegateUserID
 
                 WHERE sa.ID = @selfAssessmentId 
                 AND da.CentreID = @centreID AND csa.CentreID = @centreID
@@ -349,7 +356,8 @@
 
             if (signedOff != null)
             {
-                groupBy += (bool)signedOff ? " HAVING MAX(casv.Verified) IS NOT NULL " : " HAVING MAX(casv.Verified) IS NULL ";
+                groupBy += (bool)signedOff ? " HAVING MAX(sar.[DateTime]) <  MAX(casv.Verified) AND MAX(casv.Verified) IS NOT NULL " :
+                        " HAVING MAX(sar.[DateTime]) >= MAX(casv.Verified) OR MAX(casv.Verified) IS NULL ";
             }
 
             string orderBy;

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -106,16 +106,33 @@
             ";
 
         private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate";
-        private const string signedOffFields = @"(SELECT TOP (1) casv.Verified
-FROM CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
-             CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
-WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
-ORDER BY casv.Requested DESC) AS SignedOffDate,
-(SELECT TOP(1) casv.SignedOff
-FROM   CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
-             CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
-WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
-ORDER BY casv.Requested DESC) AS SignedOff,";
+        private const string signedOffFields = @"(SELECT CASE 
+				WHEN MAX(sar.[DateTime]) >= MAX(casv.Verified) THEN NULL
+				ELSE MAX(casv.Verified)
+				END AS Verified
+			FROM CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
+					CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
+					CandidateAssessments AS ca1 ON cas.CandidateAssessmentID = ca1.ID LEFT JOIN
+					SelfAssessmentResults AS sar ON ca1.SelfAssessmentID = sar.SelfAssessmentID AND ca1.DelegateUserID = sar.DelegateUserID
+			WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
+			GROUP BY ca1.ID ) AS SignedOffDate,
+
+			(SELECT CASE 
+						WHEN MAX(sar.[DateTime]) >= MAX(casv.Verified) THEN NULL
+						ELSE (
+								SELECT TOP(1) casv.SignedOff
+								FROM   CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
+										CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
+								WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
+								ORDER BY casv.Verified DESC
+							)
+						END AS SignedOff
+			FROM CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
+					CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID INNER JOIN
+					CandidateAssessments AS ca1 ON cas.CandidateAssessmentID = ca1.ID LEFT JOIN
+					SelfAssessmentResults AS sar ON ca1.SelfAssessmentID = sar.SelfAssessmentID AND ca1.DelegateUserID = sar.DelegateUserID
+			WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
+			GROUP BY ca1.ID) AS SignedOff,";
 
         public SupervisorDataService(IDbConnection connection, ILogger<SupervisorDataService> logger)
         {
@@ -583,7 +600,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         public IEnumerable<DelegateSelfAssessment> GetSelfAssessmentsForSupervisorDelegateId(int supervisorDelegateId, int? adminIdCategoryId)
         {
             return connection.Query<DelegateSelfAssessment>(
-                @$"SELECT {delegateSelfAssessmentFields}, COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.CompetencyAssessment, sg.SubGroup, pg.ProfessionalGroup,CONVERT(BIT, IIF(cas.CandidateAssessmentID IS NULL, 0, 1)) AS IsAssignedToSupervisor,ca.DelegateUserID,
+                @$"SELECT {delegateSelfAssessmentFields}, COALESCE(ca.LastAccessed, ca.StartedDate) AS LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, r.RoleProfile, sg.SubGroup, pg.ProfessionalGroup,CONVERT(BIT, IIF(cas.CandidateAssessmentID IS NULL, 0, 1)) AS IsAssignedToSupervisor,ca.DelegateUserID,
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
@@ -785,7 +802,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                             (SELECT SubGroup
                              FROM    NRPSubGroups
                              WHERE (ID = rp.NRPSubGroupID)) AS NRPSubGroup,
-                             (SELECT CompetencyAssessment
+                             (SELECT RoleProfile
                              FROM    NRPRoles
                              WHERE (ID = rp.NRPRoleID)) AS NRPRole, 0 AS SelfAssessmentReviewID
                 FROM   SelfAssessments AS rp INNER JOIN
@@ -816,7 +833,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  (SELECT SubGroup
                  FROM    NRPSubGroups
                  WHERE (ID = rp.NRPSubGroupID)) AS NRPSubGroup,
-                 (SELECT CompetencyAssessment
+                 (SELECT RoleProfile
                  FROM    NRPRoles
                  WHERE (ID = rp.NRPRoleID)) AS NRPRole, 0 AS SelfAssessmentReviewID
                  FROM   SelfAssessments AS rp 
@@ -1147,7 +1164,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
         {
             return connection.Query<SelfAssessmentResultSummary>(
                 @"SELECT ca.ID, ca.SelfAssessmentID, sa.Name AS RoleName, sa.ReviewerCommentsLabel, COALESCE (sasr.SelfAssessmentReview, 1) AS SelfAssessmentReview, COALESCE (sasr.ResultsReview, 1) AS SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, 
-             ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, npg.ProfessionalGroup, nsg.SubGroup, nr.CompetencyAssessment, casv.ID AS CandidateAssessmentSupervisorVerificationId,
+             ca.LastAccessed, ca.CompleteByDate, ca.LaunchCount, ca.CompletedDate, npg.ProfessionalGroup, nsg.SubGroup, nr.RoleProfile, casv.ID AS CandidateAssessmentSupervisorVerificationId,
                  (SELECT COUNT(sas1.CompetencyID) AS CompetencyAssessmentQuestionCount
                  FROM    SelfAssessmentStructure AS sas1 INNER JOIN
                               CandidateAssessments AS ca1 ON sas1.SelfAssessmentID = ca1.SelfAssessmentID INNER JOIN

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -244,6 +244,7 @@
                         saDelegate.LastAccessed = DateHelper.GetLocalDateTime(saDelegate.LastAccessed);
                         saDelegate.SubmittedDate = DateHelper.GetLocalDateTime(saDelegate.SubmittedDate);
                         saDelegate.RemovedDate = DateHelper.GetLocalDateTime(saDelegate.RemovedDate);
+                        saDelegate.SignedOff = saDelegate.SignedOff is null ? null : DateHelper.GetLocalDateTime(saDelegate.SignedOff.Value);
                     }
                 }
 

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/SelfAssessmentOverview.cshtml
@@ -178,7 +178,8 @@
                          view-data="@(new ViewDataDictionary(ViewData) { { "IsSupervisorResultsReviewed", Model.SelfAssessment.IsSupervisorResultsReviewed } })" />
                 <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
                 <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
-                         view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) }})" />
+                         view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) },
+                                { "IsOngoingSelfAssessment", latestResult > latestSignoff }})" />
                 @if (Model.AllQuestionsVerifiedOrNotRequired)
                 {
                     @if (!Model.SupervisorSignOffs.Any())

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ReviewSelfAssessment.cshtml
@@ -177,10 +177,10 @@
                                     @if (!string.IsNullOrWhiteSpace(competency.Description) && !competency.AlwaysShowDescription)
                                     {
                                         <details class="nhsuk-details">
-                                            <summary class="nhsuk-details__summary"> 
-                                                    <span class="nhsuk-details__summary-text">
-                                                        @competency.Name
-                                                    </span>
+                                            <summary class="nhsuk-details__summary">
+                                                <span class="nhsuk-details__summary-text">
+                                                    @competency.Name
+                                                </span>
                                             </summary>
                                             <div class="nhsuk-details__text">
                                                 @(Html.Raw(@competency.Description))
@@ -225,7 +225,8 @@
 {
     <div class="nhsuk-u-margin-top-4">
         <h3>Self Assessment Sign-off Status</h3>
-        <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", true }})" />
+        <partial name="Shared/_SupervisorSignOffSummary" model="@Model.SupervisorSignOffs" view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", true },
+{ "IsOngoingSelfAssessment", !Model.DelegateSelfAssessment.SignedOff }})" />
     </div>
 }
 @if (Model.CompetencyGroups.Any())

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -5,13 +5,14 @@
 
 @if (Model.Any())
 {
+    var notValidated = Model.FirstOrDefault().Verified != null && Model.FirstOrDefault().SignedOff && (bool)ViewData["IsOngoingSelfAssessment"];
     <dl class="nhsuk-summary-list">
         <div class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">
                 @Model.FirstOrDefault().SupervisorRoleName
             </dt>
             <dd class="nhsuk-summary-list__value">
-                @Model.FirstOrDefault().SupervisorName (@Model.FirstOrDefault().SupervisorEmail)
+                @(notValidated ? "" : $"{Model.FirstOrDefault().SupervisorName} ({Model.FirstOrDefault().SupervisorEmail})")
                 @if (Model.FirstOrDefault().Removed != null)
                 {
                     <span class="nhsuk-tag nhsuk-tag--red">Removed @Model.FirstOrDefault().Removed.Value.ToShortDateString()</span>
@@ -34,6 +35,10 @@
                 {
                     <span class="nhsuk-tag">Requested @Model.FirstOrDefault().Requested.Value.ToShortDateString()</span>
                 }
+                else if (notValidated)
+                {
+                    <span class="nhsuk-tag nhsuk-tag--red">Not validated</span>
+                }
                 else if (Model.FirstOrDefault().SignedOff && Model.FirstOrDefault().Verified != null)
                 {
                     <span class="nhsuk-tag nhsuk-tag--green">Signed off @Model.FirstOrDefault().Verified.Value.ToShortDateString()</span>
@@ -44,7 +49,7 @@
                 }
             </dd>
             <dd class="nhsuk-summary-list__actions">
-                @if (Model.FirstOrDefault().Verified == null && Model.FirstOrDefault().Removed == null)
+                @if (!notValidated && Model.FirstOrDefault().Verified == null && Model.FirstOrDefault().Removed == null)
                 {
                     @if (Model.FirstOrDefault().EmailSent == null || Model.FirstOrDefault().EmailSent.Value.ToShortDateString() != ClockUtility.UtcNow.ToShortDateString())
                     {
@@ -54,7 +59,8 @@
                         }
                     }
 
-                    @if (Context.Request.Path.Value!.Contains("SelfAssessment")) {
+                    @if (Context.Request.Path.Value!.Contains("SelfAssessment"))
+                    {
                         <a asp-action="WithdrawSupervisorSignOffRequest" asp-route-selfAssessmentId=@ViewContext.RouteData.Values["selfAssessmentId"]
                            asp-route-candidateAssessmentSupervisorVerificationId="@Model.FirstOrDefault().ID" asp-route-vocabulary="Proficiencies" asp-route-source="SupervisorSignOffSummary">Withdraw</a>
                     }
@@ -66,7 +72,10 @@
                 Comments
             </dt>
             <dd class="nhsuk-summary-list__value">
-                @Model.FirstOrDefault().Comments
+                @if (!notValidated)
+                {
+                    @Model.FirstOrDefault().Comments
+                }
             </dd>
             @if ((Model.Count() - 1) > 0)
             {


### PR DESCRIPTION
### JIRA link
[TD-6313](https://hee-tis.atlassian.net/browse/TD-6313)

### Description
SQL queries have been modified to return sign-offs based on the current status of the self-assessment.
The relevant views are modified to display the 'Not validated' status of the self-assessment.

### Screenshots
<img width="985" height="847" alt="image" src="https://github.com/user-attachments/assets/2ff673a5-ffed-4f34-9518-94e32b708979" />

<img width="939" height="822" alt="image" src="https://github.com/user-attachments/assets/ff4d2ba9-051e-4e46-a786-925dee4c4dcd" />

<img width="722" height="749" alt="image" src="https://github.com/user-attachments/assets/26ae3565-ef1c-488b-a9b1-9842cbf16d17" />


-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6313]: https://hee-tis.atlassian.net/browse/TD-6313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ