### PR TITLE
TD-6763 Export doesnot include the Centre email address - Tracking sy…

### DIFF
--- a/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
+++ b/DigitalLearningSolutions.Data/Models/User/DelegateUserCard.cs
@@ -50,8 +50,8 @@
         public bool IsAdmin => AdminId.HasValue;
         public bool IsYetToBeClaimed => RegistrationConfirmationHash != null;
         public bool IsEmailVerified => EmailVerified != null;
-        public string? CentreEmail { get; set; }
         public string? Email { get; set; }
+        public string? CentreEmail { get; set; }
         public string? PrimaryEmail { get; set; }
         public RegistrationType RegistrationType => (SelfReg, ExternalReg) switch
         {

--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -35,8 +35,8 @@
         private const string LastName = "Last name";
         private const string FirstName = "First name";
         private const string DelegateId = "ID";
-        private const string PrimaryEmail = "PrimaryEmail";
         private const string CentreEmail = "CentreEmail";
+        private const string PrimaryEmail = "PrimaryEmail";
         private const string ProfessionalRegistrationNumber = "Professional Registration Number";
         private const string JobGroup = "Job group";
         private const string RegisteredDate = "Registered";
@@ -331,8 +331,8 @@
                     new DataColumn(LastName),
                     new DataColumn(FirstName),
                     new DataColumn(DelegateId),
-                    new DataColumn(PrimaryEmail),
                     new DataColumn(CentreEmail),
+                    new DataColumn(PrimaryEmail),
                     new DataColumn(ProfessionalRegistrationNumber),
                     new DataColumn(JobGroup),
                     new DataColumn(RegisteredDate),
@@ -371,8 +371,8 @@
             row[LastName] = delegateRecord.LastName;
             row[FirstName] = delegateRecord.FirstName;
             row[DelegateId] = delegateRecord.CandidateNumber;
-            row[PrimaryEmail] = delegateRecord.PrimaryEmail;
             row[CentreEmail] = delegateRecord.Email;
+            row[PrimaryEmail] = delegateRecord.PrimaryEmail;
             row[ProfessionalRegistrationNumber] = PrnHelper.GetPrnDisplayString(
                 delegateRecord.HasBeenPromptedForPrn,
                 delegateRecord.ProfessionalRegistrationNumber


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6763

### Description
The Centre Email Address and Primary Email Address fields have been added to the export report, allowing them to display in the Excel sheet when delegates are exported

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/c5a14be3-d714-4a85-b7ce-eecb158498e7" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
