### PR TITLE
TD-6954 Fixing the reason why the save button is not working

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -84,7 +84,7 @@
     <input type="hidden" asp-for="MinimumOptionalCompetencies" />
     <input type="hidden" asp-for="ManageOptionalCompetenciesPrompt" />
     <input type="hidden" asp-for="VocabularyPlural" />
-        
+    <input type="hidden" asp-for="VocabularySingular" />
     <button class="nhsuk-button" type="submit">
         Save
     </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetMinimumOptionalCompetencies.cshtml
@@ -46,7 +46,8 @@
     </nhs-form-group>
     <input type="hidden" asp-for="ID" />
     <input type="hidden" asp-for="OptionalCompetenciesCount" />
-    <input type="hidden" asp-for="VocabularyPlural" />
+        <input type="hidden" asp-for="VocabularySingular" />
+        <input type="hidden" asp-for="VocabularyPlural" />
     <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">
         Save

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SetOptionalCompetencyLearnerPrompt.cshtml
@@ -47,7 +47,8 @@
         <span nhs-validation-for="ManageOptionalCompetenciesPrompt"></span>
     </nhs-form-group>
     <input type="hidden" asp-for="ID" />
-    <input type="hidden" asp-for="VocabularyPlural" />
+        <input type="hidden" asp-for="VocabularyPlural" />
+        <input type="hidden" asp-for="VocabularySingular" />
 
         <hr class="nhsuk-section-break nhsuk-section-break--m" />
     <button class="nhsuk-button" type="submit">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6954

### Description
Adding VocabularySingular as a hidden field to all three Optional Proficiencies pages makes the POST method ModelState.IsValid return true and allows the data to be saved successfully.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/a6464084-7c57-4c45-a5c5-6c167fe3983d" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/3efca344-5884-4e4d-a40e-3f8a8b633598" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
