### PR TITLE
TD-6476 Changing job groups enrolling on completed courses resolved

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Services/GroupServiceTests/GroupsServiceEnrolDelegateTests.cs
@@ -111,7 +111,7 @@
         }
 
         [Test]
-        public void EnrolDelegateOnGroupCourses_adds_new_progress_record_when_existing_progress_record_is_completed()
+        public void EnrolDelegateOnGroupCourses_does_not_create_new_progress_record_when_existing_progress_record_is_completed()
         {
             // Given
             var existingProgressRecord = ProgressTestHelper.GetDefaultProgress(completed: testDate);
@@ -135,22 +135,25 @@
             using (new AssertionScope())
             {
                 DelegateProgressRecordMustNotHaveBeenUpdated();
-                A.CallTo(
-                    () => progressDataService.CreateNewDelegateProgress(
-                        reusableDelegateDetails.Id,
-                        reusableGroupCourse.CustomisationId,
-                        reusableGroupCourse.CurrentVersion,
-                        null,
-                        3,
-                        null,
-                        A<DateTime?>._,
-                        A<int>._,
-                        testDate
-                    )
-                ).MustHaveHappened();
-                A.CallTo(() => progressDataService.CreateNewAspProgress(GenericRelatedTutorialId, GenericNewProgressId))
-                    .MustHaveHappened();
+
+                A.CallTo(() => progressDataService.CreateNewDelegateProgress(
+                    A<int>._,
+                    A<int>._,
+                    A<int>._,
+                    A<DateTime?>._,
+                    A<int>._,
+                    A<int?>._,
+                    A<DateTime?>._,
+                    A<int>._,
+                    A<DateTime>._
+                )).MustNotHaveHappened();
+
+                A.CallTo(() => progressDataService.CreateNewAspProgress(
+                    A<int>._,
+                    A<int>._
+                )).MustNotHaveHappened();
             }
+
         }
 
         [Test]

--- a/DigitalLearningSolutions.Web/Services/GroupsService.cs
+++ b/DigitalLearningSolutions.Web/Services/GroupsService.cs
@@ -721,7 +721,11 @@
                 delegateUserId,
                 groupCourse.CustomisationId
             );
-
+            // If the delegate has already completed this course, do nothing
+            if (candidateProgressOnCourse.Any(p => p.Completed != null))
+            {
+                return;
+            }
             var existingRecordsToUpdate = candidateProgressOnCourse.Where(
                 p => ProgressShouldBeUpdatedOnEnrolment(p, isAddCourseToGroup)
             ).ToList();


### PR DESCRIPTION
### JIRA link
[TD-6476](https://hee-tis.atlassian.net/browse/TD-6476)

### Description
When changing groups, there was no validation to check whether the delegate had already completed the course.

If an existing progress record is found with a non-null Completed date, this indicates that the course has already been completed. In this scenario, the method now exits early instead of updating the existing progress record or creating a new one.

Previously, the logic fell through to the creation path and generated a new progress record. This resulted in the learner being re-enrolled on a course they had already completed.

This change prevents unintended re-enrolment for completed courses.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6476]: https://hee-tis.atlassian.net/browse/TD-6476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ