### PR TITLE
TD-6953 Capabilities page improvements

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
@@ -37,9 +37,6 @@
     @if (primaryFramework != null)
     {
         <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-                Primary framework
-            </dt>
             <dd class="nhsuk-summary-list__value">
                 @primaryFramework.FrameworkName (@primaryFramework.AssessmentFrameworkCompetencyCount @Model.VocabularyPlural.ToLower())
             </dd>
@@ -47,7 +44,7 @@
             {
                 <dd class="nhsuk-summary-list__actions">
                     <a asp-action="AddCompetencies" asp-route-competencyAssessmentId="@Model.ID" asp-route-frameworkId="@primaryFramework.ID">
-                        Manage<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
+                        Add @Model.VocabularyPlural.ToLower()<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
                     </a>
                 </dd>
             }
@@ -59,9 +56,6 @@
     @foreach (var framework in linkedFrameworks)
     {
         <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-                Additional framework @i
-            </dt>
             <dd class="nhsuk-summary-list__value">
                 @framework.FrameworkName (@framework.AssessmentFrameworkCompetencyCount @Model.VocabularyPlural.ToLower())
             </dd>
@@ -69,7 +63,7 @@
             {
                 <dd class="nhsuk-summary-list__actions">
                     <a asp-action="AddCompetencies" asp-route-competencyAssessmentId="@Model.ID" asp-route-frameworkId="@framework.ID">
-                        Manage<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
+                        Add @Model.VocabularyPlural.ToLower()<span class="nhsuk-u-visually-hidden"> @Model.VocabularyPlural.ToLower()</span>
                     </a>
                 </dd>
             }
@@ -213,7 +207,9 @@
 }
 else
 {
-    <p>There are no @Model.VocabularyPlural.ToLower() selected for this self-assessment.</p>
+     <p> @Model.VocabularyPlural will appear here after you have added them from the frameworks linked to the self-assessment</p>
+    <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible" />
+
 }
 
 <form method="post">
@@ -224,7 +220,7 @@ else
     @if (Model.UserRole > 1)
     {
         <button class="nhsuk-button" type="submit">
-            Submit
+            Save
         </button>
     }
     <div class="nhsuk-back-link">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6953

### Description

Rename page title to “Capabilities”
Update action label from “Manage” to “Add capabilities”
Remove redundant “Primary framework” label (where context already makes this clear)
Add helper text when no capabilities are present:
“Capabilities will appear here after you have added them from linked frameworks.”
Insert an NHS section break to improve visual separation of content
Change button label from “Submit” to “Save”

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b049c0c1-fbc0-4f81-bfed-f575cbb74894" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
