### PR TITLE
TD-7216 Issue showing console '403' error when 'Preview' the self-ass…

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1696,7 +1696,7 @@
                 if (selfAssessment == null)
                 {
                     ModelState.Clear();
-                    ModelState.AddModelError("HasCompetencies", $"You need to add at least 1 required competency group.");
+                    ModelState.AddModelError("HasCompetencies", $"You need to add at least one required competency group.");
                     bool hasCompetencies = competencyAssessmentService.GetCompetenciesForCompetencyAssessment(competencyAssessmentId).Any();
                     var competencyAssessmentTaskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(competencyAssessmentId, null);
                     var model = new ManageCompetencyAssessmentViewModel(competencyAssessmentBase, competencyAssessmentTaskStatus, hasCompetencies);

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1692,6 +1692,16 @@
 
             if (selfAssessmentService.CanDelegateAccessSelfAssessment(userId, competencyAssessmentId, centreId))
             {
+                var selfAssessment = selfAssessmentService.GetSelfAssessmentForCandidateById(candidateId, competencyAssessmentId);
+                if (selfAssessment == null)
+                {
+                    ModelState.Clear();
+                    ModelState.AddModelError("HasCompetencies", $"You need to add at least 1 required competency group.");
+                    bool hasCompetencies = competencyAssessmentService.GetCompetenciesForCompetencyAssessment(competencyAssessmentId).Any();
+                    var competencyAssessmentTaskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(competencyAssessmentId, null);
+                    var model = new ManageCompetencyAssessmentViewModel(competencyAssessmentBase, competencyAssessmentTaskStatus, hasCompetencies);
+                    return View("ManageCompetencyAssessment", model);
+                }
                 return RedirectToAction("SelfAssessment", "LearningPortal", new { selfAssessmentId = competencyAssessmentId });
             }
             else

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -1696,7 +1696,7 @@
                 if (selfAssessment == null)
                 {
                     ModelState.Clear();
-                    ModelState.AddModelError("HasCompetencies", $"You need to add at least one required competency group.");
+                    ModelState.AddModelError("HasCompetencies", $"To preview this self-assessment, you must include some competencies that are not marked as optional.");
                     bool hasCompetencies = competencyAssessmentService.GetCompetenciesForCompetencyAssessment(competencyAssessmentId).Any();
                     var competencyAssessmentTaskStatus = competencyAssessmentService.GetCompetencyAssessmentTaskStatus(competencyAssessmentId, null);
                     var model = new ManageCompetencyAssessmentViewModel(competencyAssessmentBase, competencyAssessmentTaskStatus, hasCompetencies);

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyAssessment.cshtml
@@ -29,6 +29,10 @@
 <h1>@ViewData["Title"]</h1>
 
 <div class="nhsuk-u-reading-width">
+    @if (!ViewData.ModelState.IsValid)
+    {
+        <partial name="_ErrorSummary" />
+    }
     <dl class="nhsuk-summary-list nhsuk-summary-list--no-border">
 
         <div class="nhsuk-summary-list__row">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7216

### Description
Added handling for cases where no self-assessment exists for the candidate because competency groups are optional. The action now redirects back to the Manage Competency Assessment page and displays a validation message in the error summary, informing the user that at least one competency group must be added before proceeding.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/12c0b725-a66d-4e6f-b849-37fc04803c05" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
