### PR TITLE
TD-6945 Remove duplicated assessment name from page titles

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentFeatures.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentFeatures.cshtml
@@ -21,7 +21,12 @@
     </nav>
 }
 
-<h1>Create a new self-assessment</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+Create a new self-assessment</h1>
 <h2> Which features of the framework do you want to copy into the self-assessment?</h2>
 <p class="nhsuk-body-m">The framework itself will be used as the source for this self-assessment. </p>
 <p class="nhsuk-body-m">Select any additional features you want to copy into the self-assessment. You can edit all features later if needed.</p>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentSummary.cshtml
@@ -21,8 +21,12 @@
     </nav>
 }
 
-
-<h1> Check your answer before creating self-assessment</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+ Check your answer before creating self-assessment</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
@@ -13,7 +13,7 @@
         {
             <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Confirm) })" />
         }
-        <h1 class="nhsuk-heading-xl">Make @Model.FrameworkName primary framework</h1>
+        <h1 class="nhsuk-heading-xl">Primary framework</h1>
     </div>
 </div>
 
@@ -23,7 +23,7 @@
 
             <fieldset class="nhsuk-fieldset">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-                    Which features of the framework do you want to copy into this @Model.FrameworkName framework?
+                 @Model.FrameworkName for Registered @Model.AssessmentName primary framework which features of the framework do you want to copy?
                 </legend>
                 <div class="nhsuk-checkboxes">
                     <div class="nhsuk-checkboxes__item ">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
@@ -13,7 +13,13 @@
         {
             <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Confirm) })" />
         }
-        <h1 class="nhsuk-heading-xl">Primary framework</h1>
+        <h1 class="app-page-heading">
+            <span class="nhsuk-caption-xl">
+                @Model.AssessmentName
+                <span class="nhsuk-u-visually-hidden"> – </span>
+            </span>
+            Primary framework
+        </h1>
     </div>
 </div>
 

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -21,8 +21,13 @@
         </div>
     </nav>
 }
-
-<h1>Provider and category</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Provider and category
+</h1>
 <p>This will be visible to users when they browse the self-assessment. It will help them to identify where it is from and what it contains.</p>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -22,8 +22,8 @@
     </nav>
 }
 
-<h1>Edit @Model.CompetencyAssessmentName provider and category</h1>
-<p>This will be visible to users when they browse assessments. It will help them to identify where the assessment is from and what it contains.</p>
+<h1>Provider and category</h1>
+<p>This will be visible to users when they browse the self-assessment. It will help them to identify where it is from and what it contains.</p>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -35,7 +35,7 @@
                       label="Introductory text"
                       rows="5"
                       css-class="html-editor"
-                      hint-text="The learner will see this text when they launch the self-assessment, it should inform them of what it covers, how to complete it and where to get more information."
+                      hint-text="The learner will see this text when they launch the assessment, it should tell them what the assessment covers, how to complete it and where to get more information"
                       populate-with-current-value="true"
                       spell-check="false" />
     </nhs-form-group>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -23,7 +23,7 @@
     </nav>
 }
 
-<h1>Edit @Model.CompetencyAssessmentName introductory text</h1>
+<h1>Introductory description</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {
@@ -35,7 +35,7 @@
                       label="Introductory text"
                       rows="5"
                       css-class="html-editor"
-                      hint-text="The learner will see this text when they launch the assessment, it should tell them what the assessment covers, how to complete it and where to get more information"
+                      hint-text="The learner will see this text when they launch the self-assessment, it should inform them of what it covers, how to complete it and where to get more information."
                       populate-with-current-value="true"
                       spell-check="false" />
     </nhs-form-group>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -22,8 +22,13 @@
         </div>
     </nav>
 }
-
-<h1>Introductory description</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Introductory description
+</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
@@ -22,7 +22,13 @@
         </div>
     </nav>
 }
-<h1 class="nhsuk-heading-xl">Role requirement filters</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Role requirement filters
+</h1>
 <form method="post" asp-action="EditRoleRequirementsFlags">
     <nhs-form-group nhs-validation-for="IncludeRequirementsFilters">
         <fieldset class="nhsuk-fieldset" aria-describedby="role-requirements-filters-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
@@ -22,7 +22,7 @@
         </div>
     </nav>
 }
-<h1>Edit include role requirements filters</h1>
+<h1 class="nhsuk-heading-xl">Role requirement filters</h1>
 <form method="post" asp-action="EditRoleRequirementsFlags">
     <nhs-form-group nhs-validation-for="IncludeRequirementsFilters">
         <fieldset class="nhsuk-fieldset" aria-describedby="role-requirements-filters-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
@@ -23,7 +23,7 @@
         </div>
     </nav>
 }
-<h1>Edit @Model.VocabularySingular.ToLower() role requirements</h1>
+<h1 class="nhsuk-heading-xl">@Model.VocabularySingular.ToLower() role requirements</h1>
 <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
@@ -23,7 +23,13 @@
         </div>
     </nav>
 }
-<h1 class="nhsuk-heading-xl">@Model.VocabularySingular.ToLower() role requirements</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    @Model.VocabularySingular.ToLower() role requirements
+</h1>
 <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
@@ -22,7 +22,7 @@
     </nav>
 }
 
-<h1>Edit @Model.CompetencyAssessmentName national NHS role profile links</h1>
+<h1 class="nhsuk-heading-xl">National NHS role profile links</h1>
 @if (Model.TaskStatus != null | Model.ActionName != "EditGroup")
 {
     <dl class="nhsuk-summary-list">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
@@ -21,8 +21,13 @@
         </div>
     </nav>
 }
-
-<h1 class="nhsuk-heading-xl">National NHS role profile links</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    National NHS role profile links
+</h1>
 @if (Model.TaskStatus != null | Model.ActionName != "EditGroup")
 {
     <dl class="nhsuk-summary-list">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -21,8 +21,12 @@
         </div>
     </nav>
 }
-
-<h1>Choose self-assessment vocabulary</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Choose self-assessment vocabulary</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -22,7 +22,7 @@
     </nav>
 }
 
-<h1>Edit @Model.CompetencyAssessmentName vocabulary</h1>
+<h1>Choose self-assessment vocabulary</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {
@@ -30,11 +30,7 @@
     }
     <nhs-form-group nhs-validation-for="Vocabulary">
         <fieldset class="nhsuk-fieldset">
-            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">
-                <h2 class="nhsuk-fieldset__heading">
-                    Choose assessment vocabulary - the name given to the building blocks of your assessment.
-                </h2>
-            </legend>
+           
             <div class="nhsuk-radios">
                 <div class="nhsuk-radios__item">
                     <input class="nhsuk-radios__input" asp-for="Vocabulary" type="radio" value="Capability" aria-describedby="vocabulary-item-1-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -30,7 +30,11 @@
     }
     <nhs-form-group nhs-validation-for="Vocabulary">
         <fieldset class="nhsuk-fieldset">
-           
+            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">
+                <h2 class="nhsuk-fieldset__heading">
+                    Choose assessment vocabulary - the name given to the building blocks of your assessment.
+                </h2>
+            </legend>
             <div class="nhsuk-radios">
                 <div class="nhsuk-radios__item">
                     <input class="nhsuk-radios__input" asp-for="Vocabulary" type="radio" value="Capability" aria-describedby="vocabulary-item-1-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
@@ -22,7 +22,7 @@
         </div>
     </nav>
 }
-<h1>Edit role requirement enforcement</h1>
+<h1 class="nhsuk-heading-xl">Enforce role requirements</h1>
 <form method="post" asp-action="EditRoleRequirementsFlags">
     <nhs-form-group nhs-validation-for="EnforceRoleRequirementsForSignOff">
         <fieldset class="nhsuk-fieldset" aria-describedby="enforce-role-requirements-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
@@ -22,7 +22,13 @@
         </div>
     </nav>
 }
-<h1 class="nhsuk-heading-xl">Enforce role requirements</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Enforce role requirements
+</h1>
 <form method="post" asp-action="EditRoleRequirementsFlags">
     <nhs-form-group nhs-validation-for="EnforceRoleRequirementsForSignOff">
         <fieldset class="nhsuk-fieldset" aria-describedby="enforce-role-requirements-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
@@ -21,7 +21,7 @@
         </div>
     </nav>
 }
-<h1>Self assessment @Model.VocabularySingular.ToLower() role requirements</h1>
+<h1 class="nhsuk-heading-xl">@Model.VocabularySingular.ToLower() role requirements</h1>
 <p class="nhsuk-lede-text">
     Specify whether role requirements will be enforced for the @Model.CompetencyAssessmentName self assessment. When requirements are set, they must be met by the learner before the self assessment can be signed off.
 </p>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
@@ -22,7 +22,12 @@
     </nav>
 }
 
-<h1 class="nhsuk-heading-xl">@Model.VocabularySingular.ToLower() role requirements</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+@Model.VocabularySingular.ToLower() role requirements</h1>
 
 <p class="nhsuk-lede-text">
     Specify whether role requirements will be enforced for the @Model.CompetencyAssessmentName self-assessment. When requirements are set, they must be met by the learner before the self-assessment can be signed off.

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -21,7 +21,13 @@
         </div>
     </nav>
 }
-<h1>Manage optional @Model.VocabularyPlural.ToLower()</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+  Manage optional @Model.VocabularyPlural.ToLower()
+  </h1>
 <p class="nhsuk-lede-text">
     Manage optional @Model.VocabularyPlural.ToLower() for the assessment @Model.CompetencyAssessmentName.
     Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self-assessment by a learner if required.

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -22,8 +22,9 @@
     </nav>
 }
 <h1>Manage optional @Model.VocabularyPlural.ToLower()</h1>
-<p>
-    Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self-assessment by a learner if required.
+<p class="nhsuk-lede-text">
+    Manage optional @Model.VocabularyPlural.ToLower() for the assessment @Model.CompetencyAssessmentName.
+    Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self assessment by a learner if required.
 </p>
 <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -22,9 +22,8 @@
     </nav>
 }
 <h1>Manage optional @Model.VocabularyPlural.ToLower()</h1>
-<p class="nhsuk-lede-text">
-    Manage optional @Model.VocabularyPlural.ToLower() for the assessment @Model.CompetencyAssessmentName.
-    Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self assessment by a learner if required.
+<p>
+    Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self-assessment by a learner if required.
 </p>
 <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishReview.cshtml
@@ -21,7 +21,12 @@
         </div>
     </nav>
 }
-<h1>Publish @Model.CompetencyAssessmentName self assesment </h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>Publish self-assesment
+</h1>
 <p>Please ensure that all of the reviewers who are required to approve the self assesment are listed below.</p>
 <input type="hidden" asp-for="CompetencyAssessmentID" />
 <input type="hidden" asp-for="CompetencyAssessmentName" />

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishWithoutReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishWithoutReview.cshtml
@@ -21,7 +21,12 @@
         </div>
     </nav>
 }
-<h1>Publish without review</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>Publish without review
+</h1>
 
 <form method="post">
     <div class="nhsuk-grid-row">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -39,7 +39,7 @@
 
     </div>
 </div>
-<h1>Select framework sources for @Model.CompetencyAssessmentName</h1>
+<h1 class="nhsuk-heading-xl">Select framework sources</h1>
 <dl class="nhsuk-summary-list">
     @if (Model.PrimaryFramework != null)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -39,7 +39,12 @@
 
     </div>
 </div>
-<h1 class="nhsuk-heading-xl">Select framework sources</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+Select framework sources</h1>
 <dl class="nhsuk-summary-list">
     @if (Model.PrimaryFramework != null)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -21,7 +21,13 @@
         </div>
     </nav>
 }
-<h1>Select optional competencies</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Select optional competencies
+</h1>
 
 <p class="nhsuk-lede-text">
     Optional competencies can be added to the assessment individually or as a group.

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SendForReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SendForReview.cshtml
@@ -19,7 +19,13 @@
         </div>
     </nav>
 }
-<h1>Send for review</h1>
+
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+Send for review</h1>
 <h2>Who should review this self-assessment?</h2>
 @if (errorHasOccurred)
 {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
@@ -21,7 +21,12 @@
         </div>
     </nav>
 }
-<h1>Set a minimum number of optional @Model.VocabularyPlural.ToLower()</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>Set a minimum number of optional @Model.VocabularyPlural.ToLower()
+</h1>
 
 <p class="nhsuk-lede-text">
     If required, you can specify a minimum number of optional @Model.VocabularyPlural.ToLower() that a learner must select when completing their @Model.CompetencyAssessmentName self-assessment.

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
@@ -22,7 +22,12 @@
         </div>
     </nav>
 }
-<h1>Optional @Model.VocabularyPlural.ToLower() learner prompt</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>Optional @Model.VocabularyPlural.ToLower() learner prompt
+</h1>
 
 <p class="nhsuk-lede-text">
     Provide an optional prompt to help learners choose the right optional @Model.VocabularyPlural.ToLower() to include in their @Model.CompetencyAssessmentName self-assessment.

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SubmitReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SubmitReview.cshtml
@@ -19,7 +19,14 @@
         </div>
     </nav>
 }
-<h1>Submit review</h1>
+
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+    Submit review
+</h1>
 @if (Model.SelfAssessmentReview.SignOffRequired)
 {
     <div class="nhsuk-warning-callout">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
@@ -26,7 +26,12 @@
         </div>
     </nav>
 }
-<h1 class="nhsuk-heading-xl">@Model.VocabularyPlural to assess</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+  @Model.VocabularyPlural to assess</h1>
 <h2>Linked frameworks</h2>
 <dl class="nhsuk-summary-list">
     @if (primaryFramework != null)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
@@ -26,7 +26,7 @@
         </div>
     </nav>
 }
-<h1>@Model.VocabularyPlural to assess for @Model.CompetencyAssessmentName</h1>
+<h1 class="nhsuk-heading-xl">@Model.VocabularyPlural to assess</h1>
 <h2>Linked frameworks</h2>
 <dl class="nhsuk-summary-list">
     @if (primaryFramework != null)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6945

### Description
I have reviewed the self-assessment interface notes and feedback document and ensured that the titles of each competency assessment page are aligned accordingly.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/2bf5d88c-364b-47b2-bbe4-a4a457e0a061" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/79a9559a-c52a-4ebd-989d-d9bbf9c683a3" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/779aefa0-2d08-4680-a7a1-322180038871" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
