### PR TITLE
TD-7444-Moved warning callout partial outside legend tag.

### DIFF
--- a/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
+++ b/DigitalLearningSolutions.Web/Views/CompetencyAssessments/CompetencyAssessmentOptions.cshtml
@@ -84,15 +84,15 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="app-page-heading">
+                    <h1 class="app-page-heading nhsuk-u-margin-bottom-0">
                         <span class="nhsuk-caption-xl">
                             @Model.CompetencyAssessmentName
                             <span class="nhsuk-u-visually-hidden"> – </span>
                         </span>
                         Display learner declaration?
                     </h1>
-                    <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 </legend>
+                <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 <div id="example-hints-hint" class="nhsuk-hint">
                     Do you want to prompt learners to agree to the self-assessment process when they first start the self-assessment?
                 </div>
@@ -119,15 +119,15 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="app-page-heading">
+                    <h1 class="app-page-heading nhsuk-u-margin-bottom-0">
                         <span class="nhsuk-caption-xl">
                             @Model.CompetencyAssessmentName
                             <span class="nhsuk-u-visually-hidden"> – </span>
                         </span>
                         Include signposting?
                     </h1>
-                    <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 </legend>
+                <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 <div id="example-hints-hint" class="nhsuk-hint">
                     Do you want to display signposted learning content when a learner submits their self-assessment results?
                 </div>
@@ -154,15 +154,15 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="app-page-heading">
+                    <h1 class="app-page-heading nhsuk-u-margin-bottom-0">
                         <span class="nhsuk-caption-xl">
                             @Model.CompetencyAssessmentName
                             <span class="nhsuk-u-visually-hidden"> – </span>
                         </span>
                         Use linear navigation?
                     </h1>
-                    <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 </legend>
+                <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 <div id="example-hints-hint" class="nhsuk-hint">
                     Do you want the learner to work through @Model.VocabularyPlural.ToLower() using next and previous links? If not, the learner will navigate between @Model.VocabularyPlural.ToLower() using the @Model.VocabularySingular.ToLower() menu.
                 </div>
@@ -189,15 +189,15 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="app-page-heading">
+                    <h1 class="app-page-heading nhsuk-u-margin-bottom-0">
                         <span class="nhsuk-caption-xl">
                             @Model.CompetencyAssessmentName
                             <span class="nhsuk-u-visually-hidden"> – </span>
                         </span>
                         Use description expanders?
                     </h1>
-                    <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 </legend>
+                <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 <div id="example-hints-hint" class="nhsuk-hint">
                     Do you want to show @Model.VocabularySingular.ToLower() descriptions using expanders? If not, the description will be displayed on the page without the user needing to expand it.
                 </div>
@@ -224,15 +224,15 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="app-page-heading">
+                    <h1 class="app-page-heading nhsuk-u-margin-bottom-0">
                         <span class="nhsuk-caption-xl">
                             @Model.CompetencyAssessmentName
                             <span class="nhsuk-u-visually-hidden"> – </span>
                         </span>
                         Custom question label
                     </h1>
-                    <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 </legend>
+                <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 <div id="example-hints-hint" class="nhsuk-hint">
                     Do you want to specify a custom label for self-assessment questions? If not, they will be labelled as “question”.
                 </div>
@@ -271,15 +271,15 @@
         <div class="nhsuk-form-group">
             <fieldset class="nhsuk-fieldset" aria-describedby="example-hints-hint">
                 <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                    <h1 class="app-page-heading">
+                    <h1 class="app-page-heading nhsuk-u-margin-bottom-0">
                         <span class="nhsuk-caption-xl">
                             @Model.CompetencyAssessmentName
                             <span class="nhsuk-u-visually-hidden"> – </span>
                         </span>
                         Reviewer comments label
                     </h1>
-                    <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 </legend>
+                <partial name="Shared/_PublishedSelfAssessmentWarning" model="new PublishedSelfAssessmentViewModel { UserRole = Model.UserRole, PublishStatusID = Model.PublishStatusID }" />
                 <div id="example-hints-hint" class="nhsuk-hint">
                     Do you want to specify a custom supervisor comments prompt? If not, they will be labelled as “Reviewer comments”.
                 </div>


### PR DESCRIPTION
### JIRA link
[TD-7444](https://hee-tis.atlassian.net/browse/TD-7444)

### Description
Moved warning callout partial outside legend tag.

### Screenshots
<img width="1071" height="883" alt="image" src="https://github.com/user-attachments/assets/45ecf673-f729-4255-ba33-6165e26cc13c" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7444]: https://hee-tis.atlassian.net/browse/TD-7444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ