### PR TITLE
TD-7032 Adding Hyphen To Sign Off

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
@@ -49,7 +49,7 @@
                 </h3>
                 <p>
                     You have submitted new self assessment results since this self assessment was signed off.
-                    Please resubmit your self assessment for sign off once these results are confirmed.
+                    Please resubmit your self assessment for sign-off once these results are confirmed.
                 </p>
             </div>
         }


### PR DESCRIPTION
### JIRA link
[TD-7032](https://hee-tis.atlassian.net/browse/TD-7032)

### Description
Adding Hyphen To Sign Off wording.

### Screenshots
<img width="1292" height="371" alt="image" src="https://github.com/user-attachments/assets/fe404dac-8c8b-44d7-8c27-44a7cd58f65d" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7032]: https://hee-tis.atlassian.net/browse/TD-7032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ