### PR TITLE
TD-6954 Separates ungrouped competencies so that group select is unavailable.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/SelectOptionalCompetencies.cshtml
@@ -1,4 +1,4 @@
-﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
+﻿﻿@using DigitalLearningSolutions.Web.ViewModels.CompetencyAssessments
 @model SelectOptionalCompetenciesViewModel;
 @{
     ViewData["Title"] = $"Select optional {Model.VocabularyPlural.ToLower()}";
@@ -42,11 +42,9 @@
         </legend>
         @foreach (var competencyGroup in Model.CompetencyGroups)
         {
-            @if (competencyGroup.Count() > 1)
+            @if (competencyGroup.Any(x => x.GroupId != 0))
             {
-
                 <div class="nhsuk-u-margin-bottom-6">
-
                         <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
                         @competencyGroup.Key
                         </legend>
@@ -60,7 +58,11 @@
                         @foreach (var competency in competencyGroup)
                         {
                             <div class="nhsuk-checkboxes__item">
-                                <input class="nhsuk-checkboxes__input" data-group="@competencyGroup.Key" id="competency-check-@competency.StructureId" name="SelectedCompetencyIds" checked="@(Model.SelectedCompetencyIds != null ? Model.SelectedCompetencyIds.Contains((int)competency.CompetencyID) : false)" type="checkbox" value="@competency.StructureId">
+                                <input class="nhsuk-checkboxes__input"
+                                data-group="@competencyGroup.Key"
+                                  id="competency-check-@competency.StructureId"
+                                  name="SelectedCompetencyIds"
+                                checked="@(competencyGroup.Any(x => x.GroupOptionalCompetencies) || competency.Optional ? "checked" : null)"type="checkbox" value="@competency.StructureId">
                                 <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.StructureId">
                                     @foreach (var flag in competency.CompetencyFlags)
                                     {
@@ -75,10 +77,39 @@
                             </div>
                         }
                     </div>
-                </div>
-            }
+                    </div>
+                }
+                else
+                {
+                    <div class="nhsuk-u-margin-bottom-6">
+                        
+                        <div class="nhsuk-checkboxes">
+                            @foreach (var competency in competencyGroup)
+                            {
+                                <div class="nhsuk-checkboxes__item">
+                                    <input class="nhsuk-checkboxes__input"
+                                           data-group="@competencyGroup.Key"
+                                           id="competency-check-@competency.StructureId"
+                                           name="SelectedCompetencyIds"
+                                           checked="@(competencyGroup.Any(x => x.GroupOptionalCompetencies) || competency.Optional ? "checked" : null)" type="checkbox" value="@competency.StructureId">
+                                    <label class="nhsuk-label nhsuk-checkboxes__label" for="competency-check-@competency.StructureId">
+                                        @foreach (var flag in competency.CompetencyFlags)
+                                        {
+                                            <span class="nhsuk-u-padding-right-2 @(ViewData["cssClass"]?.ToString())">
+                                                <strong class="nhsuk-tag @flag.FlagTagClass">
+                                                    @flag.FlagName
+                                                </strong>
+                                            </span>
+                                        }
+                                        @competency.CompetencyName
+                                    </label>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
 
-        }
+            }
     </fieldset>
     <input type="hidden" asp-for="ID" />
     <input type="hidden" asp-for="MinimumOptionalCompetencies" />


### PR DESCRIPTION
### JIRA link
[TD-6954](https://hee-tis.atlassian.net/browse/TD-6954)

### Description
Separates ungrouped competencies so that group select is unavailable.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6954]: https://hee-tis.atlassian.net/browse/TD-6954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ