### PR TITLE
TD-5307 Select competency framework source

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -119,7 +119,7 @@
                         SelfAssessmentFrameworks saf2
                         INNER JOIN Frameworks f ON f.ID = saf2.FrameworkId
                     WHERE 
-                        saf2.SelfAssessmentId = sa.ID
+                        saf2.SelfAssessmentId = sa.ID AND saf2.RemovedDate IS NULL
                     FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, ''
                 ) AS LinkedFrameworks,
                  (SELECT ProfessionalGroup

--- a/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessment.cs
+++ b/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessment.cs
@@ -18,13 +18,18 @@
         public string? Owner { get; set; }
         public DateTime? Archived { get; set; }
         public DateTime LastEdit { get; set; }
-        public string? LinkedFrameworks { get; set; }
+        public string LinkedFrameworks
+        {
+            get => linkedFrameworks ?? "None";
+            set => linkedFrameworks = value;
+        }
         public string? NRPProfessionalGroup { get; set; }
         public string? NRPSubGroup { get; set; }
         public string? NRPRole { get; set; }
         public int? CompetencyAssessmentReviewID { get; set; }
         private string? brand;
         private string? category;
+        private string? linkedFrameworks;
         private static string? GetValidOrNull(string? toValidate)
         {
             return toValidate != null && toValidate.ToLower() == "undefined" ? null : toValidate;

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -426,31 +426,40 @@
         {
             var adminId = GetAdminID();
             var competencyAssessmentId = model.CompetencyAssessmentId;
-            if (!ModelState.IsValid || (model.FrameworkId == 0 && model.ActionName == "AddFramework"))
+            if (!ModelState.IsValid)
             {
-                if (model.FrameworkId == 0 && model.ActionName == "AddFramework")
-                {
-                    ModelState.AddModelError(nameof(model.FrameworkId), "You must select the framework sources you wish to add to the competency assessment");
-                }
                 var frameworks = frameworkService.GetAllFrameworks(adminId);
                 var competencyAssessmentBase = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
+
                 if (competencyAssessmentBase == null)
                 {
-                    logger.LogWarning($"Failed to load Vocabulary page for competencyAssessmentId: {competencyAssessmentId} adminId: {adminId}");
+                    logger.LogWarning( $"Failed to load Vocabulary page for competencyAssessmentId: {competencyAssessmentId} adminId: {adminId}");
                     return StatusCode(500);
                 }
+
                 if (competencyAssessmentBase.UserRole < 2)
                 {
                     return StatusCode(403);
                 }
+
                 var primaryFrameworkId = competencyAssessmentService.GetPrimaryLinkedFrameworkId(competencyAssessmentId);
                 var additionalFrameworks = competencyAssessmentService.GetLinkedFrameworkIds(competencyAssessmentId);
-                var viewModel = new SelectFrameworkSourcesViewModel(competencyAssessmentBase, frameworks, additionalFrameworks, primaryFrameworkId, model.TaskStatus, model.ActionName);
+
+                var viewModel = new SelectFrameworkSourcesViewModel(
+                    competencyAssessmentBase,
+                    frameworks,
+                    additionalFrameworks,
+                    primaryFrameworkId,
+                    model.TaskStatus,
+                    model.ActionName
+                );
+
                 return View("SelectFrameworkSources", viewModel);
             }
+
             if (actionName == "AddFramework")
             {
-                competencyAssessmentService.InsertSelfAssessmentFramework(adminId, competencyAssessmentId, model.FrameworkId);
+                competencyAssessmentService.InsertSelfAssessmentFramework(adminId, competencyAssessmentId, model.FrameworkId.Value);
                 return RedirectToAction("SelectFrameworkSources", new { competencyAssessmentId, actionName = "Summary" });
             }
             else

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -426,9 +426,12 @@
         {
             var adminId = GetAdminID();
             var competencyAssessmentId = model.CompetencyAssessmentId;
-            if (!ModelState.IsValid)
+            if (!ModelState.IsValid || (model.FrameworkId == 0 && model.ActionName == "AddFramework"))
             {
-
+                if (model.FrameworkId == 0 && model.ActionName == "AddFramework")
+                {
+                    ModelState.AddModelError(nameof(model.FrameworkId), "You must select the framework sources you wish to add to the competency assessment");
+                }
                 var frameworks = frameworkService.GetAllFrameworks(adminId);
                 var competencyAssessmentBase = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
                 if (competencyAssessmentBase == null)

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectFrameworkSourcesFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectFrameworkSourcesFormData.cs
@@ -1,10 +1,11 @@
 ﻿namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 {
+    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     public class SelectFrameworkSourcesFormData
     {
         [Required(ErrorMessage = "Select a framework")]
-        public int FrameworkId { get; set; }
+        public int? FrameworkId { get; set; }
         public int CompetencyAssessmentId { get; set; }
         public bool? TaskStatus { get; set; }
         public string? ActionName { get; set; }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -1,6 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model SelectFrameworkSourcesViewModel;
 @{
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = "Select Framework Sources";
     ViewData["Application"] = "Framework Service";
 }
@@ -29,6 +30,15 @@
     }
 </style>
 
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new[] { nameof(Model.FrameworkId) })" />
+        }
+
+    </div>
+</div>
 <h1>Select framework sources for @Model.CompetencyAssessmentName</h1>
 <dl class="nhsuk-summary-list">
     @if (Model.PrimaryFramework != null)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-5307

### Description
I added a check to ensure that when a framework source is not selected, the user is notified
I also modified the SelfAssessmentFields query to remove framework sources that have already been removed from the competency assessment
### Screenshots
before removing the framework source
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/8c382ea9-5902-4952-b910-0b0abac36a68" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/45405ebf-2863-4670-ab92-602795fc52e3" />
when you click the add button without selecting any framework source
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/111cc731-d963-4564-a5f9-5521a075ab2f" />
After removing the framework  source
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b9019489-2293-4b93-8fb4-8ae4cfe793a5" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/6135147f-852c-4e12-a4ec-70a45eb3462f" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
