### PR TITLE
TD-7112 Remove the Log in button in DLS

### DIFF
--- a/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
+++ b/DigitalLearningSolutions.Data/Extensions/ConfigurationExtensions.cs
@@ -11,7 +11,6 @@
         private const string LearningHubOpenApiKey = "LearningHubOpenAPIKey";
         private const string LearningHubOpenApiBaseUrl = "LearningHubOpenAPIBaseUrl";
         private const string PricingPageEnabled = "FeatureManagement:PricingPage";
-        private const string ShowDlsLoginButton = "FeatureManagement:ShowDlsLoginButton";
         
         private const string LearningHubAuthBaseUrl = "BaseUrl";
         private const string LearningHubAuthLoginEndpoint = "LoginEndpoint";
@@ -117,11 +116,6 @@
         public static bool IsPricingPageEnabled(this IConfiguration config)
         {
             bool.TryParse(config[PricingPageEnabled], out bool isEnabled);
-            return isEnabled;
-        }
-        public static bool IsDlsLoginButtonShown(this IConfiguration config)
-        {
-            bool.TryParse(config[ShowDlsLoginButton], out bool isEnabled);
             return isEnabled;
         }
         public static int GetLearningHubSsoHashTolerance(this IConfiguration config)

--- a/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
@@ -16,6 +16,5 @@
         public const string LoginWithLearningHub = "LoginWithLearningHub";
         public const string TableauSelfAssessmentDashboards = "TableauSelfAssessmentDashboards";
         public const string ShowDlsLoginButton = "ShowDlsLoginButton";
-
     }
 }

--- a/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FeatureFlags.cs
@@ -15,5 +15,7 @@
         public const string ShowSelfAssessmentProgressButtons = "ShowSelfAssessmentProgressButtons";
         public const string LoginWithLearningHub = "LoginWithLearningHub";
         public const string TableauSelfAssessmentDashboards = "TableauSelfAssessmentDashboards";
+        public const string ShowDlsLoginButton = "ShowDlsLoginButton";
+
     }
 }

--- a/DigitalLearningSolutions.Web/Views/Home/Welcome.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Home/Welcome.cshtml
@@ -25,22 +25,21 @@
             else
             {
                 <feature name="@(FeatureFlags.LoginWithLearningHub)">
-                    <p class="nhsuk-body-m">If you have linked your account you can login through the Learning hub.</p>
+                    <p class="nhsuk-body-m">If you have linked your account you can login through the Learning Hub.</p>
                     <a class="nhsuk-button auth-button--blue" role="button" asp-controller="Login" asp-action="SharedAuth">
                         Log in with Learning hub
                     </a>
                     <p class="nhsuk-u-font-weight-bold">Or</p>
                 </feature>
 
-                @if (Model.ShowDlsLoginButton)
-                {
+                <feature name="@(FeatureFlags.ShowDlsLoginButton)">
                     <a class="nhsuk-button auth-button auth-button--left"
                        role="button"
                        asp-controller="Login"
                        asp-action="Index">
                         Log in
                     </a>
-                }
+                </feature>
                 <a class="nhsuk-button nhsuk-button--secondary auth-button" role="button" asp-controller="Register" asp-action="Start">
                     Register
                 </a>

--- a/DigitalLearningSolutions.Web/Views/Shared/_NavMenuItems.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Shared/_NavMenuItems.cshtml
@@ -1,6 +1,7 @@
 ﻿@using DigitalLearningSolutions.Data.Enums
 @using DigitalLearningSolutions.Data.Extensions
 @using DigitalLearningSolutions.Web.Extensions
+@using DigitalLearningSolutions.Web.Helpers
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
 
@@ -32,14 +33,13 @@
 }
 else
 {
-    @if (Configuration.IsDlsLoginButtonShown())
-    {
+    <feature name="@(FeatureFlags.ShowDlsLoginButton)">
   <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.LogIn)">
     <a class="nhsuk-header__navigation-link" asp-controller="Login" asp-action="Index">
       Log in
     </a>
   </li>
-    }
+    </feature>
   <li class="nhsuk-header__navigation-item @Html.GetSelectedCssClassIfTabSelected(NavMenuTab.Register)">
     <a class="nhsuk-header__navigation-link" asp-controller="Register" asp-action="Start">
       Register


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7112

### Description
Hid the Login option in the navigation bar and on the Welcome page. Also capitalised the "H" in "Hub" in the statement above the "Login with Learning Hub" button.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/0cf6ff8e-8b47-48f4-b05e-493f8530e32c" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
