### PR TITLE
TD-7343 Added auto focus to the check box

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -579,6 +579,9 @@
                         competency.CompetencyFlags = competencyFlags.Where(f => f.CompetencyId == competency.CompetencyID);
                 }
                 var models = new AddCompetenciesViewModel(competencyAssessmentBase, groupedCompetencies, ungroupedCompetencies, frameworkId, framework.FrameworkName, model.SelectedCompetencyIds);
+                ModelState.Clear();
+                ModelState.AddModelError("SelectedCompetencyIds", $"You must select at least one {models.VocabularySingular}");
+                ViewBag.RequiredCheckboxMessage = "You must select at least one "+ models.VocabularySingular;
                 return View("AddCompetencies", models);
             }
             if (model.SelectedCompetencyIds != null)

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewFormData.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewFormData.cs
@@ -1,11 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
+﻿namespace DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 {
     public class AddCompetenciesFormData
     {
         public int ID { get; set; }
-        [Required(ErrorMessage = "Select at least one competency")]
         public int[] SelectedCompetencyIds { get; set; }
         public int FrameworkId { get; set; }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/CompetencyAssessments/AddCompetenciesViewModel.cs
@@ -28,7 +28,7 @@
         public string VocabularyPlural { get; set; }
         public IEnumerable<FrameworkCompetencyGroup> GroupedCompetencies { get; set; }
         public IEnumerable<FrameworkCompetency> UngroupedCompetencies { get; set; }
-        [Required(ErrorMessage = "Select at least one competency")]
+        [Required]
         public int[] SelectedCompetencyIds { get; set; }
         public int FrameworkId { get; set; }
         public string? FrameworkName { get; set; }

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/AddCompetencies.cshtml
@@ -4,6 +4,8 @@
     ViewData["Title"] = $"Add {@Model.VocabularyPlural.ToLower()} to self-assessment";
     ViewData["Application"] = "Framework service";
     var errorHasOccurred = !ViewData.ModelState.IsValid;
+    var noSelection = Model.SelectedCompetencyIds == null || !Model.SelectedCompetencyIds.Any();
+    var isFirst = true;
 }
 <link rel="stylesheet" href="@Url.Content("~/css/frameworks/frameworksShared.css")" asp-append-version="true">
 @section NavMenuItems {
@@ -40,6 +42,11 @@
                     Add @Model.VocabularyPlural.ToLower() to assessment
                 </h1>
             </legend>
+            <div class="nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
+                <span class="error-message--margin-bottom-1 nhsuk-error-message">
+                    <span>@ViewBag.RequiredCheckboxMessage</span>
+                </span>
+            </div>
             @if (Model.GroupedCompetencies.Count() > 0)
             {
                 @foreach (var competencyGroup in Model.GroupedCompetencies)
@@ -62,8 +69,18 @@
                             <div class="nhsuk-checkboxes">
                                 @foreach (var competency in competencyGroup.FrameworkCompetencies)
                                 {
+                                    var shouldAutofocus = noSelection && isFirst;
+                                    isFirst = false;
                                     <div class="nhsuk-checkboxes__item">
-                                        <input class="nhsuk-checkboxes__input select-all-checkbox" data-group="@competencyGroup.CompetencyGroupID" id="competency-check-@competencyGroup.CompetencyGroupID-@competency.CompetencyID" name="SelectedCompetencyIds" checked="@(Model.SelectedCompetencyIds != null ? Model.SelectedCompetencyIds.Contains((int)competency.CompetencyID) : false)" type="checkbox" value="@competency.CompetencyID">
+                                        <input class="nhsuk-checkboxes__input select-all-checkbox"
+                                        data-group="@competencyGroup.CompetencyGroupID"
+                                        id="competency-check-@competencyGroup.CompetencyGroupID-@competency.CompetencyID"
+                                        name="SelectedCompetencyIds"
+                                        checked="@(Model.SelectedCompetencyIds != null ?
+                                        Model.SelectedCompetencyIds.Contains((int)competency.CompetencyID) : false)"
+                                        type="checkbox"
+                                         @(shouldAutofocus ? "autofocus" : "")
+                                        value="@competency.CompetencyID">
                                         <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competencyGroup.CompetencyGroupID-@competency.CompetencyID">
                                             @foreach (var flag in competency.CompetencyFlags)
                                             {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7343

### Description
Make the error message dynamic and set focus automatically on the checkbox when validation fails.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/6c7633de-2532-4ea7-8313-f76a06f26e01" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
