### PR TITLE
TD-7471 Issue retaining previous Minimum optional competency value wh…

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -1321,7 +1321,7 @@
                 @"UPDATE SelfAssessments
                     SET 
                     [MinimumOptionalCompetencies] = @minimumOptionalCompetecies
-                    WHERE id = @selfAssessmentId AND ISNULL(MinimumOptionalCompetencies, 0) <> @minimumOptionalCompetecies;"
+                    WHERE id = @selfAssessmentId;"
             ,
                 new { selfAssessmentId, minimumOptionalCompetecies }
             );

--- a/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
+++ b/DigitalLearningSolutions.Web/Controllers/CompetencyAssessmentsController/CompetencyAssessments.cs
@@ -729,6 +729,7 @@
                 return View("SelectOptionalCompetencies", viewModel);
             }
             competencyAssessmentService.UpdateOptionalCompetenciesInAssessment(model.ID, model.GroupIds ?? [], model.SelectedCompetencyIds ?? []);
+            competencyAssessmentService.UpdateMinimumOptionalCompetencies(model.ID, 0);
             return RedirectToAction("ManageOptionalCompetencies", new { competencyAssessmentId = model.ID, vocabularyPlural = model.VocabularyPlural });
         }
         [HttpGet]


### PR DESCRIPTION


### JIRA link
https://hee-tis.atlassian.net/browse/TD-7471

### Description
Removed the WHERE clause that prevented the update query from setting the MinimumOptionalCompetencies field when @minimumOptionalCompetencies = 0. Also added the UpdateMinimumOptionalCompetencies method to the SelectOptionalCompetencies action so that MinimumOptionalCompetencies is reset to 0 whenever the optional competencies selection changes.

### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/a8cd3319-600b-4aee-a706-3b6a5540101c" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/d7b89f86-51b4-411f-84c2-9b5106082f80" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
