### PR TITLE
TD-7229-Hidden the 'Mark this task as complete' checkbox for the viewer role

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -429,7 +429,10 @@
                 </dl>
             </div>
         </div>
-        <vc:single-checkbox asp-for="@nameof(Model.SelfAssessmentOptionsTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        @if (Model.UserRole > 1)
+        {
+            <vc:single-checkbox asp-for="@nameof(Model.SelfAssessmentOptionsTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        }
     }
     @if (index > 0 && Model.CurrentStep < (int)OptionLabel.Summary)
     {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentWorkingGroup.cshtml
@@ -127,10 +127,10 @@
             Add as reviewer
         </button>
     }
-    <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-
     @if (Model.UserRole > 1)
     {
+        <vc:single-checkbox asp-for="@nameof(Model.CompetencyAssessmentTaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+
         <div class=" nhsuk-u-margin-top-6">
             @if (Model.ActionName == "CollaboratorReview")
             {

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditBranding.cshtml
@@ -63,9 +63,6 @@
             <input type="text" id="category-field" name="Category" maxlength="100" class="nhsuk-input nhsuk-u-width-two-thirds" asp-for="Category" />
         </div>
     </nhs-form-group>
-    <nhs-form-group>
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
     <input name="ID" type="hidden" asp-for="ID" />
     <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
     <input name="userRole" type="hidden" asp-for="UserRole" />
@@ -73,6 +70,9 @@
     <input name="Brand" type="hidden" asp-for="Brand" />
     @if (Model.UserRole > 1)
     {
+        <nhs-form-group>
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        </nhs-form-group>
         <button class="nhsuk-button" type="submit">
             Save
         </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditDescription.cshtml
@@ -46,12 +46,12 @@
                           populate-with-current-value="true"
                           spell-check="false" />
         </nhs-form-group>
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
         <input name="ID" type="hidden" asp-for="ID" />
         <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
         <input name="userRole" type="hidden" asp-for="UserRole" />
         @if (Model.UserRole > 1)
         {
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
             <button class="nhsuk-button" type="submit">
                 Save
             </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditRoleProfileLinks.cshtml
@@ -246,9 +246,6 @@ else if (Model.ActionName == "EditRole" && Model.SubGroupId != null)
 else if (Model.ActionName == "Summary")
 {
     <form method="post">
-        <nhs-form-group>
-            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-        </nhs-form-group>
         <input type="hidden" asp-for="ID" />
         <input type="hidden" asp-for="CompetencyAssessmentName" />
         <input type="hidden" asp-for="ProfessionalGroupId" />
@@ -261,6 +258,10 @@ else if (Model.ActionName == "Summary")
         <input type="hidden" asp-for="GroupName" />
         @if (Model.UserRole > 1)
         {
+            <nhs-form-group>
+                <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+            </nhs-form-group>
+
             <button class="nhsuk-button" type="submit">
                 Save
             </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/EditVocabulary.cshtml
@@ -79,14 +79,15 @@
         </fieldset>
         <span nhs-validation-for="Vocabulary"></span>
     </nhs-form-group>
-    <nhs-form-group nhs-validation-for="TaskStatus">
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
     <input name="ID" type="hidden" asp-for="ID" />
     <input name="CompetencyAssessmentName" type="hidden" asp-for="CompetencyAssessmentName" />
     <input name="userRole" type="hidden" asp-for="UserRole" />
     @if (Model.UserRole > 1)
     {
+        <nhs-form-group nhs-validation-for="TaskStatus">
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        </nhs-form-group>
+
         <button class="nhsuk-button" type="submit">
             Save
         </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageCompetencyRoleRequirements.cshtml
@@ -97,10 +97,10 @@
             <input type="hidden" asp-for="Id" />
             <input type="hidden" asp-for="EnforceRoleRequirementsForSignOff" />
             <input type="hidden" asp-for="IncludeRequirementsFilters" />
-            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
         </nhs-form-group>
         @if (Model.UserRole > 1)
         {
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
             <button class="nhsuk-button" type="submit">
                 Save
             </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageOptionalCompetencies.cshtml
@@ -107,11 +107,10 @@
             <input type="hidden" asp-for="SelectedCompetencyIds" />
             <input type="hidden" asp-for="GroupIds" />
             <input type="hidden" asp-for="VocabularyPlural" />
-
-            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
         </nhs-form-group>
         @if (Model.UserRole > 1)
         {
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
             <button class="nhsuk-button" type="submit">
                 Save
             </button>

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
@@ -156,12 +156,14 @@
 
             </dl>
 
-            <nhs-form-group>
-                <vc:single-checkbox asp-for="@nameof(Model.TaskCompleteChecked)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-            </nhs-form-group>
+            @if (Model.UserRole > 1)
+            {
+                <nhs-form-group>
+                    <vc:single-checkbox asp-for="@nameof(Model.TaskCompleteChecked)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+                </nhs-form-group>
+            }
+
             <input type="hidden" asp-for="@Model.Signoff.CompetencyAssessmentId" />
-
-
 
             <div class="nhsuk-u-margin-top-8">
                 @if (Model.UserRole > 1)

--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ViewSelectedCompetencies.cshtml
@@ -210,17 +210,13 @@
         }
     }
 }
-
-
-
-
 <form method="post">
-    <input name="ID" type="hidden" asp-for="ID" />
-    <nhs-form-group>
-        <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
-    </nhs-form-group>
+    <input name="ID" type="hidden" asp-for="ID" />.
     @if (Model.UserRole > 1)
     {
+        <nhs-form-group>
+            <vc:single-checkbox asp-for="@nameof(Model.TaskStatus)" label="Mark this task as complete." hint-text="You will still be able to make changes after marking this task as complete."></vc:single-checkbox>
+        </nhs-form-group>
         <button class="nhsuk-button" type="submit">
             Save
         </button>


### PR DESCRIPTION
### JIRA link
[TD-7229](https://hee-tis.atlassian.net/browse/TD-7229)

### Description
Hidden the 'Mark this task as complete' checkbox for the viewer role.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7229]: https://hee-tis.atlassian.net/browse/TD-7229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ