### PR TITLE
TD-6954 Optional proficiencies content cleanup

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -21,6 +21,7 @@
         </div>
     </nav>
 }
+<div class="nhsuk-form-group">
 <h1 class="app-page-heading">
     <span class="nhsuk-caption-xl">
         @Model.CompetencyAssessmentName
@@ -28,9 +29,8 @@
     </span>
   Manage optional @Model.VocabularyPlural.ToLower()
   </h1>
-<p class="nhsuk-lede-text">
-    Manage optional @Model.VocabularyPlural.ToLower() for the assessment @Model.CompetencyAssessmentName.
-    Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self-assessment by a learner if required.
+<p>
+ Optional proficiencies can be selected for inclusion in a self-assessment by a learner if required.
 </p>
 <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
@@ -84,7 +84,7 @@
         </div>
         <div class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">
-                Optional @Model.VocabularySingular.ToLower() learner prompt
+                Optional learner prompt
             </dt>
             <dd class="nhsuk-summary-list__value">
                 @Html.Raw(Model.ManageOptionalCompetenciesPrompt == null ? "No learner prompt specified" : Model.ManageOptionalCompetenciesPrompt.ToString())
@@ -121,4 +121,5 @@
         </svg>
         Cancel
     </a>
+</div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -21,6 +21,7 @@
         </div>
     </nav>
 }
+<div class="nhsuk-form-group">
 <h1 class="app-page-heading">
     <span class="nhsuk-caption-xl">
         @Model.CompetencyAssessmentName
@@ -29,15 +30,13 @@
     Select optional competencies
 </h1>
 
-<p class="nhsuk-lede-text">
-    Optional competencies can be added to the assessment individually or as a group.
+<p>
+ Optional competencies can be added to the assessment individually or as a group.
 </p>
 <form method="post" asp-action="SelectOptionalCompetencies">
     <fieldset class="nhsuk-fieldset">
         <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-            <h2 class="nhsuk-fieldset__heading">
-                Which @Model.VocabularySingular.ToLower() groups and/or @Model.VocabularyPlural.ToLower() should be optional?
-            </h2>
+         Which @Model.VocabularySingular.ToLower() groups and/or @Model.VocabularyPlural.ToLower() should be optional?
         </legend>
         @foreach (var competencyGroup in Model.CompetencyGroups)
         {
@@ -45,9 +44,9 @@
             {
 
                 <div class="nhsuk-u-margin-bottom-6">
-                    <h3>
+                        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
                         @competencyGroup.Key
-                    </h3>
+                        </legend>
                     <div class="nhsuk-checkboxes">
                         <div class="nhsuk-checkboxes__item">
                             <input class="nhsuk-checkboxes__input" data-group="@competencyGroup.First().GroupId" id="competency-check-@competencyGroup.First().GroupId" name="GroupIds" checked="@competencyGroup.Any(x => x.GroupOptionalCompetencies)" type="checkbox" value="@competencyGroup.First().GroupId">
@@ -93,6 +92,7 @@
         </svg>
         Cancel
     </a>
+    </div>
 </div>
 @section scripts {
     <script src="@Url.Content("~/js/frameworks/selectoptionalcompetencies.js")" asp-append-version="true"></script>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
@@ -21,6 +21,7 @@
         </div>
     </nav>
 }
+<div class="nhsuk-form-group">
 <h1 class="app-page-heading">
     <span class="nhsuk-caption-xl">
         @Model.CompetencyAssessmentName
@@ -28,8 +29,8 @@
     </span>Set a minimum number of optional @Model.VocabularyPlural.ToLower()
 </h1>
 
-<p class="nhsuk-lede-text">
-    If required, you can specify a minimum number of optional @Model.VocabularyPlural.ToLower() that a learner must select when completing their @Model.CompetencyAssessmentName self-assessment.
+<p>
+ You can specify a minimum number of optional @Model.VocabularyPlural.ToLower() that a learner must select when completing their self-assessment.
 </p>
 <form method="post" asp-action="SetMinimumOptionalCompetencies">
     <nhs-form-group nhs-validation-for="MinimumOptionalCompetencies">
@@ -56,4 +57,5 @@
         </svg>
         Cancel
     </a>
+</div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
@@ -22,29 +22,31 @@
         </div>
     </nav>
 }
+<div class="nhsuk-form-group">
 <h1 class="app-page-heading">
     <span class="nhsuk-caption-xl">
         @Model.CompetencyAssessmentName
         <span class="nhsuk-u-visually-hidden"> – </span>
-    </span>Optional @Model.VocabularyPlural.ToLower() learner prompt
+    </span>Optional learner prompt
 </h1>
 
-<p class="nhsuk-lede-text">
-    Provide an optional prompt to help learners choose the right optional @Model.VocabularyPlural.ToLower() to include in their @Model.CompetencyAssessmentName self-assessment.
+<p>
+    Provide a prompt to help learners choose the right optional @Model.VocabularyPlural.ToLower() to include in their self-assessment.
 </p>
 <form method="post" asp-action="SetOptionalCompetencyLearnerPrompt">
     <nhs-form-group nhs-validation-for="ManageOptionalCompetenciesPrompt">
         <vc:text-area asp-for="ManageOptionalCompetenciesPrompt"
                       character-count="null"
-                      label="Set optional @Model.VocabularyPlural.ToLower()"
+                      label=""
                       rows="5"
                       css-class="html-editor"
-                      hint-text="This text will be displayed above the optional @Model.VocabularyPlural.ToLower() list to help the learner to choose them."
+                      hint-text="This text will be displayed above the optional @Model.VocabularyPlural.ToLower() list."
                       populate-with-current-value="true"
                       spell-check="false" />
         <span nhs-validation-for="ManageOptionalCompetenciesPrompt"></span>
     </nhs-form-group>
     <input type="hidden" asp-for="ID" />
+        <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">
         Save
     </button>
@@ -57,6 +59,7 @@
         </svg>
         Cancel
     </a>
+</div>
 </div>
 @section scripts {
     <script src="@Url.Content("~/js/frameworks/htmleditor.js")" asp-append-version="true"></script>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6954

### Description
Refined optional proficiencies content to support dynamic terminology and improve readability and consistency across all pages.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/e52c7803-0596-497c-836f-dcf847d792d0" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/fb10c698-507b-4282-909a-6b19ce768d55" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/76949b6a-8596-43e3-b322-cf975026a4a3" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
