### PR TITLE
TD-6954 selection and deselection is not working

### DIFF
--- a/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
@@ -4,7 +4,7 @@
   groups.forEach((group) => {
     const groupToggle =
       group.querySelector<HTMLInputElement>('input[name="GroupIds"]');
-
+    // All individual competency checkboxes in the group
     const childCheckboxes =
       group.querySelectorAll<HTMLInputElement>(
         'input[name="SelectedCompetencyIds"]',

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
@@ -6,32 +6,27 @@
       group.querySelector<HTMLInputElement>('input[name="GroupIds"]');
 
     const childCheckboxes =
-      group.querySelectorAll<HTMLInputElement>('input[name="SelectedCompetencyIds"]');
+      group.querySelectorAll<HTMLInputElement>(
+        'input[name="SelectedCompetencyIds"]',
+      );
 
     if (!groupToggle) {
       return;
     }
 
-    const syncChildren = () => {
-      if (groupToggle.checked) {
-        childCheckboxes.forEach((checkbox) => {
-          checkbox.checked = true;
-        });
-      }
+    const setChildrenCheckedState = (checked: boolean) => {
+      childCheckboxes.forEach((checkboxElement) => {
+        const checkbox = checkboxElement;
+        checkbox.checked = checked;
+      });
     };
 
-    syncChildren();
+    if (groupToggle.checked) {
+      setChildrenCheckedState(true);
+    }
 
     groupToggle.addEventListener('change', () => {
-      if (groupToggle.checked) {
-        childCheckboxes.forEach((checkbox) => {
-          checkbox.checked = true;
-        });
-      } else {
-        childCheckboxes.forEach((checkbox) => {
-          checkbox.checked = false;
-        });
-      }
+      setChildrenCheckedState(groupToggle.checked);
     });
   });
 });

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
@@ -1,26 +1,36 @@
 ﻿document.addEventListener('DOMContentLoaded', () => {
-  // Explicitly tell TypeScript these are HTMLInputElements
   const groups = document.querySelectorAll<HTMLDivElement>('.nhsuk-checkboxes');
 
   groups.forEach((group) => {
-    // Cast the specific input types
-    const groupToggle = group.querySelector<HTMLInputElement>('input[name="GroupIds"]');
-    const childCheckboxes = group.querySelectorAll<HTMLInputElement>('input[name="SelectedCompetencyIds"]');
+    const groupToggle =
+      group.querySelector<HTMLInputElement>('input[name="GroupIds"]');
 
-    if (!groupToggle) return;
+    const childCheckboxes =
+      group.querySelectorAll<HTMLInputElement>('input[name="SelectedCompetencyIds"]');
+
+    if (!groupToggle) {
+      return;
+    }
 
     const syncChildren = () => {
       if (groupToggle.checked) {
-        childCheckboxes.forEach(cb => cb.checked = true);
+        childCheckboxes.forEach((checkbox) => {
+          checkbox.checked = true;
+        });
       }
     };
 
     syncChildren();
 
     groupToggle.addEventListener('change', () => {
-      syncChildren();
-      if (!groupToggle.checked) {
-        childCheckboxes.forEach(cb => cb.checked = false);
+      if (groupToggle.checked) {
+        childCheckboxes.forEach((checkbox) => {
+          checkbox.checked = true;
+        });
+      } else {
+        childCheckboxes.forEach((checkbox) => {
+          checkbox.checked = false;
+        });
       }
     });
   });

--- a/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
+++ b/DigitalLearningSolutions.Web/Scripts/frameworks/selectoptionalcompetencies.ts
@@ -1,27 +1,27 @@
 ﻿document.addEventListener('DOMContentLoaded', () => {
+  // Explicitly tell TypeScript these are HTMLInputElements
   const groups = document.querySelectorAll<HTMLDivElement>('.nhsuk-checkboxes');
 
   groups.forEach((group) => {
+    // Cast the specific input types
     const groupToggle = group.querySelector<HTMLInputElement>('input[name="GroupIds"]');
+    const childCheckboxes = group.querySelectorAll<HTMLInputElement>('input[name="SelectedCompetencyIds"]');
+
     if (!groupToggle) return;
 
-    // All individual competency checkboxes in the group
-    const childCheckboxes = group.querySelectorAll<HTMLInputElement>(
-      'input[name="SelectedCompetencyIds"]',
-    );
-
-    const updateState = () => {
-      const isChecked = groupToggle.checked;
-
-      childCheckboxes.forEach((_, index) => {
-        childCheckboxes[index].checked = isChecked;
-      });
+    const syncChildren = () => {
+      if (groupToggle.checked) {
+        childCheckboxes.forEach(cb => cb.checked = true);
+      }
     };
 
-    // Run when the group checkbox changes
-    groupToggle.addEventListener('change', updateState);
+    syncChildren();
 
-    // Also run at page load in case some are pre-checked server-side
-    updateState();
+    groupToggle.addEventListener('change', () => {
+      syncChildren();
+      if (!groupToggle.checked) {
+        childCheckboxes.forEach(cb => cb.checked = false);
+      }
+    });
   });
 });

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -60,7 +60,11 @@
                         @foreach (var competency in competencyGroup)
                         {
                             <div class="nhsuk-checkboxes__item">
-                                <input class="nhsuk-checkboxes__input" data-group="@competencyGroup.Key" id="competency-check-@competency.StructureId" name="SelectedCompetencyIds" checked="@(Model.SelectedCompetencyIds != null ? Model.SelectedCompetencyIds.Contains((int)competency.CompetencyID) : false)" type="checkbox" value="@competency.StructureId">
+                                <input class="nhsuk-checkboxes__input"
+                                data-group="@competencyGroup.Key"
+                                  id="competency-check-@competency.StructureId"
+                                  name="SelectedCompetencyIds"
+                                checked="@(competencyGroup.Any(x => x.GroupOptionalCompetencies) || competency.Optional ? "checked" : null)"type="checkbox" value="@competency.StructureId">
                                 <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.StructureId">
                                     @foreach (var flag in competency.CompetencyFlags)
                                     {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6954

### Description
Replaced the DOMContentLoaded block so that when a group checkbox is selected, all child competencies are automatically checked, while still preserving existing individual competency selections when the group checkbox is not selected.

I also updated the competency checkbox logic to evaluate the Optional and GroupOptionalCompetencies properties for each competency item within the loop.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/6c47250c-0602-4098-b855-590c7bbafcd7" />

<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/f95d9830-7a30-4b4a-bc39-e5586467d1a8" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
