### PR TITLE
TD-7218-Corrected the wording in 'Sign Off'.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
@@ -31,7 +31,7 @@
     <h2>@Model.SelfAssessment.SignOffRoleName Sign-off</h2>
     <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
              view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) },
-                    { "IsOngoingSelfAssessment", latestResult > latestSignoff }})" />
+                                 { "IsOngoingSelfAssessment", latestResult > latestSignoff }})" />
     @if (Model.AllQuestionsVerifiedOrNotRequired)
     {
         @if (!Model.SupervisorSignOffs.Any())
@@ -54,9 +54,9 @@
             </div>
         }
         @if (!Model.SupervisorSignOffs.Where(x => x.Verified == null).Any()
-       && (latestResult > latestSignoff || !signedOff)
-       && (Model.NumberOfSelfAssessedOptionalCompetencies >= Model.SelfAssessment.MinimumOptionalCompetencies)
-       )
+            && (latestResult > latestSignoff || !signedOff)
+            && (Model.NumberOfSelfAssessedOptionalCompetencies >= Model.SelfAssessment.MinimumOptionalCompetencies)
+            )
         {
             <a class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-2"
                asp-action="RequestSignOff"
@@ -71,7 +71,7 @@
     {
         <p class="nhsuk-body-l">
             All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
-            before requesting @Model.SelfAssessment.SignOffRoleName sign off of the @Model.SelfAssessment.Name.
+            before requesting @Model.SelfAssessment.SignOffRoleName.ToLower() sign-off of the @Model.SelfAssessment.Name.
         </p>
     }
 </div>

--- a/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Supervisor/Shared/_SupervisorSignOffSummary.cshtml
@@ -88,7 +88,7 @@
         {
             <div class="nhsuk-summary-list__row">
                 <dt class="nhsuk-summary-list__key">
-                    Previous sign off requests
+                    Previous sign-off requests
                 </dt>
                 <dd class="nhsuk-summary-list__value">
                     @(Model.Count() - 1)


### PR DESCRIPTION
### JIRA link
[TD-7218](https://hee-tis.atlassian.net/browse/TD-7218)
#)

### Description
Corrected the wording in 'Sign Off'.

### Screenshots

<img width="1125" height="597" alt="image" src="https://github.com/user-attachments/assets/c0e655cc-c88c-4c7b-b0dc-f1e2059238f6" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7218]: https://hee-tis.atlassian.net/browse/TD-7218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ