### PR TITLE
TD-6789 rework framework dashboard

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Index.cshtml
@@ -21,7 +21,7 @@
     </nav>
 }
 <h1>Frameworks Dashboard</h1>
-<p class="nhsuk-body-m">Welcome <span class="nhsuk-u-font-weight-bold">@Model.Username</span>. You are accessing as a <span class="nhsuk-u-font-weight-bold">@(Model.IsFrameworkDeveloper ? "Framework Developer" : Model.IsFrameworkContributor ? "Framework Contributor" : "Framework Viewer")</span><feature name="@(FeatureFlags.WorkforceManagerInterface)"> and a <span class="nhsuk-u-font-weight-bold">@(Model.IsWorkforceManager ? "Workforce Manager" : Model.IsWorkforceContributor ? "Role Profile Contributor" : "Role Profile Viewer")</span></feature>.</p>
+<p class="nhsuk-body-m">Welcome <span class="nhsuk-u-font-weight-bold">@Model.Username</span>. You are accessing as a <span class="nhsuk-u-font-weight-bold">@(Model.IsFrameworkDeveloper ? "Framework Developer" : Model.IsFrameworkContributor ? "Framework Contributor" : "Framework Viewer")</span><feature name="@(FeatureFlags.WorkforceManagerInterface)"> and a <span class="nhsuk-u-font-weight-bold">@(Model.IsWorkforceManager | Model.IsFrameworkDeveloper ? "Self Assessment Developer" :  "Self Assessment Viewer")</span></feature>.</p>
 <h2>Your to do list</h2>
 @if (Model.DashboardToDoItems.Count() > 0)
 {
@@ -78,14 +78,14 @@ else
             <div class="nhsuk-card">
                 <div class="nhsuk-card__content">
                     <p class="nhsuk-heading-xl nhsuk-u-font-size-32 nhsuk-u-margin-bottom-3">
-                        @Model.DashboardData.CompetencyAssessmentCount Assessments
+                        @Model.DashboardData.CompetencyAssessmentCount Self Assessments
                     </p>
                     <ul class="nhsuk-contents-list__list">
-                        @if (Model.IsWorkforceManager | Model.IsWorkforceContributor)
+                        @if (Model.IsFrameworkDeveloper | Model.IsWorkforceManager | Model.IsWorkforceContributor)
                         {
-                            <li class="nhsuk-contents-list__item"><a asp-controller="CompetencyAssessments" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Manage My Competency Assessments (@Model.DashboardData.MyCompetencyAssessmentCount)</a></li>
+                            <li class="nhsuk-contents-list__item"><a asp-controller="CompetencyAssessments" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Manage My Self Assessments (@Model.DashboardData.MyCompetencyAssessmentCount)</a></li>
                         }
-                        <li class="nhsuk-contents-list__item"><a asp-controller="CompetencyAssessments" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="ViewCompetencyAssessments" asp-route-tabname="All">View All Competency Assessments</a></li>
+                        <li class="nhsuk-contents-list__item"><a asp-controller="CompetencyAssessments" class="nhsuk-contents-list__link nhsuk-link--no-visited-state" asp-action="ViewCompetencyAssessments" asp-route-tabname="All">View All Self Assessments</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
### JIRA link
[TD-6789](https://hee-tis.atlassian.net/browse/TD-6789)

### Description
Reworks the framework dashboard so that Framework developers are automatically granted self assessment developer permissions.

### Screenshots

<img width="1511" height="1211" alt="image" src="https://github.com/user-attachments/assets/78ad8a83-ee95-4617-861a-6028800f8d09" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6789]: https://hee-tis.atlassian.net/browse/TD-6789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ