### PR TITLE
TD-6892 Optional learner prompt is not clearing up

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -1324,7 +1324,7 @@
                 @"UPDATE SelfAssessments
                     SET 
                     [ManageOptionalCompetenciesPrompt] = @manageOptionalCompetenciesPrompt
-                    WHERE id = @selfAssessmentId;"
+                    WHERE id = @selfAssessmentId AND ISNULL(ManageOptionalCompetenciesPrompt, '') <> ISNULL(@manageOptionalCompetenciesPrompt, '');"
             ,
                 new { selfAssessmentId, manageOptionalCompetenciesPrompt }
             );

--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -1324,7 +1324,7 @@
                 @"UPDATE SelfAssessments
                     SET 
                     [ManageOptionalCompetenciesPrompt] = @manageOptionalCompetenciesPrompt
-                    WHERE id = @selfAssessmentId AND ISNULL(ManageOptionalCompetenciesPrompt, '') <> @manageOptionalCompetenciesPrompt;"
+                    WHERE id = @selfAssessmentId;"
             ,
                 new { selfAssessmentId, manageOptionalCompetenciesPrompt }
             );


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6892

### Description
Removed the WHERE clause that prevented the update query from updating the ManageOptionalCompetenciesPrompt field when the optional learner prompt was empty or NULL.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/6dbe6335-cdaf-4ad5-b1ae-2b67fb10226c" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/7935dda6-fdf1-42db-9288-a309e01a0ea0" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
