### PR TITLE
TD-7105-Issue not listing the 'Optional competency' on self assessment which is made 'optional' from the same group

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/ManageOptionalCompetencies.cshtml
@@ -12,23 +12,23 @@
 @if (ViewBag.FromAddOptionalPage != null)
 {
     @section breadcrumbs {
-    <li class="nhsuk-breadcrumb__item">
-        <div style="max-height:10px">
-            <vc:back-link asp-controller="LearningPortal" asp-action="AddOptionalCompetencies" asp-all-route-data="@backLinkData" link-text="Go back" />
-        </div>
-    </li>
+        <li class="nhsuk-breadcrumb__item">
+            <div style="max-height:10px">
+                <vc:back-link asp-controller="LearningPortal" asp-action="AddOptionalCompetencies" asp-all-route-data="@backLinkData" link-text="Go back" />
+            </div>
+        </li>
     }
 }
 else
 {
     @section breadcrumbs {
-    <li class="nhsuk-breadcrumb__item">
-        <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
-    </li>
-    <li class="nhsuk-breadcrumb__item">
-        <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.VocabPlural() home</a>
-    </li>
-    <li class="nhsuk-breadcrumb__item">Manage optional @Model.VocabPlural()</li>
+        <li class="nhsuk-breadcrumb__item">
+            <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessment" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@(Model.SelfAssessment.Name) introduction</a>
+        </li>
+        <li class="nhsuk-breadcrumb__item">
+            <a class="nhsuk-breadcrumb__link" asp-action="SelfAssessmentOverview" asp-route-vocabulary="@Model.VocabPlural()" asp-route-selfAssessmentId="@Model.SelfAssessment.Id">@Model.VocabPlural() home</a>
+        </li>
+        <li class="nhsuk-breadcrumb__item">Manage optional @Model.VocabPlural()</li>
     }
 }
 
@@ -88,7 +88,7 @@ else
 
                 @foreach (var competencyGroup in Model.CompetencyGroups)
                 {
-                    @if (competencyGroup.Count() > 1)
+                    @if (competencyGroup.Count() > 0)
                     {
                         @if (competencyGroup.Any(x => x.GroupOptionalCompetencies))
                         {


### PR DESCRIPTION
### JIRA link
[TD-7105](https://hee-tis.atlassian.net/browse/TD-7105)

### Description
CompetencyGroup.Count() check corrected.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7105]: https://hee-tis.atlassian.net/browse/TD-7105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ