### PR TITLE
TD-7229-Changed "Cancel" button to a link

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/ManageSupervisionSettings.cshtml
@@ -173,7 +173,12 @@
                         Save
                     </button>
                 }
-                <a class="nhsuk-button nhsuk-button--secondary" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.Signoff.CompetencyAssessmentId">
+            </div>
+            <div class="nhsuk-back-link">
+                <a class="nhsuk-back-link__link" asp-action="ManageCompetencyAssessment" asp-route-competencyAssessmentId="@Model.Signoff.CompetencyAssessmentId">
+                    <svg class="nhsuk-icon nhsuk-icon__chevron-left" focusable='false' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+                    </svg>
                     Cancel
                 </a>
             </div>


### PR DESCRIPTION
### JIRA link
[TD-7229](https://hee-tis.atlassian.net/browse/TD-7229)

### Description
Changed "Cancel" button to a link

### Screenshots

<img width="1092" height="682" alt="image" src="https://github.com/user-attachments/assets/1092d284-d94c-473d-9120-d70a9739de8f" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7229]: https://hee-tis.atlassian.net/browse/TD-7229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ