### PR TITLE
TD-484 improve enforce role requirements wording

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
@@ -30,7 +30,7 @@
                 <h2>Do you want to enforce role requirements for the @Model.CompetencyAssessmentName self assessment?</h2>
             </legend>
             <div id="enforce-role-requirements-hint" class="nhsuk-hint">
-                When requirements are set, they must be met by the learner before the self assessment can be signed off.
+                When role requirements are enforced, a learner can only request confirmation of self assessment results that are meeting the role requirements set for required competency assessment questions (even if none are set).
             </div>
             <span nhs-validation-for="EnforceRoleRequirementsForSignOff"></span>
             <div class="nhsuk-radios nhsuk-radios--inline">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
@@ -30,7 +30,7 @@
                 <h2>Do you want to enforce role requirements for the @Model.CompetencyAssessmentName self assessment?</h2>
             </legend>
             <div id="enforce-role-requirements-hint" class="nhsuk-hint">
-                When role requirements are enforced, a learner can only request confirmation of self assessment results that are meeting the role requirements set for required competency assessment questions (even if none are set).
+                When role requirements are enforced, learners can only request confirmation for self‑assessment results that meet the required competency criteria, even if no specific requirements are set.
             </div>
             <span nhs-validation-for="EnforceRoleRequirementsForSignOff"></span>
             <div class="nhsuk-radios nhsuk-radios--inline">


### PR DESCRIPTION
### JIRA link
[TD-484](https://hee-tis.atlassian.net/browse/TD-484)

### Description
Tweaks the wording of the enforce role requirements flag setting page to: When role requirements are enforced, a learner can only request confirmation of self assessment results that are meeting the role requirements set for required competency assessment questions (even if none are set).

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-484]: https://hee-tis.atlassian.net/browse/TD-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ