### PR TITLE
TD-6453 Removes two week retirement warning limit from self enrolment 

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Available.cs
+++ b/DigitalLearningSolutions.Web/Controllers/LearningPortalController/Available.cs
@@ -61,7 +61,7 @@
         public IActionResult EnrolOnSelfAssessment(int selfAssessmentId)
         {
            var selfAssessment = selfAssessmentService.GetSelfAssessmentRetirementDateById(selfAssessmentId);
-            if(CheckRetirementDate(selfAssessment.RetirementDate)) return RedirectToAction("ConfirmRetirement", new { selfAssessmentId });
+            if(selfAssessment.RetirementDate >= DateTime.Today) return RedirectToAction("ConfirmRetirement", new { selfAssessmentId });
             courseService.EnrolOnSelfAssessment(selfAssessmentId, User.GetUserIdKnownNotNull(), User.GetCentreIdKnownNotNull());
             return RedirectToAction("SelfAssessment", new { selfAssessmentId });
         }
@@ -87,14 +87,6 @@
              courseService.EnrolOnSelfAssessment(retirementViewModel.SelfAssessmentId, User.GetUserIdKnownNotNull(), User.GetCentreIdKnownNotNull());
             return RedirectToAction("SelfAssessment", new { retirementViewModel.SelfAssessmentId });
         }
-        private  bool CheckRetirementDate(DateTime? date)
-        {
-            if (date == null)
-                return false;
-
-            DateTime twoWeeksbeforeRetirementdate = DateTime.Today.AddDays(14);
-            DateTime today = DateTime.Today;
-            return (date >= today  && date <= twoWeeksbeforeRetirementdate);
-        }
+        
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-6453](https://hee-tis.atlassian.net/browse/TD-6453)

### Description
Removes the two-week retirement warning limit from self-enrolment 

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-6453]: https://hee-tis.atlassian.net/browse/TD-6453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ