### PR TITLE
TD-6428 Date format mismatch and wrong heading

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/ConfirmRetirement.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/ConfirmRetirement.cshtml
@@ -20,9 +20,9 @@
     {
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
     }
-    <h1 id="page-heading">Confirm Retirement</h1>
+    <h1 id="page-heading">Confirm Enrolment</h1>
             <p class="nhsuk-body-m">You are about to enrol on a retiring <strong>@Model.Name</strong> self-assessment.</p>
-            <p class="nhsuk-body-m">     Retirement date:   <strong>@Model.RetirementDate?.ToString("dd MMMM yyyy")</strong>  </p>
+            <p class="nhsuk-body-m">     Retirement date:   <strong>@Model.RetirementDate?.ToString("dd/MM/yyyy")</strong>  </p>
             <p class="nhsuk-body-m">After this date, the <strong>@Model.Name</strong> self-assessment will no longer be accessible.</p>
 
             <p class="nhsuk-body-m">Please consider:</p>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6428

### Description
I Updated the date format and corrected the heading on the ConfirmRetirement.cshtml page.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/722005c8-ca92-474b-a964-2d92748ac20e" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
