### PR TITLE
TD-7349-Issue not showing 'Working group members' for 'View' only users

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -33,73 +33,74 @@
         @Model.CompetencyAssessmentName
         <span class="nhsuk-u-visually-hidden"> – </span>
     </span>
-Select working group members</h1>
+    Select working group members
+</h1>
 <form method="post">
-    @if (Model.UserRole > 1)
-    {
-        <label class="nhsuk-label nhsuk-u-margin-top-6">
-            <p>Add a user as a:</p>
-        </label>
-        <ul class="nhsuk-list nhsuk-list--bullet">
-            <li>Contributor</li>
-            <li>Reviewer</li>
-        </ul>
-        <label class="nhsuk-label nhsuk-u-margin-top-6">
+    <label class="nhsuk-label nhsuk-u-margin-top-6">
+        <p>Add a user as a:</p>
+    </label>
+    <ul class="nhsuk-list nhsuk-list--bullet">
+        <li>Contributor</li>
+        <li>Reviewer</li>
+    </ul>
+    <label class="nhsuk-label nhsuk-u-margin-top-6">
         <p>to help create your competency assessment</p>
-        </label>
-        <div class="nhsuk-table__panel-with-heading-tab">
-         <h2 class="nhsuk-table__heading-tab">Working group members</h2>
-         <table role="presentation" class="nhsuk-table-responsive">
+    </label>
+    <div class="nhsuk-table__panel-with-heading-tab">
+        <h2 class="nhsuk-table__heading-tab">Working group members</h2>
+        <table role="presentation" class="nhsuk-table-responsive">
             <thead role="rowgroup" class="nhsuk-table__head">
-            <tr role="row">
-                <th role="columnheader" class="" scope="col">
-                    User
-                </th>
-                <th role="columnheader" class="" scope="col">
-                    Role
-                </th>
-                @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
-                {
+                <tr role="row">
                     <th role="columnheader" class="" scope="col">
-                        Actions
+                        User
                     </th>
-                }
-            </tr>
-        </thead>
-        <tbody class="nhsuk-table__body">
-            @foreach (var collaborator in Model.Collaborators)
-            {
-                <tr role="row" class="nhsuk-table__row collaborator-row">
-                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                        <span class="nhsuk-table-responsive__heading">User </span>
-                        <span class="framework-collaborator-user">
-                            @collaborator.UserEmail @(collaborator.UserActive == true ? "" : "(inactive)")
-                        </span>
-                    </td>
-                    <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                        <span class="nhsuk-table-responsive__heading">Role </span>
-                        <span class="framework-collaborator-role">
-                            <partial name="Shared/_RoleTag" model="collaborator" />
-                        </span>
-                    </td>
+                    <th role="columnheader" class="" scope="col">
+                        Role
+                    </th>
                     @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
                     {
-                        <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
-                            <span class="nhsuk-table-responsive__heading">Actions </span>
-                            @if (collaborator.CompetencyAssessmentRole != "Owner")
-                            {
-                                <a asp-action="RemoveCollaborator" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-id="@collaborator.ID" )">
-                                    Remove
-                                </a>
-                            }
-
-                        </td>
+                        <th role="columnheader" class="" scope="col">
+                            Actions
+                        </th>
                     }
                 </tr>
-            }
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody class="nhsuk-table__body">
+                @foreach (var collaborator in Model.Collaborators)
+                {
+                    <tr role="row" class="nhsuk-table__row collaborator-row">
+                        <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                            <span class="nhsuk-table-responsive__heading">User </span>
+                            <span class="framework-collaborator-user">
+                                @collaborator.UserEmail @(collaborator.UserActive == true ? "" : "(inactive)")
+                            </span>
+                        </td>
+                        <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                            <span class="nhsuk-table-responsive__heading">Role </span>
+                            <span class="framework-collaborator-role">
+                                <partial name="Shared/_RoleTag" model="collaborator" />
+                            </span>
+                        </td>
+                        @if (Model.Collaborators.Count() > 1 && Model.UserRole > 1)
+                        {
+                            <td role="cell" class="nhsuk-table__cell nhsuk-u-font-size-16">
+                                <span class="nhsuk-table-responsive__heading">Actions </span>
+                                @if (collaborator.CompetencyAssessmentRole != "Owner")
+                                {
+                                    <a asp-action="RemoveCollaborator" asp-route-actionName="Collaborators" asp-route-competencyAssessmentId="@Model.CompetencyAssessmentID" asp-route-id="@collaborator.ID" )">
+                                        Remove
+                                    </a>
+                                }
+
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+    @if (Model.UserRole > 1)
+    {
         <div class="@(Model.Error ? "nhsuk-form-group nhsuk-form-group--error" : "nhsuk-form-group")">
             <div class=" sort-select-container">
                 <label class="nhsuk-label" for="UserEmail">


### PR DESCRIPTION
### JIRA link
[TD-7349](https://hee-tis.atlassian.net/browse/TD-7349)

### Description
Allowed to display (view only) collaborators for viewer role.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7349]: https://hee-tis.atlassian.net/browse/TD-7349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ