### PR TITLE
TD_2987_Code_Changes for Developing the Change Role Feature on the self assessment interface within the Supervisor module for the users.

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -38,6 +38,9 @@
         IEnumerable<SupervisorForEnrolDelegate> GetSupervisorForEnrolDelegate(int CentreID, int CategoryID);
         IEnumerable<SupervisorDelegateDetail> GetSupervisorDelegateDetailsForAdminIdWithoutRemovedClause(int adminId);
         SupervisorDelegateDetail GetSupervisorDelegateDetailsByIdWithoutRemoveClause(int supervisorDelegateId, int adminId, int delegateUserId);
+        List<int> GetCandidateAssessmentSupervisorVerifications(int supervisorDelegateId);
+        List<int> GetSelfAssessmentResultSupervisorVerifications(int supervisorDelegateId, int selfAssessmentId);
+
         //UPDATE DATA
         bool ConfirmSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId);
         bool RemoveSupervisorDelegateById(int supervisorDelegateId, int delegateUserId, int adminId);
@@ -105,7 +108,7 @@
             INNER JOIN Users AS au ON  aa.UserID = au.ID
             ";
 
-        private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate";
+        private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, sasr.AllowSupervisorRoleSelection";
         private const string signedOffFields = @"(SELECT TOP (1) casv.Verified
 FROM CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
              CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
@@ -116,6 +119,9 @@ FROM   CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
              CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
 WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
 ORDER BY casv.Requested DESC) AS SignedOff,";
+
+        private const string rolecount = @"(select COUNT(*) as RoleCount From SelfAssessmentSupervisorRoles AS sasr where sa.ID = sasr.SelfAssessmentID ) as RoleCount,";
+
 
         public SupervisorDataService(IDbConnection connection, ILogger<SupervisorDataService> logger)
         {
@@ -587,6 +593,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  (SELECT COUNT(*) AS Expr1
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
+                {rolecount}
                 {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
                  FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
@@ -1366,6 +1373,37 @@ WHERE (cas.CandidateAssessmentID = @candidateAssessmentId) AND (cas.SupervisorDe
                     INNER JOIN SupervisorDelegates AS SD ON SD.ID = CAS.SupervisorDelegateId
                     INNER JOIN AdminAccounts AS AA ON AA.ID = SD.SupervisorAdminID AND AA.UserID = SD.DelegateUserID
                         WHERE CA.ID = @candidateAssessmentId AND NonReportable = 0 ", new { candidateAssessmentId });
+        }
+
+        public List<int> GetSelfAssessmentResultSupervisorVerifications(int supervisorDelegateId, int selfAssessmentId)
+        {
+            var verificationIds = new List<int>();
+            verificationIds = connection.Query<int>(
+                $@"SELECT sarsv.ID FROM SelfAssessmentResultSupervisorVerifications as sarsv
+                    LEFT JOIN CandidateAssessmentSupervisors AS cas ON cas.ID = sarsv.CandidateAssessmentSupervisorID
+                    INNER JOIN SelfAssessmentResults AS srs ON sarsv.SelfAssessmentResultId = srs.ID
+                    INNER JOIN SelfAssessments AS sa ON srs.SelfAssessmentID = sa.ID
+                    WHERE cas.SupervisorDelegateId = @supervisorDelegateId
+                          AND cas.Removed IS NULL AND sarsv.Verified IS NULL
+                          AND sa.ID = @selfAssessmentId", new { supervisorDelegateId, selfAssessmentId }
+            ).ToList();
+
+            return verificationIds;
+        }
+
+        public List<int> GetCandidateAssessmentSupervisorVerifications(int supervisorDelegateId)
+        {
+            var verificationIds = new List<int>();
+            verificationIds = [.. connection.Query<int>(
+                $@"SELECT casv.ID  FROM CandidateAssessmentSupervisorVerifications as casv
+                    LEFT JOIN CandidateAssessmentSupervisors AS cas ON cas.ID = casv.CandidateAssessmentSupervisorID 
+					Inner JOIN CandidateAssessments AS ca ON ca.ID = cas.CandidateAssessmentID
+                    WHERE cas.SupervisorDelegateId = 445
+                    AND cas.Removed IS NULL AND casv.Verified IS NULL AND casv.SignedOff = 0
+                ", new { supervisorDelegateId}
+            )];
+
+            return verificationIds;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -1076,7 +1076,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                 );
 
             connection.Execute(
-                @"DELETE FROM cas
+                @"DELETE FROM casv
 	                FROM CandidateAssessmentSupervisors AS cas
                     INNER JOIN CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID
 				    LEFT JOIN CandidateAssessmentSupervisorVerifications AS casv ON cas.ID = casv.CandidateAssessmentSupervisorID

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -50,6 +50,9 @@
         bool RemoveCandidateAssessment(int candidateAssessmentId);
         void UpdateNotificationSent(int supervisorDelegateId);
         void UpdateCandidateAssessmentSupervisorVerificationById(int? candidateAssessmentSupervisorVerificationId, string? supervisorComments, bool signedOff);
+
+
+        bool UpdateCandidateAssessmentSupervisorRoleByIds(int candidateAssessmentId, int supervisorDelegateId, int selfAssessmentSupervisorRoleId);
         //INSERT DATA
         int AddSuperviseDelegate(int? supervisorAdminId, int? delegateUserId, string delegateEmail, string supervisorEmail, int centreId);
         int EnrolDelegateOnAssessment(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int? selfAssessmentSupervisorRoleId, int adminId, int centreId, bool isLoggedInUser);
@@ -108,7 +111,7 @@
             INNER JOIN Users AS au ON  aa.UserID = au.ID
             ";
 
-        private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, COALESCE (sasr.RoleName, 'Supervisor') AS SupervisorRoleTitle, ca.StartedDate, sasr.AllowSupervisorRoleSelection";
+        private const string delegateSelfAssessmentFields = "ca.ID, sa.ID AS SelfAssessmentID, sa.Name AS RoleName, sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, ca.StartedDate, sasr.AllowSupervisorRoleSelection";
         private const string signedOffFields = @"(SELECT TOP (1) casv.Verified
 FROM CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
              CandidateAssessmentSupervisors AS cas ON casv.CandidateAssessmentSupervisorID = cas.ID
@@ -120,7 +123,11 @@ FROM   CandidateAssessmentSupervisorVerifications AS casv INNER JOIN
 WHERE(cas.CandidateAssessmentID = ca.ID) AND(casv.Requested IS NOT NULL) AND(casv.Verified IS NOT NULL)
 ORDER BY casv.Requested DESC) AS SignedOff,";
 
-        private const string rolecount = @"(select COUNT(*) as RoleCount From SelfAssessmentSupervisorRoles AS sasr where sa.ID = sasr.SelfAssessmentID ) as RoleCount,";
+        // adding new property select subqueries to the existing delegateSelfAssessmentFields for the changeRole functionality
+        private const string rolecount = @"(SELECT COUNT(*) as RoleCount From SelfAssessmentSupervisorRoles AS sasr where sa.ID = sasr.SelfAssessmentID ) as RoleCount,";
+
+        // adding new property select subqueries to the existing delegateSelfAssessmentFields for the changeRole functionality
+        private const string supervisorRoleTitle = @"(SELECT SASR.RoleName FROM SelfAssessmentSupervisorRoles AS sasr Where sasr.id = cas.SelfAssessmentSupervisorRoleID),";
 
 
         public SupervisorDataService(IDbConnection connection, ILogger<SupervisorDataService> logger)
@@ -594,6 +601,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                  FROM    CandidateAssessmentSupervisorVerifications AS casv
                  WHERE (CandidateAssessmentSupervisorID = cas.ID) AND (Requested IS NOT NULL) AND (Verified IS NULL)) AS SignOffRequested,
                 {rolecount}
+                {supervisorRoleTitle}
                 {signedOffFields}
                  (SELECT COUNT(*) AS Expr1
                  FROM   SelfAssessmentResultSupervisorVerifications AS sarsv
@@ -1067,7 +1075,7 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
                           AND sa.ID = @selfAssessmentId", new { supervisorDelegateId, selfAssessmentId }
                 );
 
-            var deletedCandidateAssessmentSupervisors = connection.Execute(
+            connection.Execute(
                 @"DELETE FROM cas
 	                FROM CandidateAssessmentSupervisors AS cas
                     INNER JOIN CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID
@@ -1078,34 +1086,15 @@ ORDER BY casv.Requested DESC) AS SignedOff,";
 					    AND (casv.ID IS NULL)
 					    AND (sarsr.ID IS NULL)",
                 new { selfAssessmentId, supervisorDelegateId });
-            if (deletedCandidateAssessmentSupervisors < 1)
-            {
-                deletedCandidateAssessmentSupervisors = connection.Execute(
+
+            connection.Execute(
                     @"UPDATE cas SET Removed = getUTCDate()
                         FROM CandidateAssessmentSupervisors AS cas
 	                    INNER JOIN CandidateAssessments AS ca ON cas.CandidateAssessmentID = ca.ID
                         WHERE (ca.SelfAssessmentID = @selfAssessmentId) AND (cas.SupervisorDelegateId = @supervisorDelegateId)",
                     new { selfAssessmentId, supervisorDelegateId });
-            }
 
-            if (deletedCandidateAssessmentSupervisors >= 1)
-            {
-                connection.Execute(
-                    @"UPDATE SupervisorDelegates SET Removed = getUTCDate() 
-                    WHERE ID = @supervisorDelegateId AND NOT EXISTS(
-                        SELECT *
-                        FROM CandidateAssessmentSupervisors
-                        WHERE (SupervisorDelegateId = @supervisorDelegateId) AND (Removed IS NULL))",
-                    new { supervisorDelegateId });
-            }
 
-            if (deletedCandidateAssessmentSupervisors < 1)
-            {
-                logger.LogWarning(
-                    $"Not removing Candidate Assessment Supervisor as db update failed. selfAssessmentId: {selfAssessmentId}, supervisorDelegateId: {supervisorDelegateId}"
-                );
-                return false;
-            }
 
             return true;
         }
@@ -1404,6 +1393,25 @@ WHERE (cas.CandidateAssessmentID = @candidateAssessmentId) AND (cas.SupervisorDe
             )];
 
             return verificationIds;
+        }
+
+        public bool UpdateCandidateAssessmentSupervisorRoleByIds(int candidateAssessmentId, int supervisorDelegateId, int selfAssessmentSupervisorRoleId)
+        {
+            var numberOfAffectedRows = connection.Execute(
+                @"UPDATE CandidateAssessmentSupervisors 
+                    SET SelfAssessmentSupervisorRoleID = @selfAssessmentSupervisorRoleId
+                    WHERE CandidateAssessmentID = @candidateAssessmentId 
+                    AND SupervisorDelegateId = @supervisorDelegateId
+                    AND Removed IS NULL",
+                new { candidateAssessmentId, supervisorDelegateId, selfAssessmentSupervisorRoleId });
+            if (numberOfAffectedRows < 1)
+            {
+                logger.LogWarning(
+                    $"Not updating Candidate Assessment Supervisor Role as db update failed. candidateAssessmentId: {candidateAssessmentId}, supervisorDelegateId: {supervisorDelegateId}, selfAssessmentSupervisorRoleId: {selfAssessmentSupervisorRoleId}"
+                );
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/Supervisor/DelegateSelfAssessment.cs
@@ -29,5 +29,7 @@
         public bool IsAssignedToSupervisor { get; set; }
         public bool NonReportable { get; set; }
         public string? Vocabulary { get; set; }
+        public bool AllowSupervisorRoleSelection { get; set; }
+        public int RoleCount { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -333,6 +333,18 @@
                 SupervisorDelegateDetail = superviseDelegate,
                 DelegateSelfAssessments = delegateSelfAssessments
             };
+            foreach (var item in model.DelegateSelfAssessments)
+            {
+                if (item.SupervisorRoleTitle.ToUpper() == "EDUCATOR/MANAGER" || item.SupervisorRoleTitle.ToUpper() == "SUPERVISOR")
+                {
+                    item.SupervisorRoleTitle = "Supervising";
+                }
+
+                if (item.SupervisorRoleTitle.ToUpper() == "ASSESSOR" || item.SupervisorRoleTitle.ToUpper() == "NOMINATED SUPERVISOR")
+                {
+                    item.SupervisorRoleTitle = "Not Supervising";
+                }
+            }
             return View("DelegateProfileAssessments", model);
         }
 
@@ -1569,6 +1581,112 @@
             }
             return View("SelfAssessments/CompetencySelfAssessmentCertificate", model);
         }
+
+        public IActionResult ChangeRoleDelegateSelection(int selfAssessmentId, int supervisorDelegateId, int candidateAssessmentId, IDictionary<string, string> routeModelValues)
+        {
+
+            var supervisorRoles = supervisorService.GetSupervisorRolesForSelfAssessment(selfAssessmentId);
+            var roleOptions = new List<SelectOption<string>>();
+            if (supervisorRoles.Any())
+            {
+                foreach (var role in supervisorRoles)
+                {
+                    roleOptions.Add(new SelectOption<string> { Value = role.RoleName, Text = role.RoleName });
+                }
+
+                roleOptions.Add(new SelectOption<string>
+                {
+                    Value = "RemoveAsSupervisor",
+                    Text = "Remove me as a supervisor from this self assessment"
+                });
+            }
+
+            var model = new ChangeRoleSelectionViewModel()
+            {
+                DelegateFirstName = routeModelValues["firstName"],
+                DelegateLastName = routeModelValues["lastName"],
+                SelfAssessmentID = selfAssessmentId,
+                CandidateAssessmentID = candidateAssessmentId,
+                SupervisorDelegateID = supervisorDelegateId,
+                SupervisorRoleOptions = new OptionViewModel<string>()
+                {
+                    Options = roleOptions,
+                    GroupName = "ChangeRoleRadioButtons"
+                },
+            };
+            return View("ChangeRoleDelegateSelfAssessment", model);
+
+        }
+
+        public IActionResult ConfirmChangeRoleDelegateSelection(ChangeRoleSelectionViewModel model)
+        {
+            if (String.IsNullOrEmpty(model.SupervisorRoleOptions.SelectedValue))
+            {
+                ModelState.AddModelError("SupervisorRoleOptions", "You must select a Role");
+
+                var supervisorRoles = supervisorService.GetSupervisorRolesForSelfAssessment(model.SelfAssessmentID);
+                var roleOptions = new List<SelectOption<string>>();
+                if (supervisorRoles.Any())
+                {
+                    foreach (var role in supervisorRoles)
+                    {
+                        roleOptions.Add(new SelectOption<string> { Value = role.RoleName, Text = role.RoleName });
+                    }
+
+                    roleOptions.Add(new SelectOption<string>
+                    {
+                        Value = "RemoveAsSupervisor",
+                        Text = "Remove me as a supervisor from this self assessment"
+                    });
+                }
+                model.SupervisorRoleOptions = new OptionViewModel<string>()
+                {
+                    Options = roleOptions,
+                    GroupName = "ChangeRoleRadioButtons"
+                };
+
+                return View("ChangeRoleDelegateSelfAssessment", model);
+            }
+            if (model.SupervisorRoleOptions.SelectedValue == "RemoveAsSupervisor")
+            {
+                var removed = supervisorService.RemoveCandidateAssessmentSupervisor(model.CandidateAssessmentID, model.SupervisorDelegateID);
+            }
+            else
+            {
+                var supervisorRoles = supervisorService.GetSupervisorRolesForSelfAssessment(model.SelfAssessmentID);
+
+                var selectedRole = supervisorRoles.Where(x => x.RoleName == model.SupervisorRoleOptions.SelectedValue).FirstOrDefault();
+
+                if (selectedRole != null)
+                {
+                    if (!selectedRole.ResultsReview)
+                    {
+                        var selfAssessmentVerifications = supervisorService.GetSelfAssessmentResultSupervisorVerifications(model.SupervisorDelegateID, model.SelfAssessmentID);
+                        foreach (var verificationId in selfAssessmentVerifications)
+                        {
+                            supervisorService.RemoveSelfAssessmentResultSupervisorVerificationById(verificationId);
+                        }
+                    }
+
+                    if (!selectedRole.SelfAssessmentReview)
+                    {
+                        var supervisorVerifications = supervisorService.GetCandidateAssessmentSupervisorVerifications(model.SupervisorDelegateID);
+                        foreach (var verificationId in supervisorVerifications)
+                        {
+                            supervisorService.RemoveCandidateAssessmentSupervisorVerification(verificationId);
+                        }
+                    }
+                }
+
+
+            }
+
+            return RedirectToAction("DelegateProfileAssessments", new { supervisorDelegateId = model.SupervisorDelegateID });
+
+        }
+
+
+
         private static string RenderRazorViewToString(Controller controller, string viewName, object model = null)
         {
             controller.ViewData.Model = model;

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -333,16 +333,20 @@
                 SupervisorDelegateDetail = superviseDelegate,
                 DelegateSelfAssessments = delegateSelfAssessments
             };
+
+            // Dictionary to map SupervisorRoleTitle to new titles now or in the future
+            var roleMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase){
+                { "EDUCATOR/MANAGER", "Supervising" },
+                { "SUPERVISOR", "Supervising" },
+                { "ASSESSOR", "Not Supervising" },
+                { "NOMINATED SUPERVISOR", "Not Supervising" }
+            };
             foreach (var item in model.DelegateSelfAssessments)
             {
-                if (item.SupervisorRoleTitle.ToUpper() == "EDUCATOR/MANAGER" || item.SupervisorRoleTitle.ToUpper() == "SUPERVISOR")
-                {
-                    item.SupervisorRoleTitle = "Supervising";
-                }
 
-                if (item.SupervisorRoleTitle.ToUpper() == "ASSESSOR" || item.SupervisorRoleTitle.ToUpper() == "NOMINATED SUPERVISOR")
+                if (roleMappings.ContainsKey(item.SupervisorRoleTitle.ToUpper()))
                 {
-                    item.SupervisorRoleTitle = "Not Supervising";
+                    item.SupervisorRoleTitle = roleMappings[item.SupervisorRoleTitle.ToUpper()];
                 }
             }
             return View("DelegateProfileAssessments", model);
@@ -1649,7 +1653,7 @@
             }
             if (model.SupervisorRoleOptions.SelectedValue == "RemoveAsSupervisor")
             {
-                var removed = supervisorService.RemoveCandidateAssessmentSupervisor(model.CandidateAssessmentID, model.SupervisorDelegateID);
+                supervisorService.RemoveCandidateAssessmentSupervisor(model.SelfAssessmentID, model.SupervisorDelegateID);
             }
             else
             {
@@ -1659,8 +1663,12 @@
 
                 if (selectedRole != null)
                 {
+
+                    // update the candidate assessment supervisor tables with the role selected from the UI
+                    var affected = supervisorService.UpdateCandidateAssessmentSupervisorRoleByIds(model.CandidateAssessmentID, model.SupervisorDelegateID, selectedRole.ID);
                     if (!selectedRole.ResultsReview)
                     {
+                        //fetch the associated selfAssessmentResultSupervisorVerificationsIds and remove them as stated
                         var selfAssessmentVerifications = supervisorService.GetSelfAssessmentResultSupervisorVerifications(model.SupervisorDelegateID, model.SelfAssessmentID);
                         foreach (var verificationId in selfAssessmentVerifications)
                         {
@@ -1670,6 +1678,7 @@
 
                     if (!selectedRole.SelfAssessmentReview)
                     {
+                        //fetch the associated candidateAssessmentSupervisorVerificationsIds and remove them as stated
                         var supervisorVerifications = supervisorService.GetCandidateAssessmentSupervisorVerifications(model.SupervisorDelegateID);
                         foreach (var verificationId in supervisorVerifications)
                         {

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -343,11 +343,14 @@
             };
             foreach (var item in model.DelegateSelfAssessments)
             {
-
-                if (roleMappings.ContainsKey(item.SupervisorRoleTitle.ToUpper()))
+                if (item.SupervisorRoleTitle != null)
                 {
-                    item.SupervisorRoleTitle = roleMappings[item.SupervisorRoleTitle.ToUpper()];
+                    if (roleMappings.ContainsKey(item.SupervisorRoleTitle?.ToUpper()))
+                    {
+                        item.SupervisorRoleTitle = roleMappings[item.SupervisorRoleTitle.ToUpper()];
+                    }
                 }
+                
             }
             return View("DelegateProfileAssessments", model);
         }

--- a/DigitalLearningSolutions.Web/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Web/Services/SupervisorService.cs
@@ -36,6 +36,10 @@ namespace DigitalLearningSolutions.Web.Services
         IEnumerable<SupervisorDelegateDetail> GetSupervisorDelegateDetailsForAdminIdWithoutRemovedClause(int adminId);
         SupervisorDelegateDetail GetSupervisorDelegateDetailsByIdWithoutRemoveClause(int supervisorDelegateId, int adminId, int delegateUserId);
 
+        List<int> GetCandidateAssessmentSupervisorVerifications(int supervisorDelegateID);
+        List<int> GetSelfAssessmentResultSupervisorVerifications(int supervisorDelegateID, int selfAssessmentID);
+
+
         //UPDATE DATA
         bool ConfirmSupervisorDelegateById(int supervisorDelegateId, int candidateId, int adminId);
         bool RemoveSupervisorDelegateById(int supervisorDelegateId, int delegateUserId, int adminId);
@@ -276,6 +280,16 @@ namespace DigitalLearningSolutions.Web.Services
         public SupervisorDelegateDetail GetSupervisorDelegateDetailsByIdWithoutRemoveClause(int supervisorDelegateId, int adminId, int delegateUserId)
         {
             return supervisorDataService.GetSupervisorDelegateDetailsByIdWithoutRemoveClause(supervisorDelegateId, adminId, delegateUserId);
+        }
+
+        public List<int> GetCandidateAssessmentSupervisorVerifications(int supervisorDelegateId)
+        {
+            return supervisorDataService.GetCandidateAssessmentSupervisorVerifications(supervisorDelegateId);
+        }
+
+        public List<int> GetSelfAssessmentResultSupervisorVerifications(int supervisorDelegateId, int selfAssessmentId)
+        {
+            return supervisorDataService.GetSelfAssessmentResultSupervisorVerifications(supervisorDelegateId, selfAssessmentId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/Services/SupervisorService.cs
+++ b/DigitalLearningSolutions.Web/Services/SupervisorService.cs
@@ -49,6 +49,8 @@ namespace DigitalLearningSolutions.Web.Services
         bool RemoveCandidateAssessment(int candidateAssessmentId);
         void UpdateNotificationSent(int supervisorDelegateId);
         void UpdateCandidateAssessmentSupervisorVerificationById(int? candidateAssessmentSupervisorVerificationId, string? supervisorComments, bool signedOff);
+
+        bool UpdateCandidateAssessmentSupervisorRoleByIds(int candidateAssessmentSuperisorId, int supervisorDelegateId, int selfAssessmentSupervisorRoleId);
         //INSERT DATA
         int AddSuperviseDelegate(int? supervisorAdminId, int? delegateUserId, string delegateEmail, string supervisorEmail, int centreId);
         int EnrolDelegateOnAssessment(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int? selfAssessmentSupervisorRoleId, int adminId, int centreId, bool isLoggedInUser);
@@ -290,6 +292,11 @@ namespace DigitalLearningSolutions.Web.Services
         public List<int> GetSelfAssessmentResultSupervisorVerifications(int supervisorDelegateId, int selfAssessmentId)
         {
             return supervisorDataService.GetSelfAssessmentResultSupervisorVerifications(supervisorDelegateId, selfAssessmentId);
+        }
+
+        public bool UpdateCandidateAssessmentSupervisorRoleByIds(int candidateAssessmentSuperisorId, int supervisorDelegateId, int selfAssessmentSupervisorRoleId)
+        {
+            return supervisorDataService.UpdateCandidateAssessmentSupervisorRoleByIds(candidateAssessmentSuperisorId, supervisorDelegateId, selfAssessmentSupervisorRoleId);
         }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/Supervisor/ChangeRoleSelectionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Supervisor/ChangeRoleSelectionViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace DigitalLearningSolutions.Web.ViewModels.Supervisor
+{
+
+    public class ChangeRoleSelectionViewModel()
+    {
+        public string DelegateFirstName { get; set; }
+        public string DelegateLastName { get; set; }
+        public int CandidateAssessmentID { get; set; }
+        public int SupervisorDelegateID { get; set; }
+        public int SelfAssessmentID { get; set; }
+        public OptionViewModel<string> SupervisorRoleOptions { get; set; } = new();
+    }
+
+
+    public class OptionViewModel<T>
+    {
+        public string GroupName { get; set; } = "RoleOptions"; // Radio button group name
+        public List<SelectOption<T>> Options { get; set; } = new();
+        public T SelectedValue { get; set; } = default!;
+    }
+
+    public class SelectOption<T>
+    {
+        public T Value { get; set; } = default!;
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/Supervisor/ChangeRoleDelegateSelfAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/ChangeRoleDelegateSelfAssessment.cshtml
@@ -1,0 +1,66 @@
+﻿@using DigitalLearningSolutions.Data.Models.Supervisor;
+@using DigitalLearningSolutions.Data.Utilities
+@using DigitalLearningSolutions.Web.ViewModels.Supervisor
+@model ChangeRoleSelectionViewModel
+@inject IClockUtility ClockUtility
+@{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    ViewData["Title"] = "Change Role on Delegate SelfAssessment";
+    ViewData["Application"] = "Supervisor";
+    ViewData["HeaderPathName"] = "Supervisor";
+}
+
+<link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
+<link rel="stylesheet" href="@Url.Content("~/css/shared/searchableElements/searchableElements.css")" asp-append-version="true">
+@section NavMenuItems {
+    <partial name="Shared/_NavMenuItems" />
+}
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="Index">Supervisor</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Supervisor" asp-action="MyStaffList">My Staff</a></li>
+                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader"  asp-controller="Supervisor" asp-route-supervisorDelegateId="@Model.SupervisorDelegateID" asp-action="DelegateProfileAssessments">@Model.DelegateFirstName @Model.DelegateLastName</a></li>
+                <li class="nhsuk-breadcrumb__item">Change Role</li>
+            </ol>
+        </div>
+        <p class="nhsuk-breadcrumb__back">
+            <a class="nhsuk-breadcrumb__backlink" asp-controller="Supervisor" asp-action="MyStaffList">Back to My Staff</a>
+        </p>
+    </nav>
+}
+
+@if (errorHasOccurred)
+{
+    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SupervisorRoleOptions.Options) })" />
+}
+
+
+<h2>Change Supervisor Role</h2>
+
+<h3>Choose Role</h3>
+<form asp-action="ConfirmChangeRoleDelegateSelection" method="post">
+    @foreach (var opt in Model.SupervisorRoleOptions.Options)
+    {
+        <div class="nhsuk-radios__item">
+
+            <input class="nhsuk-radios__input" id="supervisor-role-@opt.Value" type="radio"
+                   asp-for="SupervisorRoleOptions.SelectedValue"
+                   value="@opt.Value" />
+            <label class="nhsuk-label nhsuk-radios__label" for="supervisor-role-@opt.Value">@opt.Text</label>
+        </div>
+    }
+
+    <br />
+    <button type="submit" class="nhsuk-button nhsuk-u-margin-top-5">Submit</button>
+
+    <input type="hidden" asp-for="CandidateAssessmentID" value="@Model.CandidateAssessmentID" />
+    <input type="hidden" asp-for="SupervisorDelegateID" value="@Model.SupervisorDelegateID" />
+    <input type="hidden" asp-for="SelfAssessmentID" value="@Model.SelfAssessmentID" />
+    <input type="hidden" asp-for="SupervisorRoleOptions.Options" value="@Model.SupervisorRoleOptions.Options" />
+    <input type="hidden" asp-for="DelegateFirstName" value="@Model.DelegateFirstName" />
+    <input type="hidden" asp-for="DelegateLastName" value="@Model.DelegateLastName" />
+</form>
+
+

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_DelegateProfileAssessmentGrid.cshtml
@@ -4,6 +4,16 @@
 @model DelegateSelfAssessmentsViewModel;
 @inject IClockUtility ClockUtility
 
+
+@{
+    var routeModelValues = new Dictionary<string, string>
+    {
+      { "firstName", Model.SupervisorDelegateDetail.FirstName},
+      { "lastName", Model.SupervisorDelegateDetail.LastName},
+    };
+}
+
+
 <table role="table" class="nhsuk-table-responsive">
     <caption class="nhsuk-table__caption"><h2>Self assessments</h2></caption>
     <thead role="rowgroup" class="nhsuk-table__head">
@@ -79,6 +89,11 @@
                             {
                                 <a asp-action="RemoveDelegateSelfAssessmentsupervisor" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Stop supervising</a>
 
+                            }
+                            @if (delegateSelfAssessment.AllowSupervisorRoleSelection == true && delegateSelfAssessment.RoleCount > 1)
+                            {
+
+                                <a asp-action="ChangeRoleDelegateSelection" asp-all-route-data="routeModelValues" asp-route-supervisorDelegateId="@ViewContext.RouteData.Values["supervisorDelegateId"]" asp-route-selfAssessmentId="@delegateSelfAssessment.SelfAssessmentID" asp-route-candidateAssessmentId="@delegateSelfAssessment.ID">Change Role</a>
                             }
                         }
                         else


### PR DESCRIPTION
### JIRA link
[TD-2987](https://hee-tis.atlassian.net/browse/TD-2987)

### Description
_Using this feature, user will be able to change their respective roles available for a specific self assessment, they would be able to choose whether they are 'Educator/Managers' or 'Assessors' or 'Remove Them As Supervisors from the Self Assessment'.

### Screenshots
<img width="2430" height="1458" alt="image" src="https://github.com/user-attachments/assets/e3c125d5-0ed0-4d8a-84cc-3f63af28ea72" />
<img width="2459" height="1467" alt="image" src="https://github.com/user-attachments/assets/b7ba54cf-fad0-43ae-87f8-d9324152bf41" />
<img width="2374" height="1362" alt="image" src="https://github.com/user-attachments/assets/7660d208-975b-4630-82ea-9f76e42f879a" />
<img width="1220" height="680" alt="image" src="https://github.com/user-attachments/assets/c5a9acf8-124e-4b4d-bd21-3e90b104ca43" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-2987]: https://hee-tis.atlassian.net/browse/TD-2987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ