### PR TITLE
TD-7439 Needs changing Log in button on Registration screen to 'Log i…

### DIFF
--- a/DigitalLearningSolutions.Web/Views/Register/PersonalInformation.cshtml
+++ b/DigitalLearningSolutions.Web/Views/Register/PersonalInformation.cshtml
@@ -1,4 +1,5 @@
 @using DigitalLearningSolutions.Web.ViewModels.Register
+@using DigitalLearningSolutions.Web.Helpers
 @model PersonalInformationViewModel
 @{
   var errorHasOccurred = !ViewData.ModelState.IsValid;
@@ -100,10 +101,16 @@
     <p class="nhsuk-u-font-size-24">
       Alternatively, if you already have an account and would like to register at a new centre, log in and register through the My Account page:
     </p>
+        <feature name="@(FeatureFlags.LoginWithLearningHub)">
+            <a class="nhsuk-button nhsuk-button--secondary" role="button" asp-controller="Login" asp-action="SharedAuth">
+                Log in with Learning Hub
+            </a>
+        </feature>
+         <feature name="@(FeatureFlags.ShowDlsLoginButton)">
     <a class="nhsuk-button nhsuk-button--secondary" asp-controller="Login" asp-action="Index" role="button">
       Log in
     </a>
-
+     </feature> 
     <div class="nhsuk-u-margin-top-3">
       <vc:cancel-link asp-controller="Home" asp-action="Index" />
     </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7439

### Description
Added the "Log in with Learning Hub" button to the Register page and feature-flagged the Login button.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/10ff9f56-847e-474c-a95d-420e5c34e925" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
