### PR TITLE
TD-7148 Duplicate Self-assessment tags showing on Learning Portal - S…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_TagRow.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/Shared/_TagRow.cshtml
@@ -71,12 +71,7 @@
             <strong class="nhsuk-tag nhsuk-tag--grey">Learning assessment and certification</strong>
         </div>
     }
-    @if (Model.IsSelfAssessment)
-    {
-        <div class="card-filter-tag">
-            <strong class="nhsuk-tag nhsuk-tag--grey">Self-assessment</strong>
-        </div>
-    }
+   
     @if (Model.IncludesSignposting)
     {
         <div class="card-filter-tag">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7148

### Description
Removed the second self-assessment condition from the tags to eliminate duplicate tags.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/e415fe36-da7b-4d13-a0a4-2f99ed373e11" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
