### PR TITLE
TD-6442 Requires self-assessment applied in Supervisor dashboard, it …

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/SupervisorCompetencyFilterHelper.cs
@@ -53,7 +53,7 @@ namespace DigitalLearningSolutions.Web.Helpers
                     (f == (int)SelfAssessmentCompetencyFilter.ConfirmationRejected && c.AssessmentQuestions.Any(q => q.Verified.HasValue && q.SignedOff != true)) ||
                     (f == (int)SelfAssessmentCompetencyFilter.PendingConfirmation && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Verified == null && q.Requested != null && q.UserIsVerifier == false)) ||
                     (f == (int)SelfAssessmentCompetencyFilter.AwaitingConfirmation && c.AssessmentQuestions.Any(q => q.Verified == null && q.Requested != null && q.UserIsVerifier == true)) ||
-                    (f == (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment && c.AssessmentQuestions.Any(q => q.ResultId == null)) ||
+                    (f == (int)SelfAssessmentCompetencyFilter.RequiresSelfAssessment && c.AssessmentQuestions.Any(q => q.ResultId == null || q.Result == null)) ||
                     (f == (int)SelfAssessmentCompetencyFilter.SelfAssessed && c.AssessmentQuestions.Any(q => q.ResultId != null && q.Requested == null && q.SignedOff == null))
                 );
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6442

### Description
I align the filtering logic for RequiresSelfAssessment so that it is identical on both the Learning Portal and the Supervisor page
### Screenshots
screenshot from learningportal
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/14f9466f-d821-464c-9c48-fa6fde344a98" />
screenshot from supervisor
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/1073fd38-1c62-4a59-a46a-13bc85442924" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
