### PR TITLE
TD-6596 Fixing Centre email address value is blank in the tracking system delegate card 

### DIFF
--- a/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
@@ -20,7 +20,6 @@
             FirstName = delegateEntity.UserAccount.FirstName;
             LastName = delegateEntity.UserAccount.LastName;
             EmailAddress = delegateEntity.UserCentreDetails?.Email ?? delegateEntity.UserAccount.PrimaryEmail;
-            CentreEmail = delegateEntity.UserCentreDetails?.Email;
             PrimaryEmail = delegateEntity.UserAccount.PrimaryEmail;
             Password = delegateEntity.UserAccount.PasswordHash;
             CandidateNumber = delegateEntity.DelegateAccount.CandidateNumber;
@@ -50,7 +49,7 @@
         public bool IsAdmin => AdminId.HasValue;
         public bool IsYetToBeClaimed => RegistrationConfirmationHash != null;
         public bool IsEmailVerified => EmailVerified != null;
-        public string? CentreEmail { get; set; }
+        public string? Email { get; set; }
         public string? PrimaryEmail { get; set; }
         public RegistrationType RegistrationType => (SelfReg, ExternalReg) switch
         {

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateInfoViewModel.cs
@@ -29,7 +29,7 @@
             IsAdmin = delegateUser.IsAdmin;
             IsPasswordSet = delegateUser.IsPasswordSet;
             RegistrationType = delegateUser.RegistrationType;
-            CentreEmail = delegateUser.CentreEmail;
+            CentreEmail = delegateUser.Email;
             PrimaryEmail = delegateUser.PrimaryEmail;
             Email = delegateUser.EmailAddress;
             JobGroupId = delegateUser.JobGroupId;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6596

### Description
Replacing the CentreEmail field with Email so the correct email address is shown when a value exists

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/166a8848-51dd-487b-a8d1-68c9cae0e731" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/d902d1d7-9f2b-4c72-ba2d-9cf3ee8e6c0f" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b98dd9b7-018f-40e1-a6f6-307006103aa1" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
