### PR TITLE
TD-483-Added vocabulary to Remove Competency Group confirmation page.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/RemoveCompetencyGroupConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/RemoveCompetencyGroupConfirm.cshtml
@@ -30,10 +30,10 @@
         <form asp-action="DeleteCompetencyGroup" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId" asp-route-competencyGroupId="@Model.CompetencyGroupId">
             <div class="nhsuk-u-reading-width">
                 <h1 id="form-heading" class="nhsuk-fieldset__heading nhsuk-label--l">
-                    Remove Competency Group and @Model.CompetencyCount Competencies
+                    Remove @Model.VocabularySingular Group and @Model.CompetencyCount @(Model.CompetencyCount > 1 ? Model.VocabularyPlural : Model.VocabularySingular)
                 </h1>
                 <p>
-                    This action will remove the competency group and the @Model.CompetencyCount competencies it contains. Are you sure you wish to continue?
+                    This action will remove the @Model.VocabularySingular.ToLower() group and the @Model.CompetencyCount @(Model.CompetencyCount > 1 ? Model.VocabularyPlural.ToLower() : Model.VocabularySingular.ToLower()) it contains.
                 </p>
                 <p>
                     Are you sure that you wish to proceed?


### PR DESCRIPTION
### JIRA link
[TD-483](https://hee-tis.atlassian.net/browse/TD-483)

### Description
Added vocabulary to Remove Competency Group confirmation page.
Removed aditional text 'Are you sure you wish to continue?'

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-483]: https://hee-tis.atlassian.net/browse/TD-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ