### PR TITLE
TD-6955 Role requirements page consistency fixes

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditCompetencyRoleRequirements.cshtml
@@ -92,12 +92,8 @@
         </tbody>
     </table>
 }
-<div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyRoleRequirements" asp-route-competencyAssessmentId="@Model.Id">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        Cancel
-    </a>
-</div>
-</div>
+    <div class="nhsuk-u-margin-top-4">
+        <a class="nhsuk-button" asp-action="ManageCompetencyRoleRequirements" asp-route-competencyAssessmentId="@Model.Id">
+            Done
+        </a>
+    </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditIncludeRequirementsFilters.cshtml
@@ -35,10 +35,10 @@
     <nhs-form-group nhs-validation-for="IncludeRequirementsFilters">
         <fieldset class="nhsuk-fieldset" aria-describedby="role-requirements-filters-hint">
             <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-                Do you want to include role requirements filters in the self-assessment?
+                    Do you want to enforce role requirements filters for the self-assessment?
             </legend>
             <div id="role-requirements-filters-hint" class="nhsuk-hint">
-                This will allow the learner to filter self-assessment competencies based on whether they are meeting the role requirements set.
+                    This will allow the learner to filter self-assessment @Model.VocabularyPlural.ToLower() based on whether they are meeting the role requirements set.
             </div>
             <span nhs-validation-for="IncludeRequirementsFilters"></span>
             <div class="nhsuk-radios nhsuk-radios--inline">
@@ -56,6 +56,7 @@
     <input type="hidden" asp-for="Id" />
     <input type="hidden" asp-for="EnforceRoleRequirementsForSignOff" />
     <input type="hidden" asp-for="TaskStatus" />
+    <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button nhsuk-button--primary" type="submit">Save</button>
 </form>
 <div class="nhsuk-back-link">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditQuestionResponseRoleRequirements.cshtml
@@ -67,7 +67,7 @@
     </div>
 </dl>
 <form method="post" asp-action="EditQuestionResponseRoleRequirements">
-    <h2>Set role requirements for each possible response</h2>
+    <h2>Set role requirements for each response</h2>
     @foreach (var response in Model.GroupedCompetencyWithAssessmentRoleRequirements.First().Competencies.First().Questions.First().Responses)
     {
         <nhs-form-group>
@@ -76,7 +76,7 @@
                     @response.ResponseLabel
                 </legend>
                 <div id="response-@response.ResponseValue-hint" class="nhsuk-hint">
-                    Choose a role requirement status for learners choosing this response
+                    Select a role requirement status for learners choosing this response
                 </div>
 
                 <div class="nhsuk-radios" data-module="nhsuk-radios">
@@ -137,6 +137,7 @@
     }
     @if (Model.CountAssessmentQuestionInSelfAssessment > 1)
     {
+        <hr class="nhsuk-section-break nhsuk-section-break--m" />
         <fieldset class="nhsuk-fieldset">
             <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
                 Apply to all?
@@ -147,6 +148,7 @@
     <input type="hidden" asp-for="@Model.Id" />
     <input type="hidden" asp-for="@Model.CompetencyId" />
     <input type="hidden" asp-for="@Model.AssessmentQuestionId" />
+        <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">
         Save
     </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EnforceRoleRequirementsForSignOff.cshtml
@@ -38,7 +38,7 @@
                 Do you want to enforce role requirements for the self-assessment?
             </legend>
             <div id="enforce-role-requirements-hint" class="nhsuk-hint">
-                When role requirements are enforced, learners can only request confirmation for self‑assessment results that meet the required competency criteria, even if no specific requirements are set.
+                    When requirements are set, they must be met by the learner before the self-assessment can be signed off.
             </div>
             <span nhs-validation-for="EnforceRoleRequirementsForSignOff"></span>
             <div class="nhsuk-radios nhsuk-radios--inline">
@@ -56,6 +56,7 @@
     <input type="hidden" asp-for="Id" />
     <input type="hidden" asp-for="IncludeRequirementsFilters" />
     <input type="hidden" asp-for="TaskStatus" />
+        <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button nhsuk-button--primary" type="submit">Save</button>
 </form>
 <div class="nhsuk-back-link">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6955

### Description
I adjust spacing between radio buttons and the “Save” button
I use the correct label text
I change the “Cancel” button to “Done”
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/59e8c1cb-07e3-4dc0-bf6d-638b6c0aeabc" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/057c82ec-f5b1-41dd-9aa9-f88c724ee177" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/0150e1fe-6174-4a63-9ff4-b2644b88f26d" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
