### PR TITLE
TD-7111-Header path added for a self-assessment

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_Layout.cshtml
@@ -7,6 +7,10 @@
 @{
     var userResearchUrl = Configuration["UserResearchUrl"];
     Context.Request.Cookies.TryGetValue("Dls-cookie-consent", out string cookieConsent);
+    var selfAssessmentId = ViewContext.RouteData.Values["selfAssessmentId"];
+    var headerPath = selfAssessmentId == null
+        ? $"{Configuration["AppRootPath"]}/LearningPortal/Current"
+        : $"{Configuration["AppRootPath"]}/LearningPortal/SelfAssessment/{selfAssessmentId}";
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -58,8 +62,8 @@
             <div class="nhsuk-header__container">
                 <div class="nhsuk-header__logo nhsuk-header__transactional--logo">
                     <a class="nhsuk-header__link"
-                       href="/"
-                       aria-label="NHS homepage">
+                       href="@headerPath"
+                       aria-label="NHS Digital Learning Solutions - @(ViewData["SelfAssessmentTitle"])">
                         <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NHS Logo" focusable="false" viewBox="0 0 40 16" height="40" width="100">
                             <title>NHS</title>
                             <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
@@ -68,7 +72,7 @@
                         </svg>
                     </a>
                     <div class="nhsuk-header__transactional-service-name">
-                        <a class="nhsuk-header__transactional-service-name--link" href="/">@ViewData["SelfAssessmentTitle"]</a>
+                        <a class="nhsuk-header__transactional-service-name--link" href="@headerPath">@ViewData["SelfAssessmentTitle"]</a>
                         <sup class="header-beta">Beta</sup>
                     </div>
                 </div>


### PR DESCRIPTION
### JIRA link
[TD-7111](https://hee-tis.atlassian.net/browse/TD-7111)

### Description
Header path added for a self-assessment

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7111]: https://hee-tis.atlassian.net/browse/TD-7111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ