### PR TITLE
TD-6145 Backend and logic changes to support configurable self assessment declaration display

### DIFF
--- a/DigitalLearningSolutions.Data.Migrations/202510221132_AddIncludeLearnerDeclarationPromptToSelfAssessmentsTable.cs
+++ b/DigitalLearningSolutions.Data.Migrations/202510221132_AddIncludeLearnerDeclarationPromptToSelfAssessmentsTable.cs
@@ -1,0 +1,18 @@
+﻿namespace DigitalLearningSolutions.Data.Migrations
+{
+    using FluentMigrator;
+
+    [Migration(202510221132)]
+    public  class AddIncludeLearnerDeclarationPromptToSelfAssessmentsTable : Migration
+    {
+        public override void Up()
+        {
+            Alter.Table("SelfAssessments").AddColumn("IncludeLearnerDeclarationPrompt").AsBoolean().WithDefaultValue(false);
+        }
+
+        public override void Down()
+        {
+            Delete.Column("IncludeLearnerDeclarationPrompt").FromTable("SelfAssessments");
+        }
+    }
+}

--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/CandidateAssessmentsDataService.cs
@@ -223,7 +223,8 @@
                         SA.ManageSupervisorsDescription,
                         CA.NonReportable,
 					 U.FirstName +' '+ U.LastName AS DelegateName,
-                    SA.MinimumOptionalCompetencies
+                    SA.MinimumOptionalCompetencies,
+					SA.IncludeLearnerDeclarationPrompt
                     FROM CandidateAssessments CA
                     JOIN SelfAssessments SA
                         ON CA.SelfAssessmentID = SA.ID
@@ -248,7 +249,7 @@
                         CA.LaunchCount, CA.SubmittedDate, SA.LinearNavigation, SA.UseDescriptionExpanders,
                         SA.ManageOptionalCompetenciesPrompt, SA.SupervisorSelfAssessmentReview, SA.SupervisorResultsReview,
                         SA.ReviewerCommentsLabel,SA.EnforceRoleRequirementsForSignOff, SA.ManageSupervisorsDescription,CA.NonReportable,
-                        U.FirstName , U.LastName,SA.MinimumOptionalCompetencies, CA.SelfAssessmentProcessAgreed",
+                        U.FirstName , U.LastName,SA.MinimumOptionalCompetencies, CA.SelfAssessmentProcessAgreed, SA.IncludeLearnerDeclarationPrompt",
                 new { delegateUserId, selfAssessmentId }
             );
         }

--- a/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/SelfAssessments/SelfAssessment.cs
@@ -17,6 +17,7 @@ namespace DigitalLearningSolutions.Data.Models.SelfAssessments
 
         public DateTime? EnrolmentCutoffDate { get; set; }
         public string? RetirementReason { get; set; }
+        public bool IncludeLearnerDeclarationPrompt { get; set; }
 
     }
 }

--- a/DigitalLearningSolutions.Web.Tests/TestHelpers/SelfAssessmentTestHelper.cs
+++ b/DigitalLearningSolutions.Web.Tests/TestHelpers/SelfAssessmentTestHelper.cs
@@ -27,7 +27,8 @@ namespace DigitalLearningSolutions.Web.Tests.TestHelpers
             bool useDescriptionExpanders = true,
             string vocabulary = "Capability",
             string verificationRoleName = "Supervisor",
-            string signOffRoleName = "Supervisor"
+            string signOffRoleName = "Supervisor",
+            bool includeLearnerDeclarationPrompt = true
         )
         {
             return new CurrentSelfAssessment
@@ -47,6 +48,7 @@ namespace DigitalLearningSolutions.Web.Tests.TestHelpers
                 Vocabulary = vocabulary,
                 VerificationRoleName = verificationRoleName,
                 SignOffRoleName = signOffRoleName,
+                IncludeLearnerDeclarationPrompt = includeLearnerDeclarationPrompt
             };
         }
 

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -67,8 +67,10 @@
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-
-            selfAssessmentService.IncrementLaunchCount(selfAssessmentId, delegateUserId);
+            if (selfAssessment.IncludeLearnerDeclarationPrompt)
+            {
+                selfAssessmentService.IncrementLaunchCount(selfAssessmentId, delegateUserId);
+            }
             selfAssessmentService.UpdateLastAccessed(selfAssessmentId, delegateUserId);
             var supervisors = selfAssessmentService.GetAllSupervisorsForSelfAssessmentId(
                 selfAssessmentId,

--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/SelfAssessment.cs
@@ -67,10 +67,7 @@
                 );
                 return RedirectToAction("StatusCode", "LearningSolutions", new { code = 403 });
             }
-            if (selfAssessment.IncludeLearnerDeclarationPrompt)
-            {
-                selfAssessmentService.IncrementLaunchCount(selfAssessmentId, delegateUserId);
-            }
+            selfAssessmentService.IncrementLaunchCount(selfAssessmentId, delegateUserId);
             selfAssessmentService.UpdateLastAccessed(selfAssessmentId, delegateUserId);
             var supervisors = selfAssessmentService.GetAllSupervisorsForSelfAssessmentId(
                 selfAssessmentId,
@@ -1906,3 +1903,4 @@
         }
     }
 }
+

--- a/DigitalLearningSolutions.Web/ServiceFilter/RequireProcessAgreementFilter .cs
+++ b/DigitalLearningSolutions.Web/ServiceFilter/RequireProcessAgreementFilter .cs
@@ -49,7 +49,7 @@
                     context.Result = new RedirectToActionResult("StatusCode", "LearningSolutions", new { code = 403 });
                     return;
                 }
-
+                if (!selfAssessment.IncludeLearnerDeclarationPrompt) return;
                 var actionName = context.RouteData.Values["action"]?.ToString();
                 if (actionName == "AgreeSelfAssessmentProcess" || actionName == "ProcessAgreed")
                 {


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-6145

### Description
I introduced a migration to add a new IncludeLearnerDeclarationPrompt bit field to the SelfAssessments table.
I added a check to ensure that when the IncludeLearnerDeclarationPrompt property is set to true, the IncrementLaunchCount method is executed.
I added the IncludeLearnerDeclarationPrompt property to the SelfAssessment class.
I also updated the GetSelfAssessmentForCandidateById method to include the IncludeLearnerDeclarationPrompt field.
Finally, I updated the RequireProcessAgreementFilter to check whether the SelfAssessment is configured to display the learner declaration agreement.
### Screenshots
When IncludeLearnerDeclarationPrompt  is false
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/9c97733a-0aed-45c0-9d50-f46f0d64348b" />
When IncludeLearnerDeclarationPrompt  is true
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/d195f2b0-e9ea-496e-8067-7fd44d734109" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
