### PR TITLE
TD-6442 Require self-assessment filter does not return the correct results when the results are cleared and filtered

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -54,7 +54,7 @@ namespace DigitalLearningSolutions.Web.Helpers
             // Define reusable filter checks
             var filterChecks = new Dictionary<SelfAssessmentCompetencyFilter, Func<Competency, bool>>
             {
-                [SelfAssessmentCompetencyFilter.RequiresSelfAssessment] = c => c.AssessmentQuestions.Any(q => q.ResultId == null),
+                [SelfAssessmentCompetencyFilter.RequiresSelfAssessment] = c => c.AssessmentQuestions.Any(q => q.ResultId == null || q.Result == 0),
                 [SelfAssessmentCompetencyFilter.SelfAssessed] = c => c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null),
                 [SelfAssessmentCompetencyFilter.ConfirmationRequested] = c => c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null),
                 [SelfAssessmentCompetencyFilter.ConfirmationRejected] = c => c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true),

--- a/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/CompetencyFilterHelper.cs
@@ -54,7 +54,7 @@ namespace DigitalLearningSolutions.Web.Helpers
             // Define reusable filter checks
             var filterChecks = new Dictionary<SelfAssessmentCompetencyFilter, Func<Competency, bool>>
             {
-                [SelfAssessmentCompetencyFilter.RequiresSelfAssessment] = c => c.AssessmentQuestions.Any(q => q.ResultId == null || q.Result == 0),
+                [SelfAssessmentCompetencyFilter.RequiresSelfAssessment] = c => c.AssessmentQuestions.Any(q => q.ResultId == null || q.Result == null),
                 [SelfAssessmentCompetencyFilter.SelfAssessed] = c => c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null),
                 [SelfAssessmentCompetencyFilter.ConfirmationRequested] = c => c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null),
                 [SelfAssessmentCompetencyFilter.ConfirmationRejected] = c => c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true),


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6442

### Description
Updated the RequiresSelfAssessment filter logic to include questions with a Result value of null in addition to those with a null ResultId, ensuring that competencies with unassessed or null results are correctly included in the filter

### Screenshots
before applying the filter
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/a8db3061-94fd-452d-955f-51676232ceb7" />
applying the filter before clearing the competency
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/a9811cea-da7d-4d8b-b37e-b3bf8cc21035" />
applying the filter after clearing the competency
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/8425a3c5-6f57-441b-9e97-634efda61c56" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
