### PR TITLE
TD-6945 Looks caption missing when there is an error on the screen

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1065,6 +1065,7 @@
                         var errModel = new OptionsLabelsViewModel(data);
                         errModel.ReviewerCommentsLabel = model.ReviewerCommentsLabel;
                         errModel.ReviewerCommentsLabelText = model.ReviewerCommentsLabelText;
+                        errModel.CompetencyAssessmentName  = model.CompetencyAssessmentName;
                         errModel.Error = true;
                         return View("CompetencyAssessmentOptions", errModel);
                     }
@@ -1689,7 +1690,7 @@
                 return StatusCode(500);
             }
 
-            var model = new CompetencyAssessmentPreviewViewModel(competencyAssessmentId, centreId, centreName);
+            var model = new CompetencyAssessmentPreviewViewModel(competencyAssessmentId, competencyAssessmentBase.CompetencyAssessmentName, centreId, centreName);
 
             return View("CompetencyAssessmentPreviewConfirm", model);
         }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/CompetencyAssessmentPreviewViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/CompetencyAssessmentPreviewViewModel.cs
@@ -4,13 +4,15 @@
     {
         public CompetencyAssessmentPreviewViewModel()
         { }
-        public CompetencyAssessmentPreviewViewModel(int competencyAssessmentId, int centreId, string centreName)
+        public CompetencyAssessmentPreviewViewModel(int competencyAssessmentId,string competencyAssessmentName, int centreId, string centreName)
         {
             CompetencyAssessmentId = competencyAssessmentId;
+            CompetencyAssessmentName = competencyAssessmentName;
             CentreId = centreId;
             CentreName = centreName;
         }
         public int CompetencyAssessmentId { get; set; }
+        public string CompetencyAssessmentName { get; set; } = string.Empty;
         public int CentreId { get; set; }
         public string CentreName { get; set; } = string.Empty;
     }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -76,6 +76,7 @@
 
 <form asp-action="OptionsLabels" method="post">
     <input type="hidden" name="CurrentStep" value="@Model.CurrentStep" />
+    <input type="hidden" name="CompetencyAssessmentName" value="@Model.CompetencyAssessmentName" />
 
     @if (Model.CurrentStep == (int)OptionLabel.Declaration)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentPreviewConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentPreviewConfirm.cshtml
@@ -28,7 +28,11 @@
     <div class="nhsuk-form-group" id="form-group">
         <form asp-action="PreviewConfirm" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId" asp-route-competencyGroupId="@Model.CompetencyAssessmentId">
             <div class="nhsuk-u-reading-width">
-                <h1 id="form-heading" class="nhsuk-fieldset__heading nhsuk-label--l">
+                <h1 class="app-page-heading">
+                    <span class="nhsuk-caption-xl">
+                        @Model.CompetencyAssessmentName
+                        <span class="nhsuk-u-visually-hidden"> – </span>
+                    </span>
                     Preview self-assessment
                 </h1>
                 <p class="nhsuk-body-l">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Name.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/Name.cshtml
@@ -43,7 +43,12 @@ else
 }
 else
 {
-    <h1>Edit self-assessment name</h1>
+    <h1 class="app-page-heading">
+        <span class="nhsuk-caption-xl">
+            @Model.CompetencyAssessmentName
+            <span class="nhsuk-u-visually-hidden"> – </span>
+        </span>Edit self-assessment name
+    </h1>
 }
 <form method="post">
     <div class="nhsuk-u-reading-width">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6945

### Description
The CompetencyAssessmentName field has been added to the error model so that the caption appears when the error is enabled

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/afa9f4c3-48eb-4c67-9aa4-8f584f853b97" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/2eff5f87-f52f-4382-892e-873e090697b2" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
