### PR TITLE
TD-6941 Changing competencyAssessment to selfAssessment

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1501,7 +1501,7 @@
             {
                 var required = send.SignOffRequiredChecked.IndexOf(collaborator) != -1;
                 competencyAssessmentService.InsertSelfAssessmentReview(send.CompetencyAssessmentID, collaborator, required);
-                frameworkNotificationService.SendReviewRequestForCompetencyAssessment(collaborator, adminId, required, false, User.GetCentreIdKnownNotNull());
+                frameworkNotificationService.SendReviewRequestForSelfAssessment(collaborator, adminId, required, false, User.GetCentreIdKnownNotNull());
             }
             competencyAssessmentService.UpdateCompetencyAssessmentPublishStatus(send.CompetencyAssessmentID, 2, adminId);
             var taskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(send.CompetencyAssessmentID, null);
@@ -1588,7 +1588,7 @@
             }
             commentId = competencyAssessmentService.InsertComment(submit.CompetencyAssessmentID, adminId, submit.SelfAssessmentReview.Comment, null);
             competencyAssessmentService.UpdateSelfAssessmentReview(submit.CompetencyAssessmentID, submit.SelfAssessmentReview.ID, submit.SelfAssessmentReview.SignedOff, commentId);
-            frameworkNotificationService.SendCompetencyAssessmentsReviewOutcomeNotification(submit.SelfAssessmentReview.ID, centreId);
+            frameworkNotificationService.SendSelfAssessmentsReviewOutcomeNotification(submit.SelfAssessmentReview.ID, centreId);
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = submit.CompetencyAssessmentID });
         }
         [HttpGet]
@@ -1620,7 +1620,7 @@
         public IActionResult ResendRequest(int reviewId, int competencyAssessmentId, int competencyAssessmentCollaboratorId, bool required)
         {
             var adminId = GetAdminID();
-            frameworkNotificationService.SendReviewRequestForCompetencyAssessment(competencyAssessmentCollaboratorId, adminId, required, true, User.GetCentreIdKnownNotNull());
+            frameworkNotificationService.SendReviewRequestForSelfAssessment(competencyAssessmentCollaboratorId, adminId, required, true, User.GetCentreIdKnownNotNull());
             competencyAssessmentService.UpdateReviewRequestedDate(reviewId);
             return RedirectToAction("PublishReview", new { competencyAssessmentId });
         }
@@ -1630,7 +1630,7 @@
             competencyAssessmentService.InsertCompetencySelfAssessmentReview(reviewId);
             var review = competencyAssessmentService.GetSelfAssessmentReviewNotification(reviewId);
             if (review == null) return StatusCode(404);
-            frameworkNotificationService.SendReviewRequestForCompetencyAssessment(review.SelfAssessmentCollaboratorID, adminId, review.SignOffRequired, false, User.GetCentreIdKnownNotNull());
+            frameworkNotificationService.SendReviewRequestForSelfAssessment(review.SelfAssessmentCollaboratorID, adminId, review.SignOffRequired, false, User.GetCentreIdKnownNotNull());
             return RedirectToAction("PublishReview", new { competencyAssessmentId });
         }
         public IActionResult RemoveRequest(int competencyAssessmentId, int reviewId)

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1501,7 +1501,7 @@
             {
                 var required = send.SignOffRequiredChecked.IndexOf(collaborator) != -1;
                 competencyAssessmentService.InsertSelfAssessmentReview(send.CompetencyAssessmentID, collaborator, required);
-                frameworkNotificationService.SendReviewRequestForSelfAssessment(collaborator, adminId, required, false, User.GetCentreIdKnownNotNull());
+                selfAssessmentNotificationService.SendReviewRequestForSelfAssessment(collaborator, adminId, required, false, User.GetCentreIdKnownNotNull());
             }
             competencyAssessmentService.UpdateCompetencyAssessmentPublishStatus(send.CompetencyAssessmentID, 2, adminId);
             var taskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(send.CompetencyAssessmentID, null);
@@ -1588,7 +1588,7 @@
             }
             commentId = competencyAssessmentService.InsertComment(submit.CompetencyAssessmentID, adminId, submit.SelfAssessmentReview.Comment, null);
             competencyAssessmentService.UpdateSelfAssessmentReview(submit.CompetencyAssessmentID, submit.SelfAssessmentReview.ID, submit.SelfAssessmentReview.SignedOff, commentId);
-            frameworkNotificationService.SendSelfAssessmentsReviewOutcomeNotification(submit.SelfAssessmentReview.ID, centreId);
+            selfAssessmentNotificationService.SendSelfAssessmentsReviewOutcomeNotification(submit.SelfAssessmentReview.ID, centreId);
             return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = submit.CompetencyAssessmentID });
         }
         [HttpGet]
@@ -1620,7 +1620,7 @@
         public IActionResult ResendRequest(int reviewId, int competencyAssessmentId, int competencyAssessmentCollaboratorId, bool required)
         {
             var adminId = GetAdminID();
-            frameworkNotificationService.SendReviewRequestForSelfAssessment(competencyAssessmentCollaboratorId, adminId, required, true, User.GetCentreIdKnownNotNull());
+            selfAssessmentNotificationService.SendReviewRequestForSelfAssessment(competencyAssessmentCollaboratorId, adminId, required, true, User.GetCentreIdKnownNotNull());
             competencyAssessmentService.UpdateReviewRequestedDate(reviewId);
             return RedirectToAction("PublishReview", new { competencyAssessmentId });
         }
@@ -1630,7 +1630,7 @@
             competencyAssessmentService.InsertCompetencySelfAssessmentReview(reviewId);
             var review = competencyAssessmentService.GetSelfAssessmentReviewNotification(reviewId);
             if (review == null) return StatusCode(404);
-            frameworkNotificationService.SendReviewRequestForSelfAssessment(review.SelfAssessmentCollaboratorID, adminId, review.SignOffRequired, false, User.GetCentreIdKnownNotNull());
+            selfAssessmentNotificationService.SendReviewRequestForSelfAssessment(review.SelfAssessmentCollaboratorID, adminId, review.SignOffRequired, false, User.GetCentreIdKnownNotNull());
             return RedirectToAction("PublishReview", new { competencyAssessmentId });
         }
         public IActionResult RemoveRequest(int competencyAssessmentId, int reviewId)

--- a/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
@@ -25,8 +25,8 @@
         void SendSignOffRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int delegateUserId, int centreId);
         void SendProfileAssessmentSignedOff(int supervisorDelegateId, int candidateAssessmentId, string? supervisorComments, bool signedOff, int adminId, int centreId);
         void SendSupervisorDelegateReminder(int supervisorDelegateId, int adminId, int centreId);
-        void SendReviewRequestForCompetencyAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId);
-        void SendCompetencyAssessmentsReviewOutcomeNotification(int reviewId, int centreId);
+        void SendReviewRequestForSelfAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId);
+        void SendSelfAssessmentsReviewOutcomeNotification(int reviewId, int centreId);
     }
 
     public class FrameworkNotificationService : IFrameworkNotificationService
@@ -142,7 +142,7 @@
             };
             emailService.SendEmail(new Email(emailSubjectLine, builder, collaboratorNotification.UserEmail, collaboratorNotification.InvitedByEmail));
         }
-        public void SendReviewRequestForCompetencyAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId)
+        public void SendReviewRequestForSelfAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId)
         {
             string centreName = GetCentreName(centreId);
             var collaboratorNotification = competencyAssessmentService.GetCollaboratorNotification(id, invitedByAdminId);
@@ -170,12 +170,12 @@
         }
         public string GetCompetencyAssessmentUrl(int selfAssessmentID, string actionName, int? id = null)
         {
-            var competencyAssessmentUrl = GetDLSUriBuilder();
+            var selfAssessmentUrl = GetDLSUriBuilder();
 
-            competencyAssessmentUrl.Path += id != null
-                        ? $"CompetencyAssessments/{selfAssessmentID}/{id}/{actionName}"
-                        : $"CompetencyAssessments/{selfAssessmentID}/{actionName}";
-            return competencyAssessmentUrl.Uri.ToString();
+            selfAssessmentUrl.Path += id != null
+                        ? $"Self-Assessment/{selfAssessmentID}/{id}/{actionName}"
+                        : $"Self-Assessment/{selfAssessmentID}/{actionName}";
+            return selfAssessmentUrl.Uri.ToString();
         }
         public string GetCurrentActivitiesUrl()
         {
@@ -234,7 +234,7 @@
             };
             emailService.SendEmail(new Email(emailSubjectLine, builder, outcomeNotification.OwnerEmail, outcomeNotification.UserEmail));
         }
-        public void SendCompetencyAssessmentsReviewOutcomeNotification(int reviewId, int centreId)
+        public void SendSelfAssessmentsReviewOutcomeNotification(int reviewId, int centreId)
         {
             string centreName = GetCentreName(centreId);
             var outcomeNotification = competencyAssessmentService.GetSelfAssessmentReviewNotification(reviewId);
@@ -243,25 +243,25 @@
                 throw new NotificationDataException($"No record found when trying to fetch review outcome Data. reviewId: {reviewId}");
             }
             var competencyAssessmentUrl = GetCompetencyAssessmentUrl(outcomeNotification.SelfAssessmentID, "PublishReview");
-            string emailSubjectLine = $"Competency Assessment Review Outcome - {(outcomeNotification.SignedOff ? "Approved" : "Rejected")} - Digital Learning Solutions";
-            string approvalStatus = outcomeNotification.ReviewerFirstName + (outcomeNotification.SignedOff ? " approved the competency assessment for publishing." : " did not approve the competency assessment for publishing.");
+            string emailSubjectLine = $"Self-assessment Review Outcome - {(outcomeNotification.SignedOff ? "Approved" : "Rejected")} - Digital Learning Solutions";
+            string approvalStatus = outcomeNotification.ReviewerFirstName + (outcomeNotification.SignedOff ? " approved the self-assessment for publishing." : " did not approve the self-assessment for publishing.");
             string commentsText = outcomeNotification.ReviewerFirstName + (outcomeNotification.Comment != null ? " left the following review comment: " + outcomeNotification.Comment : " did not leave a review comment.");
             string commentsHtml = "<p>" + outcomeNotification.ReviewerFirstName + (outcomeNotification.Comment != null ? " left the following review comment:</p><hr/><p>" + outcomeNotification.Comment + "</p><hr/>" : " did not leave a review comment.</p>");
             string reviewerFullName = $"{outcomeNotification.ReviewerFirstName} {outcomeNotification.ReviewerLastName} {(outcomeNotification.ReviewerActive == true ? "" : " (inactive)")}";
             var builder = new BodyBuilder
             {
                 TextBody = $@"Dear {outcomeNotification.OwnerFirstName},
-                              Your competency assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by {reviewerFullName} ({outcomeNotification.UserEmail}) ({centreName}).
+                              Your self-assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by {reviewerFullName} ({outcomeNotification.UserEmail}) ({centreName}).
                               {approvalStatus}
                               {commentsText}
-                              The full competency assessment review status, can be viewed by visiting: {competencyAssessmentUrl}. Once all of the required reviewers have approved the competency assessment, you may publish it. You will need to login to the Digital Learning Solutions platform to access the competency assessment.",
+                              The full self-assessment review status, can be viewed by visiting: {competencyAssessmentUrl}. Once all of the required reviewers have approved the self-assessment, you may publish it. You will need to login to the Digital Learning Solutions platform to access the self-assessment.",
                 HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'>
                                 <p>Dear {outcomeNotification.OwnerFirstName},</p>
-                                <p>Your competency assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by <a href='mailto:{outcomeNotification.UserEmail}'>{reviewerFullName} ({centreName})</a>.</p>
+                                <p>Your self-assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by <a href='mailto:{outcomeNotification.UserEmail}'>{reviewerFullName} ({centreName})</a>.</p>
                                 <p>{approvalStatus}</p>
                                 {commentsHtml}
-                                <p><a href='{competencyAssessmentUrl}'>Click here</a> to view the full review status for the competency assessment. Once all of the required reviewers have approved the competency assessment, you may publish it.</p>
-                                <p>You will need to login to the Digital Learning Solutions platform to access the competency assessment.</p>
+                                <p><a href='{competencyAssessmentUrl}'>Click here</a> to view the full review status for the self-assessment. Once all of the required reviewers have approved the self-assessment, you may publish it.</p>
+                                <p>You will need to login to the Digital Learning Solutions platform to access the self-assessment.</p>
                             </body>",
             };
             emailService.SendEmail(new Email(emailSubjectLine, builder, outcomeNotification.OwnerEmail, outcomeNotification.UserEmail));

--- a/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/FrameworkNotificationService.cs
@@ -25,8 +25,6 @@
         void SendSignOffRequest(int candidateAssessmentSupervisorId, int selfAssessmentID, int delegateUserId, int centreId);
         void SendProfileAssessmentSignedOff(int supervisorDelegateId, int candidateAssessmentId, string? supervisorComments, bool signedOff, int adminId, int centreId);
         void SendSupervisorDelegateReminder(int supervisorDelegateId, int adminId, int centreId);
-        void SendReviewRequestForSelfAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId);
-        void SendSelfAssessmentsReviewOutcomeNotification(int reviewId, int centreId);
     }
 
     public class FrameworkNotificationService : IFrameworkNotificationService
@@ -142,41 +140,14 @@
             };
             emailService.SendEmail(new Email(emailSubjectLine, builder, collaboratorNotification.UserEmail, collaboratorNotification.InvitedByEmail));
         }
-        public void SendReviewRequestForSelfAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId)
-        {
-            string centreName = GetCentreName(centreId);
-            var collaboratorNotification = competencyAssessmentService.GetCollaboratorNotification(id, invitedByAdminId);
-            if (collaboratorNotification == null)
-            {
-                throw new NotificationDataException($"No record found when trying to fetch collaboratorNotification Data. id: {id}, invitedByAdminId: {invitedByAdminId}");
-            }
-            var competencyAssessmentUrl = GetCompetencyAssessmentUrl(collaboratorNotification.SelfAssessmentID, "Review", collaboratorNotification.SelfAssessmentReviewID);
-            string emailSubjectLine = (reminder ? " REMINDER: " : "") + "Self-assessment Review Request - Digital Learning Solutions";
-            string signOffRequired = required ? "You are required to sign-off this self-assessment before it can be published." : "You are not required to sign-off this self-assessment before it is published.";
-            var builder = new BodyBuilder
-            {
-                TextBody = $@"Dear colleague,
-                              You have been requested to review the self-assessment, {collaboratorNotification?.CompetencyAssessmentName}, by {collaboratorNotification?.InvitedByName} ({collaboratorNotification?.InvitedByEmail}) ({centreName}).
-                              To review the self-assessment, visit this url: {competencyAssessmentUrl}. Click the Review self-assessment button to submit your review and, if appropriate, sign-off the self-assessment. {signOffRequired}. You will need to be registered on the Digital Learning Solutions platform to review the self-assessment.",
-                HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'><p>Dear colleague,</p><p>You have been requested to review the self-assessment, {collaboratorNotification?.CompetencyAssessmentName}, by <a href='mailto:{collaboratorNotification?.InvitedByEmail}'>{collaboratorNotification?.InvitedByName} ({centreName})</a>.</p><p><a href='{competencyAssessmentUrl}'>Click here</a> to review the self-assessment. Click the Review self-assessment button to submit your review and, if appropriate, sign-off the self-assessment.</p><p>{signOffRequired}</p><p>You will need to be registered on the Digital Learning Solutions platform to view the self-assessment.</p></body>"
-            };
-            emailService.SendEmail(new Email(emailSubjectLine, builder, collaboratorNotification.UserEmail, collaboratorNotification.InvitedByEmail));
-        }
+       
         public string GetFrameworkUrl(int frameworkId, string tab)
         {
             var frameworkUrl = GetDLSUriBuilder();
             frameworkUrl.Path += $"Framework/{frameworkId}/{tab}/";
             return frameworkUrl.Uri.ToString();
         }
-        public string GetCompetencyAssessmentUrl(int selfAssessmentID, string actionName, int? id = null)
-        {
-            var selfAssessmentUrl = GetDLSUriBuilder();
-
-            selfAssessmentUrl.Path += id != null
-                        ? $"Self-Assessment/{selfAssessmentID}/{id}/{actionName}"
-                        : $"Self-Assessment/{selfAssessmentID}/{actionName}";
-            return selfAssessmentUrl.Uri.ToString();
-        }
+      
         public string GetCurrentActivitiesUrl()
         {
             var dlsUrlBuilder = GetDLSUriBuilder();
@@ -234,39 +205,6 @@
             };
             emailService.SendEmail(new Email(emailSubjectLine, builder, outcomeNotification.OwnerEmail, outcomeNotification.UserEmail));
         }
-        public void SendSelfAssessmentsReviewOutcomeNotification(int reviewId, int centreId)
-        {
-            string centreName = GetCentreName(centreId);
-            var outcomeNotification = competencyAssessmentService.GetSelfAssessmentReviewNotification(reviewId);
-            if (outcomeNotification == null)
-            {
-                throw new NotificationDataException($"No record found when trying to fetch review outcome Data. reviewId: {reviewId}");
-            }
-            var competencyAssessmentUrl = GetCompetencyAssessmentUrl(outcomeNotification.SelfAssessmentID, "PublishReview");
-            string emailSubjectLine = $"Self-assessment Review Outcome - {(outcomeNotification.SignedOff ? "Approved" : "Rejected")} - Digital Learning Solutions";
-            string approvalStatus = outcomeNotification.ReviewerFirstName + (outcomeNotification.SignedOff ? " approved the self-assessment for publishing." : " did not approve the self-assessment for publishing.");
-            string commentsText = outcomeNotification.ReviewerFirstName + (outcomeNotification.Comment != null ? " left the following review comment: " + outcomeNotification.Comment : " did not leave a review comment.");
-            string commentsHtml = "<p>" + outcomeNotification.ReviewerFirstName + (outcomeNotification.Comment != null ? " left the following review comment:</p><hr/><p>" + outcomeNotification.Comment + "</p><hr/>" : " did not leave a review comment.</p>");
-            string reviewerFullName = $"{outcomeNotification.ReviewerFirstName} {outcomeNotification.ReviewerLastName} {(outcomeNotification.ReviewerActive == true ? "" : " (inactive)")}";
-            var builder = new BodyBuilder
-            {
-                TextBody = $@"Dear {outcomeNotification.OwnerFirstName},
-                              Your self-assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by {reviewerFullName} ({outcomeNotification.UserEmail}) ({centreName}).
-                              {approvalStatus}
-                              {commentsText}
-                              The full self-assessment review status, can be viewed by visiting: {competencyAssessmentUrl}. Once all of the required reviewers have approved the self-assessment, you may publish it. You will need to login to the Digital Learning Solutions platform to access the self-assessment.",
-                HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'>
-                                <p>Dear {outcomeNotification.OwnerFirstName},</p>
-                                <p>Your self-assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by <a href='mailto:{outcomeNotification.UserEmail}'>{reviewerFullName} ({centreName})</a>.</p>
-                                <p>{approvalStatus}</p>
-                                {commentsHtml}
-                                <p><a href='{competencyAssessmentUrl}'>Click here</a> to view the full review status for the self-assessment. Once all of the required reviewers have approved the self-assessment, you may publish it.</p>
-                                <p>You will need to login to the Digital Learning Solutions platform to access the self-assessment.</p>
-                            </body>",
-            };
-            emailService.SendEmail(new Email(emailSubjectLine, builder, outcomeNotification.OwnerEmail, outcomeNotification.UserEmail));
-        }
-
         public void SendSupervisorDelegateInvite(int supervisorDelegateId, int adminId, int centreId)
         {
 

--- a/DigitalLearningSolutions.Web/Services/SelfAssessmentNotificationService.cs
+++ b/DigitalLearningSolutions.Web/Services/SelfAssessmentNotificationService.cs
@@ -10,6 +10,8 @@
     public interface ISelfAssessmentNotificationService
     {
         void SendCompetencyAssessmentCollaboratorInvite(int id, int invitedByAdminId);
+        void SendReviewRequestForSelfAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId);
+        void SendSelfAssessmentsReviewOutcomeNotification(int reviewId, int centreId);
     }
 
     public class SelfAssessmentNotificationService : ISelfAssessmentNotificationService
@@ -18,15 +20,19 @@
         private readonly IConfigDataService configDataService;
         private readonly IEmailService emailService;
         private readonly ICompetencyAssessmentService competencyAssessmentService;
+        private readonly ICentresDataService centresDataService;
+
         public SelfAssessmentNotificationService(
            ICompetencyAssessmentService competencyAssessmentService,
            IConfigDataService configDataService,
-           IEmailService emailService
+           IEmailService emailService,
+           ICentresDataService centresDataService
        )
         {
             this.competencyAssessmentService = competencyAssessmentService;
             this.configDataService = configDataService;
             this.emailService = emailService;
+            this.centresDataService = centresDataService;
         }
         public void SendCompetencyAssessmentCollaboratorInvite(int id, int invitedByAdminId)
         {
@@ -37,22 +43,83 @@
             }
 
             var competencyAssessmentUrl = GetCompetencyAssessmentkUrl(collaboratorNotification.SelfAssessmentID, "Manage");
-            string emailSubjectLine = $"Competency assessment {collaboratorNotification.CompetencyAssessmentRole} Invitation - Digital Learning Solutions";
+            string emailSubjectLine = $"Self-assessment {collaboratorNotification.CompetencyAssessmentRole} Invitation - Digital Learning Solutions";
 
             var builder = new BodyBuilder
             {
                 TextBody = $@"Dear colleague,
-                              You have been identified as a {collaboratorNotification.CompetencyAssessmentRole} for the competency assessment, {collaboratorNotification.CompetencyAssessmentName} by {collaboratorNotification.InvitedByName} ({collaboratorNotification.InvitedByEmail}).
-                              To access the competency assessment, visit this url: {competencyAssessmentUrl}. You must be registered on the Digital Learning Solutions platform to view the self-assessment.",
+                              You have been identified as a {collaboratorNotification.CompetencyAssessmentRole} for the self-assessment, {collaboratorNotification.CompetencyAssessmentName} by {collaboratorNotification.InvitedByName} ({collaboratorNotification.InvitedByEmail}).
+                              To access the self-assessment, visit this url: {competencyAssessmentUrl}. You must be registered on the Digital Learning Solutions platform to view the self-assessment.",
                 HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'>
                                 <p>Dear colleague,</p>
-                                <p>You have been identified as a {collaboratorNotification.CompetencyAssessmentRole} for the  competency assessment {collaboratorNotification.CompetencyAssessmentName}, by <a href='mailto:{collaboratorNotification.InvitedByEmail}'>{collaboratorNotification.InvitedByName}</a>.</p>
+                                <p>You have been identified as a {collaboratorNotification.CompetencyAssessmentRole} for the  self-assessment {collaboratorNotification.CompetencyAssessmentName}, by <a href='mailto:{collaboratorNotification.InvitedByEmail}'>{collaboratorNotification.InvitedByName}</a>.</p>
                                 <p><a href='{competencyAssessmentUrl}'>Use this link</a> to access the self-assessment. You must be registered on the Digital Learning Solutions platform to view the self-assessment.</p>
                             </body>",
             };
             emailService.SendEmail(new Email(emailSubjectLine, builder, collaboratorNotification.UserEmail, collaboratorNotification.InvitedByEmail));
         }
+        public void SendReviewRequestForSelfAssessment(int id, int invitedByAdminId, bool required, bool reminder, int centreId)
+        {
+            string centreName = GetCentreName(centreId);
+            var collaboratorNotification = this.competencyAssessmentService.GetCollaboratorNotification(id, invitedByAdminId);
+            if (collaboratorNotification == null)
+            {
+                throw new NotificationDataException($"No record found when trying to fetch collaboratorNotification Data. id: {id}, invitedByAdminId: {invitedByAdminId}");
+            }
+            var competencyAssessmentUrl = GetSelfAssessmentUrl(collaboratorNotification.SelfAssessmentID, "Review", collaboratorNotification.SelfAssessmentReviewID);
+            string emailSubjectLine = (reminder ? " REMINDER: " : "") + "Self-assessment Review Request - Digital Learning Solutions";
+            string signOffRequired = required ? "You are required to sign-off this self-assessment before it can be published." : "You are not required to sign-off this self-assessment before it is published.";
+            var builder = new BodyBuilder
+            {
+                TextBody = $@"Dear colleague,
+                              You have been requested to review the self-assessment, {collaboratorNotification?.CompetencyAssessmentName}, by {collaboratorNotification?.InvitedByName} ({collaboratorNotification?.InvitedByEmail}) ({centreName}).
+                              To review the self-assessment, visit this url: {competencyAssessmentUrl}. Click the Review self-assessment button to submit your review and, if appropriate, sign-off the self-assessment. {signOffRequired}. You will need to be registered on the Digital Learning Solutions platform to review the self-assessment.",
+                HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'><p>Dear colleague,</p><p>You have been requested to review the self-assessment, {collaboratorNotification?.CompetencyAssessmentName}, by <a href='mailto:{collaboratorNotification?.InvitedByEmail}'>{collaboratorNotification?.InvitedByName} ({centreName})</a>.</p><p><a href='{competencyAssessmentUrl}'>Click here</a> to review the self-assessment. Click the Review self-assessment button to submit your review and, if appropriate, sign-off the self-assessment.</p><p>{signOffRequired}</p><p>You will need to be registered on the Digital Learning Solutions platform to view the self-assessment.</p></body>"
+            };
+            emailService.SendEmail(new Email(emailSubjectLine, builder, collaboratorNotification.UserEmail, collaboratorNotification.InvitedByEmail));
+        }
+        public void SendSelfAssessmentsReviewOutcomeNotification(int reviewId, int centreId)
+        {
+            string centreName = GetCentreName(centreId);
+            var outcomeNotification = this.competencyAssessmentService.GetSelfAssessmentReviewNotification(reviewId);
+            if (outcomeNotification == null)
+            {
+                throw new NotificationDataException($"No record found when trying to fetch review outcome Data. reviewId: {reviewId}");
+            }
+            var competencyAssessmentUrl = GetSelfAssessmentUrl(outcomeNotification.SelfAssessmentID, "PublishReview");
+            string emailSubjectLine = $"Self-assessment Review Outcome - {(outcomeNotification.SignedOff ? "Approved" : "Rejected")} - Digital Learning Solutions";
+            string approvalStatus = outcomeNotification.ReviewerFirstName + (outcomeNotification.SignedOff ? " approved the self-assessment for publishing." : " did not approve the self-assessment for publishing.");
+            string commentsText = outcomeNotification.ReviewerFirstName + (outcomeNotification.Comment != null ? " left the following review comment: " + outcomeNotification.Comment : " did not leave a review comment.");
+            string commentsHtml = "<p>" + outcomeNotification.ReviewerFirstName + (outcomeNotification.Comment != null ? " left the following review comment:</p><hr/><p>" + outcomeNotification.Comment + "</p><hr/>" : " did not leave a review comment.</p>");
+            string reviewerFullName = $"{outcomeNotification.ReviewerFirstName} {outcomeNotification.ReviewerLastName} {(outcomeNotification.ReviewerActive == true ? "" : " (inactive)")}";
+            var builder = new BodyBuilder
+            {
+                TextBody = $@"Dear {outcomeNotification.OwnerFirstName},
+                              Your self-assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by {reviewerFullName} ({outcomeNotification.UserEmail}) ({centreName}).
+                              {approvalStatus}
+                              {commentsText}
+                              The full self-assessment review status, can be viewed by visiting: {competencyAssessmentUrl}. Once all of the required reviewers have approved the self-assessment, you may publish it. You will need to login to the Digital Learning Solutions platform to access the self-assessment.",
+                HtmlBody = $@"<body style= 'font-family: Calibri; font-size: small;'>
+                                <p>Dear {outcomeNotification.OwnerFirstName},</p>
+                                <p>Your self-assessment, {outcomeNotification.SelfAssessmentName}, has been reviewed by <a href='mailto:{outcomeNotification.UserEmail}'>{reviewerFullName} ({centreName})</a>.</p>
+                                <p>{approvalStatus}</p>
+                                {commentsHtml}
+                                <p><a href='{competencyAssessmentUrl}'>Click here</a> to view the full review status for the self-assessment. Once all of the required reviewers have approved the self-assessment, you may publish it.</p>
+                                <p>You will need to login to the Digital Learning Solutions platform to access the self-assessment.</p>
+                            </body>",
+            };
+            emailService.SendEmail(new Email(emailSubjectLine, builder, outcomeNotification.OwnerEmail, outcomeNotification.UserEmail));
+        }
 
+        public string GetSelfAssessmentUrl(int selfAssessmentID, string actionName, int? id = null)
+        {
+            var selfAssessmentUrl = GetDLSUriBuilder();
+
+            selfAssessmentUrl.Path += id != null
+                        ? $"Self-Assessment/{selfAssessmentID}/{id}/{actionName}"
+                        : $"Self-Assessment/{selfAssessmentID}/{actionName}";
+            return selfAssessmentUrl.Uri.ToString();
+        }
         public string GetCompetencyAssessmentkUrl(int competencyAssessmentID, string tab)
         {
             var competencyAssessmentUrl = GetDLSUriBuilder();
@@ -65,6 +132,9 @@
                                        throw new ConfigValueMissingException(configDataService.GetConfigValueMissingExceptionMessage("AppBaseUrl"));
             return new UriBuilder(trackingSystemBaseUrl);
         }
-
+        public string GetCentreName(int centreId)
+        {
+            return centresDataService.GetCentreName(centreId);
+        }
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Index.cshtml
@@ -11,15 +11,7 @@
 @section NavMenuItems {
     <partial name="Shared/_NavMenuItems" />
 }
-@section NavBreadcrumbs {
-<nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
-    <div class="nhsuk-width-container">
-        <ol class="nhsuk-breadcrumb__list">
-            <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link trigger-loader" asp-controller="Frameworks" asp-action="Index">Home</a></li>
-        </ol>
-     </div>
-</nav>
-}
+
 <h1>Frameworks dashboard</h1>
 <h2>Your to do list</h2>
 @if (Model.DashboardToDoItems.Count() > 0)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6941

### Description
Removed the Home breadcrumb from the Dashboard page.
Updated the competency wording in emails sent to Contributors and Reviewers when they are added to a Working Group.
Moved the SendReviewRequestForSelfAssessment and SendSelfAssessmentsReviewOutcomeNotification methods from FrameworkNotificationService to SelfAssessmentNotificationService.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/2e07c6f4-fd6a-4d68-bbb5-0014f2c5060f" />
<img width="761" height="362" alt="image" src="https://github.com/user-attachments/assets/6e4f499e-02e8-4eda-8e50-e1b959504dd5" />
<img width="1538" height="636" alt="image" src="https://github.com/user-attachments/assets/b7e206ec-d3ff-4b6a-832d-37f933cac996" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
