### PR TITLE
TD-6596 Display both primary and centre emails addresses in tracking system

### DIFF
--- a/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
@@ -20,6 +20,8 @@
             FirstName = delegateEntity.UserAccount.FirstName;
             LastName = delegateEntity.UserAccount.LastName;
             EmailAddress = delegateEntity.UserCentreDetails?.Email ?? delegateEntity.UserAccount.PrimaryEmail;
+            CentreEmail = delegateEntity.UserCentreDetails?.Email;
+            PrimaryEmail = delegateEntity.UserAccount.PrimaryEmail;
             Password = delegateEntity.UserAccount.PasswordHash;
             CandidateNumber = delegateEntity.DelegateAccount.CandidateNumber;
             DateRegistered = delegateEntity.DelegateAccount.DateRegistered;
@@ -48,7 +50,8 @@
         public bool IsAdmin => AdminId.HasValue;
         public bool IsYetToBeClaimed => RegistrationConfirmationHash != null;
         public bool IsEmailVerified => EmailVerified != null;
-
+        public string? CentreEmail { get; set; }
+        public string? PrimaryEmail { get; set; }
         public RegistrationType RegistrationType => (SelfReg, ExternalReg) switch
         {
             (true, true) => RegistrationType.SelfRegisteredExternal,

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -1,6 +1,4 @@
-﻿using DigitalLearningSolutions.Data.Models.Centres;
-
-namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Shared
+﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Shared
 {
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -1,4 +1,6 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Shared
+﻿using DigitalLearningSolutions.Data.Models.Centres;
+
+namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Shared
 {
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Helpers;
@@ -29,7 +31,8 @@
             IsAdmin = delegateUser.IsAdmin;
             IsPasswordSet = delegateUser.IsPasswordSet;
             RegistrationType = delegateUser.RegistrationType;
-
+            CentreEmail = delegateUser.CentreEmail;
+            PrimaryEmail = delegateUser.PrimaryEmail;
             Email = delegateUser.EmailAddress;
             JobGroupId = delegateUser.JobGroupId;
             JobGroup = delegateUser.JobGroupName;
@@ -62,6 +65,8 @@
         public RegistrationType RegistrationType { get; set; }
 
         public string? Email { get; set; }
+        public string? CentreEmail { get; set; }
+        public string? PrimaryEmail { get; set; }
         public int JobGroupId { get; set; }
         public string? JobGroup { get; set; }
         public string? RegistrationDate { get; set; }

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/AllDelegates/_SearchableDelegateCard.cshtml
@@ -30,11 +30,16 @@
 
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
                     <dt class="nhsuk-summary-list__key ">
-                        Email
+                        Primary email
                     </dt>
-                    <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.Email, "email") />
+                    <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.PrimaryEmail, "email") />
                 </div>
-
+                <div class="nhsuk-summary-list__row details-list-with-button__row">
+                    <dt class="nhsuk-summary-list__key ">
+                        Centre email
+                    </dt>
+                    <partial name="_SearchableSummaryFieldValue" model=@(Model.DelegateInfo.CentreEmail, "email") />
+                </div>
                 <div class="nhsuk-summary-list__row details-list-with-button__row">
                     <dt class="nhsuk-summary-list__key">
                         ID


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6596

### Description
The email field has been replaced with the primary email and centre email on all delegate page.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b59b3d2b-117c-4ad4-9895-c3d491b0c7b0" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
