### PR TITLE
TD-5308- Added maximum length to input control

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -23,7 +23,7 @@
 }
 
 <h1>Edit @Model.CompetencyAssessmentName provider and category</h1>
-<p>This will be visible to users when they browse assessments. It wiull help them to identify where the assessment is from and what it contains.</p>
+<p>This will be visible to users when they browse assessments. It will help them to identify where the assessment is from and what it contains.</p>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {
@@ -40,7 +40,7 @@
             <label class="nhsuk-label" for="brand-field">
                 New provider name
             </label>
-            <input type="text" id="brand-field" name="Brand" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Brand" />
+            <input type="text" id="brand-field" name="Brand" maxlength="50" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Brand" />
         </div>
     </nhs-form-group>
     <nhs-form-group nhs-validation-for="CategoryID">
@@ -54,7 +54,7 @@
             <label class="nhsuk-label" for="category-field">
                 New category name
             </label>
-            <input type="text" id="category-field" name="Category" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Category" />
+            <input type="text" id="category-field" name="Category" maxlength="100" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Category" />
         </div>
     </nhs-form-group>
     <nhs-form-group>


### PR DESCRIPTION
### JIRA link
[TD-5308](https://hee-tis.atlassian.net/browse/TD-5308)

### Description
Added maximum length to input control
Spelling error corrected.

Note: Browser back issue - I noticed that when we submit new brand (provider name) or category by selecting '* New provider *' or '* New category *' and if we click browser back, it shows following provider/category name instead of submitted provider or category.

<img width="1116" height="799" alt="image" src="https://github.com/user-attachments/assets/4ec061c3-2447-4c6c-bb18-f5d6d5313077" />

Tried to resolve browser back issue and noticed that we need JavaScript reload script. Please comment if we need to fix this.

 
### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5308]: https://hee-tis.atlassian.net/browse/TD-5308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ