### PR TITLE
TD-7136 Self assessment retirement

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -116,6 +116,8 @@
         void InsertSelfAssessmentReview(int competencyAssessmentId, int selfAssessmentCollaboratorID, bool required);
         int InsertComment(int selfAssessmentID, int adminId, string comment, int? replyToCommentId);
         int InsertCompetencySelfAssessmentReview(int reviewId);
+        void RetireCompetencyAssessment(int competencyAssessmentId, DateTime? retirementDate, string retirementReason);
+
 
         //DELETE DATA
         bool RemoveFrameworkCompetenciesFromAssessment(int competencyAssessmentId, int frameworkId);
@@ -143,6 +145,8 @@
                 sa.ManageOptionalCompetenciesPrompt,
                 sa.IncludeLearnerDeclarationPrompt, sa.IncludesSignposting, sa.LinearNavigation, sa.UseDescriptionExpanders, sa.QuestionLabel, sa.ReviewerCommentsLabel,
                 sa.SupervisorSelfAssessmentReview, sa.SupervisorResultsReview, sar.ID AS SelfAssessmentReviewID, sa.SignOffSupervisorStatement, sa.SignOffRequestorStatement,
+                sa.RetirementReason,
+                sa.RetirementDate,
                 sar.SelfAssessmentCommentID";
 
         private const string SelfAssessmentFields =
@@ -1773,6 +1777,17 @@ ORDER BY
 
             return id;
         }
+        public void RetireCompetencyAssessment(int competencyAssessmentId, DateTime? retirementDate, string retirementReason)
+        {
+            // Example using Dapper
+            connection.Execute(
+                @"UPDATE SelfAssessments
+          SET RetirementDate = @retirementDate, RetirementReason = @retirementReason
+          WHERE ID = @competencyAssessmentId",
+                new { retirementDate, retirementReason, competencyAssessmentId }
+            );
+        }
+
         public bool UpdateCompetencyAssessmentReviewTaskStatus(int assessmentId, bool taskStatus)
         {
             var numberOfAffectedRows = connection.Execute(

--- a/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessmentBase.cs
+++ b/DigitalLearningSolutions.Data/Models/CompetencyAssessments/CompetencyAssessmentBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Data.Models.CompetencyAssessments
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
     public class CompetencyAssessmentBase
     {
@@ -36,6 +37,9 @@
         public string? SignOffSupervisorStatement { get; set; }
         public int? SelfAssessmentReviewID { get; set; }
         public int? SelfAssessmentCommentID { get; set; }
+        public DateTime? RetirementDate { get; set; }
+        public string? RetirementReason { get; set; }
+
     }
 }
 

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1,5 +1,6 @@
 ﻿namespace DigitalLearningSolutions.Web.Controllers.CompetencyAssessmentsController
 {
+    using System;
     using DigitalLearningSolutions.Data.Enums;
     using DigitalLearningSolutions.Data.Extensions;
     using DigitalLearningSolutions.Data.Models.CompetencyAssessments;
@@ -1734,6 +1735,42 @@
 
             return RedirectToAction("SelfAssessment", "LearningPortal", new { selfAssessmentId = model.CompetencyAssessmentId });
         }
+
+        [HttpGet]
+        [Route("/Self-Assessment/{competencyAssessmentId}/Retire")]
+        public IActionResult RetireCompetencyAssessment(int competencyAssessmentId)
+        {
+            var adminId = GetAdminID();
+            var assessment = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
+            if (assessment == null) return StatusCode(404);
+
+            var model = new RetireCompetencyAssessmentViewModel(competencyAssessmentId, assessment);
+            return View("RetireCompetencyAssessment", model);
+        }
+
+        [HttpPost]
+        [Route("/Self-Assessment/{competencyAssessmentId}/Retire")]
+        public IActionResult RetireCompetencyAssessment(RetireCompetencyAssessmentViewModel model, int competencyAssessmentId)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View("RetireCompetencyAssessment", model);
+            }
+
+            model.RetirementDate = new DateTime(model.Year!.Value, model.Month!.Value, model.Day!.Value);
+            
+
+            var adminId = GetAdminID();
+            competencyAssessmentService.RetireCompetencyAssessment(
+                model.CompetencyAssessmentId,
+                model.RetirementDate,
+                model.RetirementReason!,
+                adminId
+            );
+
+            return RedirectToAction("ManageCompetencyAssessment", new { competencyAssessmentId = model.CompetencyAssessmentId });
+        }
+
 
         private void SetManagesupervisionData(ManagesupervisionViewModel data)
         {

--- a/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
+++ b/DigitalLearningSolutions.Web/Services/CompetencyAssessmentService.cs
@@ -5,6 +5,7 @@ using DigitalLearningSolutions.Web.Models;
 using DigitalLearningSolutions.Web.ViewModels.Frameworks;
 using DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Centre.Reports;
 using DocumentFormat.OpenXml.Drawing.Charts;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -122,6 +123,8 @@ namespace DigitalLearningSolutions.Web.Services
         void RemoveCollaboratorFromCompetencyAssessment(int competencyAssessmentId, int id);
         CompetencyAssessmentCollaboratorNotification? GetCollaboratorNotification(int id, int invitedByAdminId);
         bool HasCompetencyWithSignpostedLearning(int competencyAssessmentId);
+        void RetireCompetencyAssessment(int competencyAssessmentId, DateTime? RetirementDate, string retirementReason, int adminId);
+
     }
     public class CompetencyAssessmentService : ICompetencyAssessmentService
     {
@@ -589,5 +592,21 @@ namespace DigitalLearningSolutions.Web.Services
         {
            return competencyAssessmentDataService.UpdateCompetencyAssessmentReviewTaskStatus(assessmentId, taskStatus);
         }
+        public void RetireCompetencyAssessment(int competencyAssessmentId, DateTime? RetirementDate, string retirementReason, int adminId)
+        {
+            // Persist retirement info
+            competencyAssessmentDataService.RetireCompetencyAssessment(competencyAssessmentId, RetirementDate, retirementReason);
+
+            // Update publish status
+            var today = DateTime.UtcNow.Date;
+            int status;
+            if (RetirementDate > today)
+                status = 4; // Scheduled for retirement (amber)
+            else
+                status = 5; // Retired (red)
+
+            competencyAssessmentDataService.UpdateCompetencyAssessmentPublishStatus(competencyAssessmentId, status, adminId);
+        }
+
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/ManageCompetencyAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/ManageCompetencyAssessmentViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using DigitalLearningSolutions.Data.Models.CompetencyAssessments;
 using DigitalLearningSolutions.Web.Helpers;
+using System;
 
 namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 {
@@ -20,6 +21,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
             VocabularyPlural = FrameworkVocabularyHelper.VocabularyPlural(competencyAssessmentBase.Vocabulary);
             SelfAssessmentReviewID = competencyAssessmentBase.SelfAssessmentReviewID;
             SelfAssessmentCommentID = competencyAssessmentBase.SelfAssessmentCommentID;
+            RetirementDate = competencyAssessmentBase.RetirementDate;
         }
         public string CompetencyAssessmentName { get; set; }
         public int PublishStatusID { get; set; }
@@ -30,5 +32,6 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
         public int? SelfAssessmentReviewID { get; set; }
         public int? SelfAssessmentCommentID { get; set; }
         public bool HasCompetencies { get; set; }
+        public DateTime? RetirementDate { get; set; }
     }
 }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/RetireCompetencyAssessmentViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/RetireCompetencyAssessmentViewModel.cs
@@ -1,0 +1,35 @@
+﻿using DocumentFormat.OpenXml.Drawing.Charts;
+using System;
+using System.ComponentModel.DataAnnotations;
+using DigitalLearningSolutions.Data.Models.CompetencyAssessments;
+
+namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
+{
+    public class RetireCompetencyAssessmentViewModel
+    {
+        public int CompetencyAssessmentId { get; set; }
+
+        [Required(ErrorMessage = "Enter a reason for retirement")]
+        [StringLength(2000, ErrorMessage = "Reason must be 2000 characters or fewer")]
+        public string? RetirementReason { get; set; }
+
+        public DateTime? RetirementDate { get; set; }
+        public int? Day { get; set; }
+        public int? Month { get; set; }
+        public int? Year { get; set; }
+        public RetireCompetencyAssessmentViewModel(int competencyAssessmentId, CompetencyAssessmentBase? assessment)
+        {
+            if (assessment?.RetirementDate != null)
+            {
+                Day = assessment.RetirementDate.Value.Day;
+                Month = assessment.RetirementDate.Value.Month;
+                Year = assessment.RetirementDate.Value.Year;
+            }
+            RetirementReason = assessment.RetirementReason;
+            CompetencyAssessmentId = competencyAssessmentId;
+        }
+        public RetireCompetencyAssessmentViewModel()
+        {
+        }
+    }
+}

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
@@ -55,9 +55,29 @@
             <dt class="nhsuk-summary-list__key">
                 Publish status
             </dt>
+            @{
+                var statusClass = Model.PublishStatusID switch
+                {
+                    1 => "nhsuk-tag--grey",
+                    2 => "nhsuk-tag--yellow",
+                    3 => "nhsuk-tag--green",
+                    4 => "nhsuk-tag--red",
+                    5 => "nhsuk-tag--red"
+                };
+
+                var statusText = Model.PublishStatusID switch
+                {
+                    1 => "Draft",
+                    2 => "In review",
+                    3 => "Published",
+                    4 => "Scheduled For Retirement",
+                    5 => "Retired"
+                };
+            }
+
             <dd class="nhsuk-summary-list__value">
-                <strong class="nhsuk-u-margin-right-3 nhsuk-tag @(Model.PublishStatusID == 1 ? "nhsuk-tag--grey" : Model.PublishStatusID == 2 ? "nhsuk-tag--yellow" : "nhsuk-tag--green")">
-                    @(Model.PublishStatusID == 1 ? "Draft" : Model.PublishStatusID == 2 ? "In review" : "Published")
+                <strong class="nhsuk-u-margin-right-3 nhsuk-tag @statusClass">
+                    @statusText
                 </strong>
             </dd>
             @if (Model.SelfAssessmentReviewID != null && Model.SelfAssessmentCommentID is null)
@@ -237,16 +257,16 @@
             <li class="nhsuk-task-list__item">
 
                 @if (Model.CompetencyAssessmentTaskStatus.IntroductoryTextTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.BrandingTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.VocabularyTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.WorkingGroupTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.NationalRoleProfileTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.FrameworkLinksTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.SelectCompetenciesTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.OptionalCompetenciesTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.RoleRequirementsTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.SupervisorRolesTaskStatus != true ||
-                            Model.CompetencyAssessmentTaskStatus.SelfAssessmentOptionsTaskStatus != true)
+               Model.CompetencyAssessmentTaskStatus.BrandingTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.VocabularyTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.WorkingGroupTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.NationalRoleProfileTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.FrameworkLinksTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.SelectCompetenciesTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.OptionalCompetenciesTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.RoleRequirementsTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.SupervisorRolesTaskStatus != true ||
+               Model.CompetencyAssessmentTaskStatus.SelfAssessmentOptionsTaskStatus != true)
                 {
                     <div class="nhsuk-task-list__name-and-hint" aria-describedby="review-status">
                         <div>
@@ -280,4 +300,25 @@
             </li>
         }
     </ul>
+    @{
+        var hasRetirement = Model.RetirementDate != null;
+    }
+    <div class="nhsuk-u-margin-top-6">
+        @if (!hasRetirement && Model.UserRole > 1)
+        {
+            <form asp-action="RetireCompetencyAssessment" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]" method="get">
+                <button class="nhsuk-button nhsuk-button--warning" data-module="nhsuk-button" type="submit">
+                    Retire competency assessment
+                </button>
+            </form>
+        }
+        else if (hasRetirement && Model.UserRole > 1)
+        {
+            <form asp-action="RetireCompetencyAssessment" asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]" method="get">
+                <button class="nhsuk-button nhsuk-button--warning" data-module="nhsuk-button" type="submit">
+                    Manage retirement
+                </button>
+            </form>
+        }
+    </div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/RetireCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/RetireCompetencyAssessment.cshtml
@@ -1,0 +1,80 @@
+﻿@using DigitalLearningSolutions.Data.Utilities
+@model DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments.RetireCompetencyAssessmentViewModel
+@inject IClockUtility ClockUtility
+@{
+    ViewData["Title"] = "Retire competency assessment";
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+    var exampleDate = ClockUtility.UtcToday;
+    var hintTextLines = new List<string> { $"For example, {exampleDate.Day} {exampleDate.Month} {exampleDate.Year}" };
+}
+<link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
+@section NavMenuItems {
+    <partial name="~/Views/Frameworks/Shared/_NavMenuItems.cshtml" />
+}
+@section NavBreadcrumbs {
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+        <div class="nhsuk-width-container">
+            <ol class="nhsuk-breadcrumb__list">
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader"
+                       asp-controller="Frameworks"
+                       asp-action="Index">Home</a>
+                </li>
+
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader"
+                       asp-action="ViewCompetencyAssessments"
+                       asp-route-tabname="Mine">Self-assessments</a>
+                </li>
+
+                <li class="nhsuk-breadcrumb__item">
+                    <a class="nhsuk-breadcrumb__link trigger-loader"
+                       asp-action="ManageCompetencyAssessment"
+                       asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId">Manage self-assessment</a>
+                </li>
+                <li class="nhsuk-breadcrumb__item">Retire self assessment</li>
+
+            </ol>
+        </div>
+    </nav>
+}
+@if (errorHasOccurred)
+{
+    <vc:error-summary order-of-property-names="@(new[] { nameof(Model.RetirementDate), nameof(Model.RetirementReason)})" />
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<form class="nhsuk-u-margin-bottom-3" method="post" asp-controller="CompetencyAssessments" asp-action="RetireCompetencyAssessment" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId">
+    <nhs-form-group nhs-validation-for="RetirementDate">
+  <vc:date-input id="retirement-date"
+                   label="This is the date when self assessment would be retired"
+                   day-id="Day"
+                   month-id="Month"
+                   year-id="Year"
+                   css-class="@(errorHasOccurred ? " nhsuk-u-margin-bottom-3" : "")"
+                   hint-text-lines="@hintTextLines" />
+    </nhs-form-group>
+    <nhs-form-group nhs-validation-for="RetirementReason">
+        <vc:text-area asp-for="RetirementReason"
+                      character-count="null"
+                      label="Retirement Reason"
+                      rows="5"
+                      css-class="html-editor"
+                      hint-text="You need to provide a retirement reason for this self-assessment"
+                      populate-with-current-value="true"
+                      spell-check="false" />
+    </nhs-form-group>
+
+    <a class="nhsuk-button nhsuk-button--secondary" asp-controller="CompetencyAssessments" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId" role="button">Back</a>
+    <button class="nhsuk-button" type="submit">Submit</button>
+</form>
+
+<div class="nhsuk-back-link">
+    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentId">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        Cancel
+    </a>
+</div>

--- a/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_StatusTag.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Shared/_StatusTag.cshtml
@@ -1,27 +1,41 @@
 ﻿@using DigitalLearningSolutions.Data.Models.Frameworks;
 @model int
 @{
-  switch (Model)
-  {
-    case 3:
-      // Use the text block below to separate html elements from code
-      <text>
-        <strong class="nhsuk-tag status-tag nhsuk-tag--green">
-          Published
-        </strong>
-      </text>
-      break;  // Always break each case
-    case 2:
-      <text>
-        <strong class="nhsuk-tag status-tag nhsuk-tag--yellow">
-          In review
-        </strong>
-      </text>
-      break;
-    case 1:
-      <strong class="nhsuk-tag status-tag nhsuk-tag--red">
-        Draft
-      </strong>
-      break;
-  }
+    switch (Model)
+    {
+        case 3:
+            // Use the text block below to separate html elements from code
+            <text>
+                <strong class="nhsuk-tag status-tag nhsuk-tag--green">
+                    Published
+                </strong>
+            </text>
+            break;  // Always break each case
+        case 2:
+            <text>
+                <strong class="nhsuk-tag status-tag nhsuk-tag--yellow">
+                    In review
+                </strong>
+            </text>
+            break;
+        case 1:
+            <strong class="nhsuk-tag status-tag nhsuk-tag--red">
+                Draft
+            </strong>
+            break;
+        case 4:
+            <text>
+                <strong class="nhsuk-tag status-tag nhsuk-tag--red">
+                    Scheduled For Retirement
+                </strong>
+            </text>
+            break;
+        case 5:
+            <text>
+                <strong class="nhsuk-tag status-tag nhsuk-tag--red">
+                    Retired
+                </strong>
+            </text>
+            break;
+    }
 }


### PR DESCRIPTION
### JIRA link
[TD-7136](https://hee-tis.atlassian.net/browse/TD-7136)

### Description
Added self-assessment retirement functionality

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7136]: https://hee-tis.atlassian.net/browse/TD-7136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ