### PR TITLE
TD-7346 Need to add Competences vocabulary option also to Frameworks section same as showing on Self-assessments

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Frameworks/Developer/Type.cshtml
@@ -64,6 +64,7 @@ else
       <option value="Capability" selected="selected">Capabilities</option>
       <option value="Competency">Competencies</option>
       <option value="Proficiency">Proficiencies</option>
+      <option value="Competence">Competences</option>
     </select>
     <span nhs-validation-for="FrameworkConfig"></span>
   </nhs-form-group>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7346

### Description
I added the "Competences" vocabulary option to the dropdown in the Frameworks section.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b2d293ad-5e12-4493-8e4d-c416d1571031" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
