### PR TITLE
TD-7030 Add a not started to the filter options

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SelfAssessmentDataService/SelfAssessmentDataService.cs
@@ -153,7 +153,7 @@
 
         void RemoveEnrolment(int selfAssessmentId, int delegateUserId);
         (IEnumerable<SelfAssessmentDelegate>, int) GetSelfAssessmentDelegates(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff);
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, bool? started);
 
         IEnumerable<SelfAssessmentDelegate> GetDelegatesOnSelfAssessmentForExport(int? selfAssessmentId, int centreId);
 
@@ -269,7 +269,7 @@
         }
 
         public (IEnumerable<SelfAssessmentDelegate>, int) GetSelfAssessmentDelegates(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff)
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, bool? started)
         {
             searchString = searchString == null ? string.Empty : searchString.Trim();
 
@@ -326,6 +326,7 @@
                 AND ((@isDelegateActive IS NULL) OR (@isDelegateActive = 1 AND (da.Active = 1)) OR (@isDelegateActive = 0 AND (da.Active = 0)))
 				AND ((@removed IS NULL) OR (@removed = 1 AND (ca.RemovedDate IS NOT NULL)) OR (@removed = 0 AND (ca.RemovedDate IS NULL)))
                 AND ((@submitted IS NULL) OR (@submitted = 1 AND (ca.SubmittedDate IS NOT NULL)) OR (@submitted = 0 AND (ca.SubmittedDate IS NULL)))
+                AND ((@started IS NULL) OR (@started = 1 AND (ca.LaunchCount >= 1)) OR (@started = 0 AND (ca.LaunchCount = 0)))
                 AND COALESCE(ucd.Email, u.PrimaryEmail) LIKE '%_@_%' ";
 
             var groupBy = $@" GROUP BY 
@@ -393,7 +394,8 @@
                     isDelegateActive,
                     removed,
                     submitted,
-                    signedOff
+                    signedOff,
+                    started
                 },
                 commandTimeout: 3000
             );
@@ -415,7 +417,8 @@
                     isDelegateActive,
                     removed,
                     submitted,
-                    signedOff
+                    signedOff,
+                    started
                 },
                 commandTimeout: 3000
             );

--- a/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/Controllers/TrackingSystem/Delegates/CourseDelegatesControllerTests.cs
@@ -95,7 +95,7 @@
             var selfAssessmentDelegate = new SelfAssessmentDelegate(6, "Lname");
 
             A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentDelegatesPerPage("", 0, 10, "SearchableName", "Ascending",
-                6, UserCentreId, null, null, null, null, null))
+                6, UserCentreId, null, null, null, null, null, null))
                 .Returns((new SelfAssessmentDelegatesData(
                         new List<SelfAssessmentDelegate> { selfAssessmentDelegate }
                     ), 1)
@@ -137,7 +137,7 @@
             var selfAssessmentDelegate = new SelfAssessmentDelegate(6, "Lname");
 
             A.CallTo(() => selfAssessmentDelegatesService.GetSelfAssessmentDelegatesPerPage("", 0, 10, "SearchableName", "Ascending",
-                10, UserCentreId, null, null, null, null, null))
+                10, UserCentreId, null, null, null, null, null, null))
                 .Returns((new SelfAssessmentDelegatesData(
                         new List<SelfAssessmentDelegate> { selfAssessmentDelegate }
                     ), 0)

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -129,8 +129,8 @@
             var adminCategoryId = User.GetAdminCategoryId();
 
 
-            bool? isDelegateActive, isProgressLocked, removed, hasCompleted, submitted, signedOff;
-            isDelegateActive = isProgressLocked = removed = hasCompleted = submitted = signedOff = null;
+            bool? isDelegateActive, isProgressLocked, removed, hasCompleted, submitted, signedOff, started;
+            isDelegateActive = isProgressLocked = removed = hasCompleted = submitted = signedOff = started =null;
 
             string? answer1, answer2, answer3;
             answer1 = answer2 = answer3 = null;
@@ -181,6 +181,9 @@
 
                         if (filter.Contains("Answer3"))
                             answer3 = filterValue;
+
+                        if (filter.Contains("LearnerActivity"))
+                            started = filterValue;
                     }
                 }
             }
@@ -211,7 +214,7 @@
                 else
                 {
                     (selfAssessmentDelegatesData, resultCount) = selfAssessmentService.GetSelfAssessmentDelegatesPerPage(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
-                    selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff, adminCategoryId);
+                    selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff, adminCategoryId, started);
 
                     if (selfAssessmentDelegatesData?.Delegates == null && resultCount == null)
                     {
@@ -223,7 +226,7 @@
                     {
                         page = 1; offSet = 0;
                         (selfAssessmentDelegatesData, resultCount) = selfAssessmentService.GetSelfAssessmentDelegatesPerPage(searchString ?? string.Empty, offSet, itemsPerPage ?? 0, sortBy, sortDirection,
-                            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff, adminCategoryId);
+                            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff, adminCategoryId, started);
                     }
 
                     var adminId = User.GetCustomClaimAsRequiredInt(CustomClaimTypes.UserAdminId);

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/SelfAssessmentDelegateFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/SelfAssessmentDelegateFilterOptions.cs
@@ -72,5 +72,20 @@
             FilterStatus.Default
         );
     }
+    public static class SelfAssessmentLearnerActivityFilterOptions
+    {
+        private const string Group = "LearnerActivity";
 
+        public static readonly FilterOptionModel Started = new FilterOptionModel(
+            "Started",
+            FilteringHelper.BuildFilterValueString(Group, nameof(SelfAssessmentDelegate.LaunchCount), "true"),
+            FilterStatus.Success
+        );
+
+        public static readonly FilterOptionModel NotStarted = new FilterOptionModel(
+            "Not started",
+            FilteringHelper.BuildFilterValueString(Group, nameof(SelfAssessmentDelegate.LaunchCount), "false"),
+            FilterStatus.Default
+        );
+    }
 }

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentService.cs
@@ -132,7 +132,7 @@
 
         void RemoveEnrolment(int selfAssessmentId, int delegateUserId);
         public (SelfAssessmentDelegatesData, int?) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int? adminCategoryId);
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int? adminCategoryId, bool? started);
         public SelfAssessmentDelegatesData GetSelfAssessmentActivityDelegatesExport(string searchString, int itemsPerPage, string sortBy, string sortDirection,
            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, int currentRun, bool? submitted, bool? signedOff);
         public int GetSelfAssessmentActivityDelegatesExportCount(string searchString, string sortBy, string sortDirection,
@@ -480,7 +480,7 @@
         }
 
         public (SelfAssessmentDelegatesData, int?) GetSelfAssessmentDelegatesPerPage(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection,
-            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int? adminCategoryId)
+            int? selfAssessmentId, int centreId, bool? isDelegateActive, bool? removed, bool? submitted, bool? signedOff, int? adminCategoryId, bool? started)
         {
 
             var selfAssessmentCategoryId = selfAssessmentDataService.GetSelfAssessmentCategoryId((int)selfAssessmentId);
@@ -492,7 +492,7 @@
             }
 
             (var delegateselfAssessments, int resultCount) = selfAssessmentDataService.GetSelfAssessmentDelegates(searchString, offSet, itemsPerPage, sortBy, sortDirection,
-            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff);
+            selfAssessmentId, centreId, isDelegateActive, removed, submitted, signedOff, started);
 
             List<SelfAssessmentDelegate> selfAssessmentDelegateList = new List<SelfAssessmentDelegate>();
             foreach (var delegateInfo in delegateselfAssessments)

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelfAssessmentDelegateViewModelFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/CourseDelegates/SelfAssessmentDelegateViewModelFilterOptions.cs
@@ -29,6 +29,11 @@
             SelfAssessmentSignedOffFilterOptions.SignedOff,
             SelfAssessmentSignedOffFilterOptions.NotSignedOff,
         };
+        public static readonly IEnumerable<FilterOptionModel> LearnerActivityStatusOptions = new[]
+       {
+            SelfAssessmentLearnerActivityFilterOptions.Started,
+            SelfAssessmentLearnerActivityFilterOptions.NotStarted,
+        };
 
         public static List<FilterModel> GetAllSelfAssessmentDelegatesFilterViewModels()
         {
@@ -38,6 +43,7 @@
                 new FilterModel("RemovedStatus", "Removed status", RemovedStatusOptions, "status"),
                 new FilterModel("SubmittedStatus", "Submitted status", SubmittedStatusOptions,"status"),
                 new FilterModel("SignedOffStatus", "Signed off status", SignedOffStatusOptions, "status"),
+                new FilterModel("LearnerActivityStatus", "Learner activity status", LearnerActivityStatusOptions, "status"),
             };
             return filters;
         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7030

### Description
Introduced ‘Started’ and ‘Not started’ filter options in SelfAssessmentLearnerActivityFilterOptions, using LaunchCount to determine whether a learner has begun the assessment or not
Added a started filter to the WHERE clause to allow filtering delegates based on whether they have launched (started) the assessment or not
Extended the GetSelfAssessmentDelegates method by adding a nullable started parameter to support filtering results by started status.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/99465f6b-2b14-4ea2-8b85-1d7bd4b9a283" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/474f5868-043e-48f8-8d31-ff5b046ba637" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [x] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
