### PR TITLE
TD-6392 Adding Course Name To Complete Notifications Email

### DIFF
--- a/DigitalLearningSolutions.Web/Services/NotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/NotificationService.cs
@@ -159,7 +159,11 @@
                     " Note: This message has been copied to the administrator(s) managing this activity, for their information.";
             }
 
-            const string emailSubjectLine = "Digital Learning Solutions Activity Complete";
+            string courseName = progressCompletionData.CourseName.Length > 30
+                                ? progressCompletionData.CourseName.Substring(0, 30)
+                                : progressCompletionData.CourseName;
+
+            string emailSubjectLine = $"Digital Learning Solutions Activity Complete - {courseName}";
             var delegateNameOrGenericTitle = progress.DelegateFirstName ?? "Digital Learning Solutions Delegate";
             var emailsToCc = GetEmailsToCc(
                 progressCompletionData.AdminId,


### PR DESCRIPTION
### JIRA link
[TD-6392](https://hee-tis.atlassian.net/browse/TD-6392)

### Description
Adding Course Name To Complete Notifications Email

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6392]: https://hee-tis.atlassian.net/browse/TD-6392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ