### PR TITLE
TD-7342 Issue skipping navigating to the Select proficiencies to asse…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -438,6 +438,11 @@
                 competencyAssessmentService.InsertSelfAssessmentFramework(adminId, competencyAssessmentId, model.FrameworkId.Value);
                 return RedirectToAction("SelectFrameworkSources", new { competencyAssessmentId, actionName = "Summary" });
             }
+            else if (actionName == "ViewSelected")
+            {
+                competencyAssessmentService.InsertSelfAssessmentFramework(adminId, competencyAssessmentId, model.FrameworkId.Value);
+                return RedirectToAction("ViewSelectedCompetencies", new { competencyAssessmentId });
+            }
             else
             {
                 competencyAssessmentService.UpdateFrameworkLinksTaskStatus(model.CompetencyAssessmentId, model.TaskStatus ?? false, null);
@@ -484,7 +489,7 @@
             var linkedFrameworks = competencyAssessmentService.GetLinkedFrameworksForCompetencyAssessment(competencyAssessmentId);
             if (!linkedFrameworks.Any())
             {
-                return RedirectToAction("AddCompetenciesSelectFramework", new { competencyAssessmentId });
+                return RedirectToAction("SelectFrameworkSources", new { competencyAssessmentId, actionName = "ViewSelected" });
             }
             var adminId = GetAdminID();
             var competencyAssessmentBase = competencyAssessmentService.GetCompetencyAssessmentBaseById(competencyAssessmentId, adminId);
@@ -496,7 +501,8 @@
             return View(model);
         }
         [Route("/Self-Assessment/{competencyAssessmentId}/Competencies/Add/SelectFramework")]
-        public IActionResult AddCompetenciesSelectFramework(int competencyAssessmentId)
+        [Route("/Self-Assessment/{competencyAssessmentId}/{actionName}/Competencies/Add/SelectFramework")]
+        public IActionResult AddCompetenciesSelectFramework(int competencyAssessmentId, string? actionName)
         {
             var linkedFrameworks = competencyAssessmentService.GetLinkedFrameworksForCompetencyAssessment(competencyAssessmentId);
             if (!linkedFrameworks.Any())
@@ -513,6 +519,7 @@
         }
         [HttpPost]
         [Route("/Self-Assessment/{competencyAssessmentId}/Competencies/Add/SelectFramework")]
+        [Route("/Self-Assessment/{competencyAssessmentId}/{actionName}/Competencies/Add/SelectFramework")]
         public IActionResult AddCompetenciesSelectFramework(AddCompetenciesSelectFrameworkFormData formdata)
         {
             if (!ModelState.IsValid)

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectFrameworkSourcesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/SelectFrameworkSourcesViewModel.cs
@@ -23,7 +23,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
             Frameworks = [.. frameworks
                 .Where(f => !excludedIds.Contains(f.ID))
                 .OrderBy(f => f.FrameworkName)];
-            AdditionalFrameworks = [.. additionalFrameworksIds.Select(id => frameworks.First(f => f.ID == id))];
+            AdditionalFrameworks = [.. additionalFrameworksIds.Select(id => frameworks.FirstOrDefault(f => f.ID == id))];
             ActionName = actionName;
         }
         public IEnumerable<BrandedFramework> Frameworks { get; set; }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -78,7 +78,7 @@
             int i = 0;
             foreach (var framework in Model.AdditionalFrameworks)
             {
-                if (framework == null) continue; // Safety check in case an item in the list is null
+                if (framework == null) continue;
 
                 <div class="nhsuk-summary-list__row">
                     <dt class="nhsuk-summary-list__key">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -73,16 +73,19 @@
                 }
             </div>
         }
-        @if (Model.AdditionalFrameworks.Count() > 0)
+        @if (Model?.AdditionalFrameworks != null && Model.AdditionalFrameworks.Any())
         {
-            for (int i = 0; i < Model.AdditionalFrameworks.Count(); i++)
+            int i = 0;
+            foreach (var framework in Model.AdditionalFrameworks)
             {
+                if (framework == null) continue; // Safety check in case an item in the list is null
+
                 <div class="nhsuk-summary-list__row">
                     <dt class="nhsuk-summary-list__key">
                         Additional framework @(i + 1)
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                        @Model.AdditionalFrameworks.ElementAt(i).FrameworkName
+                        @framework.FrameworkName
                     </dd>
                     @if (Model.UserRole > 1)
                     {
@@ -90,28 +93,32 @@
                             <ul class="nhsuk-summary-list__actions-list nhsuk-summary-list__actions-list--inline left-align-actions">
                                 <li class="nhsuk-summary-list__actions-list-item">
                                     <a asp-action="RemoveFramework"
-                                       asp-route-frameworkId="@Model.AdditionalFrameworks.ElementAt(i).ID"
+                                       asp-route-frameworkId="@framework.ID"
                                        asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                                        Remove <span class="nhsuk-u-visually-hidden">@Model.AdditionalFrameworks.ElementAt(i).FrameworkName</span>
+                                        Remove <span class="nhsuk-u-visually-hidden">@framework.FrameworkName</span>
                                     </a>
                                 </li>
                                 <li class="nhsuk-summary-list__actions-list-item">
-                                    <a asp-action="ConfirmMaKePrimaryFramework"
-                                       asp-route-frameworkId="@Model.AdditionalFrameworks.ElementAt(i).ID"
+                                    <a asp-action="ConfirmMakePrimaryFramework"
+                                       asp-route-frameworkId="@framework.ID"
                                        asp-route-competencyAssessmentId="@ViewContext.RouteData.Values["competencyAssessmentId"]">
-                                        Make primary <span class="nhsuk-u-visually-hidden">@Model.AdditionalFrameworks.ElementAt(i).FrameworkName</span>
+                                        Make primary <span class="nhsuk-u-visually-hidden">@framework.FrameworkName</span>
                                     </a>
                                 </li>
-
                             </ul>
                         </dd>
                     }
                 </div>
+                i++;
             }
+        }
+        else
+        {
+            <p>No additional frameworks available.</p>
         }
     </dl>
 }
-@if (Model.ActionName == "AddFramework")
+@if (Model.ActionName == "AddFramework" || Model.ActionName == "ViewSelected")
 {
     <form method="post">
         <div class="nhsuk-form-group">

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectFrameworkSources.cshtml
@@ -112,10 +112,6 @@
                 i++;
             }
         }
-        else
-        {
-            <p>No additional frameworks available.</p>
-        }
     </dl>
 }
 @if (Model.ActionName == "AddFramework" || Model.ActionName == "ViewSelected")


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7342

### Description
Updated the workflow so that the action method now redirects to SelectFrameworkSources from ViewSelectedCompetencies. Introduced an ActionName parameter to identify the originating page, allowing the application to return users to the appropriate starting point after a framework has been added.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/3600aff6-1d7d-4061-b880-16c0b07a3b96" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
