### PR TITLE
TD-484-Passed competencyId param to DeleteCompetencyAssessmentQuestionRoleRequirement(+)

### DIFF
--- a/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
@@ -98,7 +98,7 @@ namespace DigitalLearningSolutions.Web.Services
         void RemoveCollaboratorFromCompetencyAssessment(int competencyAssessmentId, int id);
         CompetencyAssessmentCollaboratorNotification? GetCollaboratorNotification(int id, int invitedByAdminId);
         bool HasCompetencyWithSignpostedLearning(int competencyAssessmentId);
-       }
+    }
     public class CompetencyAssessmentService : ICompetencyAssessmentService
     {
         private readonly ICompetencyAssessmentDataService competencyAssessmentDataService;
@@ -486,9 +486,9 @@ namespace DigitalLearningSolutions.Web.Services
             int rowCount = 0;
             foreach (var responseRoleRequirement in responseRoleRequirements)
             {
-                competencyAssessmentDataService.DeleteCompetencyAssessmentQuestionRoleRequirement(assessmentId, null, assessmentQuestionId, responseRoleRequirement.Key);
-                if(responseRoleRequirement.Value != null)
-                { 
+                competencyAssessmentDataService.DeleteCompetencyAssessmentQuestionRoleRequirement(assessmentId, competencyId, assessmentQuestionId, responseRoleRequirement.Key);
+                if (responseRoleRequirement.Value != null)
+                {
                     rowCount += competencyAssessmentDataService.InsertCompetencyAssessmentQuestionRoleRequirement(assessmentId, competencyId, assessmentQuestionId, responseRoleRequirement.Key, responseRoleRequirement.Value);
                 }
             }


### PR DESCRIPTION
### JIRA link
[TD-484](https://hee-tis.atlassian.net/browse/TD-484)

### Description
The **competencyId** parameter has been passed to DeleteCompetencyAssessmentQuestionRoleRequirement(+) to ensure that only the matching records are deleted.

Issue 1 has been fixed.
Issue 2 : Not an issue, working as expected.
Issue 3 : I do not believe this is an issue. Addressing it would require creating a database field to retain the value, which does not seem appropriate.
@rshrirohit @kevwhitt-hee , I would appreciate your perspective on this.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-484]: https://hee-tis.atlassian.net/browse/TD-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ