### PR TITLE
TD-6835 - Added reviewer role check to prevent editing of competency assessment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -209,6 +209,7 @@
             {
                 competencyAssessmentBase = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
             }
+            if (competencyAssessmentBase.UserRole < 2) actionName = "Summary";
             var professionalGroups = competencyAssessmentService.GetNRPProfessionalGroups();
             var subGroups = competencyAssessmentService.GetNRPSubGroups(competencyAssessmentBase.NRPProfessionalGroupID);
             var roles = competencyAssessmentService.GetNRPRoles(competencyAssessmentBase.NRPSubGroupID);
@@ -878,7 +879,8 @@
                 CompetencyAssessmentTaskStatus = taskStatus.WorkingGroupTaskStatus,
                 UserEmail = null,
                 Error = false,
-                ActionName = actionName
+                ActionName = actionName,
+                UserRole = competencyAssessmentBase.UserRole
             };
             if (TempData["CompetencyAssessmentError"] != null)
             {
@@ -955,6 +957,7 @@
             data.ReviewerCommentsLabelText = competencyAssessmentBase.ReviewerCommentsLabel?.Trim();
             data.IsSupervisionSwitchedOn = competencyAssessmentBase.SupervisorSelfAssessmentReview && competencyAssessmentBase.SupervisorResultsReview;
             data.IsSignpostedLearning = competencyAssessmentService.HasCompetencyWithSignpostedLearning(competencyAssessmentId);
+            data.UserRole = competencyAssessmentBase.UserRole;
 
             var taskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(competencyAssessmentId, null);
             data.SelfAssessmentOptionsTaskStatus = taskStatus.SelfAssessmentOptionsTaskStatus;
@@ -962,7 +965,7 @@
             SetOptionsLabelsData(data);
 
             var step = (int)OptionLabel.Declaration;
-            if (taskStatus.SelfAssessmentOptionsTaskStatus != null)
+            if (taskStatus.SelfAssessmentOptionsTaskStatus != null || competencyAssessmentBase.UserRole < 2)
                 step = (int)OptionLabel.Summary;
 
             ValidateStep(data, ref step);
@@ -979,6 +982,10 @@
             var result = ValidateCompetencyAssessmentAndRole(competencyAssessmentId, adminId, "competency assessment options");
             if (result.StatusCode != 200)
                 return result;
+
+            var competencyAssessmentBase = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
+            if (competencyAssessmentBase.UserRole < 2)
+                step = (int)OptionLabel.Summary;
 
             var data = GetOptionsLabelslData();
 
@@ -1223,12 +1230,13 @@
                             competencyAssessmentBase.SignOffSupervisorStatement,
                             competencyAssessmentBase.SignOffRequestorStatement,
                             this.config.GetLearnerDefaultText(),
-                            this.config.GetSupervisorDefaultText());
+                            this.config.GetSupervisorDefaultText(),
+                            competencyAssessmentBase.UserRole);
 
             SetManagesupervisionData(model);
 
             var competencyAssessmentTaskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(competencyAssessmentId, null);
-            if (competencyAssessmentTaskStatus.SupervisorRolesTaskStatus != null)
+            if (competencyAssessmentTaskStatus.SupervisorRolesTaskStatus != null || competencyAssessmentBase.UserRole < 2)
                 return RedirectToAction("ManageSupervisionSettings", "CompetencyAssessments",
                 new
                 {
@@ -1428,17 +1436,20 @@
             if (actionName == "SupervisorRoles")
             {
                 var model = new ManagesupervisionViewModel(competencyAssessmentId, baseData.CompetencyAssessmentName,
-               baseData.SupervisorResultsReview,
-               baseData.SupervisorSelfAssessmentReview,
-               baseData.SignOffSupervisorStatement,
-                baseData.SignOffRequestorStatement,
-                this.config.GetLearnerDefaultText(),
-                 this.config.GetSupervisorDefaultText());
+                                baseData.SupervisorResultsReview,
+                                baseData.SupervisorSelfAssessmentReview,
+                                baseData.SignOffSupervisorStatement,
+                                baseData.SignOffRequestorStatement,
+                                this.config.GetLearnerDefaultText(),
+                                this.config.GetSupervisorDefaultText(),
+                                baseData.UserRole);
+
                 model.TaskCompleteChecked = competencyAssessmentTaskStatus.SupervisorRolesTaskStatus;
                 SetManagesupervisionData(model);
                 return View(model);
             }
             var data = GetManagesupervisionData();
+            data.UserRole = baseData.UserRole;
             var dataModel = new ManagesupervisionViewModel(competencyAssessmentId, data, this.config.GetLearnerDefaultText(), this.config.GetSupervisorDefaultText());
             dataModel.TaskCompleteChecked = competencyAssessmentTaskStatus.SupervisorRolesTaskStatus;
             return View(dataModel);
@@ -1784,10 +1795,6 @@
                 {
                     logger.LogWarning($"Failed to load {pageName} page for competencyAssessmentId: {competencyAssessmentId} adminId: {adminId}");
                     return StatusCode(500);
-                }
-                if (competencyAssessmentBase.UserRole < 2)
-                {
-                    return StatusCode(403);
                 }
             }
             else

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/ManagesupervisionViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/ManagesupervisionViewModel.cs
@@ -34,14 +34,16 @@
             SupervisorDeclaration.DefaultText = supervisorDefaultText.Replace("{{CompetencyAssessmentName}}", CompetencyAssessmentName);
             LearnerDeclaration = model.LearnerDeclaration;
             LearnerDeclaration.DefaultText = learnerDefaultText.Replace("{{CompetencyAssessmentName}}", CompetencyAssessmentName);
+            UserRole = model.UserRole;
         }
         public ManagesupervisionViewModel(int competencyAssessmentId, string competencyAssessmentName,
-            bool supervisorResultsReview,
-            bool SupervisorSelfAssessmentReview,
-            string? signOffSupervisorStatement,
-            string? signOffRequestorStatement,
-            string learnerDefaultText,
-             string supervisorDefaultText)
+                bool supervisorResultsReview,
+                bool SupervisorSelfAssessmentReview,
+                string? signOffSupervisorStatement,
+                string? signOffRequestorStatement,
+                string learnerDefaultText,
+                string supervisorDefaultText,
+                int userRole)
         {
             CompetencyAssessmentId = competencyAssessmentId;
             CompetencyAssessmentName = competencyAssessmentName;
@@ -58,6 +60,7 @@
             LearnerDeclaration.DefaultText = learnerDefaultText.Replace("{{CompetencyAssessmentName}}", CompetencyAssessmentName);
             LearnerDeclaration.CompetencyAssessmentName = competencyAssessmentName;
             LearnerDeclaration.CompetencyAssessmentId = competencyAssessmentId;
+            UserRole = userRole;
         }
         public SupervisedSelfAssessmentSignoffViewModel Signoff { get; set; } = new SupervisedSelfAssessmentSignoffViewModel();
         public SupervisorSignoffDeclarationViewModel SupervisorDeclaration { get; set; } = new SupervisorSignoffDeclarationViewModel();
@@ -65,6 +68,7 @@
         public bool? TaskCompleteChecked { get; set; }
         public int CompetencyAssessmentId { get; set; }
         public string CompetencyAssessmentName { get; set; } = string.Empty;
+        public int UserRole { get; set; }
 
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/OptionsLabelsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/OptionsLabelsViewModel.cs
@@ -26,6 +26,7 @@
             SelfAssessmentOptionsTaskStatus = optionsLabels.SelfAssessmentOptionsTaskStatus;
             IsSupervisionSwitchedOn = optionsLabels.IsSupervisionSwitchedOn;
             IsSignpostedLearning = optionsLabels.IsSignpostedLearning;
+            UserRole = optionsLabels.UserRole;
         }
 
         public int FrameworkId { get; set; }
@@ -47,7 +48,8 @@
         public string? Vocabulary { get; set; }
         public bool? SelfAssessmentOptionsTaskStatus { get; set; }
         public bool Error { get; set; }
-        
+        public int UserRole { get; set; }
+
     }
     public enum OptionLabel
     {

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/WorkingGroupCollaboratorsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/WorkingGroupCollaboratorsViewModel.cs
@@ -12,6 +12,7 @@
         public string? UserEmail { get; set; }
         public bool Error { get; set; }
         public string? ActionName { get; set; }
+        public int UserRole { get; set; }
 
     }
 }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetenciesSelectFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetenciesSelectFramework.cshtml
@@ -50,5 +50,8 @@
         <span nhs-validation-for="FrameworkId"></span>
     </div>
     <input type="hidden" asp-for="@Model.ID" />
-    <button type="submit" class="nhsuk-button">Next</button>
+    @if (Model.UserRole > 1)
+    {
+        <button type="submit" class="nhsuk-button">Next</button>
+    }
 </form>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -43,6 +43,19 @@
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">Manage Competency Assessment</a></li>
                 @foreach (var item in steps)
                 {
+                    @if (Model.UserRole < 2)
+                    {
+
+                        @if (Model.CurrentStep == item.Step)
+                        {
+                            <li class="nhsuk-breadcrumb__item">
+                                @item.Text
+                            </li>
+                            break;
+                        }
+
+                        continue;
+                    }
                     <li class="nhsuk-breadcrumb__item">
                         @if (Model.CurrentStep == item.Step)
                         {
@@ -51,7 +64,7 @@
                         }
                         else
                         {
-                            <a class="abc" asp-action="OptionsLabels" asp-route-step="@item.Step">@item.Text</a>
+                            <a class="nhsuk-breadcrumb__link trigger-loader" asp-action="OptionsLabels" asp-route-step="@item.Step">@item.Text</a>
                         }
                     </li>
                 }
@@ -287,11 +300,14 @@
                             <dd class="nhsuk-summary-list__value">
                                 @(Model.IncludeLearnerDeclarationPrompt ? "Yes" : "No")
                             </dd>
-                            <dd class="nhsuk-summary-list__actions">
-                                <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.Declaration)">
-                                    Change
-                                </a>
-                            </dd>
+                            @if (Model.UserRole > 1)
+                            {
+                                <dd class="nhsuk-summary-list__actions">
+                                    <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.Declaration)">
+                                        Change
+                                    </a>
+                                </dd>
+                            }
                         </div>
                     }
                     @if (Model.IsSignpostedLearning)
@@ -303,11 +319,14 @@
                             <dd class="nhsuk-summary-list__value">
                                 @(Model.IncludesSignposting ? "Yes" : "No")
                             </dd>
-                            <dd class="nhsuk-summary-list__actions">
-                                <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.Signposting)">
-                                    Change
-                                </a>
-                            </dd>
+                            @if (Model.UserRole > 1)
+                            {
+                                <dd class="nhsuk-summary-list__actions">
+                                    <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.Signposting)">
+                                        Change
+                                    </a>
+                                </dd>
+                            }
                         </div>
                     }
                     <div class="nhsuk-summary-list__row">
@@ -317,11 +336,14 @@
                         <dd class="nhsuk-summary-list__value">
                             @(Model.LinearNavigation ? "Yes" : "No")
                         </dd>
-                        <dd class="nhsuk-summary-list__actions">
-                            <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.LinearNavigation)">
-                                Change
-                            </a>
-                        </dd>
+                        @if (Model.UserRole > 1)
+                        {
+                            <dd class="nhsuk-summary-list__actions">
+                                <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.LinearNavigation)">
+                                    Change
+                                </a>
+                            </dd>
+                        }
                     </div>
                     <div class="nhsuk-summary-list__row">
                         <dt class="nhsuk-summary-list__key">
@@ -330,11 +352,14 @@
                         <dd class="nhsuk-summary-list__value">
                             @(Model.UseDescriptionExpanders ? "Yes" : "No")
                         </dd>
-                        <dd class="nhsuk-summary-list__actions">
-                            <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.DescriptionExpanders)">
-                                Change
-                            </a>
-                        </dd>
+                        @if (Model.UserRole > 1)
+                        {
+                            <dd class="nhsuk-summary-list__actions">
+                                <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.DescriptionExpanders)">
+                                    Change
+                                </a>
+                            </dd>
+                        }
                     </div>
                     <div class="nhsuk-summary-list__row">
                         <dt class="nhsuk-summary-list__key">
@@ -343,11 +368,14 @@
                         <dd class="nhsuk-summary-list__value">
                             @(Model.QuestionLabel ? "Yes - " + Model.QuestionLabelText : "No")
                         </dd>
-                        <dd class="nhsuk-summary-list__actions">
-                            <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.QuestionLabels)">
-                                Change
-                            </a>
-                        </dd>
+                        @if (Model.UserRole > 1)
+                        {
+                            <dd class="nhsuk-summary-list__actions">
+                                <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.QuestionLabels)">
+                                    Change
+                                </a>
+                            </dd>
+                        }
                     </div>
                     @if (Model.IsSupervisionSwitchedOn)
                     {
@@ -358,11 +386,14 @@
                             <dd class="nhsuk-summary-list__value">
                                 @(Model.ReviewerCommentsLabel ? "Yes - " + Model.ReviewerCommentsLabelText : "No")
                             </dd>
-                            <dd class="nhsuk-summary-list__actions">
-                                <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.CommentsLabel)">
-                                    Change
-                                </a>
-                            </dd>
+                            @if (Model.UserRole > 1)
+                            {
+                                <dd class="nhsuk-summary-list__actions">
+                                    <a asp-action="OptionsLabels" asp-route-step="@((int)OptionLabel.CommentsLabel)">
+                                        Change
+                                    </a>
+                                </dd>
+                            }
                         </div>
                     }
                 </dl>
@@ -376,10 +407,12 @@
             Back
         </a>
     }
-    <button class="nhsuk-button" type="submit">
-        @(Model.CurrentStep == (int)OptionLabel.Summary ? "Submit" : Model.SelfAssessmentOptionsTaskStatus == null ? "Next" : "Save")
-    </button>
-
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            @(Model.CurrentStep == (int)OptionLabel.Summary ? "Submit" : Model.SelfAssessmentOptionsTaskStatus == null ? "Next" : "Save")
+        </button>
+    }
     <div class="nhsuk-back-link">
         @if (Model.SelfAssessmentOptionsTaskStatus == null)
         {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -39,7 +39,7 @@
                 <th role="columnheader" class="" scope="col">
                     Role
                 </th>
-                @if (Model.Collaborators.Count() > 1)
+                @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
                 {
                     <th role="columnheader" class="" scope="col">
                         Actions
@@ -63,7 +63,7 @@
                             <partial name="Shared/_RoleTag" model="collaborator" />
                         </span>
                     </td>
-                    @if (Model.Collaborators.Count() > 1)
+                    @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
                     {
                         <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
                             <span class="nhsuk-table-responsive__heading">Actions </span>
@@ -83,46 +83,62 @@
 </div>
 <input type="hidden" asp-for="ActionName" />
 <form method="post">
-    <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
-        <h2>Add a user to the working group</h2>
-    </label>
-    <div class="@(Model.Error? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
-        <div class=" sort-select-container">
-            <label class="nhsuk-label" for="UserEmail">
-                User email address
-            </label>
+    @if (Model.UserRole > 1)
+    {
+        <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
+            <h2>Add a user to the working group</h2>
+        </label>
+        <div class="@(Model.Error ? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
+            <div class=" sort-select-container">
+                <label class="nhsuk-label" for="UserEmail">
+                    User email address
+                </label>
 
-            <div class="nhsuk-hint" id="add-user-hint">
-                Provide the email address of a user with a registered DLS admin account to add as a Contributor (to help create your competency assessment) or Reviewer (to review your competency assessment and mark it as ready for publication).
+                <div class="nhsuk-hint" id="add-user-hint">
+                    Provide the email address of a user with a registered DLS admin account to add as a Contributor (to help create your competency assessment) or Reviewer (to review your competency assessment and mark it as ready for publication).
+                </div>
+                @if (Model.Error)
+                {
+                    <span class="nhsuk-error-message" id="no-admin-error">
+                        <span class="nhsuk-u-visually-hidden">Error:</span> @errMsg
+                    </span>
+                }
+                <input class="@(Model.Error ? "nhsuk-input nhsuk-input--error" : "nhsuk-input")" id="UserEmail" aria-describedby="add-user-hint" type="email" name="UserEmail" />
             </div>
-            @if (Model.Error)
-            {
-                <span class="nhsuk-error-message" id="no-admin-error">
-                    <span class="nhsuk-u-visually-hidden">Error:</span> @errMsg
-                </span>
-            }
-            <input class="@(Model.Error? "nhsuk-input nhsuk-input--error" : "nhsuk-input")" id="UserEmail" aria-describedby="add-user-hint" type="email" name="UserEmail" />
         </div>
-    </div>
-    <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="True" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
-        Add  as Contributor
-    </button>
-    <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="False" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
-        Add as Reviewer
-    </button>
+
+        <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="True" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
+            Add  as Contributor
+        </button>
+        <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="False" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
+            Add as Reviewer
+        </button>
+    }
     <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    <div class=" nhsuk-u-margin-top-6">
-        @if (Model.ActionName == "CollaboratorReview")
-        {
-            <a class="nhsuk-button" asp-action="SendForReview" asp-route-actionName="CollaboratorReview" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
-                Done
-            </a>
-        }
-        else
-        {
-            <button class="nhsuk-button" asp-route-actionName="Summary" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-taskStatus="@Model.CompetencyAssessmentTaskStatus">
-                Done
-            </button>
-        }
+
+    @if (Model.UserRole > 1)
+    {
+        <div class=" nhsuk-u-margin-top-6">
+            @if (Model.ActionName == "CollaboratorReview")
+            {
+                <a class="nhsuk-button" asp-action="SendForReview" asp-route-actionName="CollaboratorReview" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
+                    Done
+                </a>
+            }
+            else
+            {
+                <button class="nhsuk-button" asp-route-actionName="Summary" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-taskStatus="@Model.CompetencyAssessmentTaskStatus">
+                    Done
+                </button>
+            }
+        </div>
+    }
+    <div class="nhsuk-back-link">
+        <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
+        </a>
     </div>
 </form>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -65,9 +65,12 @@
     <input name="userRole" type="hidden" asp-for="UserRole" />
     <input name="Category" type="hidden" asp-for="Category" />
     <input name="Brand" type="hidden" asp-for="Brand" />
-    <button class="nhsuk-button" type="submit">
-        Save
-    </button>
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            Save
+        </button>
+    }
 </form>
 <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -43,9 +43,12 @@
     <input name="ID" type="hidden" asp-for="ID" />
     <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
     <input name="userRole" type="hidden" asp-for="UserRole" />
-    <button class="nhsuk-button" type="submit">
-        Save
-    </button>
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            Save
+        </button>
+    }
     <div class="nhsuk-back-link">
         <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
             <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
@@ -34,11 +34,14 @@
             <dd class="nhsuk-summary-list__value">
                 @Model.GroupName
             </dd>
-            <dd class="nhsuk-summary-list__actions">
-                <a asp-action="EditRoleProfileLinks" asp-route-actionName="EditGroup" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                    Change<span class="nhsuk-u-visually-hidden"> professional group link</span>
-                </a>
-            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a asp-action="EditRoleProfileLinks" asp-route-actionName="EditGroup" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                        Change<span class="nhsuk-u-visually-hidden"> professional group link</span>
+                    </a>
+                </dd>
+            }
         </div>
         @if (Model.ProfessionalGroupId != null && Model.ActionName != "EditSubGroup")
         {
@@ -49,11 +52,14 @@
                 <dd class="nhsuk-summary-list__value">
                     @Model.SubGroupName
                 </dd>
-                <dd class="nhsuk-summary-list__actions">
-                    <a asp-action="EditRoleProfileLinks" asp-route-actionName="EditSubGroup" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                        Change<span class="nhsuk-u-visually-hidden"> sub group link</span>
-                    </a>
-                </dd>
+                @if (Model.UserRole > 1)
+                {
+                    <dd class="nhsuk-summary-list__actions">
+                        <a asp-action="EditRoleProfileLinks" asp-route-actionName="EditSubGroup" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                            Change<span class="nhsuk-u-visually-hidden"> sub group link</span>
+                        </a>
+                    </dd>
+                }
             </div>
         }
         @if (Model.SubGroupId != null && Model.ActionName == "Summary")
@@ -65,11 +71,14 @@
                 <dd class="nhsuk-summary-list__value">
                     @Model.RoleName
                 </dd>
-                <dd class="nhsuk-summary-list__actions">
-                    <a asp-action="EditRoleProfileLinks" asp-route-actionName="EditRole" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                        Change<span class="nhsuk-u-visually-hidden"> role profile link</span>
-                    </a>
-                </dd>
+                @if (Model.UserRole > 1)
+                {
+                    <dd class="nhsuk-summary-list__actions">
+                        <a asp-action="EditRoleProfileLinks" asp-route-actionName="EditRole" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                            Change<span class="nhsuk-u-visually-hidden"> role profile link</span>
+                        </a>
+                    </dd>
+                }
             </div>
         }
     </dl>
@@ -244,9 +253,12 @@ else if (Model.ActionName == "Summary")
         <input type="hidden" asp-for="RoleName" />
         <input type="hidden" asp-for="SubGroupName" />
         <input type="hidden" asp-for="GroupName" />
-        <button class="nhsuk-button" type="submit">
-            Save
-        </button>
+        @if (Model.UserRole > 1)
+        {
+            <button class="nhsuk-button" type="submit">
+                Save
+            </button>
+        }
     </form>
 }
 <div class="nhsuk-back-link">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -84,9 +84,12 @@
     <input name="ID" type="hidden" asp-for="ID" />
     <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
     <input name="userRole" type="hidden" asp-for="UserRole" />
-    <button class="nhsuk-button" type="submit">
-        Save
-    </button>
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            Save
+        </button>
+    }
     <div class="nhsuk-back-link">
         <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
             <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
@@ -42,9 +42,12 @@
                 </dd>
             }
             <dd class="nhsuk-summary-list__actions">
-                <a asp-action="CompetencyAssessmentName" asp-route-actionName="Edit" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                    Change<span class="nhsuk-u-visually-hidden"> assessment name</span>
-                </a>
+                @if (Model.UserRole > 1)
+                {
+                    <a asp-action="CompetencyAssessmentName" asp-route-actionName="Edit" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                        Change<span class="nhsuk-u-visually-hidden"> assessment name</span>
+                    </a>
+                }
             </dd>
         </div>
         <div class="nhsuk-summary-list__row">
@@ -228,7 +231,7 @@
                 <partial name="Shared/_TaskStatusTag" model="@Model.CompetencyAssessmentTaskStatus.SelfAssessmentOptionsTaskStatus" />
             </div>
         </li>
-        @if (Model.PublishStatusID != 3)
+        @if (Model.PublishStatusID != 3 && Model.UserRole > 1)
         {
             <li class="nhsuk-task-list__item">
 

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
@@ -40,9 +40,12 @@
                 <text>No. Do not enforce role requirements.</text>
             }
         </dd>
-        <dd class="nhsuk-summary-list__actions">
-            <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditEnforceRoleRequirementsForSignOff">Change<span class="nhsuk-u-visually-hidden"> role requirements enforcement</span></a>
-        </dd>
+        @if (Model.UserRole > 1)
+        {
+            <dd class="nhsuk-summary-list__actions">
+                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditEnforceRoleRequirementsForSignOff">Change<span class="nhsuk-u-visually-hidden"> role requirements enforcement</span></a>
+            </dd>
+        }
     </div>
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
@@ -58,9 +61,12 @@
                 <text>No. Do not include filters.</text>
             }
         </dd>
-        <dd class="nhsuk-summary-list__actions">
-            <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditIncludeRequirementsFilters">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
-        </dd>
+        @if (Model.UserRole > 1)
+        {
+            <dd class="nhsuk-summary-list__actions">
+                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditIncludeRequirementsFilters">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
+            </dd>
+        }
     </div>
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
@@ -69,9 +75,12 @@
         <dd class="nhsuk-summary-list__value">
             @Model.CountCompetencyRequirements @Model.VocabularySingular.ToLower() assessment questions with role requirements set.
         </dd>
-        <dd class="nhsuk-summary-list__actions">
-            <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditCompetencyRoleRequirements">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
-        </dd>
+        @if (Model.UserRole > 1)
+        {
+            <dd class="nhsuk-summary-list__actions">
+                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditCompetencyRoleRequirements">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
+            </dd>
+        }
     </div>
 </dl>
 <form method="post" asp-action="ManageCompetencyRoleRequirements">
@@ -81,9 +90,12 @@
         <input type="hidden" asp-for="IncludeRequirementsFilters" />
         <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
     </nhs-form-group>
-    <button class="nhsuk-button" type="submit">
-        Save
-    </button>
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            Save
+        </button>
+    }
 </form>
 <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.Id">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -42,20 +42,23 @@
                     @(Model.CompetencyGroups.Count(g =>
                                     g.Any(c => c.GroupOptionalCompetencies)
                                     )) optional @Model.VocabularySingular.ToLower() groups
-                    <br />
+                                      <br />
                     @(Model.CompetencyGroups
                                     .Where(g => g.All(c => !c.GroupOptionalCompetencies))
                                     .Sum(g => g.Count())) individual optional @Model.VocabularyPlural.ToLower() from
                     @(Model.CompetencyGroups.Count(g =>
                                     g.All(c => !c.GroupOptionalCompetencies)
                                     )) groups
-                </text>
+            </text>
 
-            }
+                        }
         </dd>
-        <dd class="nhsuk-summary-list__actions">
-            <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SelectOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> optional @Model.VocabularyPlural.ToLower()</span></a>
-        </dd>
+        @if (Model.UserRole > 1)
+        {
+            <dd class="nhsuk-summary-list__actions">
+                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SelectOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> optional @Model.VocabularyPlural.ToLower()</span></a>
+            </dd>
+        }
     </div>
     @if (Model.SelectedCompetencyIds.Any())
     {
@@ -66,9 +69,12 @@
             <dd class="nhsuk-summary-list__value">
                 @(Model.MinimumOptionalCompetencies == null | Model.MinimumOptionalCompetencies == 0 ? "No minimum set" : Model.MinimumOptionalCompetencies.ToString())
             </dd>
-            <dd class="nhsuk-summary-list__actions">
-                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SetMinimumOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> minimum optional @Model.VocabularyPlural.ToLower()</span></a>
-            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SetMinimumOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> minimum optional @Model.VocabularyPlural.ToLower()</span></a>
+                </dd>
+            }
         </div>
         <div class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">
@@ -77,9 +83,12 @@
             <dd class="nhsuk-summary-list__value">
                 @Html.Raw(Model.ManageOptionalCompetenciesPrompt == null ? "No learner prompt specified" : Model.ManageOptionalCompetenciesPrompt.ToString())
             </dd>
-            <dd class="nhsuk-summary-list__actions">
-                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SetOptionalCompetencyLearnerPrompt">Change<span class="nhsuk-u-visually-hidden"> learner prompt</span></a>
-            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SetOptionalCompetencyLearnerPrompt">Change<span class="nhsuk-u-visually-hidden"> learner prompt</span></a>
+                </dd>
+            }
         </div>
     }
 </dl>
@@ -92,9 +101,12 @@
         <input type="hidden" asp-for="GroupIds" />
         <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
     </nhs-form-group>
-    <button class="nhsuk-button" type="submit">
-        Save
-    </button>
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            Save
+        </button>
+    }
 </form>
 <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
@@ -13,7 +13,10 @@
             <ol class="nhsuk-breadcrumb__list">
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Competency Assessments</a></li>
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId">Manage Competency Assessment</a></li>
-                <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="SupervisedSelfAssessmentSignoff" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId" asp-route-actionName="Signoff">Supervisor roles</a></li>
+                @if (Model.UserRole > 1)
+                {
+                    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="SupervisedSelfAssessmentSignoff" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId" asp-route-actionName="Signoff">Supervisor roles</a></li>
+                }
                 @if (@Model.Signoff.SignoffText == "Yes")
                 {
                     <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="SupervisorSignoffDeclaration" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId" asp-route-actionName="Supervisor">Supervisor sign off declaration</a></li>
@@ -47,15 +50,18 @@
                     <dd class="nhsuk-summary-list__value">
                         @Model.Signoff.SignoffText
                     </dd>
-                    <dd class="nhsuk-summary-list__actions">
-                        <ul class="nhsuk-summary-list__actions-list left-align-actions">
-                            <li class="nhsuk-summary-list__actions-list-item">
-                                <a asp-action="SupervisedSelfAssessmentSignoff" asp-route-actionName="Signoff" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                                    Change<span class="nhsuk-u-visually-hidden"> Supervisor signs off self assessment</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </dd>
+                    @if (Model.UserRole > 1)
+                    {
+                        <dd class="nhsuk-summary-list__actions">
+                            <ul class="nhsuk-summary-list__actions-list left-align-actions">
+                                <li class="nhsuk-summary-list__actions-list-item">
+                                    <a asp-action="SupervisedSelfAssessmentSignoff" asp-route-actionName="Signoff" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                                        Change<span class="nhsuk-u-visually-hidden"> Supervisor signs off self assessment</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </dd>
+                    }
                 </div>
                 @if (@Model.Signoff.SignoffText == "Yes")
                 {
@@ -80,16 +86,19 @@
                                 </details>
                             </div>
                         </dd>
-                        <dd class="nhsuk-summary-list__actions">
-                            <ul class="nhsuk-summary-list__actions-list left-align-actions">
-                                <li class="nhsuk-summary-list__actions-list-item">
-                                    <a asp-action="SupervisorSignoffDeclaration" asp-route-actionName="Supervisor" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                        @if (Model.UserRole > 1)
+                        {
+                            <dd class="nhsuk-summary-list__actions">
+                                <ul class="nhsuk-summary-list__actions-list left-align-actions">
+                                    <li class="nhsuk-summary-list__actions-list-item">
+                                        <a asp-action="SupervisorSignoffDeclaration" asp-route-actionName="Supervisor" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
 
-                                        Change<span class="nhsuk-u-visually-hidden"> Supervisor sign off statement</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </dd>
+                                            Change<span class="nhsuk-u-visually-hidden"> Supervisor sign off statement</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </dd>
+                        }
                     </div>
                     <div class="nhsuk-summary-list__row">
                         <dt class="nhsuk-summary-list__key">
@@ -113,16 +122,19 @@
                                 </details>
                             </div>
                         </dd>
-                        <dd class="nhsuk-summary-list__actions">
-                            <ul class="nhsuk-summary-list__actions-list left-align-actions">
-                                <li class="nhsuk-summary-list__actions-list-item">
-                                    <a asp-action="LearnerSignoffDeclaration" asp-route-actionName="Learner" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                        @if (Model.UserRole > 1)
+                        {
+                            <dd class="nhsuk-summary-list__actions">
+                                <ul class="nhsuk-summary-list__actions-list left-align-actions">
+                                    <li class="nhsuk-summary-list__actions-list-item">
+                                        <a asp-action="LearnerSignoffDeclaration" asp-route-actionName="Learner" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
 
-                                        Change<span class="nhsuk-u-visually-hidden"> Learner sign off statement</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </dd>
+                                            Change<span class="nhsuk-u-visually-hidden"> Learner sign off statement</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </dd>
+                        }
                     </div>
                     <div class="nhsuk-summary-list__row">
                         <dt class="nhsuk-summary-list__key">
@@ -145,12 +157,13 @@
 
 
             <div class="nhsuk-u-margin-top-8">
-
-                <button class="nhsuk-button nhsuk-button--primary" type="submit">
-                    Save
-                </button>
+                @if (Model.UserRole > 1)
+                {
+                    <button class="nhsuk-button nhsuk-button--primary" type="submit">
+                        Save
+                    </button>
+                }
                 <a class="nhsuk-button nhsuk-button--secondary" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.Signoff.CompetencyAssessmentId">
-
                     Cancel
                 </a>
             </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -50,15 +50,18 @@
             <dd class="nhsuk-summary-list__value">
                 @Model.PrimaryFramework.FrameworkName
             </dd>
-            <dd class="nhsuk-summary-list__actions">
-                <ul class="nhsuk-summary-list__actions-list left-align-actions">
-                    <li class="nhsuk-summary-list__actions-list-item">
-                        <a asp-action="RemoveFramework" asp-route-frameworkId="@Model.PrimaryFramework.ID" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                            Remove<span class="nhsuk-u-visually-hidden"> @Model.PrimaryFramework.FrameworkName</span>
-                        </a>
-                    </li>
-                </ul>
-            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <ul class="nhsuk-summary-list__actions-list left-align-actions">
+                        <li class="nhsuk-summary-list__actions-list-item">
+                            <a asp-action="RemoveFramework" asp-route-frameworkId="@Model.PrimaryFramework.ID" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                                Remove<span class="nhsuk-u-visually-hidden"> @Model.PrimaryFramework.FrameworkName</span>
+                            </a>
+                        </li>
+                    </ul>
+                </dd>
+            }
         </div>
     }
     @if (Model.AdditionalFrameworks.Count() > 0)
@@ -67,30 +70,33 @@
         {
             <div class="nhsuk-summary-list__row">
                 <dt class="nhsuk-summary-list__key">
-                    Additional framework @(i+1)
+                    Additional framework @(i + 1)
                 </dt>
                 <dd class="nhsuk-summary-list__value">
                     @Model.AdditionalFrameworks.ElementAt(i).FrameworkName
                 </dd>
-                <dd class="nhsuk-summary-list__actions">
-                    <ul class="nhsuk-summary-list__actions-list nhsuk-summary-list__actions-list--inline left-align-actions">
-                        <li class="nhsuk-summary-list__actions-list-item">
-                            <a asp-action="RemoveFramework"
-                               asp-route-frameworkId="@Model.AdditionalFrameworks.ElementAt(i).ID"
-                               asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                                Remove <span class="nhsuk-u-visually-hidden">@Model.AdditionalFrameworks.ElementAt(i).FrameworkName</span>
-                            </a>
-                        </li>
-                        <li class="nhsuk-summary-list__actions-list-item">
-                            <a asp-action="ConfirmMaKePrimaryFramework"
-                               asp-route-frameworkId="@Model.AdditionalFrameworks.ElementAt(i).ID"
-                               asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                                Make primary <span class="nhsuk-u-visually-hidden">@Model.AdditionalFrameworks.ElementAt(i).FrameworkName</span>
-                            </a>
-                        </li>
-                       
-                    </ul>
-                </dd>
+                @if (Model.UserRole > 1)
+                {
+                    <dd class="nhsuk-summary-list__actions">
+                        <ul class="nhsuk-summary-list__actions-list nhsuk-summary-list__actions-list--inline left-align-actions">
+                            <li class="nhsuk-summary-list__actions-list-item">
+                                <a asp-action="RemoveFramework"
+                                   asp-route-frameworkId="@Model.AdditionalFrameworks.ElementAt(i).ID"
+                                   asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                                    Remove <span class="nhsuk-u-visually-hidden">@Model.AdditionalFrameworks.ElementAt(i).FrameworkName</span>
+                                </a>
+                            </li>
+                            <li class="nhsuk-summary-list__actions-list-item">
+                                <a asp-action="ConfirmMaKePrimaryFramework"
+                                   asp-route-frameworkId="@Model.AdditionalFrameworks.ElementAt(i).ID"
+                                   asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                                    Make primary <span class="nhsuk-u-visually-hidden">@Model.AdditionalFrameworks.ElementAt(i).FrameworkName</span>
+                                </a>
+                            </li>
+
+                        </ul>
+                    </dd>
+                }
             </div>
         }
     }
@@ -118,28 +124,34 @@
         </div>
         <input type="hidden" asp-for="ActionName" />
         <input type="hidden" asp-for="TaskStatus" />
-        <button class="nhsuk-button" type="submit">Add</button>
+        @if (Model.UserRole > 1)
+        {
+            <button class="nhsuk-button" type="submit">Add</button>
+        }
     </form>
 }
 @if (Model.ActionName == "Summary")
 {
-    @if (Model.Frameworks.Any())
+    if (Model.UserRole > 1)
     {
-        <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="SelectFrameworkSources" asp-route-actionName="AddFramework" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-            Add framework
-        </a>
+        @if (Model.Frameworks.Any())
+        {
+            <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-action="SelectFrameworkSources" asp-route-actionName="AddFramework" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                Add framework
+            </a>
+        }
+        <form method="post">
+            <nhs-form-group>
+                <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+            </nhs-form-group>
+            <input type="hidden" asp-for="FrameworkId" value="0" />
+            <input type="hidden" asp-for="ActionName" />
+            <input type="hidden" asp-for="ID" />
+            <button class="nhsuk-button" type="submit">
+                Save
+            </button>
+        </form>
     }
-    <form method="post">
-        <nhs-form-group>
-            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-        </nhs-form-group>
-        <input type="hidden" asp-for="FrameworkId" value="0" />
-        <input type="hidden" asp-for="ActionName" />
-        <input type="hidden" asp-for="ID" />
-        <button class="nhsuk-button" type="submit">
-            Save
-        </button>
-    </form>
 }
 <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
@@ -38,11 +38,14 @@
             <dd class="nhsuk-summary-list__value">
                 @primaryFramework.FrameworkName (@primaryFramework.AssessmentFrameworkCompetencyCount @Model.VocabularyPlural.ToLower())
             </dd>
-            <dd class="nhsuk-summary-list__actions">
-                <a asp-action="AddCompetencies" asp-route-competencyAssessmentId="@Model.ID" asp-route-frameworkId="@primaryFramework.ID">
-                    Manage<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
-                </a>
-            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a asp-action="AddCompetencies" asp-route-competencyAssessmentId="@Model.ID" asp-route-frameworkId="@primaryFramework.ID">
+                        Manage<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
+                    </a>
+                </dd>
+            }
         </div>
     }
     @{
@@ -57,11 +60,14 @@
             <dd class="nhsuk-summary-list__value">
                 @framework.FrameworkName (@framework.AssessmentFrameworkCompetencyCount @Model.VocabularyPlural.ToLower())
             </dd>
-            <dd class="nhsuk-summary-list__actions">
-                <a asp-action="AddCompetencies" asp-route-competencyAssessmentId="@Model.ID" asp-route-frameworkId="@framework.ID">
-                    Manage<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
-                </a>
-            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a asp-action="AddCompetencies" asp-route-competencyAssessmentId="@Model.ID" asp-route-frameworkId="@framework.ID">
+                        Manage<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
+                    </a>
+                </dd>
+            }
         </div>
         i++;
     }
@@ -210,9 +216,12 @@ else
     <nhs-form-group>
         <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
     </nhs-form-group>
-    <button class="nhsuk-button" type="submit">
-        Submit
-    </button>
+    @if (Model.UserRole > 1)
+    {
+        <button class="nhsuk-button" type="submit">
+            Submit
+        </button>
+    }
     <div class="nhsuk-back-link">
         <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
             <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">


### PR DESCRIPTION
### JIRA link
[TD-6835](https://hee-tis.atlassian.net/browse/TD-6835)

### Description
Added reviewer role check in the entire competency assessment section to prevent editing of competency assessment.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6835]: https://hee-tis.atlassian.net/browse/TD-6835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ