### PR TITLE
TD-7218-Added hyphen to sign off text

### DIFF
--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
@@ -31,7 +31,7 @@
     <h2>Supervisor Sign-off</h2>
     <partial name="../../Supervisor/Shared/_SupervisorSignOffSummary.cshtml" model="Model.SupervisorSignOffs"
              view-data="@(new ViewDataDictionary(ViewData) { { "IsAllCompetencyConfirmed", competencySummaries.Sum(c => (int)c["questionsCount"]) == competencySummaries.Sum(c => (int)c["verifiedCount"]) },
-                                 { "IsOngoingSelfAssessment", latestResult > latestSignoff }})" />
+                                              { "IsOngoingSelfAssessment", latestResult > latestSignoff }})" />
     @if (Model.AllQuestionsVerifiedOrNotRequired)
     {
         @if (!Model.SupervisorSignOffs.Any())
@@ -71,7 +71,7 @@
     {
         <p class="nhsuk-body-l">
             All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
-            before requesting supervisor sign off of the @Model.SelfAssessment.Name.
+            before requesting supervisor sign-off of the @Model.SelfAssessment.Name.
         </p>
     }
 </div>

--- a/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
+++ b/DigitalLearningSolutions.Web/Views/LearningPortal/SelfAssessments/_SupervisorSignOffPanel.cshtml
@@ -70,7 +70,7 @@
     else
     {
         <p class="nhsuk-body-l">
-            All required @Model.SelfAssessment.Vocabulary.ToLower() self-assessments must be completed and confirmed,
+            All required @Model.VocabPlural().ToLower() must be completed and confirmed,
             before requesting supervisor sign-off of the @Model.SelfAssessment.Name.
         </p>
     }


### PR DESCRIPTION
### JIRA link
[TD-7218](https://hee-tis.atlassian.net/browse/TD-7218)

### Description
Added hyphen to sign off text
Corrected 'All required proficiencies....' text.
### Screenshots

<img width="1856" height="1230" alt="image" src="https://github.com/user-attachments/assets/90c40c7b-1e1f-494f-84bc-4a246866c739" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7218]: https://hee-tis.atlassian.net/browse/TD-7218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ