### PR TITLE
TD-5308-Validation added to check for whitespaces while adding new brands and categories.

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/frameworks/branding.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/branding.ts
@@ -50,27 +50,34 @@ function topicChanged() {
   if (style === 'block') {
     tb.value = '';
     tb.required = true;
+    tb.setCustomValidity("");
     tb.focus();
   } else {
+    tb.value = "";
+    tb.setCustomValidity("");
     tb.required = false;
   }
 }
 const form = document.querySelector("form") as HTMLFormElement;
 const bfield = <HTMLInputElement>document.getElementById('brand-field');
 const cfield = <HTMLInputElement>document.getElementById('category-field');
+const tfield = <HTMLInputElement>document.getElementById('topic-field');
 function wireClearOnInput(input: HTMLInputElement) {
   input.addEventListener("input", () => {
     input.setCustomValidity("");
   });
 }
 
-wireClearOnInput(bfield);
-wireClearOnInput(cfield);
+if (bfield) wireClearOnInput(bfield);
+if (cfield) wireClearOnInput(cfield);
+if (tfield) wireClearOnInput(tfield);
+
 
 form.addEventListener("submit", (e: Event) => {
   const fields = [
     { el: bfield, msg: "Please enter a valid brand." },
-    { el: cfield, msg: "Please enter a valid category." }
+    { el: cfield, msg: "Please enter a valid category." },
+    { el: tfield, msg: "Please enter a valid topic." }
   ];
 
   for (const f of fields) {

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/branding.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/branding.ts
@@ -72,25 +72,19 @@ if (bfield) wireClearOnInput(bfield);
 if (cfield) wireClearOnInput(cfield);
 if (tfield) wireClearOnInput(tfield);
 
-
 form.addEventListener("submit", (e: Event) => {
-  const fields = [
+  [
     { el: bfield, msg: "Please enter a valid brand." },
     { el: cfield, msg: "Please enter a valid category." },
     { el: tfield, msg: "Please enter a valid topic." }
-  ];
-
-  for (const f of fields) {
-    if (f.el.required) {
-      if (!f.el.value.trim()) {
-        e.preventDefault();
-        f.el.setCustomValidity(f.msg);
-        f.el.reportValidity();
-        f.el.focus();
-        return;
-      } else {
-        f.el.setCustomValidity("");
-      }
+  ].forEach(f => {
+    if (f.el.required && !f.el.value.trim()) {
+      e.preventDefault();
+      f.el.setCustomValidity(f.msg);
+      f.el.reportValidity();
+      f.el.focus();
+    } else {
+      f.el.setCustomValidity("");
     }
-  }
+  });
 });

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/branding.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/branding.ts
@@ -10,8 +10,11 @@ function brandChanged() {
   if (style === 'block') {
     tb.value = '';
     tb.required = true;
+    tb.setCustomValidity("");
     tb.focus();
   } else {
+    tb.value = "";
+    tb.setCustomValidity("");
     tb.required = false;
   }
 }
@@ -27,8 +30,11 @@ function categoryChanged() {
   if (style === 'block') {
     tb.value = '';
     tb.required = true;
+    tb.setCustomValidity("");
     tb.focus();
   } else {
+    tb.value = "";
+    tb.setCustomValidity("");
     tb.required = false;
   }
 }
@@ -49,3 +55,35 @@ function topicChanged() {
     tb.required = false;
   }
 }
+const form = document.querySelector("form") as HTMLFormElement;
+const bfield = <HTMLInputElement>document.getElementById('brand-field');
+const cfield = <HTMLInputElement>document.getElementById('category-field');
+function wireClearOnInput(input: HTMLInputElement) {
+  input.addEventListener("input", () => {
+    input.setCustomValidity("");
+  });
+}
+
+wireClearOnInput(bfield);
+wireClearOnInput(cfield);
+
+form.addEventListener("submit", (e: Event) => {
+  const fields = [
+    { el: bfield, msg: "Please enter a valid brand." },
+    { el: cfield, msg: "Please enter a valid category." }
+  ];
+
+  for (const f of fields) {
+    if (f.el.required) {
+      if (!f.el.value.trim()) {
+        e.preventDefault();
+        f.el.setCustomValidity(f.msg);
+        f.el.reportValidity();
+        f.el.focus();
+        return;
+      } else {
+        f.el.setCustomValidity("");
+      }
+    }
+  }
+});


### PR DESCRIPTION
### JIRA link
[TD-5308](https://hee-tis.atlassian.net/browse/TD-5308)

### Description
branding.ts has been modified, validation added to check for whitespaces while adding new brands, categories and topics. 

### Screenshots
N/A

-----
### Developer checks

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-5308]: https://hee-tis.atlassian.net/browse/TD-5308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ