### PR TITLE
TD-7112 Log in with Learning hub button h needs to be changed to caps

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Home/Welcome.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Home/Welcome.cshtml
@@ -27,7 +27,7 @@
                 <feature name="@(FeatureFlags.LoginWithLearningHub)">
                     <p class="nhsuk-body-m">If you have linked your account you can login through the Learning Hub.</p>
                     <a class="nhsuk-button auth-button--blue" role="button" asp-controller="Login" asp-action="SharedAuth">
-                        Log in with Learning hub
+                        Log in with Learning Hub
                     </a>
                     <p class="nhsuk-u-font-weight-bold">Or</p>
                 </feature>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7112

### Description
capitalised the "H" in "Hub" in the login button

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/6995df36-842d-47d4-b6d4-7b1e615e3ae7" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
