### PR TITLE
TD-6954  Optional proficiencies content cleanup

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -701,7 +701,7 @@
                 return View("SelectOptionalCompetencies", viewModel);
             }
             competencyAssessmentService.UpdateOptionalCompetenciesInAssessment(model.ID, model.GroupIds ?? [], model.SelectedCompetencyIds ?? []);
-            return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID });
+            return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID, vocabularyPlural = model.VocabularyPlural });
         }
         [HttpGet]
         [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/SetMinimum")]
@@ -729,7 +729,7 @@
                 return View("SetMinimumOptionalCompetencies", viewModel);
             }
             competencyAssessmentService.UpdateMinimumOptionalCompetencies(model.ID, model.MinimumOptionalCompetencies ?? 0);
-            return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID });
+            return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID, vocabularyPlural = model.VocabularyPlural });
         }
         [HttpGet]
         [Route("/CompetencyAssessments/{competencyAssessmentId}/{vocabularyPlural}/Optional/LearnerPrompt")]
@@ -757,7 +757,7 @@
                 return View("SetOptionalCompetencyLearnerPrompt", viewModel);
             }
             competencyAssessmentService.UpdateManageOptionalCompetenciesPrompt(model.ID, model.ManageOptionalCompetenciesPrompt);
-            return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID });
+            return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID, vocabularyPlural = model.VocabularyPlural });
         }
 
         [Route("/CompetencyAssessments/Framework/{frameworkId}/{competencyAssessmentId}/Features")]

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
@@ -13,8 +13,8 @@
     const updateState = () => {
       const isChecked = groupToggle.checked;
 
-      childCheckboxes.forEach((cb) => {
-        cb.checked = isChecked;
+      childCheckboxes.forEach((_, index) => {
+        childCheckboxes[index].checked = isChecked;
       });
     };
 
@@ -25,4 +25,3 @@
     updateState();
   });
 });
-

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
@@ -14,16 +14,7 @@
       const isChecked = groupToggle.checked;
 
       childCheckboxes.forEach((cb) => {
-        if (isChecked) {
-          // eslint-disable-next-line no-param-reassign
-          cb.checked = true; // force selected
-          // eslint-disable-next-line no-param-reassign
-          cb.disabled = true; // lock them
-        } else {
-          // eslint-disable-next-line no-param-reassign
-          cb.disabled = false; // re-enable when group is unchecked
-          // optional: leave cb.checked unchanged
-        }
+        cb.checked = isChecked;
       });
     };
 
@@ -34,3 +25,4 @@
     updateState();
   });
 });
+

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectOptionalCompetenciesFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectOptionalCompetenciesFormData.cs
@@ -10,5 +10,8 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
         public string? ManageOptionalCompetenciesPrompt { get; set; }
         public int[] SelectedCompetencyIds { get; set; } = [];
         public int[] GroupIds { get; set; } = [];
+        public string VocabularySingular { get; set; }
+        public string VocabularyPlural { get; set; }
+
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectOptionalCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectOptionalCompetenciesViewModel.cs
@@ -22,8 +22,6 @@
         }
         public string CompetencyAssessmentName { get; set; }
         public int UserRole { get; set; }
-        public string VocabularySingular { get; set; }
-        public string VocabularyPlural { get; set; }
         public IEnumerable<IGrouping<string, Competency>>? CompetencyGroups { get; set; }
         public string GetGroupLabel(string? key)
         {

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetMinimumOptionalCompetenciesFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetMinimumOptionalCompetenciesFormData.cs
@@ -8,5 +8,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
         public int? MinimumOptionalCompetencies { get; set; }
         public int OptionalCompetenciesCount { get; set; }
         public int ID { get; set; }
+        public string VocabularySingular { get; set; }
+        public string VocabularyPlural { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetMinimumOptionalCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetMinimumOptionalCompetenciesViewModel.cs
@@ -19,7 +19,5 @@
         }
         public string CompetencyAssessmentName { get; set; }
         public int UserRole { get; set; }
-        public string VocabularySingular { get; set; }
-        public string VocabularyPlural { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetOptionalCompetencyLearnerPromptFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetOptionalCompetencyLearnerPromptFormData.cs
@@ -7,5 +7,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
         
         public string? ManageOptionalCompetenciesPrompt { get; set; }
         public int ID { get; set; }
+        public string VocabularySingular { get; set; }
+        public string VocabularyPlural { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetOptionalCompetencyLearnerPromptViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SetOptionalCompetencyLearnerPromptViewModel.cs
@@ -18,7 +18,5 @@
         }
         public string CompetencyAssessmentName { get; set; }
         public int UserRole { get; set; }
-        public string VocabularySingular { get; set; }
-        public string VocabularyPlural { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model SelectOptionalCompetenciesViewModel;
 @{
-    ViewData["Title"] = "Manage optional competencies";
+    ViewData["Title"] = $"Manage optional {@Model.VocabularyPlural.ToLower()}";
     ViewData["Application"] = "Framework service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
@@ -106,6 +106,8 @@ Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a se
         <input type="hidden" asp-for="ManageOptionalCompetenciesPrompt" />
         <input type="hidden" asp-for="SelectedCompetencyIds" />
         <input type="hidden" asp-for="GroupIds" />
+        <input type="hidden" asp-for="VocabularyPlural" />
+
         <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
     </nhs-form-group>
     @if (Model.UserRole > 1)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model SelectOptionalCompetenciesViewModel;
 @{
-    ViewData["Title"] = "Select optional competencies";
+    ViewData["Title"] = $"Select optional {Model.VocabularyPlural.ToLower()}";
     ViewData["Application"] = "Framework service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
@@ -32,7 +32,7 @@
 </h1>
 
 <p>
- Optional competencies can be added to the assessment individually or as a group.
+        Optional @Model.VocabularyPlural.ToLower() can be added to the assessment individually or as a group.
 </p>
 <form method="post" asp-action="SelectOptionalCompetencies">
     <fieldset class="nhsuk-fieldset">
@@ -83,13 +83,15 @@
     <input type="hidden" asp-for="ID" />
     <input type="hidden" asp-for="MinimumOptionalCompetencies" />
     <input type="hidden" asp-for="ManageOptionalCompetenciesPrompt" />
+    <input type="hidden" asp-for="VocabularyPlural" />
+        
     <button class="nhsuk-button" type="submit">
         Save
     </button>
 </form>
 
 <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
+        <a class="nhsuk-back-link__link"  asp-action="ManageOptionalCompetencies" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-route-competencyAssessmentId="@Model.ID">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
         </svg>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model SetMinimumOptionalCompetenciesViewModel;
 @{
-    ViewData["Title"] = "Set minimum optional competencies";
+    ViewData["Title"] = $"Set minimum optional {Model.VocabularyPlural.ToLower()}";
     ViewData["Application"] = "Framework service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
@@ -46,6 +46,7 @@
     </nhs-form-group>
     <input type="hidden" asp-for="ID" />
     <input type="hidden" asp-for="OptionalCompetenciesCount" />
+    <input type="hidden" asp-for="VocabularyPlural" />
     <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">
         Save
@@ -53,7 +54,7 @@
 </form>
 
 <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
+        <a class="nhsuk-back-link__link" asp-action="ManageOptionalCompetencies" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-route-competencyAssessmentId="@Model.ID">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
         </svg>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model SetOptionalCompetencyLearnerPromptViewModel;
 @{
-    ViewData["Title"] = "Set optional competencies learner prompt";
+    ViewData["Title"] = $"Set optional {Model.VocabularyPlural.ToLower()} learner prompt";
     ViewData["Application"] = "Framework service";
 }
 <link rel="stylesheet" href="@Url.Content("~/css/jodit.css")" asp-append-version="true">
@@ -47,6 +47,8 @@
         <span nhs-validation-for="ManageOptionalCompetenciesPrompt"></span>
     </nhs-form-group>
     <input type="hidden" asp-for="ID" />
+    <input type="hidden" asp-for="VocabularyPlural" />
+
         <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">
         Save
@@ -54,7 +56,7 @@
 </form>
 
 <div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
+        <a class="nhsuk-back-link__link" asp-action="ManageOptionalCompetencies" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-route-competencyAssessmentId="@Model.ID">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
         </svg>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6954

### Description
Replace “Competencies” with “Vocabulary” so the page title and URL update dynamically.

Updated the JavaScript logic to:

validate selections without disabling the selected group,
allow users to check a selected group,
and ensure the related group competency is also unchecked when the group is deselected.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/aef9d12e-055e-41b2-bcf3-d603d50a9f9d" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/157b8e63-bb4c-4f08-b700-0562dad924db" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
