### PR TITLE
TD-7146 Fixed button text wrapping onto two lines

### DIFF
--- a/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
+++ b/DigitalLearningSolutions.Web/Views/TrackingSystem/Delegates/Shared/_DelegateSelfAssessmentDetails.cshtml
@@ -150,16 +150,20 @@
 
         @if (Model.RemovedDate == null)
         {
-            <div class="nhsuk-grid-row nhsuk-u-padding-top-5">
-                <div class="nhsuk-grid-column-full">
-                    <a class="nhsuk-button delete-button nhsuk-button--secondary"
+            <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">
+                    <a class="nhsuk-button nhsuk-button--secondary delete-button"
+                      style="white-space: nowrap;"
                        role="button"
                        asp-controller="ActivityDelegates"
                        asp-action="RemoveDelegateSelfAssessment"
                        asp-route-candidateAssessmentsId="@Model.CandidateAssessmentsId">
                         Remove from self-assessment
                     </a>
-                </div>
+                </dt>
+                <dd class="nhsuk-summary-list__value">
+                </dd>
+                <dd class="nhsuk-summary-list__actions"></dd>
             </div>
         }
     }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7146

### Description
Resolved the issue where the "Remove from self-assessment" button text was wrapping onto two lines and fixed the "Element 'div' cannot be nested inside element" warning.
### Screenshots
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/b2e0a2b6-8b29-48b7-abcc-4fc88eb596ec" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
