### PR TITLE
TD-6885-Task Status check added, Insert framework competencies service call added

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -857,44 +857,44 @@
         {
             var numberOfAffectedRows = connection.Execute(
                @"IF EXISTS (SELECT 1 FROM SelfAssessmentTaskStatus WHERE SelfAssessmentId = @id)
-               BEGIN
-               UPDATE SelfAssessmentTaskStatus
-                SET IntroductoryTextTaskStatus =
-                 CASE WHEN @descriptionStatus = 1 AND IntroductoryTextTaskStatus <> 1
-                 THEN 0 ELSE IntroductoryTextTaskStatus END,
-                 BrandingTaskStatus =
-                  CASE WHEN @providerandCategoryStatus = 1 AND BrandingTaskStatus <> 1
-                    THEN 0 ELSE BrandingTaskStatus END,
-                    VocabularyTaskStatus =
-                 CASE WHEN @vocabularyStatus = 1 AND VocabularyTaskStatus <> 1
-                  THEN 0 ELSE VocabularyTaskStatus END,
-                WorkingGroupTaskStatus =
-                 CASE WHEN @workingGroupStatus = 1 AND WorkingGroupTaskStatus <> 1
-                 THEN 0 ELSE WorkingGroupTaskStatus END,
-                 FrameworkLinksTaskStatus =
-                  CASE WHEN @AllframeworkCompetenciesStatus = 1 AND FrameworkLinksTaskStatus <> 1
-                  THEN 0 ELSE FrameworkLinksTaskStatus END,
-                 SelectCompetenciesTaskStatus =
-                  CASE WHEN @AllframeworkCompetenciesStatus = 1 AND SelectCompetenciesTaskStatus <> 1
-                  THEN 0 ELSE SelectCompetenciesTaskStatus END
-                 WHERE SelfAssessmentId = @id;
-                    END
-                     ELSE
                     BEGIN
-                 INSERT INTO SelfAssessmentTaskStatus
-                 (SelfAssessmentId, IntroductoryTextTaskStatus, BrandingTaskStatus, VocabularyTaskStatus, WorkingGroupTaskStatus,
-                FrameworkLinksTaskStatus,SelectCompetenciesTaskStatus)
-                 VALUES
-                 (
-                       @id,
-                    CASE WHEN @descriptionStatus = 1 THEN 0 ELSE NULL END,
-                    CASE WHEN @providerandCategoryStatus = 1 THEN 0 ELSE NULL END,
-                    CASE WHEN @vocabularyStatus = 1 THEN 0 ELSE NULL END,
-                    CASE WHEN @workingGroupStatus = 1 THEN 0 ELSE NULL END,
-                    CASE WHEN @AllframeworkCompetenciesStatus = 1 THEN 0 ELSE NULL END,
-                    CASE WHEN @AllframeworkCompetenciesStatus = 1 THEN 0 ELSE NULL END
+                        UPDATE SelfAssessmentTaskStatus
+                        SET IntroductoryTextTaskStatus =
+                            CASE WHEN @descriptionStatus = 1 AND (IntroductoryTextTaskStatus IS NULL OR IntroductoryTextTaskStatus <> 1)
+                            THEN 0 ELSE IntroductoryTextTaskStatus END,
+                        BrandingTaskStatus =
+                            CASE WHEN @providerandCategoryStatus = 1 AND (BrandingTaskStatus IS NULL OR BrandingTaskStatus <> 1)
+                            THEN 0 ELSE BrandingTaskStatus END,
+                        VocabularyTaskStatus =
+                            CASE WHEN @vocabularyStatus = 1 AND (VocabularyTaskStatus IS NULL OR VocabularyTaskStatus <> 1)
+                            THEN 0 ELSE VocabularyTaskStatus END,
+                        WorkingGroupTaskStatus =
+                            CASE WHEN @workingGroupStatus = 1 AND (WorkingGroupTaskStatus IS NULL OR WorkingGroupTaskStatus <> 1)
+                            THEN 0 ELSE WorkingGroupTaskStatus END,
+                        FrameworkLinksTaskStatus =
+                            CASE WHEN @AllframeworkCompetenciesStatus = 1 AND (FrameworkLinksTaskStatus IS NULL OR FrameworkLinksTaskStatus <> 1)
+                            THEN 0 ELSE FrameworkLinksTaskStatus END,
+                        SelectCompetenciesTaskStatus =
+                            CASE WHEN @AllframeworkCompetenciesStatus = 1 AND (SelectCompetenciesTaskStatus IS NULL OR SelectCompetenciesTaskStatus <> 1)
+                            THEN 0 ELSE SelectCompetenciesTaskStatus END
+                        WHERE SelfAssessmentId = @id;
+                    END
+                ELSE
+                    BEGIN
+                        INSERT INTO SelfAssessmentTaskStatus
+                            (SelfAssessmentId, IntroductoryTextTaskStatus, BrandingTaskStatus, VocabularyTaskStatus, WorkingGroupTaskStatus,
+                            FrameworkLinksTaskStatus,SelectCompetenciesTaskStatus)
+                        VALUES
+                        (
+                            @id,
+                            CASE WHEN @descriptionStatus = 1 THEN 0 ELSE NULL END,
+                            CASE WHEN @providerandCategoryStatus = 1 THEN 0 ELSE NULL END,
+                            CASE WHEN @vocabularyStatus = 1 THEN 0 ELSE NULL END,
+                            CASE WHEN @workingGroupStatus = 1 THEN 0 ELSE NULL END,
+                            CASE WHEN @AllframeworkCompetenciesStatus = 1 THEN 0 ELSE NULL END,
+                            CASE WHEN @AllframeworkCompetenciesStatus = 1 THEN 0 ELSE NULL END
                         );
-                        END",
+                    END",
                new { id, descriptionStatus, providerandCategoryStatus, vocabularyStatus, workingGroupStatus, AllframeworkCompetenciesStatus }
            );
             if (numberOfAffectedRows < 1)
@@ -961,7 +961,8 @@
                  FROM FrameworkCompetencies AS FC 
                 INNER JOIN FrameworkCompetencyGroups AS FCG ON FC.FrameworkCompetencyGroupID = FCG.ID INNER JOIN
 				SelfAssessments s ON s.id = @selfAssessmentId
-                WHERE FC.FrameworkID = @frameworkId"
+                WHERE FC.FrameworkID = @frameworkId
+                AND FC.CompetencyID NOT IN (SELECT CompetencyID FROM SelfAssessmentStructure WHERE SelfAssessmentID = @selfAssessmentId)"
         ,
             new { selfAssessmentId, frameworkId }
         );
@@ -985,7 +986,8 @@
             FROM FrameworkCompetencies AS fc               
             INNER JOIN SelfAssessments s ON s.id = @selfAssessmentId      
             WHERE fc.FrameworkID = @frameworkId            
-            AND fc.FrameworkCompetencyGroupID IS NULL "
+            AND fc.FrameworkCompetencyGroupID IS NULL
+            AND FC.CompetencyID NOT IN (SELECT CompetencyID FROM SelfAssessmentStructure WHERE SelfAssessmentID = @selfAssessmentId)"
         ,
             new { selfAssessmentId, frameworkId }
         );
@@ -1485,7 +1487,8 @@ ORDER BY
                     INNER JOIN AdminUsers au
                     ON fc.AdminID = au.AdminID
                     WHERE fc.FrameworkID = @frameworkId
-                    AND fc.IsDeleted = 0;",
+                    AND fc.IsDeleted = 0
+                    AND fc.AdminID NOT IN (SELECT AdminID FROM SelfAssessmentCollaborators WHERE SelfAssessmentID = @selfAssessmentId AND IsDeleted = 0);",
                 new { selfAssessmentId, frameworkId }
             );
         }

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -845,8 +845,17 @@
                 model.VocabularyStatus,
                  model.WorkingGroupStatus,
              model.AllframeworkCompetenciesStatus);
-            competencyAssessmentService.InsertIntoSelfAssessmentCollaboratorsFromFrameworkCollaborators(model.CompetencyAssessmentId, model.FrameworkId);
+
+            if (model.WorkingGroupStatus)
+                competencyAssessmentService.InsertIntoSelfAssessmentCollaboratorsFromFrameworkCollaborators(model.CompetencyAssessmentId, model.FrameworkId);
+
             competencyAssessmentService.UpdateSelfAssessmentFromFramework(model.CompetencyAssessmentId, model.FrameworkId);
+
+            if (model.AllframeworkCompetenciesStatus)
+            {
+                var insertSelfAssessmentGroupedCompetencies = competencyAssessmentService.InsertSelfAssessmentGroupedCompetencies(model.CompetencyAssessmentId, model.FrameworkId);
+                var insertSelfAssessmentUngroupedCompetencies = competencyAssessmentService.InsertSelfAssessmentUngroupedCompetencies(model.CompetencyAssessmentId, model.FrameworkId);
+            }
             return RedirectToAction("ManageCompetencyAssessment", new { model.CompetencyAssessmentId, model.FrameworkId });
         }
 
@@ -1462,7 +1471,7 @@
             TempData.Clear();
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = viewModel.CompetencyAssessmentId });
         }
-   [HttpGet]
+        [HttpGet]
         [Route("/CompetencyAssessments/{competencyAssessmentId}/SendForReview")]
         public IActionResult SendForReview(int competencyAssessmentId)
         {
@@ -1528,7 +1537,7 @@
                 return result;
             if (competencyAssessmentBase.PublishStatusID == 3) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             var taskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(publish.CompetencyAssessmentID, null);
-             competencyAssessmentService.UpdateCompetencyAssessmentReviewTaskStatus(publish.CompetencyAssessmentID, true);
+            competencyAssessmentService.UpdateCompetencyAssessmentReviewTaskStatus(publish.CompetencyAssessmentID, true);
             competencyAssessmentService.UpdateCompetencyAssessmentPublish(publish.CompetencyAssessmentID, 3, adminId, true, true);
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = publish.CompetencyAssessmentID });
         }
@@ -1602,7 +1611,7 @@
                 return result;
             if (competencyAssessmentBase.PublishStatusID == 3) return RedirectToAction("StatusCode", "LearningSolutions", new { code = 410 });
             var taskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(competencyAssessmentId, null);
-           competencyAssessmentService.UpdateCompetencyAssessmentReviewTaskStatus(competencyAssessmentId, true);
+            competencyAssessmentService.UpdateCompetencyAssessmentReviewTaskStatus(competencyAssessmentId, true);
             competencyAssessmentService.UpdateCompetencyAssessmentPublish(competencyAssessmentId, 3, adminId, true, true);
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = competencyAssessmentId });
         }


### PR DESCRIPTION
### JIRA link
[TD-6885](https://hee-tis.atlassian.net/browse/TD-6885)

### Description
Task Status check added - which helps to update  Description, Provider/category, Vocabulary and  Working groups.
Insert framework competencies service call added

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6885]: https://hee-tis.atlassian.net/browse/TD-6885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ