### PR TITLE
TD-6945 Adding caption  to  self assessment pages that the caption is…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -875,6 +875,7 @@
             var model = new WorkingGroupCollaboratorsViewModel()
             {
                 CompetencyAssessmentID = competencyAssessmentId,
+                CompetencyAssessmentName = competencyAssessmentBase.CompetencyAssessmentName,
                 Collaborators = collaborators,
                 CompetencyAssessmentTaskStatus = taskStatus.WorkingGroupTaskStatus,
                 UserEmail = null,
@@ -996,6 +997,7 @@
 
             data.CurrentStep = step;
             var model = new OptionsLabelsViewModel(data);
+            model.CompetencyAssessmentName = competencyAssessmentBase.CompetencyAssessmentName;
 
             return View("CompetencyAssessmentOptions", model);
         }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/OptionsLabelsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/OptionsLabelsViewModel.cs
@@ -32,7 +32,7 @@
         public int FrameworkId { get; set; }
         public int CompetencyAssessmentID { get; set; }
         public int CurrentStep { get; set; } = 1;
-
+        public string CompetencyAssessmentName { get; set; } = string.Empty;
         public bool IncludeLearnerDeclarationPrompt { get; set; }
         public bool IncludesSignposting { get; set; }
         public bool LinearNavigation { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/WorkingGroupCollaboratorsViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/WorkingGroupCollaboratorsViewModel.cs
@@ -6,6 +6,7 @@
     public class WorkingGroupCollaboratorsViewModel
     {
         public int CompetencyAssessmentID { get; set; }
+        public string CompetencyAssessmentName { get; set; } = string.Empty;
         public IEnumerable<CompetencyAssessmentCollaboratorDetail>? Collaborators { get; set; }
         public int AdminID { get; set; }
         public bool? CompetencyAssessmentTaskStatus { get; set; }
@@ -13,6 +14,5 @@
         public bool Error { get; set; }
         public string? ActionName { get; set; }
         public int UserRole { get; set; }
-
     }
 }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
@@ -26,8 +26,12 @@
     <nhs-form-group nhs-validation-for="SelectedCompetencyIds">
         <fieldset class="nhsuk-fieldset">
             <legend class="nhsuk-fieldset__legend">
-                <h1>
-                    Add @Model.VocabularyPlural.ToLower() to assessment from @Model.FrameworkName
+                <h1 class="app-page-heading">
+                <span class="nhsuk-caption-xl">
+                    @Model.CompetencyAssessmentName
+                    <span class="nhsuk-u-visually-hidden"> – </span>
+                </span>
+                    Add @Model.VocabularyPlural.ToLower() to assessment
                 </h1>
             </legend>
 

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetenciesSelectFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetenciesSelectFramework.cshtml
@@ -21,7 +21,12 @@
         </div>
     </nav>
 }
-<h1>Select framework source</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>Select framework source
+</h1>
 <form method="post">
     @if (!ViewData.ModelState.IsValid)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -82,7 +82,11 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">
+                    <h1 class="app-page-heading">
+                        <span class="nhsuk-caption-xl">
+                            @Model.CompetencyAssessmentName
+                            <span class="nhsuk-u-visually-hidden"> – </span>
+                        </span>
                         Display learner declaration?
                     </h1>
                 </legend>
@@ -112,7 +116,11 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">
+                    <h1 class="app-page-heading">
+                        <span class="nhsuk-caption-xl">
+                            @Model.CompetencyAssessmentName
+                            <span class="nhsuk-u-visually-hidden"> – </span>
+                        </span>
                         Include signposting?
                     </h1>
                 </legend>
@@ -142,7 +150,11 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">
+                    <h1 class="app-page-heading">
+                        <span class="nhsuk-caption-xl">
+                            @Model.CompetencyAssessmentName
+                            <span class="nhsuk-u-visually-hidden"> – </span>
+                        </span>
                         Use linear navigation?
                     </h1>
                 </legend>
@@ -172,7 +184,11 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">
+                    <h1 class="app-page-heading">
+                        <span class="nhsuk-caption-xl">
+                            @Model.CompetencyAssessmentName
+                            <span class="nhsuk-u-visually-hidden"> – </span>
+                        </span>
                         Use description expanders?
                     </h1>
                 </legend>
@@ -202,7 +218,11 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">
+                    <h1 class="app-page-heading">
+                        <span class="nhsuk-caption-xl">
+                            @Model.CompetencyAssessmentName
+                            <span class="nhsuk-u-visually-hidden"> – </span>
+                        </span>
                         Custom question label
                     </h1>
                 </legend>
@@ -244,7 +264,11 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="nhsuk-fieldset__heading">
+                    <h1 class="app-page-heading">
+                        <span class="nhsuk-caption-xl">
+                            @Model.CompetencyAssessmentName
+                            <span class="nhsuk-u-visually-hidden"> – </span>
+                        </span>
                         Reviewer comments label
                     </h1>
                 </legend>
@@ -286,9 +310,13 @@
         <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-full">
 
-                <div class="nhsuk-u-margin-bottom-8">
-                    <h1 id="page-heading" class="nhsuk-heading-xl">Summary</h1>
-                </div>
+                <h1 class="app-page-heading">
+                    <span class="nhsuk-caption-xl">
+                        @Model.CompetencyAssessmentName
+                        <span class="nhsuk-u-visually-hidden"> – </span>
+                    </span>Summary
+                </h1>
+            
 
                 <dl class="nhsuk-summary-list word-break">
                     @if (Model.IsSupervisionSwitchedOn)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -27,7 +27,12 @@
         </div>
     </nav>
 }
-<h1>Choose working group members</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+   Choose working group members</h1>
 <div class="nhsuk-table__panel-with-heading-tab">
     <h2 class="nhsuk-table__heading-tab">Working group members</h2>
     <table role="presentation" class="nhsuk-table-responsive">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditCompetencyRoleRequirements.cshtml
@@ -22,7 +22,13 @@
         </div>
     </nav>
 }
-<h1>Edit @Model.VocabularySingular.ToLower() role requirements</h1>
+<h1 class="app-page-heading">
+    <span class="nhsuk-caption-xl">
+        @Model.CompetencyAssessmentName
+        <span class="nhsuk-u-visually-hidden"> – </span>
+    </span>
+   Edit @Model.VocabularySingular.ToLower() role requirements
+ </h1>
 <p class="nhsuk-lede-text">
     Manage role requirements @Model.CompetencyAssessmentName @Model.VocabularySingular.ToLower() self-assessment questions.
 </p>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6945

### Description
I added captions to the self-assessment pages where they were previously missing.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/64932b4f-34b4-4788-81a6-34e1cc8e35af" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/54e897d9-cd8a-48e5-bd31-256268db1265" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/20e14cbd-468b-4d04-86d1-164171671621" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
