### PR TITLE
TD-6954 Resolving issue observed during testing

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -638,7 +638,7 @@
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = model.ID });
         }
         [HttpGet]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/Manage")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/Manage")]
         public IActionResult ManageOptionalCompetencies(int competencyAssessmentId)
         {
             var adminId = GetAdminID();
@@ -656,7 +656,7 @@
             return View(model);
         }
         [HttpPost]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/Manage")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/Manage")]
         public IActionResult ManageOptionalCompetencies(ViewSelectedCompetenciesFormData model)
         {
             if (model.TaskStatus == null)
@@ -667,7 +667,7 @@
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = model.ID });
         }
         [HttpGet]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/Select")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/Select")]
         public IActionResult SelectOptionalCompetencies(int competencyAssessmentId)
         {
             var adminId = GetAdminID();
@@ -685,7 +685,7 @@
             return View(model);
         }
         [HttpPost]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/Select")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/Select")]
         public IActionResult SelectOptionalCompetencies(SelectOptionalCompetenciesFormData model)
         {
             if (!ModelState.IsValid)
@@ -704,7 +704,7 @@
             return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID });
         }
         [HttpGet]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/SetMinimum")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/SetMinimum")]
         public IActionResult SetMinimumOptionalCompetencies(int competencyAssessmentId)
         {
             var adminId = GetAdminID();
@@ -717,7 +717,7 @@
             return View("SetMinimumOptionalCompetencies", viewModel);
         }
         [HttpPost]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/SetMinimum")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/SetMinimum")]
         public IActionResult SetMinimumOptionalCompetencies(SetMinimumOptionalCompetenciesFormData model)
         {
             if (!ModelState.IsValid)
@@ -732,7 +732,7 @@
             return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID });
         }
         [HttpGet]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/LearnerPrompt")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/LearnerPrompt")]
         public IActionResult SetOptionalCompetencyLearnerPrompt(int competencyAssessmentId)
         {
             var adminId = GetAdminID();
@@ -745,7 +745,7 @@
             return View("SetOptionalCompetencyLearnerPrompt", viewModel);
         }
         [HttpPost]
-        [Route("/CompetencyAssessments/{competencyAssessmentId}/Competencies/Optional/LearnerPrompt")]
+        [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/LearnerPrompt")]
         public IActionResult SetOptionalCompetencyLearnerPrompt(SetOptionalCompetencyLearnerPromptFormData model)
         {
             if (!ModelState.IsValid)

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectOptionalCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectOptionalCompetenciesViewModel.cs
@@ -25,5 +25,17 @@
         public string VocabularySingular { get; set; }
         public string VocabularyPlural { get; set; }
         public IEnumerable<IGrouping<string, Competency>>? CompetencyGroups { get; set; }
+        public string GetGroupLabel(string? key)
+        {
+            if (string.IsNullOrWhiteSpace(key)) return "";
+
+            if (string.IsNullOrWhiteSpace(VocabularyPlural))
+                return key;
+            var keyLower = key.ToLower();
+            var vocab = VocabularyPlural.ToLower();
+            if (keyLower.Contains(vocab) || keyLower.Contains("proficiencies"))
+                return key;
+            return $"{key} {vocab}";
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
@@ -178,7 +178,7 @@
             else
             {
                 <div class="nhsuk-task-list__name-and-hint" aria-describedby="optional-competencies-status">
-                    <a class="nhsuk-link nhsuk-task-list__link" asp-action="ManageOptionalCompetencies" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
+                    <a class="nhsuk-link nhsuk-task-list__link" asp-action="ManageOptionalCompetencies" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
                         Manage optional @Model.VocabularyPlural.ToLower()
                     </a>
                 </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -15,7 +15,7 @@
             <ol class="nhsuk-breadcrumb__list">
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Self-assessments</a></li>
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Manage self-assessment</a></li>
-                <li class="nhsuk-breadcrumb__item">Optional Competencies</li>
+                <li class="nhsuk-breadcrumb__item">Optional @Model.VocabularyPlural.ToLower()</li>
             </ol>
             <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Back to manage self-assessment</a></p>
         </div>
@@ -62,7 +62,7 @@
         @if (Model.UserRole > 1)
         {
             <dd class="nhsuk-summary-list__actions">
-                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SelectOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> optional @Model.VocabularyPlural.ToLower()</span></a>
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SelectOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> optional @Model.VocabularyPlural.ToLower()</span></a>
             </dd>
         }
     </div>
@@ -78,7 +78,7 @@
             @if (Model.UserRole > 1)
             {
                 <dd class="nhsuk-summary-list__actions">
-                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SetMinimumOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> minimum optional @Model.VocabularyPlural.ToLower()</span></a>
+                        <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SetMinimumOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> minimum optional @Model.VocabularyPlural.ToLower()</span></a>
                 </dd>
             }
         </div>
@@ -92,7 +92,7 @@
             @if (Model.UserRole > 1)
             {
                 <dd class="nhsuk-summary-list__actions">
-                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-action="SetOptionalCompetencyLearnerPrompt">Change<span class="nhsuk-u-visually-hidden"> learner prompt</span></a>
+                        <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SetOptionalCompetencyLearnerPrompt">Change<span class="nhsuk-u-visually-hidden"> learner prompt</span></a>
                 </dd>
             }
         </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -15,7 +15,7 @@
             <ol class="nhsuk-breadcrumb__list">
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Self-assessments</a></li>
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Manage self-assessment</a></li>
-                <li class="nhsuk-breadcrumb__item">Optional Competencies</li>
+                <li class="nhsuk-breadcrumb__item">Optional @Model.VocabularyPlural.ToLower()</li>
             </ol>
             <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Back to manage self-assessment</a></p>
         </div>
@@ -27,7 +27,7 @@
         @Model.CompetencyAssessmentName
         <span class="nhsuk-u-visually-hidden"> – </span>
     </span>
-    Select optional competencies
+    Select optional @Model.VocabularyPlural.ToLower()
 </h1>
 
 <p>
@@ -49,15 +49,11 @@
                         <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
                         @competencyGroup.Key
                         </legend>
-
-                    <h2>
-                        @competencyGroup.Key
-                    </h2>
                     <div class="nhsuk-checkboxes">
                         <div class="nhsuk-checkboxes__item">
                             <input class="nhsuk-checkboxes__input" data-group="@competencyGroup.First().GroupId" id="competency-check-@competencyGroup.First().GroupId" name="GroupIds" checked="@competencyGroup.Any(x => x.GroupOptionalCompetencies)" type="checkbox" value="@competencyGroup.First().GroupId">
                             <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competencyGroup.First().GroupId">
-                                <strong>@competencyGroup.Key @Model.VocabularyPlural.ToLower() optional as a group</strong>
+                                    <strong>@Model.GetGroupLabel(competencyGroup.Key) optional as a group</strong>
                             </label>
                         </div>
                         @foreach (var competency in competencyGroup)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
@@ -15,7 +15,7 @@
             <ol class="nhsuk-breadcrumb__list">
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Self-assessments</a></li>
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Manage self-assessment</a></li>
-                <li class="nhsuk-breadcrumb__item">Optional Competencies</li>
+                <li class="nhsuk-breadcrumb__item">Optional @Model.VocabularyPlural.ToLower()</li>
             </ol>
             <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Back to manage self-assessment</a></p>
         </div>
@@ -45,6 +45,7 @@
     </nhs-form-group>
     <input type="hidden" asp-for="ID" />
     <input type="hidden" asp-for="OptionalCompetenciesCount" />
+    <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">
         Save
     </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
@@ -16,7 +16,7 @@
             <ol class="nhsuk-breadcrumb__list">
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ViewCompetencyAssessments" asp-route-tabname="Mine">Self-assessments</a></li>
                 <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Manage self-assessment</a></li>
-                <li class="nhsuk-breadcrumb__item">Optional Competencies</li>
+                <li class="nhsuk-breadcrumb__item">Optional @Model.VocabularyPlural.ToLower()</li>
             </ol>
             <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">Back to manage self-assessment</a></p>
         </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6954

### Description
Replaced “competencies” with vocabulary to make it dynamic. Handled duplication in the labels. Adjusted spacing for the save button and text field.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/5b7bd28c-18b6-46e2-914c-09fc9b7cbbc5" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/45e54680-f2f1-4783-b0cc-5e12aa35fa63" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation
