### PR TITLE
TD-7480 Limits dynamic worksheet name to keep it within character limit.

### DIFF
--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -98,7 +98,7 @@
                 ClosedXmlHelper.RenameWorksheetColumn(workbook, "Answer" + promptNumber.ToString(), promptLabel);
                 if (prompt.Options.Count() > 0)
                 {
-                    ClosedXmlHelper.AddSheetToWorkbook(workbook, promptLabel, prompt.Options, TableTheme);
+                    ClosedXmlHelper.AddSheetToWorkbook(workbook, promptLabel.Substring(0,30), prompt.Options, TableTheme);
                     var worksheetNumber = workbook.Worksheets.Count;
                     var optionsCount = prompt.Options.Count();
                     //Ensure a blank value exists in the drop down list if the prompt is not mandatory

--- a/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
+++ b/DigitalLearningSolutions.Web/Services/DelegateDownloadFileService.cs
@@ -98,7 +98,8 @@
                 ClosedXmlHelper.RenameWorksheetColumn(workbook, "Answer" + promptNumber.ToString(), promptLabel);
                 if (prompt.Options.Count() > 0)
                 {
-                    ClosedXmlHelper.AddSheetToWorkbook(workbook, promptLabel.Substring(0,30), prompt.Options, TableTheme);
+                    var length = promptLabel.Length > 30 ? 30 : promptLabel.Length;
+                    ClosedXmlHelper.AddSheetToWorkbook(workbook, promptLabel.Substring(0, length), prompt.Options, TableTheme);
                     var worksheetNumber = workbook.Worksheets.Count;
                     var optionsCount = prompt.Options.Count();
                     //Ensure a blank value exists in the drop down list if the prompt is not mandatory


### PR DESCRIPTION
### JIRA link
[TD-7480](https://hee-tis.atlassian.net/browse/TD-7480)

### Description
Uses substring to limit the dynamic worksheet name to keep it within the character limit.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7480]: https://hee-tis.atlassian.net/browse/TD-7480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ