### PR TITLE
TD-6788 Make Primary framework changes the status to Not yet started and Add framework button doesn't appear in the page

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -841,6 +841,7 @@
                 model.VocabularyStatus,
                  model.WorkingGroupStatus,
              model.AllframeworkCompetenciesStatus);
+            competencyAssessmentService.UpdateSelfAssessmentFromFramework(model.CompetencyAssessmentId, model.FrameworkId );
             return RedirectToAction("ManageCompetencyAssessment", new { model.CompetencyAssessmentId, model.FrameworkId });
         }
 

--- a/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
@@ -233,8 +233,7 @@ namespace DigitalLearningSolutions.Web.Services
 
         public bool RemoveSelfAssessmentFramework(int assessmentId, int frameworkId, int adminId)
         {
-            UpdateFrameworkLinksTaskStatus(assessmentId, false, true);
-            return competencyAssessmentDataService.RemoveSelfAssessmentFramework(assessmentId, frameworkId, adminId);
+           return competencyAssessmentDataService.RemoveSelfAssessmentFramework(assessmentId, frameworkId, adminId);
         }
 
         public int GetCompetencyCountByFrameworkId(int competencyAssessmentId, int frameworkId)

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/ConfirmMakePrimaryFrameworkViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/ConfirmMakePrimaryFrameworkViewModel.cs
@@ -15,6 +15,10 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
             FrameworkName = framework.FrameworkName;
             FrameworkId = framework.ID;
             Vocabulary = competencyAssessmentBase.Vocabulary;
+            DescriptionStatus = true;
+            ProviderandCategoryStatus = true;
+            VocabularyStatus = true;
+            WorkingGroupStatus = true;
         }
         public int CompetencyAssessmentId { get; set; }
         public int UserRole { get; set; }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
@@ -79,7 +79,7 @@
                                aria-describedby="AllframeworkCompetenciesStatus-item-hint"
                                type="checkbox" />
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="AllframeworkCompetenciesStatus">
-                            Working group
+                        All framework competencies
                         </label>
                         <div class="nhsuk-hint nhsuk-checkboxes__hint" id="AllframeworkCompetenciesStatus-item-hint">
                             All competencies in the framework will be copied.

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
@@ -27,8 +27,10 @@
                 </legend>
                 <div class="nhsuk-checkboxes">
                     <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" id="DescriptionStatus" name="DescriptionStatus" type="checkbox" aria-describedby="DescriptionStatus-hint" value="true">
-                        <label class="nhsuk-label nhsuk-checkboxes__label" for="DescriptionStatus">
+                        <input class="nhsuk-checkboxes__input"
+                               asp-for="DescriptionStatus"
+                               type="checkbox"/>
+                               <label class="nhsuk-label nhsuk-checkboxes__label" for="DescriptionStatus">
                             Description
                         </label>
                         <div class="nhsuk-hint nhsuk-checkboxes__hint" id="DescriptionStatus-item-hint">
@@ -38,7 +40,7 @@
                 </div>
                 <div class="nhsuk-checkboxes">
                     <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" id="ProviderandCategoryStatus" name="ProviderandCategoryStatus" type="checkbox" aria-describedby="ProviderandCategoryStatus-hint" value="true">
+                        <input class="nhsuk-checkboxes__input" asp-for="ProviderandCategoryStatus" type="checkbox" />
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="ProviderandCategoryStatus">
                             Provider and category
                         </label>
@@ -49,7 +51,7 @@
                 </div>
                 <div class="nhsuk-checkboxes">
                     <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" id="VocabularyStatus" name="VocabularyStatus" type="checkbox" aria-describedby="VocabularyStatus-hint" value="true">
+                        <input class="nhsuk-checkboxes__input" asp-for="VocabularyStatus" type="checkbox" />
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="DescriptionStatus">
                             Vocabulary
                         </label>
@@ -61,7 +63,7 @@
 
                 <div class="nhsuk-checkboxes">
                     <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" id="WorkingGroupStatus" name="WorkingGroupStatus" type="checkbox" aria-describedby="WorkingGroupStatus-hint" value="true">
+                        <input class="nhsuk-checkboxes__input" asp-for="WorkingGroupStatus" type="checkbox" />
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="WorkingGroupStatus">
                             Working group
                         </label>
@@ -73,7 +75,7 @@
 
                 <div class="nhsuk-checkboxes">
                     <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" id="AllframeworkCompetenciesStatus" name="AllframeworkCompetenciesStatus" type="checkbox" aria-describedby="AllframeworkCompetenciesStatus-hint" value="true">
+                        <input class="nhsuk-checkboxes__input" asp-for="AllframeworkCompetenciesStatus" type="checkbox" />
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="AllframeworkCompetenciesStatus">
                             All framework competencies
                         </label>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
@@ -25,73 +25,79 @@
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
                     Which features of the framework do you want to copy into this @Model.FrameworkName framework?
                 </legend>
-                <div class="nhsuk-checkboxes">
-                    <div class="nhsuk-checkboxes__item ">
+                <div class="nhsuk-checkboxes__item">
+                    <input class="nhsuk-checkboxes__input"
+                           asp-for="DescriptionStatus"
+                           aria-describedby="VocabularyStatus-item-hint"
+                           type="checkbox" />
+                    <label class="nhsuk-label nhsuk-checkboxes__label" for="DescriptionStatus">
+                        Description
+                    </label>
+                    <div class="nhsuk-hint nhsuk-checkboxes__hint" id="DescriptionStatus-item-hint">
+                        The framework description will be copied into the competency assessment description.
+                    </div>
+                </div>
+                <div class="nhsuk-checkboxes__item">
+                    <input class="nhsuk-checkboxes__input"
+                           asp-for="ProviderandCategoryStatus"
+                           aria-describedby="ProviderandCategoryStatus-item-hint"
+                           type="checkbox" />
+                    <label class="nhsuk-label nhsuk-checkboxes__label" for="ProviderandCategoryStatus">
+                        Provider and category
+                    </label>
+                    <div class="nhsuk-hint nhsuk-checkboxes__hint" id="ProviderandCategoryStatus-item-hint">
+                        The framework branding (provider and category) will be copied.
+                    </div>
+                </div>
+                <div class="nhsuk-checkboxes__item">
+                    <input class="nhsuk-checkboxes__input"
+                           asp-for="VocabularyStatus"
+                           aria-describedby="VocabularyStatus-item-hint"
+                           type="checkbox" />
+                    <label class="nhsuk-label nhsuk-checkboxes__label" for="VocabularyStatus">
+                        Vocabulary
+                    </label>
+                    <div class="nhsuk-hint nhsuk-checkboxes__hint" id="VocabularyStatus-item-hint">
+                        The framework vocabulary (such as proficiency, competency, or capability) will be copied.
+                    </div>
+                </div>
+                <div class="nhsuk-checkboxes__item">
+                    <input class="nhsuk-checkboxes__input"
+                           asp-for="WorkingGroupStatus"
+                           aria-describedby="WorkingGroupStatus-item-hint"
+                           type="checkbox" />
+                    <label class="nhsuk-label nhsuk-checkboxes__label" for="WorkingGroupStatus">
+                        Working group
+                    </label>
+                    <div class="nhsuk-hint nhsuk-checkboxes__hint" id="WorkingGroupStatus-item-hint">
+                        Contributors and reviewers from the framework will be copied.
+                    </div>
+                </div>
+                    <div class="nhsuk-checkboxes__item">
                         <input class="nhsuk-checkboxes__input"
-                               asp-for="DescriptionStatus"
-                               type="checkbox"/>
-                               <label class="nhsuk-label nhsuk-checkboxes__label" for="DescriptionStatus">
-                            Description
-                        </label>
-                        <div class="nhsuk-hint nhsuk-checkboxes__hint" id="DescriptionStatus-item-hint">
-                            The framework description will be copied into the competency assessment description.
-                        </div>
-                    </div>
-                </div>
-                <div class="nhsuk-checkboxes">
-                    <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" asp-for="ProviderandCategoryStatus" type="checkbox" />
-                        <label class="nhsuk-label nhsuk-checkboxes__label" for="ProviderandCategoryStatus">
-                            Provider and category
-                        </label>
-                        <div class="nhsuk-hint nhsuk-checkboxes__hint" id="ProviderandCategoryStatus-item-hint">
-                            The framework branding (provider and category) will be copied.
-                        </div>
-                    </div>
-                </div>
-                <div class="nhsuk-checkboxes">
-                    <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" asp-for="VocabularyStatus" type="checkbox" />
-                        <label class="nhsuk-label nhsuk-checkboxes__label" for="DescriptionStatus">
-                            Vocabulary
-                        </label>
-                        <div class="nhsuk-hint nhsuk-checkboxes__hint" id="VocabularyStatus-item-hint">
-                            The framework vocabulary (such as proficiency, competency, or capability) will be copied.
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nhsuk-checkboxes">
-                    <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" asp-for="WorkingGroupStatus" type="checkbox" />
-                        <label class="nhsuk-label nhsuk-checkboxes__label" for="WorkingGroupStatus">
-                            Working group
-                        </label>
-                        <div class="nhsuk-hint nhsuk-checkboxes__hint" id="WorkingGroupStatus-item-hint">
-                            Contributors and reviewers from the framework will be copied.
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nhsuk-checkboxes">
-                    <div class="nhsuk-checkboxes__item ">
-                        <input class="nhsuk-checkboxes__input" asp-for="AllframeworkCompetenciesStatus" type="checkbox" />
+                               asp-for="AllframeworkCompetenciesStatus"
+                               aria-describedby="AllframeworkCompetenciesStatus-item-hint"
+                               type="checkbox" />
                         <label class="nhsuk-label nhsuk-checkboxes__label" for="AllframeworkCompetenciesStatus">
-                            All framework competencies
+                            Working group
                         </label>
                         <div class="nhsuk-hint nhsuk-checkboxes__hint" id="AllframeworkCompetenciesStatus-item-hint">
                             All competencies in the framework will be copied.
                         </div>
                     </div>
-                </div>
             </fieldset>
             <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible" />
 
             <nhs-form-group>
                 <div class="nhsuk-checkboxes__item">
+                    <input class="nhsuk-checkboxes__input"
+                           id="Confirm"
+                           name="Confirm"
+                           type="checkbox"
+                           aria-describedby="Confirm-hint"
+                           value="true">
 
-                    <input class="nhsuk-checkboxes__input" id="Confirm" name="Confirm" type="checkbox" aria-describedby="Confirm-hint" value="true">
-                    <label class="nhsuk-label nhsuk-checkboxes__label" for="@Model.Confirm">
+                    <label class="nhsuk-label nhsuk-checkboxes__label" for="Confirm">
                         I am sure that I wish to make @Model.FrameworkName the primary framework
                     </label>
                 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6788

### Description
The Make primary framework feature properties are now set to true before the view is rendered, ensuring the checkboxes are selected by default.

I removed the method that was updating the framework source status and updated the view so the checkboxes are bound to the model by default.
### Screenshots

<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/11406ec9-483a-4ef7-bd2a-c0cfcb8152b8" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/0aad4e46-b184-4cdb-92d4-f6187b43b853" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/5411c42e-317e-4669-8b32-b9a94deb111d" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
