### PR TITLE
TD-7146 Adding hyphen  to self-assessment

### DIFF
--- a/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesStatisticsViewModelFilterOptionsTests.cs
+++ b/DigitalLearningSolutions.Web.Tests/ViewModels/TrackingSystem/Delegates/DelegateCourses/DelegateCoursesStatisticsViewModelFilterOptionsTests.cs
@@ -104,7 +104,7 @@
                     FilterStatus.Default
                 ),
                 new FilterOptionModel(
-                    "Self assessment",
+                    "Self-assessment",
                     "Type" + FilteringHelper.Separator + "SelfAssessment" + FilteringHelper.Separator +
                     "true",
                     FilterStatus.Default

--- a/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SupervisorController/Supervisor.cs
@@ -754,7 +754,7 @@
 
             if (selfAssessmentID < 1)
             {
-                ModelState.AddModelError("selfAssessmentId", "You must select a self assessment");
+                ModelState.AddModelError("selfAssessmentId", "You must select a self-assessment");
                 multiPageFormService.SetMultiPageFormData(
                     sessionEnrolOnCompetencyAssessment,
                     MultiPageFormDataFeature.EnrolDelegateOnProfileAssessment,

--- a/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/TrackingSystem/Delegates/ActivityDelegatesController.cs
@@ -240,7 +240,7 @@
                             var selfAssessedCount = questions.Count(q => q.Result.HasValue);
                             var verifiedCount = questions.Count(q => !((q.Result == null || q.Verified == null || q.SignedOff != true) && q.Required));
 
-                            saDelegate.Progress = "Self assessed: " + selfAssessedCount + " / " + questions.Count() + Environment.NewLine +
+                            saDelegate.Progress = "Self-assessed: " + selfAssessedCount + " / " + questions.Count() + Environment.NewLine +
                                                 "Confirmed: " + verifiedCount + " / " + questions.Count();
                         }
                         saDelegate.StartedDate = (DateTime)DateHelper.GetLocalDateTime(saDelegate.StartedDate);

--- a/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
+++ b/DigitalLearningSolutions.Web/Extensions/EnumExtensions.cs
@@ -22,7 +22,7 @@ namespace DigitalLearningSolutions.Web.Extensions
                 case SelfAssessmentCompetencyFilter.Optional:
                     return "Optional";
                 case SelfAssessmentCompetencyFilter.RequiresSelfAssessment:
-                    return "Requires self assessment";
+                    return "Requires self-assessment";
                 case SelfAssessmentCompetencyFilter.SelfAssessed:
                     return "Self-assessed" + (isSupervisorResultReview ? " (confirmation not yet requested)" : "");
                 case SelfAssessmentCompetencyFilter.ConfirmationRequested:

--- a/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateActivityFilterOptions.cs
+++ b/DigitalLearningSolutions.Web/Helpers/FilterOptions/DelegateActivityFilterOptions.cs
@@ -15,7 +15,7 @@
         );
 
         public static readonly FilterOptionModel IsSelfAssessment = new FilterOptionModel(
-            "Self assessment",
+            "Self-assessment",
             FilteringHelper.BuildFilterValueString(Group, "SelfAssessment", "true"),
             FilterStatus.Default
         );

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/SelfAssessmentReports/Index.cshtml
@@ -3,7 +3,7 @@
 @using DigitalLearningSolutions.Web.Helpers
 @model SelfAssessmentReportsViewModel
 @{
-    ViewData["Title"] = "Self-Assessment Reports";
+    ViewData["Title"] = "Self-assessment reports";
     var routeData = (new Dictionary<string, string>() { { "source", "TrackingSystem" } });
 
     if (string.Equals(Context.Request.Query["tableaulink"], "true", StringComparison.OrdinalIgnoreCase))

--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Centre/Shared/_CentreSideNavMenu.cshtml
@@ -30,7 +30,7 @@
 
   <vc:side-menu-link asp-action="Index"
                      asp-controller="SelfAssessmentReports"
-                     link-text="Self-Assessment Reports"
+                     link-text="Self-assessment reports"
                      is-current-page="Model == CentrePage.SelfAssessmentReports" />
 
 </ul>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7146

### Description
Added the missing hyphen to the self-assessment.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/8aacfa4d-8ca9-469e-80ae-5e35aa60edfc" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b4005e50-2c1b-4567-bd2b-357b73e86b8f" />
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/20bfc52f-411d-4682-9791-2afac1b027b5" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
