### PR TITLE
TD-7030 adding Started and Not started tags

### DIFF
--- a/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterableTagHelper.cs
@@ -235,6 +235,10 @@
 
             }
 
+            var learnerActivityTag = selfAssessmentDelegate.LaunchCount > 0
+                ? new SearchableTagViewModel(SelfAssessmentLearnerActivityFilterOptions.Started)
+         : new SearchableTagViewModel(SelfAssessmentLearnerActivityFilterOptions.NotStarted);
+            tags.Add(learnerActivityTag);
             return tags;
         }
         public static IEnumerable<SearchableTagViewModel> GetCurrentTagsForDelegateUser(


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7030

### Description
The code evaluates LaunchCount to determine learner activity status. It uses a conditional (ternary) operator to assign either a ‘Started’ or ‘Not started’ SearchableTagViewModel, and then adds that tag to the tags collection.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/c22e3d02-72da-40fd-9964-363e8a28149b" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
