### PR TITLE
TD-6949 Remove word “assessment” from items where redundant

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
@@ -115,7 +115,7 @@
         <li class="nhsuk-task-list__item nhsuk-task-list__item--with-link">
             <div class="nhsuk-task-list__name-and-hint" aria-describedby="vocabulary-status">
                 <a class="nhsuk-link nhsuk-task-list__link" asp-action="EditVocabulary" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                    Select assessment vocabulary
+                    Select vocabulary
                 </a>
             </div>
             <div class="nhsuk-task-list__status" id="vocabulary-status">
@@ -135,7 +135,7 @@
         <li class="nhsuk-task-list__item nhsuk-task-list__item--with-link">
             <div class="nhsuk-task-list__name-and-hint" aria-describedby="national-profiles-status">
                 <a class="nhsuk-link nhsuk-task-list__link" asp-action="EditRoleProfileLinks" asp-route-actionName="@(Model.CompetencyAssessmentTaskStatus.NationalRoleProfileTaskStatus == null ? "EditGroup" : "Summary")" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                    Link assessment to National Role profiles
+                    Link to National Role profiles
                 </a>
             </div>
             <div class="nhsuk-task-list__status" id="national-profiles-status">


### PR DESCRIPTION
### JIRA link
[TD-####](https://hee-tis.atlassian.net/browse/TD-####)

### Description
I removed “Assessment” next to “Vocabulary” and “National”
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/428240c0-8209-469d-aaa5-a3a91fc7faa6" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
