### PR TITLE
TD-7229-Hidden the 'Mark this task as complete' checkbox for the viewer role

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -318,7 +318,7 @@
                         <span class="nhsuk-u-visually-hidden"> – </span>
                     </span>Summary
                 </h1>
-            
+
 
                 <dl class="nhsuk-summary-list word-break">
                     @if (Model.IsSupervisionSwitchedOn)
@@ -429,7 +429,10 @@
                 </dl>
             </div>
         </div>
-        <vc:single-checkbox asp-for="@nameof(Model.SelfAssessmentOptionsTaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        @if (Model.UserRole > 1)
+        {
+            <vc:single-checkbox asp-for="@nameof(Model.SelfAssessmentOptionsTaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        }
     }
     @if (index > 0 && Model.CurrentStep < (int)OptionLabel.Summary)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -33,7 +33,8 @@
         @Model.CompetencyAssessmentName
         <span class="nhsuk-u-visually-hidden"> – </span>
     </span>
-Select working group members</h1>
+    Select working group members
+</h1>
 <form method="post">
     @if (Model.UserRole > 1)
     {
@@ -45,61 +46,61 @@ Select working group members</h1>
             <li>Reviewer</li>
         </ul>
         <label class="nhsuk-label nhsuk-u-margin-top-6">
-        <p>to help create your competency assessment</p>
+            <p>to help create your competency assessment</p>
         </label>
         <div class="nhsuk-table__panel-with-heading-tab">
-         <h2 class="nhsuk-table__heading-tab">Working group members</h2>
-         <table role="presentation" class="nhsuk-table-responsive">
-            <thead role="rowgroup" class="nhsuk-table__head">
-            <tr role="row">
-                <th role="columnheader" class="" scope="col">
-                    User
-                </th>
-                <th role="columnheader" class="" scope="col">
-                    Role
-                </th>
-                @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
-                {
-                    <th role="columnheader" class="" scope="col">
-                        Actions
-                    </th>
-                }
-            </tr>
-        </thead>
-        <tbody class="nhsuk-table__body">
-            @foreach (var collaborator in Model.Collaborators)
-            {
-                <tr role="row" class="nhsuk-table__row collaborator-row">
-                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                        <span class="nhsuk-table-responsive__heading">User </span>
-                        <span class="framework-collaborator-user">
-                            @collaborator.UserEmail @(collaborator.UserActive == true ? "" : "(inactive)")
-                        </span>
-                    </td>
-                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                        <span class="nhsuk-table-responsive__heading">Role </span>
-                        <span class="framework-collaborator-role">
-                            <partial name="Shared/_RoleTag" model="collaborator" />
-                        </span>
-                    </td>
-                    @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
+            <h2 class="nhsuk-table__heading-tab">Working group members</h2>
+            <table role="presentation" class="nhsuk-table-responsive">
+                <thead role="rowgroup" class="nhsuk-table__head">
+                    <tr role="row">
+                        <th role="columnheader" class="" scope="col">
+                            User
+                        </th>
+                        <th role="columnheader" class="" scope="col">
+                            Role
+                        </th>
+                        @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
+                        {
+                            <th role="columnheader" class="" scope="col">
+                                Actions
+                            </th>
+                        }
+                    </tr>
+                </thead>
+                <tbody class="nhsuk-table__body">
+                    @foreach (var collaborator in Model.Collaborators)
                     {
-                        <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                            <span class="nhsuk-table-responsive__heading">Actions </span>
-                            @if (collaborator.CompetencyAssessmentRole != "Owner")
+                        <tr role="row" class="nhsuk-table__row collaborator-row">
+                            <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                <span class="nhsuk-table-responsive__heading">User </span>
+                                <span class="framework-collaborator-user">
+                                    @collaborator.UserEmail @(collaborator.UserActive == true ? "" : "(inactive)")
+                                </span>
+                            </td>
+                            <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                <span class="nhsuk-table-responsive__heading">Role </span>
+                                <span class="framework-collaborator-role">
+                                    <partial name="Shared/_RoleTag" model="collaborator" />
+                                </span>
+                            </td>
+                            @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
                             {
-                                <a asp-action="RemoveCollaborator" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-id="@collaborator.ID" )">
-                                    Remove
-                                </a>
-                            }
+                                <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                    <span class="nhsuk-table-responsive__heading">Actions </span>
+                                    @if (collaborator.CompetencyAssessmentRole != "Owner")
+                                    {
+                                        <a asp-action="RemoveCollaborator" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-id="@collaborator.ID" )">
+                                            Remove
+                                        </a>
+                                    }
 
-                        </td>
+                                </td>
+                            }
+                        </tr>
                     }
-                </tr>
-            }
-        </tbody>
-    </table>
-</div>
+                </tbody>
+            </table>
+        </div>
         <div class="@(Model.Error ? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
             <div class=" sort-select-container">
                 <label class="nhsuk-label" for="UserEmail">
@@ -126,7 +127,10 @@ Select working group members</h1>
             Add as reviewer
         </button>
     }
-    <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+    @if (Model.UserRole > 1)
+    {
+        <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+    }
 
     @if (Model.UserRole > 1)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -130,10 +130,7 @@
     @if (Model.UserRole > 1)
     {
         <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    }
 
-    @if (Model.UserRole > 1)
-    {
         <div class=" nhsuk-u-margin-top-6">
             @if (Model.ActionName == "CollaboratorReview")
             {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -63,9 +63,12 @@
             <input type="text" id="category-field" name="Category" maxlength="100" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Category" />
         </div>
     </nhs-form-group>
-    <nhs-form-group>
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
+    @if (Model.UserRole > 1)
+    {
+        <nhs-form-group>
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        </nhs-form-group>
+    }
     <input name="ID" type="hidden" asp-for="ID" />
     <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
     <input name="userRole" type="hidden" asp-for="UserRole" />

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -46,7 +46,10 @@
                           populate-with-current-value="true"
                           spell-check="false" />
         </nhs-form-group>
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        @if (Model.UserRole > 1)
+        {
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        }
         <input name="ID" type="hidden" asp-for="ID" />
         <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
         <input name="userRole" type="hidden" asp-for="UserRole" />

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
@@ -246,9 +246,12 @@ else if (Model.ActionName == "EditRole" && Model.SubGroupId != null)
 else if (Model.ActionName == "Summary")
 {
     <form method="post">
-        <nhs-form-group>
-            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-        </nhs-form-group>
+        @if (Model.UserRole > 1)
+        {
+            <nhs-form-group>
+                <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+            </nhs-form-group>
+        }
         <input type="hidden" asp-for="ID" />
         <input type="hidden" asp-for="CompetencyAssessmentName" />
         <input type="hidden" asp-for="ProfessionalGroupId" />

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -79,9 +79,12 @@
         </fieldset>
         <span nhs-validation-for="Vocabulary"></span>
     </nhs-form-group>
-    <nhs-form-group nhs-validation-for="TaskStatus">
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
+    @if (Model.UserRole > 1)
+    {
+        <nhs-form-group nhs-validation-for="TaskStatus">
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        </nhs-form-group>
+    }
     <input name="ID" type="hidden" asp-for="ID" />
     <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
     <input name="userRole" type="hidden" asp-for="UserRole" />

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
@@ -23,10 +23,10 @@
     </nav>
 }
 <div class="nhsuk-form-group">
-<h1 class="app-page-heading">
-    <span class="nhsuk-caption-xl">
-        @Model.CompetencyAssessmentName
-        <span class="nhsuk-u-visually-hidden"> – </span>
+    <h1 class="app-page-heading">
+        <span class="nhsuk-caption-xl">
+            @Model.CompetencyAssessmentName
+            <span class="nhsuk-u-visually-hidden"> – </span>
         </span>
         Self-assessment @Model.VocabularySingular.ToLower() role requirements
     </h1>
@@ -34,84 +34,87 @@
     <p>
         Specify whether role requirements will be enforced for the self-assessment. When requirements are set, they must be met by the learner before the self-assessment can be signed off.
     </p>
-<dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-            Enforce role requirements
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-            @if (Model.EnforceRoleRequirementsForSignOff)
+    <dl class="nhsuk-summary-list">
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Enforce role requirements
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @if (Model.EnforceRoleRequirementsForSignOff)
+                {
+                    <text>Yes.</text>
+                }
+                else
+                {
+                    <text>No.</text>
+                }
+            </dd>
+            @if (Model.UserRole > 1)
             {
-                <text>Yes.</text>
+                <dd class="nhsuk-summary-list__actions">
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditEnforceRoleRequirementsForSignOff">Change<span class="nhsuk-u-visually-hidden"> role requirements enforcement</span></a>
+                </dd>
             }
-            else
+        </div>
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Role requirement filters
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @if (Model.IncludeRequirementsFilters)
+                {
+                    <text>Yes.</text>
+                }
+                else
+                {
+                    <text>No.</text>
+                }
+            </dd>
+            @if (Model.UserRole > 1)
             {
-                <text>No.</text>
+                <dd class="nhsuk-summary-list__actions">
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditIncludeRequirementsFilters">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
+                </dd>
             }
-        </dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                @Model.VocabularySingular role requirements
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @Model.CountCompetencyRequirements @Model.VocabularySingular.ToLower() assessment questions with role requirements set.
+            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditCompetencyRoleRequirements">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
+                </dd>
+            }
+        </div>
+    </dl>
+    <form method="post" asp-action="ManageCompetencyRoleRequirements">
+        <nhs-form-group>
+            <input type="hidden" asp-for="Id" />
+            <input type="hidden" asp-for="EnforceRoleRequirementsForSignOff" />
+            <input type="hidden" asp-for="IncludeRequirementsFilters" />
+            @if (Model.UserRole > 1)
+            {
+                <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+            }
+        </nhs-form-group>
         @if (Model.UserRole > 1)
         {
-            <dd class="nhsuk-summary-list__actions">
-                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditEnforceRoleRequirementsForSignOff">Change<span class="nhsuk-u-visually-hidden"> role requirements enforcement</span></a>
-            </dd>
+            <button class="nhsuk-button" type="submit">
+                Save
+            </button>
         }
+    </form>
+    <div class="nhsuk-back-link">
+        <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.Id">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
+        </a>
     </div>
-    <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-           Role requirement filters
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-            @if (Model.IncludeRequirementsFilters)
-            {
-                <text>Yes.</text>
-            }
-            else
-            {
-                <text>No.</text>
-            }
-        </dd>
-        @if (Model.UserRole > 1)
-        {
-            <dd class="nhsuk-summary-list__actions">
-                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditIncludeRequirementsFilters">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
-            </dd>
-        }
-    </div>
-    <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-            @Model.VocabularySingular role requirements
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-            @Model.CountCompetencyRequirements @Model.VocabularySingular.ToLower() assessment questions with role requirements set.
-        </dd>
-        @if (Model.UserRole > 1)
-        {
-            <dd class="nhsuk-summary-list__actions">
-                <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.Id" asp-action="EditCompetencyRoleRequirements">Change<span class="nhsuk-u-visually-hidden"> include requirements filters</span></a>
-            </dd>
-        }
-    </div>
-</dl>
-<form method="post" asp-action="ManageCompetencyRoleRequirements">
-    <nhs-form-group>
-        <input type="hidden" asp-for="Id" />
-        <input type="hidden" asp-for="EnforceRoleRequirementsForSignOff" />
-        <input type="hidden" asp-for="IncludeRequirementsFilters" />
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
-    @if (Model.UserRole > 1)
-    {
-        <button class="nhsuk-button" type="submit">
-            Save
-        </button>
-    }
-</form>
-<div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.Id">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        Cancel
-    </a>
-</div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -23,106 +23,109 @@
     </nav>
 }
 <div class="nhsuk-form-group">
-<h1 class="app-page-heading">
-    <span class="nhsuk-caption-xl">
-        @Model.CompetencyAssessmentName
-        <span class="nhsuk-u-visually-hidden"> – </span>
-    </span>
-  Manage optional @Model.VocabularyPlural.ToLower()
-  </h1>
-<p>
-Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self-assessment by a learner if required.
-</p>
-<dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key">
-            Optional @Model.VocabularyPlural.ToLower()
-        </dt>
-        <dd class="nhsuk-summary-list__value">
-            @if (!Model.SelectedCompetencyIds.Any())
-            {
-                <text>No @Model.VocabularyPlural.ToLower() have been made optional for this self-assessment.</text>
-            }
-            else
-            {
-                <text>
-                    @(Model.CompetencyGroups.Count(g =>
-                                    g.Any(c => c.GroupOptionalCompetencies)
-                                    )) optional @Model.VocabularySingular.ToLower() groups
-                                      <br />
-                    @(Model.CompetencyGroups
-                                    .Where(g => g.All(c => !c.GroupOptionalCompetencies))
-                                    .Sum(g => g.Count())) individual optional @Model.VocabularyPlural.ToLower() from
-                    @(Model.CompetencyGroups.Count(g =>
-                                    g.All(c => !c.GroupOptionalCompetencies)
-                                    )) groups
-            </text>
+    <h1 class="app-page-heading">
+        <span class="nhsuk-caption-xl">
+            @Model.CompetencyAssessmentName
+            <span class="nhsuk-u-visually-hidden"> – </span>
+        </span>
+        Manage optional @Model.VocabularyPlural.ToLower()
+    </h1>
+    <p>
+        Optional @Model.VocabularyPlural.ToLower() can be selected for inclusion in a self-assessment by a learner if required.
+    </p>
+    <dl class="nhsuk-summary-list">
+        <div class="nhsuk-summary-list__row">
+            <dt class="nhsuk-summary-list__key">
+                Optional @Model.VocabularyPlural.ToLower()
+            </dt>
+            <dd class="nhsuk-summary-list__value">
+                @if (!Model.SelectedCompetencyIds.Any())
+                {
+                    <text>No @Model.VocabularyPlural.ToLower() have been made optional for this self-assessment.</text>
+                }
+                else
+                {
+                    <text>
+                        @(Model.CompetencyGroups.Count(g =>
+                                            g.Any(c => c.GroupOptionalCompetencies)
+                                            )) optional @Model.VocabularySingular.ToLower() groups
+                                              <br />
+                        @(Model.CompetencyGroups
+                                            .Where(g => g.All(c => !c.GroupOptionalCompetencies))
+                                            .Sum(g => g.Count())) individual optional @Model.VocabularyPlural.ToLower() from
+                        @(Model.CompetencyGroups.Count(g =>
+                                            g.All(c => !c.GroupOptionalCompetencies)
+                                            )) groups
+                </text>
 
-                        }
-        </dd>
+                                }
+            </dd>
+            @if (Model.UserRole > 1)
+            {
+                <dd class="nhsuk-summary-list__actions">
+                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SelectOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> optional @Model.VocabularyPlural.ToLower()</span></a>
+                </dd>
+            }
+        </div>
+        @if (Model.SelectedCompetencyIds.Any())
+        {
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Minimum optional @Model.VocabularyPlural.ToLower()
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @(Model.MinimumOptionalCompetencies == null | Model.MinimumOptionalCompetencies == 0 ? "No minimum set" : Model.MinimumOptionalCompetencies.ToString())
+                </dd>
+                @if (Model.UserRole > 1)
+                {
+                    <dd class="nhsuk-summary-list__actions">
+                        <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SetMinimumOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> minimum optional @Model.VocabularyPlural.ToLower()</span></a>
+                    </dd>
+                }
+            </div>
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    Optional learner prompt
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                    @Html.Raw(Model.ManageOptionalCompetenciesPrompt == null ? "No learner prompt specified" : Model.ManageOptionalCompetenciesPrompt.ToString())
+                </dd>
+                @if (Model.UserRole > 1)
+                {
+                    <dd class="nhsuk-summary-list__actions">
+                        <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SetOptionalCompetencyLearnerPrompt">Change<span class="nhsuk-u-visually-hidden"> learner prompt</span></a>
+                    </dd>
+                }
+            </div>
+        }
+    </dl>
+    <form method="post">
+        <nhs-form-group>
+            <input type="hidden" asp-for="ID" />
+            <input type="hidden" asp-for="MinimumOptionalCompetencies" />
+            <input type="hidden" asp-for="ManageOptionalCompetenciesPrompt" />
+            <input type="hidden" asp-for="SelectedCompetencyIds" />
+            <input type="hidden" asp-for="GroupIds" />
+            <input type="hidden" asp-for="VocabularyPlural" />
+
+            @if (Model.UserRole > 1)
+            {
+                <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+            }
+        </nhs-form-group>
         @if (Model.UserRole > 1)
         {
-            <dd class="nhsuk-summary-list__actions">
-                    <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SelectOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> optional @Model.VocabularyPlural.ToLower()</span></a>
-            </dd>
+            <button class="nhsuk-button" type="submit">
+                Save
+            </button>
         }
+    </form>
+    <div class="nhsuk-back-link">
+        <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            Cancel
+        </a>
     </div>
-    @if (Model.SelectedCompetencyIds.Any())
-    {
-        <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-                Minimum optional @Model.VocabularyPlural.ToLower()
-            </dt>
-            <dd class="nhsuk-summary-list__value">
-                @(Model.MinimumOptionalCompetencies == null | Model.MinimumOptionalCompetencies == 0 ? "No minimum set" : Model.MinimumOptionalCompetencies.ToString())
-            </dd>
-            @if (Model.UserRole > 1)
-            {
-                <dd class="nhsuk-summary-list__actions">
-                        <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SetMinimumOptionalCompetencies">Change<span class="nhsuk-u-visually-hidden"> minimum optional @Model.VocabularyPlural.ToLower()</span></a>
-                </dd>
-            }
-        </div>
-        <div class="nhsuk-summary-list__row">
-            <dt class="nhsuk-summary-list__key">
-                Optional learner prompt
-            </dt>
-            <dd class="nhsuk-summary-list__value">
-                @Html.Raw(Model.ManageOptionalCompetenciesPrompt == null ? "No learner prompt specified" : Model.ManageOptionalCompetenciesPrompt.ToString())
-            </dd>
-            @if (Model.UserRole > 1)
-            {
-                <dd class="nhsuk-summary-list__actions">
-                        <a class="nhsuk-link" asp-route-competencyAssessmentId="@Model.ID" asp-route-vocabularyPlural="@Model.VocabularyPlural" asp-action="SetOptionalCompetencyLearnerPrompt">Change<span class="nhsuk-u-visually-hidden"> learner prompt</span></a>
-                </dd>
-            }
-        </div>
-    }
-</dl>
-<form method="post">
-    <nhs-form-group>
-        <input type="hidden" asp-for="ID" />
-        <input type="hidden" asp-for="MinimumOptionalCompetencies" />
-        <input type="hidden" asp-for="ManageOptionalCompetenciesPrompt" />
-        <input type="hidden" asp-for="SelectedCompetencyIds" />
-        <input type="hidden" asp-for="GroupIds" />
-        <input type="hidden" asp-for="VocabularyPlural" />
-
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
-    @if (Model.UserRole > 1)
-    {
-        <button class="nhsuk-button" type="submit">
-            Save
-        </button>
-    }
-</form>
-<div class="nhsuk-back-link">
-    <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.ID">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        Cancel
-    </a>
-</div>
 </div>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
@@ -156,9 +156,12 @@
 
             </dl>
 
-            <nhs-form-group>
-                <vc:single-checkbox asp-for="@nameof(Model.TaskCompleteChecked)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-            </nhs-form-group>
+            @if (Model.UserRole > 1)
+            {
+                <nhs-form-group>
+                    <vc:single-checkbox asp-for="@nameof(Model.TaskCompleteChecked)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+                </nhs-form-group>
+            }
             <input type="hidden" asp-for="@Model.Signoff.CompetencyAssessmentId" />
 
 

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
@@ -211,14 +211,17 @@
     }
 }
 
-    
+
 
 
 <form method="post">
     <input name="ID" type="hidden" asp-for="ID" />
-    <nhs-form-group>
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
+    @if (Model.UserRole > 1)
+    {
+        <nhs-form-group>
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete" hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        </nhs-form-group>
+    }
     @if (Model.UserRole > 1)
     {
         <button class="nhsuk-button" type="submit">


### PR DESCRIPTION
### JIRA link
[TD-7229](https://hee-tis.atlassian.net/browse/TD-7229)

### Description
Hidden 'Mark this task as complete' checkbox for the viewer role

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7229]: https://hee-tis.atlassian.net/browse/TD-7229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ