### PR TITLE
TD-6943-Standardised heading hierarchy

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model AddCompetenciesViewModel;
 @{
-    ViewData["Title"] = "Add Competencies to self-assessment";
+    ViewData["Title"] = "Add competencies to self-assessment";
     ViewData["Application"] = "Framework service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
@@ -15,7 +15,7 @@
             <ol class="nhsuk-breadcrumb__list">
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Self-assessments</a></li>
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Manage self-assessment</a></li>
-                <li class="nhsuk-breadcrumb__item">Select Framework Sources</li>
+                <li class="nhsuk-breadcrumb__item">Select framework sources</li>
             </ol>
             <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Back to manage self-assessment</a></p>
         </div>
@@ -38,9 +38,9 @@
                     @if (competencyGroup.FrameworkCompetencies.Count() > 0)
                     {
                         <div class="nhsuk-u-margin-bottom-6">
-                            <h3>
+                            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
                                 @competencyGroup.Name
-                            </h3>
+                            </legend>
                             @if (competencyGroup.FrameworkCompetencies.Count() > 1)
                             {
                                 <div class="nhsuk-grid-row nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-1 js-only-block">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetenciesSelectFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetenciesSelectFramework.cshtml
@@ -21,7 +21,7 @@
         </div>
     </nav>
 }
-<h1>Select Framework Source</h1>
+<h1>Select framework source</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -29,7 +29,7 @@
 }
 <h1>Choose working group members</h1>
 <div class="nhsuk-table__panel-with-heading-tab">
-    <h2 class="nhsuk-table__heading-tab">Working Group Members</h2>
+    <h2 class="nhsuk-table__heading-tab">Working group members</h2>
     <table role="presentation" class="nhsuk-table-responsive">
         <thead role="rowgroup" class="nhsuk-table__head">
             <tr role="row">
@@ -108,10 +108,10 @@
         </div>
 
         <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="True" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
-            Add  as Contributor
+            Add as contributor
         </button>
         <button class="nhsuk-button nhsuk-button--secondary button-small" asp-route-canModify="False" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
-            Add as Reviewer
+            Add as reviewer
         </button>
     }
     <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditCompetencyRoleRequirements.cshtml
@@ -33,8 +33,8 @@
         <thead class="nhsuk-table__head">
             <tr class="nhsuk-table__row">
                 <th class="nhsuk-table__header" scope="col">@Model.VocabularySingular</th>
-                <th class="nhsuk-table__header" scope="col">Assessment Question </th>
-                <th>Role Requirements</th>
+                <th class="nhsuk-table__header" scope="col">Assessment question </th>
+                <th>Role requirements</th>
                 <th class="nhsuk-table__header" scope="col">Actions</th>
             </tr>
         </thead>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
@@ -32,8 +32,8 @@
 <form method="post" asp-action="EditRoleRequirementsFlags">
     <nhs-form-group nhs-validation-for="IncludeRequirementsFilters">
         <fieldset class="nhsuk-fieldset" aria-describedby="role-requirements-filters-hint">
-            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                <h2>Do you want to include role requirements filters in the @Model.CompetencyAssessmentName self-assessment?</h2>
+            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
+                Do you want to include role requirements filters in the self-assessment?
             </legend>
             <div id="role-requirements-filters-hint" class="nhsuk-hint">
                 This will allow the learner to filter self-assessment competencies based on whether they are meeting the role requirements set.
@@ -54,7 +54,7 @@
     <input type="hidden" asp-for="Id" />
     <input type="hidden" asp-for="EnforceRoleRequirementsForSignOff" />
     <input type="hidden" asp-for="TaskStatus" />
-    <button class="nhsuk-button nhsuk-button--primary" type="submit">Save changes</button>
+    <button class="nhsuk-button nhsuk-button--primary" type="submit">Save</button>
 </form>
 <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="ManageCompetencyRoleRequirements" asp-route-competencyAssessmentId="@Model.Id">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
@@ -33,7 +33,7 @@
 <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
-            @Model.VocabularySingular Assessment
+            @Model.VocabularySingular assessment
         </dt>
         <dd class="nhsuk-summary-list__value">
             @Model.CompetencyAssessmentName
@@ -65,7 +65,7 @@
     </div>
     <div class="nhsuk-summary-list__row">
         <dt class="nhsuk-summary-list__key">
-            Assessment Question
+            Assessment question
         </dt>
         <dd class="nhsuk-summary-list__value">
             @Model.GroupedCompetencyWithAssessmentRoleRequirements.First().Competencies.First().Questions.First().Question

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -26,7 +26,8 @@
         @Model.CompetencyAssessmentName
         <span class="nhsuk-u-visually-hidden"> – </span>
     </span>
-    Choose self-assessment vocabulary</h1>
+    Select self-assessment vocabulary
+</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {
@@ -34,11 +35,6 @@
     }
     <nhs-form-group nhs-validation-for="Vocabulary">
         <fieldset class="nhsuk-fieldset">
-            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">
-                <h2 class="nhsuk-fieldset__heading">
-                    Choose assessment vocabulary - the name given to the building blocks of your assessment.
-                </h2>
-            </legend>
             <div class="nhsuk-radios">
                 <div class="nhsuk-radios__item">
                     <input class="nhsuk-radios__input" asp-for="Vocabulary" type="radio" value="Capability" aria-describedby="vocabulary-item-1-hint">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
@@ -32,8 +32,8 @@
 <form method="post" asp-action="EditRoleRequirementsFlags">
     <nhs-form-group nhs-validation-for="EnforceRoleRequirementsForSignOff">
         <fieldset class="nhsuk-fieldset" aria-describedby="enforce-role-requirements-hint">
-            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                <h2>Do you want to enforce role requirements for the @Model.CompetencyAssessmentName self-assessment?</h2>
+            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
+                Do you want to enforce role requirements for the self-assessment?
             </legend>
             <div id="enforce-role-requirements-hint" class="nhsuk-hint">
                 When role requirements are enforced, learners can only request confirmation for self‑assessment results that meet the required competency criteria, even if no specific requirements are set.
@@ -54,7 +54,7 @@
     <input type="hidden" asp-for="Id" />
     <input type="hidden" asp-for="IncludeRequirementsFilters" />
     <input type="hidden" asp-for="TaskStatus" />
-    <button class="nhsuk-button nhsuk-button--primary" type="submit">Save changes</button>
+    <button class="nhsuk-button nhsuk-button--primary" type="submit">Save</button>
 </form>
 <div class="nhsuk-back-link">
     <a class="nhsuk-back-link__link" asp-action="ManageCompetencyRoleRequirements" asp-route-competencyAssessmentId="@Model.Id">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Name.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Name.cshtml
@@ -51,9 +51,6 @@ else
         <partial name="_ErrorSummary" />
     }
     <nhs-form-group nhs-validation-for="CompetencyAssessmentName">
-        <label class="nhsuk-label" for="roleprofilename">
-            <h2>What is the name of your self-assessment?</h2>
-        </label>
         <div class="nhsuk-hint" id="assessment-name-hint">
             Choose a title that identifies scope of capabilities covered and/or the roles or levels the assessment targets.
         </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Name.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Name.cshtml
@@ -51,6 +51,9 @@ else
         <partial name="_ErrorSummary" />
     }
     <nhs-form-group nhs-validation-for="CompetencyAssessmentName">
+        <label class="nhsuk-label nhsuk-u-visually-hidden" for="roleprofilename">
+            What is the name of your self-assessment?
+        </label>
         <div class="nhsuk-hint" id="assessment-name-hint">
             Choose a title that identifies scope of capabilities covered and/or the roles or levels the assessment targets.
         </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -112,7 +112,7 @@ Select framework sources</h1>
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">Add a framework source</h1>
+                    <h2 class="nhsuk-fieldset__heading">Add a framework source</h2>
                 </legend>
                 <div class="nhsuk-radios">
                     @foreach (var framework in Model.Frameworks)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -34,20 +34,16 @@
 </p>
 <form method="post" asp-action="SelectOptionalCompetencies">
     <fieldset class="nhsuk-fieldset">
-        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-            <h2 class="nhsuk-fieldset__heading">
-                Which @Model.VocabularySingular.ToLower() groups and/or @Model.VocabularyPlural.ToLower() should be optional?
-            </h2>
-        </legend>
+
         @foreach (var competencyGroup in Model.CompetencyGroups)
         {
             @if (competencyGroup.Count() > 1)
             {
 
                 <div class="nhsuk-u-margin-bottom-6">
-                    <h3>
+                    <h2>
                         @competencyGroup.Key
-                    </h3>
+                    </h2>
                     <div class="nhsuk-checkboxes">
                         <div class="nhsuk-checkboxes__item">
                             <input class="nhsuk-checkboxes__input" data-group="@competencyGroup.First().GroupId" id="competency-check-@competencyGroup.First().GroupId" name="GroupIds" checked="@competencyGroup.Any(x => x.GroupOptionalCompetencies)" type="checkbox" value="@competencyGroup.First().GroupId">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Shared/_AssessmentsGrid.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Shared/_AssessmentsGrid.cshtml
@@ -10,7 +10,7 @@
                 Self-assessment
             </th>
             <th role="columnheader" class="" scope="col">
-                Framework Links
+                Framework links
             </th>
             <th role="columnheader" class="" scope="col">
                 Created

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Index.cshtml
@@ -4,8 +4,8 @@
 @model DashboardViewModel;
 @{
     ViewData["Title"] = "Dashboard";
-    ViewData["Application"] = "Framework Service";
-    ViewData["HeaderPathName"] = "Framework Service";
+    ViewData["Application"] = "Framework service";
+    ViewData["HeaderPathName"] = "Framework service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {


### PR DESCRIPTION
### JIRA link
[TD-6943](https://hee-tis.atlassian.net/browse/TD-6943)

### Description
Standardised heading hierarchy; removed unnecessary H2 elements; ensured all fieldsets use legends throughout the self-assessment section.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6943]: https://hee-tis.atlassian.net/browse/TD-6943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ