### PR TITLE
TD-6952 Working group page content improvements

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -895,7 +895,8 @@
         public IActionResult AssessmentWorkingGroup(WorkingGroupCollaboratorsViewModel model, bool canModify, string actionName)
         {
             int? centreID = GetCentreId();
-            if (actionName == "Collaborators" || actionName == "CollaboratorReview")
+
+            if (actionName == "Collaborators")
             {
                 var collaboratorId = competencyAssessmentService.AddCollaboratorToCompetencyAssessment(model.CompetencyAssessmentID, model.UserEmail, canModify, centreID);
                 if (collaboratorId > 0)
@@ -928,6 +929,10 @@
                 }
                 return RedirectToAction("AssessmentWorkingGroup", "CompetencyAssessments", new { model.CompetencyAssessmentID, actionName = actionName });
 
+            }
+            else if(actionName == "CollaboratorReview")
+            {
+                return RedirectToAction("SendForReview", "CompetencyAssessments", new { model.CompetencyAssessmentID, actionName = actionName });
             }
             else
             {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -37,18 +37,20 @@ Select working group members</h1>
 <form method="post">
     @if (Model.UserRole > 1)
     {
-        <label class="nhsuk-label nhsuk-u-margin-top-6" for="add-user-hint">
-            <h2>Add a user as a:</h2>
+        <label class="nhsuk-label nhsuk-u-margin-top-6">
             <p>Add a user as a:</p>
         </label>
         <ul class="nhsuk-list nhsuk-list--bullet">
             <li>Contributor</li>
             <li>Reviewer</li>
         </ul>
-<div class="nhsuk-table__panel-with-heading-tab">
-    <h2 class="nhsuk-table__heading-tab">Working group members</h2>
-    <table role="presentation" class="nhsuk-table-responsive">
-        <thead role="rowgroup" class="nhsuk-table__head">
+        <label class="nhsuk-label nhsuk-u-margin-top-6">
+        <p>to help create your competency assessment</p>
+        </label>
+        <div class="nhsuk-table__panel-with-heading-tab">
+         <h2 class="nhsuk-table__heading-tab">Working group members</h2>
+         <table role="presentation" class="nhsuk-table-responsive">
+            <thead role="rowgroup" class="nhsuk-table__head">
             <tr role="row">
                 <th role="columnheader" class="" scope="col">
                     User
@@ -98,8 +100,6 @@ Select working group members</h1>
         </tbody>
     </table>
 </div>
-<input type="hidden" asp-for="ActionName" />
-
         <div class="@(Model.Error ? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
             <div class=" sort-select-container">
                 <label class="nhsuk-label" for="UserEmail">
@@ -134,13 +134,13 @@ Select working group members</h1>
             @if (Model.ActionName == "CollaboratorReview")
             {
                 <a class="nhsuk-button" asp-action="SendForReview" asp-route-actionName="CollaboratorReview" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID">
-                    Add
+                    Save
                 </a>
             }
             else
             {
                 <button class="nhsuk-button" asp-route-actionName="Summary" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-taskStatus="@Model.CompetencyAssessmentTaskStatus">
-                    Add
+                    Save
                 </button>
             }
         </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6952

### Description
Removed the H2 heading.
Added “to help create your competency assessment” to the page.
Updated the button text from “Add” to “Save.”
Added an else if condition to return the SendForReview page.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/3631b38f-e967-4859-8e22-ba1812389f88" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
