### PR TITLE
TD-7112-Fallback login mechanism removed

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/HomeController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/HomeController.cs
@@ -48,9 +48,9 @@
         }
 
         [HttpGet]
-        public IActionResult Welcome(bool fallbackLogin = false)
+        public IActionResult Welcome()
         {
-            return View(GetLandingPageViewModel(0, fallbackLogin));
+            return View(GetLandingPageViewModel(0));
         }
 
         [HttpGet]
@@ -76,15 +76,14 @@
             return View(model);
         }
 
-        private LandingPageViewModel GetLandingPageViewModel(int sectionIndex, bool fallbackLogin = false)
+        private LandingPageViewModel GetLandingPageViewModel(int sectionIndex)
         {
             return new LandingPageViewModel
             {
                 MiniHubNavigationModel = new MiniHubNavigationModel(LandingPageMiniHubName, sections, sectionIndex),
                 UserIsLoggedIn = User.Identity.IsAuthenticated,
                 UserIsLoggedInCentre = User.GetCentreId() != null,
-                CurrentSiteBaseUrl = configuration.GetCurrentSystemBaseUrl(),
-                ShowDlsLoginButton = fallbackLogin,
+                CurrentSiteBaseUrl = configuration.GetCurrentSystemBaseUrl()
             };
         }
     }

--- a/DigitalLearningSolutions.Web/ViewModels/Home/LandingPageViewModel.cs
+++ b/DigitalLearningSolutions.Web/ViewModels/Home/LandingPageViewModel.cs
@@ -8,6 +8,5 @@ namespace DigitalLearningSolutions.Web.ViewModels.Home
         public bool UserIsLoggedIn { get; set; }
         public bool UserIsLoggedInCentre { get; set; }
         public string CurrentSiteBaseUrl { get; set; }
-        public bool ShowDlsLoginButton { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-7112](https://hee-tis.atlassian.net/browse/TD-7112)

### Description
Fallback login mechanism removed as users will be redirected to the DLS login page from LH.

### Screenshots
N/A

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [x] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7112]: https://hee-tis.atlassian.net/browse/TD-7112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ