### PR TITLE
TD-6908 Updating retirement text on learner self enrolment screen

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Available/ConfirmRetirement.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Available/ConfirmRetirement.cshtml
@@ -21,20 +21,17 @@
       <vc:error-summary order-of-property-names="@(new[] { nameof(Model.ActionConfirmed) })" />
     }
     <h1 id="page-heading">Confirm Enrolment</h1>
-            <p class="nhsuk-body-m">You are about to enrol on a retiring <strong>@Model.Name</strong> self-assessment.</p>
+            <p class="nhsuk-body-m">You are about to enrol on a retiring self-assessment</p>
             <p class="nhsuk-body-m">     Retirement date:   <strong>@Model.RetirementDate?.ToString("dd/MM/yyyy")</strong>  </p>
-            <p class="nhsuk-body-m">After this date, the <strong>@Model.Name</strong> self-assessment will no longer be accessible.</p>
-
-            <p class="nhsuk-body-m">Please consider:</p>
+            
+            <p class="nhsuk-body-m">Please note:</p>
             <ul class="nhsuk-list nhsuk-list--bullet">
-            <li>  you may have limited time to complete the self-assessment</li>
-
-          
-            <li>     if you do not complete it before the retirement date, your progress may not be saved</li>
+                <li>once enrolled you can continue to complete the self-assessment even after the retirement date</li>
+                <li>you may wish to consider enrolling on an updated version if available</li>
             </ul>
+            <p class="nhsuk-body-m">If you are unsure about what to do, contact your supervisor or manager.</p>
             <p class="nhsuk-body-m">To continue, you must acknowledge that you understand the self-assessment is retiring and still wish to enrol.</p>
-           
-           
+
             <p class="nhsuk-body-m">
                 <vc:single-checkbox asp-for="@nameof(Model.ActionConfirmed)"
                                     label="I understand this self-assessment is retiring and still want to enrol."


### PR DESCRIPTION
### JIRA link
[TD-6908](https://hee-tis.atlassian.net/browse/TD-6908)

### Description
Updating retirement text on learner self enrolment screen

### Screenshots
<img width="2492" height="1174" alt="image" src="https://github.com/user-attachments/assets/d4482dec-8f2f-4a6c-aac7-24269816be41" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6908]: https://hee-tis.atlassian.net/browse/TD-6908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ