### PR TITLE
TD-6788 Make Primary framework changes the status to Not yet started …

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -842,6 +842,7 @@
                 model.VocabularyStatus,
                  model.WorkingGroupStatus,
              model.AllframeworkCompetenciesStatus);
+            competencyAssessmentService.UpdateSelfAssessmentFromFramework(model.CompetencyAssessmentId, model.FrameworkId);
             return RedirectToAction("ManageCompetencyAssessment", new { model.CompetencyAssessmentId, model.FrameworkId });
         }
 

--- a/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
@@ -243,7 +243,6 @@ namespace DigitalLearningSolutions.Web.Services
 
         public bool RemoveSelfAssessmentFramework(int assessmentId, int frameworkId, int adminId)
         {
-            UpdateFrameworkLinksTaskStatus(assessmentId, false, true);
             return competencyAssessmentDataService.RemoveSelfAssessmentFramework(assessmentId, frameworkId, adminId);
         }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6788

### Description
I removed the method that was updating the framework source status and updated the view so the checkboxes are bound to the model by default.
I added the UpdateSelfAssessmentFromFramework method to copy values from the primary framework.
### Screenshots

<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/11406ec9-483a-4ef7-bd2a-c0cfcb8152b8" />

<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/5411c42e-317e-4669-8b32-b9a94deb111d" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
