### PR TITLE
TD-7134 Issue with the header navigation links changed to Learning po…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentFeatures.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentFeatures.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -28,7 +28,7 @@
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @if (Model.Error)
 {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentPreviewConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentPreviewConfirm.cshtml
@@ -10,7 +10,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentSummary.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -9,7 +9,7 @@
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @if (Model.Error)
 {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmMakePrimaryFramework.cshtml
@@ -6,7 +6,9 @@
     var errorHasOccurred = !ViewData.ModelState.IsValid && ViewData.ModelState.ContainsKey(nameof(Model.Confirm));
     ViewData["Title"] = "Self-assessments - make primary framework";
 }
-
+@section NavMenuItems {
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
+}
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
         @if (errorHasOccurred)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmRemoveFrameworkSource.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ConfirmRemoveFrameworkSource.cshtml
@@ -5,6 +5,9 @@
     var errorHasOccurred = !ViewData.ModelState.IsValid;
     ViewData["Title"] = "Self-assessments - remove source framework";
 }
+@section NavMenuItems {
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
+}
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
         @if (errorHasOccurred)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishReview.cshtml
@@ -7,7 +7,7 @@
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishWithoutReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/PublishWithoutReview.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Publish without review";
 }
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/RemoveCompetencyGroupConfirm.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/RemoveCompetencyGroupConfirm.cshtml
@@ -10,7 +10,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SendForReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SendForReview.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Send for review";
 }
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SubmitReview.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SubmitReview.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Submit review";
 }
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SupervisedSelfAssessmentSignoff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SupervisedSelfAssessmentSignoff.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section NavMenuItems {
-    <partial name="Shared/_NavMenuItems" />
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
 }
 @section NavBreadcrumbs {
     <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">


### PR DESCRIPTION
### JIRA link
[TD-7134](https://hee-tis.atlassian.net/browse/TD-7134)

### Description
I changed the partial view reference from Learning Portal to Framework so the correct header is rendered.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/9e460850-499a-495c-a703-fccd2e62ed8b" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/99615368-d297-4a51-b59c-bcbb39df1d5b" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7134]: https://hee-tis.atlassian.net/browse/TD-7134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ