### PR TITLE
TD-7343 Needs to add error msg on Add proficiencies to assessment'scr…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -562,7 +562,24 @@
         {
             if (!ModelState.IsValid)
             {
-                //reload model and view
+                var adminId = GetAdminID();
+                var competencyAssessmentBase = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
+                var framework = frameworkService.GetBaseFrameworkByFrameworkId(frameworkId, adminId);
+                var groupedCompetencies = frameworkService.GetFrameworkCompetencyGroups(frameworkId, competencyAssessmentId);
+                var ungroupedCompetencies = frameworkService.GetFrameworkCompetenciesUngrouped(frameworkId, competencyAssessmentId);
+                var competencyIds = ungroupedCompetencies.Select(c => c.CompetencyID).ToArray();
+                var competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
+                foreach (var competency in ungroupedCompetencies)
+                    competency.CompetencyFlags = competencyFlags.Where(f => f.CompetencyId == competency.CompetencyID);
+                foreach (var group in groupedCompetencies)
+                {
+                    competencyIds = group.FrameworkCompetencies.Select(c => c.CompetencyID).ToArray();
+                    competencyFlags = frameworkService.GetSelectedCompetencyFlagsByCompetecyIds(competencyIds);
+                    foreach (var competency in group.FrameworkCompetencies)
+                        competency.CompetencyFlags = competencyFlags.Where(f => f.CompetencyId == competency.CompetencyID);
+                }
+                var models = new AddCompetenciesViewModel(competencyAssessmentBase, groupedCompetencies, ungroupedCompetencies, frameworkId, framework.FrameworkName, model.SelectedCompetencyIds);
+                return View("AddCompetencies", models);
             }
             if (model.SelectedCompetencyIds != null)
             {

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewFormData.cs
@@ -1,8 +1,11 @@
-﻿namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 {
     public class AddCompetenciesFormData
     {
         public int ID { get; set; }
+        [Required(ErrorMessage = "Select at least one competency")]
         public int[] SelectedCompetencyIds { get; set; }
         public int FrameworkId { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewModel.cs
@@ -4,6 +4,8 @@
     using DigitalLearningSolutions.Data.Models.Frameworks;
     using DigitalLearningSolutions.Web.Helpers;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+
     public class AddCompetenciesViewModel
     {
         public AddCompetenciesViewModel(CompetencyAssessmentBase competencyAssessmentBase, IEnumerable<FrameworkCompetencyGroup> groupedCompetencies, IEnumerable<FrameworkCompetency> ungroupedCompetencies, int frameworkId, string? frameworkName, int[] selectedFrameworkCompetencies)
@@ -26,6 +28,7 @@
         public string VocabularyPlural { get; set; }
         public IEnumerable<FrameworkCompetencyGroup> GroupedCompetencies { get; set; }
         public IEnumerable<FrameworkCompetency> UngroupedCompetencies { get; set; }
+        [Required(ErrorMessage = "Select at least one competency")]
         public int[] SelectedCompetencyIds { get; set; }
         public int FrameworkId { get; set; }
         public string? FrameworkName { get; set; }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
@@ -3,6 +3,7 @@
 @{
     ViewData["Title"] = $"Add {@Model.VocabularyPlural.ToLower()} to self-assessment";
     ViewData["Application"] = "Framework service";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
@@ -24,6 +25,10 @@
 }
 
 <form method="post">
+    @if (errorHasOccurred)
+    {
+        <vc:error-summary order-of-property-names="@(new[] { nameof(Model.SelectedCompetencyIds)})" />
+    }
     <nhs-form-group nhs-validation-for="SelectedCompetencyIds">
         <fieldset class="nhsuk-fieldset">
             <legend class="nhsuk-fieldset__legend">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7343

### Description
Add an error state to the page to notify the user when no competency is selected and the “Add Selected Competency” button is clicked.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/ac43bffb-8e33-470b-9142-3dc808d3be38" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
