### PR TITLE
TD-7110 Hide Overall diagnostic score when diagnostic assessment is d…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CourseDataService.cs
@@ -324,7 +324,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                 u.HasBeenPromptedForPrn,
                 u.ProfessionalRegistrationNumber,
                 da.CentreID AS DelegateCentreId,
-                ap.ArchivedDate AS CourseArchivedDate
+                ap.ArchivedDate AS CourseArchivedDate,
+                ap.DiagAssess
             FROM Customisations cu
             INNER JOIN Applications AS ap ON ap.ApplicationID = cu.ApplicationID
             INNER JOIN Progress AS pr ON pr.CustomisationID = cu.CustomisationID
@@ -1003,7 +1004,8 @@ namespace DigitalLearningSolutions.Data.DataServices
                         u.HasBeenPromptedForPrn,
                         u.ProfessionalRegistrationNumber,
                         da.CentreID,
-                        ap.ArchivedDate",
+                        ap.ArchivedDate,
+                        ap.DiagAssess",
                 new { progressId }
             );
         }

--- a/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
+++ b/DigitalLearningSolutions.Data/Models/Courses/DelegateCourseInfo.cs
@@ -52,6 +52,7 @@
             DelegateCentreId = delegateCourseInfo.DelegateCentreId;
             CourseAdminFields = delegateCourseInfo.CourseAdminFields;
             CourseArchivedDate = delegateCourseInfo.CourseArchivedDate;
+            DiagAssess = delegateCourseInfo.DiagAssess;
         }
 
         public DelegateCourseInfo(
@@ -143,6 +144,7 @@
         public int CustomisationCentreId { get; set; }
         public bool IsCourseActive { get; set; }
         public bool AllCentresCourse { get; set; }
+        public bool DiagAssess { get; set; }
         public int ProgressId { get; set; }
         public bool IsProgressLocked { get; set; }
         public DateTime? LastUpdated { get; set; }

--- a/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/TrackingSystem/Delegates/Shared/DelegateCourseInfoViewModel.cs
@@ -94,6 +94,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
             CourseName = info.CourseName;
             IsCourseActive = info.IsCourseActive;
             CourseArchivedDate = info.CourseArchivedDate;
+            DiagAssess = info.DiagAssess;
         }
 
         public DelegateAccessRoute AccessedVia { get; set; }
@@ -127,7 +128,7 @@ namespace DigitalLearningSolutions.Web.ViewModels.TrackingSystem.Delegates.Share
         public string CourseDelegatesDisplayName { get; set; }
         public DateTime? CourseArchivedDate { get; set; }
         public bool IsCourseActive { get; set; }
-
+        public bool DiagAssess { get; set; }
         public string? PassRateDisplayString =>
             TotalAttempts != 0 ? PassRate + "%" : null;
 

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/DelegateProgress/Index.cshtml
@@ -53,12 +53,13 @@
         }
 
         <partial name="_DelegateProgressSummary" model="Model" />
-
-        <div class="nhsuk-inset-text">
-            <span class="nhsuk-u-visually-hidden">Information: </span>
-            <p class="nhsuk-body-l">Overall diagnostic score: <strong>@(Model.DiagnosticScore.HasValue ? $"{Model.DiagnosticScore}%" : "N/A")</strong></p>
-        </div>
-
+        @if(Model.DiagAssess)
+        {
+            <div class="nhsuk-inset-text">
+                <span class="nhsuk-u-visually-hidden">Information: </span>
+                <p class="nhsuk-body-l">Overall diagnostic score: <strong>@(Model.DiagnosticScore.HasValue ? $"{Model.DiagnosticScore}%" : "N/A")</strong></p>
+            </div>
+        }
         @foreach (var section in Model.Sections)
         {
             <partial name="_SectionProgress" model="section" />


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7110

### Description
Added the DiagAssess field to the SELECT statement and DelegateCourseInfo.cs to identify courses that should display the Overall Diagnostic Score. The field is used to show or hide the score as required.

### Screenshots
When DiagAssess is true, the Overall Diagnostic Score is displayed.
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/fc9b0847-8a73-4b22-b708-90ea1a8c9b7e" />
When DiagAssess is false, the Overall Diagnostic Score is hidden.
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/d4ab5619-c9c7-40cf-9181-f4c661640e9f" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
