### PR TITLE
TD-7613 competency data services query optimisation

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyAssessmentDataService.cs
@@ -151,18 +151,10 @@
 
         private const string SelfAssessmentFields =
             @", sa.CategoryID, sa.CreatedDate,
-                 (SELECT BrandName
-                 FROM    Brands
-                 WHERE (BrandID = sa.BrandID)) AS Brand,
-                 (SELECT CategoryName
-                 FROM    CourseCategories
-                 WHERE (CourseCategoryID = sa.CategoryID)) AS Category,
-                 (SELECT [Name]
-                 FROM    SelfAssessments AS sa2
-                 WHERE (ID = sa.ParentSelfAssessmentID)) AS ParentSelfAssessment,
-                 (SELECT Forename + ' ' + Surname + (CASE WHEN Active = 1 THEN '' ELSE ' (Inactive)' END) AS Expr1
-                 FROM  AdminUsers
-                 WHERE (AdminID = sa.CreatedByAdminID)) AS Owner,
+                 b.BrandName AS Brand,
+                 cc.CategoryName AS Category,
+                 sa2.[Name] AS ParentSelfAssessment,
+                 auOwner.Forename + ' ' + auOwner.Surname + (CASE WHEN auOwner.Active = 1 THEN '' ELSE ' (Inactive)' END) AS Owner,
                  sa.Archived,
                  sa.LastEdit,
                 STUFF((
@@ -175,19 +167,20 @@
                         saf2.SelfAssessmentId = sa.ID AND saf2.RemovedDate IS NULL
                     FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, ''
                 ) AS LinkedFrameworks,
-                 (SELECT ProfessionalGroup
-                 FROM    NRPProfessionalGroups
-                 WHERE (ID = sa.NRPProfessionalGroupID)) AS NRPProfessionalGroup,
-                 (SELECT SubGroup
-                 FROM    NRPSubGroups
-                 WHERE (ID = sa.NRPSubGroupID)) AS NRPSubGroup,
-                 (SELECT RoleProfile
-                 FROM    NRPRoles
-                 WHERE (ID = sa.NRPRoleID)) AS NRPRole, sar.ID AS SelfAssessmentReviewID";
+                 npg.ProfessionalGroup AS NRPProfessionalGroup,
+                 nsg.SubGroup AS NRPSubGroup,
+                 nr.RoleProfile AS NRPRole, sar.ID AS SelfAssessmentReviewID";
 
         private const string SelfAssessmentBaseTables =
             @"SelfAssessments AS sa LEFT OUTER JOIN
-             SelfAssessmentCollaborators AS sac ON sac.SelfAssessmentID = sa.ID AND sac.AdminID = @adminId AND sac.IsDeleted = 0";
+             SelfAssessmentCollaborators AS sac ON sac.SelfAssessmentID = sa.ID AND sac.AdminID = @adminId AND sac.IsDeleted = 0
+             LEFT OUTER JOIN Brands AS b ON b.BrandID = sa.BrandID
+             LEFT OUTER JOIN CourseCategories AS cc ON cc.CourseCategoryID = sa.CategoryID
+             LEFT OUTER JOIN SelfAssessments AS sa2 ON sa2.ID = sa.ParentSelfAssessmentID
+             LEFT OUTER JOIN AdminUsers AS auOwner ON auOwner.AdminID = sa.CreatedByAdminID
+             LEFT OUTER JOIN NRPProfessionalGroups AS npg ON npg.ID = sa.NRPProfessionalGroupID
+             LEFT OUTER JOIN NRPSubGroups AS nsg ON nsg.ID = sa.NRPSubGroupID
+             LEFT OUTER JOIN NRPRoles AS nr ON nr.ID = sa.NRPRoleID";
 
         private const string SelfAssessmentTables =
             @" LEFT OUTER JOIN
@@ -320,29 +313,12 @@
 
         public bool UpdateCompetencyRoleProfileLinks(int competencyAssessmentId, int adminId, int? professionalGroupId, int? subGroupId, int? roleId)
         {
-            var result = connection.ExecuteScalar(
-                @"SELECT COUNT(*) FROM SelfAssessments WHERE ID = @competencyAssessmentId AND NRPProfessionalGroupID = @professionalGroupId AND NRPSubGroupID = @subGroupId AND NRPRoleID = @roleId",
-                new { competencyAssessmentId, professionalGroupId, subGroupId, roleId }
-            );
-            int sameCount = Convert.ToInt32(result);
-            if (sameCount > 0)
-            {
-                //same so don't update:
-                return false;
-            }
-
-            //needs updating:
             var numberOfAffectedRows = connection.Execute(
                 @"UPDATE SelfAssessments SET NRPProfessionalGroupID = @professionalGroupId, NRPSubGroupID = @subGroupId, NRPRoleID = @roleId, UpdatedByAdminID = @adminId
-                    WHERE ID = @competencyAssessmentId",
+                    WHERE ID = @competencyAssessmentId AND (NRPProfessionalGroupID <> @professionalGroupId OR NRPSubGroupID <> @subGroupId OR NRPRoleID <> @roleId)",
                 new { adminId, competencyAssessmentId, professionalGroupId, subGroupId, roleId }
             );
-            if (numberOfAffectedRows > 0)
-            {
-                return true;
-            }
-
-            return false;
+            return numberOfAffectedRows > 0;
         }
         public bool UpdateCompetencyAssessmentBranding(
             int competencyAssessmentId,
@@ -950,7 +926,6 @@
                     END
                     FROM SelfAssessments s
                     INNER JOIN Frameworks F ON F.ID = @frameworkId
-                    INNER JOIN AdminUsers AU ON F.OwnerAdminID = AU.AdminID
                     INNER JOIN SelfAssessmentTaskStatus sts ON s.ID = sts.SelfAssessmentId
                     WHERE s.ID = @selfAssessmentId;",
                 new { selfAssessmentId, frameworkId }
@@ -1184,31 +1159,32 @@
                     au.Active AS UserActive,
                     CASE WHEN sc.CanModify = 1 THEN 'Contributor' ELSE 'Reviewer' END AS CompetencyAssessmentRole,
                     sa.[Name] AS CompetencyAssessmentName,
-                    (SELECT Forename + ' ' + Surname + (CASE WHEN Active = 1 THEN '' ELSE ' (Inactive)' END) AS Expr1 FROM AdminUsers AS au1 WHERE (AdminID = @invitedByAdminId)) AS InvitedByName,
-                    (SELECT Email FROM AdminUsers AS au2 WHERE (AdminID = @invitedByAdminId)) AS InvitedByEmail,
+                    auInvitedBy.Forename + ' ' + auInvitedBy.Surname + (CASE WHEN auInvitedBy.Active = 1 THEN '' ELSE ' (Inactive)' END) AS InvitedByName,
+                    auInvitedBy.Email AS InvitedByEmail,
                     sr.ID AS SelfAssessmentReviewID
                 FROM SelfAssessmentCollaborators AS sc
                     INNER JOIN SelfAssessments AS sa ON sc.SelfAssessmentID = sa.ID
                     INNER JOIN AdminUsers AS au ON sc.AdminID = au.AdminID
                     LEFT JOIN SelfAssessmentReviews AS sr 
-					    ON sr.SelfAssessmentID = sa.ID AND sr.SelfAssessmentCollaboratorID = sc.ID
+                        ON sr.SelfAssessmentID = sa.ID AND sr.SelfAssessmentCollaboratorID = sc.ID
                         AND sr.ReviewComplete IS NULL AND sr.Archived IS NULL
-                WHERE (sc.ID = @id) AND (sc.IsDeleted=0)",
-                new { invitedByAdminId, id }
-            ).FirstOrDefault();
+                    LEFT JOIN AdminUsers AS auInvitedBy ON auInvitedBy.AdminID = @invitedByAdminId
+                WHERE sc.ID = @id AND sc.IsDeleted = 0",
+                new { invitedByAdminId, id }).FirstOrDefault();
         }
 
         public bool HasCompetencyWithSignpostedLearning(int competencyAssessmentId)
         {
-            int hasSignpostedLearning = connection.QueryFirstOrDefault<int>(
-                @"SELECT count(*) FROM SelfAssessmentStructure sas INNER JOIN 
-			        CompetencyLearningResources clr ON sas.CompetencyID = clr.CompetencyID AND
-			        clr.RemovedDate IS NULL
-		        WHERE sas.SelfAssessmentID = @competencyAssessmentId",
+            var hasSignpostedLearning = connection.QueryFirstOrDefault<int?>(
+                @"SELECT TOP(1) 1 FROM SelfAssessmentStructure sas INNER JOIN 
+		        CompetencyLearningResources clr ON sas.CompetencyID = clr.CompetencyID AND
+		        clr.RemovedDate IS NULL
+	        WHERE sas.SelfAssessmentID = @competencyAssessmentId",
                 new { competencyAssessmentId });
 
-            return hasSignpostedLearning > 0;
+            return hasSignpostedLearning.HasValue;
         }
+
         public bool UpdateCompetencyAssessmentOptions(
             bool includeLearnerDeclarationPrompt,
             bool includesSignposting,

--- a/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/CompetencyLearningResourcesDataService.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.LearningResources;
     using DigitalLearningSolutions.Data.Models.SelfAssessments;
@@ -56,39 +57,37 @@
         public int AddCompetencyLearningResource(int resourceRefID, string resourceName, string description, string resourceType, string link, string catalogue, decimal rating, int competencyID, int adminId)
         {
             return connection.ExecuteScalar<int>(
-                @$" DECLARE @learningResourceReferenceID int
-                    IF NOT EXISTS(SELECT * FROM LearningResourceReferences WHERE @resourceRefID = resourceRefID)
-                        BEGIN
-                            INSERT INTO LearningResourceReferences(
-                                ResourceRefID,
-                                OriginalResourceName,
-                                OriginalDescription,
-                                OriginalResourceType,
-                                ResourceLink,
-                                OriginalCatalogueName,
-                                OriginalRating,
-                                AdminID,
-                                Added)
-                            VALUES(
-                                @resourceRefID,
-                                @resourceName,
-                                @description,
-                                @resourceType,
-                                @link,
-                                @catalogue,
-                                @rating,
-                                @adminID,
-                                GETDATE())
-                            SELECT @learningResourceReferenceID = SCOPE_IDENTITY()
-                        END
-                    ELSE
-                        BEGIN
-                            SELECT TOP 1 @learningResourceReferenceID = ID 
-                            FROM LearningResourceReferences 
-                            WHERE @resourceRefID = resourceRefID
-                        END
+                @"DECLARE @learningResourceReferenceID int = (
+                        SELECT TOP 1 ID
+                        FROM LearningResourceReferences
+                        WHERE ResourceRefID = @resourceRefID
+                    );
+                    IF @learningResourceReferenceID IS NULL
+                    BEGIN
+                        INSERT INTO LearningResourceReferences(
+                            ResourceRefID,
+                            OriginalResourceName,
+                            OriginalDescription,
+                            OriginalResourceType,
+                            ResourceLink,
+                            OriginalCatalogueName,
+                            OriginalRating,
+                            AdminID,
+                            Added)
+                        VALUES(
+                            @resourceRefID,
+                            @resourceName,
+                            @description,
+                            @resourceType,
+                            @link,
+                            @catalogue,
+                            @rating,
+                            @adminID,
+                            GETDATE());
+                        SET @learningResourceReferenceID = SCOPE_IDENTITY();
+                    END
                     INSERT INTO CompetencyLearningResources(CompetencyID, LearningResourceReferenceID, AdminID)
-                           VALUES (@competencyID, @learningResourceReferenceID, @adminID)
+                        VALUES (@competencyID, @learningResourceReferenceID, @adminID);
                     SELECT SCOPE_IDENTITY() AS CompetencyLearningResourceId",
                 new
                 {
@@ -100,13 +99,19 @@
                     catalogue,
                     rating,
                     competencyID,
-                    adminId
+                    adminID = adminId
                 }
             );
         }
 
         public IEnumerable<CompetencyResourceAssessmentQuestionParameter> GetCompetencyResourceAssessmentQuestionParameters(IEnumerable<int> competencyLearningResourceIds)
         {
+            var resourceIds = competencyLearningResourceIds?.ToArray();
+            if (resourceIds == null || resourceIds.Length == 0)
+            {
+                return new List<CompetencyResourceAssessmentQuestionParameter>();
+            }
+
             return connection.Query<CompetencyResourceAssessmentQuestionParameter>(
                 @"SELECT
                         CompetencyLearningResourceID,
@@ -117,8 +122,8 @@
                         MinResultMatch,
                         MaxResultMatch
                     FROM CompetencyResourceAssessmentQuestionParameters
-                    WHERE CompetencyLearningResourceId IN @competencyLearningResourceIds",
-                new { competencyLearningResourceIds }
+                    WHERE CompetencyLearningResourceId IN @resourceIds",
+                new { resourceIds }
             );
         }
         public IEnumerable<CompetencyLearningResource> GetActiveCompetencyLearningResourcesByCompetencyIdAndReferenceId(int competencyId, int referenceId)

--- a/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/FrameworkDataService.cs
@@ -333,7 +333,10 @@
 
         private const string FrameworkTables =
             @"Frameworks AS FW INNER JOIN AdminAccounts AS aa ON aa.ID = fw.OwnerAdminID
-                LEFT OUTER JOIN FrameworkCollaborators AS fwc ON fwc.FrameworkID = FW.ID AND fwc.AdminID = @adminId AND COALESCE(IsDeleted, 0) = 0 ";
+                LEFT OUTER JOIN FrameworkCollaborators AS fwc ON fwc.FrameworkID = FW.ID AND fwc.AdminID = @adminId AND COALESCE(fwc.IsDeleted, 0) = 0
+                LEFT OUTER JOIN Brands AS b ON b.BrandID = FW.BrandID
+                LEFT OUTER JOIN CourseCategories AS cc ON cc.CourseCategoryID = FW.CategoryID
+                LEFT OUTER JOIN CourseTopics AS ct ON ct.CourseTopicID = FW.TopicID";
 
         private const string AssessmentQuestionFields =
             @"SELECT AQ.ID, AQ.Question, AQ.MinValue, AQ.MaxValue, AQ.AssessmentQuestionInputTypeID, AQI.InputTypeName, AQ.AddedByAdminId, CASE WHEN AQ.AddedByAdminId = @adminId THEN 1 ELSE 0 END AS UserIsOwner, AQ.CommentsPrompt, AQ.CommentsHint";
@@ -372,7 +375,7 @@
             );
         }
 
-        public BaseFramework GetBaseFrameworkByFrameworkId(int frameworkId, int adminId)
+        public BaseFramework? GetBaseFrameworkByFrameworkId(int frameworkId, int adminId)
         {
             return connection.QueryFirstOrDefault<BaseFramework>(
                 $@"SELECT {BaseFrameworkFields}
@@ -382,7 +385,7 @@
             );
         }
 
-        public BrandedFramework GetBrandedFrameworkByFrameworkId(int frameworkId, int adminId)
+        public BrandedFramework? GetBrandedFrameworkByFrameworkId(int frameworkId, int adminId)
         {
             return connection.QueryFirstOrDefault<BrandedFramework>(
                 $@"SELECT {BaseFrameworkFields} {BrandedFrameworkFields}
@@ -418,13 +421,17 @@
 
         public IEnumerable<CompetencyFlag> GetSelectedCompetencyFlagsByCompetecyIds(int[] ids)
         {
-            var commaSeparatedIds = String.Join(',', ids.Distinct());
-            var competencyIdFilter = ids.Count() > 0 ? $"cf.CompetencyID IN ({commaSeparatedIds})" : "1=1";
+            if (ids == null || ids.Length == 0)
+            {
+                return Enumerable.Empty<CompetencyFlag>();
+            }
+
             return connection.Query<CompetencyFlag>(
                 $@"SELECT CompetencyId, Selected, {FlagFields}
-	                FROM CompetencyFlags AS cf
-	                INNER JOIN Flags AS fl ON cf.FlagID = fl.ID
-                    WHERE cf.Selected = 1 AND {competencyIdFilter}"
+                    FROM CompetencyFlags AS cf
+                    INNER JOIN Flags AS fl ON cf.FlagID = fl.ID
+                    WHERE cf.Selected = 1 AND cf.CompetencyID IN @competencyIds",
+                new { competencyIds = ids.Distinct().ToArray() }
             );
         }
 
@@ -537,12 +544,13 @@
                 return new BrandedFramework();
             }
 
-            return connection.QueryFirstOrDefault<BrandedFramework>(
+            var framework = connection.QueryFirstOrDefault<BrandedFramework>(
                 $@"SELECT {BaseFrameworkFields}
                       FROM {FrameworkTables}
                       WHERE FrameworkName = @frameworkName AND OwnerAdminID = @adminId",
                 new { frameworkName, adminId }
             );
+            return framework ?? new BrandedFramework();
         }
 
         public BrandedFramework? UpdateFrameworkBranding(
@@ -1538,20 +1546,17 @@ GROUP BY fc.ID, c.ID, c.Name, c.Description, fc.Ordering
 
         public FrameworkDefaultQuestionUsage GetFrameworkDefaultQuestionUsage(int frameworkId, int assessmentQuestionId)
         {
-            return connection.QueryFirstOrDefault<FrameworkDefaultQuestionUsage>(
+            return connection.QueryFirst<FrameworkDefaultQuestionUsage>(
                 @"SELECT @assessmentQuestionId AS ID,
-                 (SELECT AQ.Question + ' (' + AQI.InputTypeName + ' ' + CAST(AQ.MinValue AS nvarchar) + ' to ' + CAST(AQ.MaxValue AS nvarchar) + ')' AS Expr1
-                 FROM    AssessmentQuestions AS AQ LEFT OUTER JOIN
-                              AssessmentQuestionInputTypes AS AQI ON AQ.AssessmentQuestionInputTypeID = AQI.ID
-                 WHERE (AQ.ID = @assessmentQuestionId)) AS Question, COUNT(CompetencyID) AS Competencies,
-                 (SELECT COUNT(CompetencyID) AS Expr1
-                 FROM    CompetencyAssessmentQuestions
-                 WHERE (AssessmentQuestionID = @assessmentQuestionId) AND (CompetencyID IN
-                                  (SELECT CompetencyID
-                                  FROM    FrameworkCompetencies
-                                  WHERE (FrameworkID = @frameworkId)))) AS CompetencyAssessmentQuestions
-FROM   FrameworkCompetencies AS FC
-WHERE (FrameworkID = @frameworkId)",
+                         AQ.Question + ' (' + AQI.InputTypeName + ' ' + CAST(AQ.MinValue AS nvarchar) + ' to ' + CAST(AQ.MaxValue AS nvarchar) + ')' AS Question,
+                         COUNT(DISTINCT fc.CompetencyID) AS Competencies,
+                         COUNT(DISTINCT caq.CompetencyID) AS CompetencyAssessmentQuestions
+                    FROM AssessmentQuestions AS AQ
+                    LEFT OUTER JOIN AssessmentQuestionInputTypes AS AQI ON AQ.AssessmentQuestionInputTypeID = AQI.ID
+                    LEFT OUTER JOIN CompetencyAssessmentQuestions AS caq ON caq.AssessmentQuestionID = @assessmentQuestionId
+                    LEFT OUTER JOIN FrameworkCompetencies AS fc ON caq.CompetencyID = fc.CompetencyID AND fc.FrameworkID = @frameworkId
+                   WHERE AQ.ID = @assessmentQuestionId
+                   GROUP BY AQ.Question, AQI.InputTypeName, AQ.MinValue, AQ.MaxValue",
                 new { frameworkId, assessmentQuestionId }
             );
         }
@@ -1639,7 +1644,7 @@ WHERE (FrameworkID = @frameworkId)",
 
         public AssessmentQuestionDetail GetAssessmentQuestionDetailById(int assessmentQuestionId, int adminId)
         {
-            return connection.QueryFirstOrDefault<AssessmentQuestionDetail>(
+            return connection.QueryFirst<AssessmentQuestionDetail>(
                 $@"{AssessmentQuestionFields}{AssessmentQuestionDetailFields}
                     {AssessmentQuestionTables}
                     WHERE AQ.ID = @assessmentQuestionId",
@@ -1653,7 +1658,7 @@ WHERE (FrameworkID = @frameworkId)",
             int level
         )
         {
-            return connection.QueryFirstOrDefault<LevelDescriptor>(
+            return connection.QueryFirst<LevelDescriptor>(
                 @"SELECT COALESCE(ID,0) AS ID, @assessmentQuestionId AS AssessmentQuestionID, n AS LevelValue, LevelLabel, LevelDescription, COALESCE(UpdatedByAdminID, @adminId) AS UpdatedByAdminID
                     FROM
                     (SELECT TOP (@level) n = ROW_NUMBER() OVER (ORDER BY number)
@@ -2372,11 +2377,25 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
                     WHERE clr.ID = @competencyLearningResourceId",
                 new { competencyLearningResourceId }
             ).FirstOrDefault();
-            var questions = connection.Query<AssessmentQuestion>(
-                $@"SELECT * FROM AssessmentQuestions
-                    WHERE ID IN ({resource?.AssessmentQuestionId ?? 0}, {resource?.RelevanceAssessmentQuestionId ?? 0})"
-            );
-            resource!.AssessmentQuestion = questions.FirstOrDefault(q => q.ID == resource.AssessmentQuestionId)!;
+
+            if (resource == null)
+            {
+                return null;
+            }
+
+            var questionIds = new[] { resource.AssessmentQuestionId, resource.RelevanceAssessmentQuestionId }
+                .Where(id => id > 0)
+                .Distinct()
+                .ToArray();
+
+            var questions = questionIds.Length > 0
+                ? connection.Query<AssessmentQuestion>(
+                    @"SELECT * FROM AssessmentQuestions WHERE ID IN @questionIds",
+                    new { questionIds }
+                )
+                : Enumerable.Empty<AssessmentQuestion>();
+
+            resource.AssessmentQuestion = questions.FirstOrDefault(q => q.ID == resource.AssessmentQuestionId)!;
             resource.RelevanceAssessmentQuestion =
                 questions.FirstOrDefault(q => q.ID == resource.RelevanceAssessmentQuestionId)!;
             return resource;
@@ -2437,10 +2456,21 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
         )
         {
             int rowsAffected;
+            var dbParameters = new
+            {
+                parameter.CompetencyLearningResourceId,
+                AssessmentQuestionId = parameter.AssessmentQuestion?.ID,
+                parameter.MinResultMatch,
+                parameter.MaxResultMatch,
+                Essential = Convert.ToInt32(parameter.Essential),
+                RelevanceAssessmentQuestionId = parameter.RelevanceAssessmentQuestion?.ID,
+                CompareToRoleRequirements = Convert.ToInt32(parameter.CompareToRoleRequirements)
+            };
+
             if (parameter.IsNew)
             {
                 rowsAffected = connection.Execute(
-                    $@"INSERT INTO CompetencyResourceAssessmentQuestionParameters(
+                    @"INSERT INTO CompetencyResourceAssessmentQuestionParameters(
                         CompetencyLearningResourceID,
                         AssessmentQuestionID,
                         MinResultMatch,
@@ -2449,26 +2479,28 @@ WHERE (RP.CreatedByAdminID = @adminId) OR
                         RelevanceAssessmentQuestionID,
                         CompareToRoleRequirements)
                         VALUES(
-                            {parameter.CompetencyLearningResourceId},
-                            {parameter.AssessmentQuestion?.ID.ToString() ?? "null"},
-                            {parameter.MinResultMatch},
-                            {parameter.MaxResultMatch},
-                            {Convert.ToInt32(parameter.Essential)},
-                            {parameter.RelevanceAssessmentQuestion?.ID.ToString() ?? "null"},
-                            {Convert.ToInt32(parameter.CompareToRoleRequirements)})"
+                            @CompetencyLearningResourceId,
+                            @AssessmentQuestionId,
+                            @MinResultMatch,
+                            @MaxResultMatch,
+                            @Essential,
+                            @RelevanceAssessmentQuestionId,
+                            @CompareToRoleRequirements)",
+                    dbParameters
                 );
             }
             else
             {
                 rowsAffected = connection.Execute(
-                    $@"UPDATE CompetencyResourceAssessmentQuestionParameters
-                    SET AssessmentQuestionID = {parameter.AssessmentQuestion?.ID.ToString() ?? "null"},
-                        MinResultMatch = {parameter.MinResultMatch},
-                        MaxResultMatch = {parameter.MaxResultMatch},
-                        Essential = {Convert.ToInt32(parameter.Essential)},
-                        RelevanceAssessmentQuestionID = {parameter.RelevanceAssessmentQuestion?.ID.ToString() ?? "null"},
-                        CompareToRoleRequirements = {Convert.ToInt32(parameter.CompareToRoleRequirements)}
-                    WHERE CompetencyLearningResourceID = {parameter.CompetencyLearningResourceId}"
+                    @"UPDATE CompetencyResourceAssessmentQuestionParameters
+                    SET AssessmentQuestionID = @AssessmentQuestionId,
+                        MinResultMatch = @MinResultMatch,
+                        MaxResultMatch = @MaxResultMatch,
+                        Essential = @Essential,
+                        RelevanceAssessmentQuestionID = @RelevanceAssessmentQuestionId,
+                        CompareToRoleRequirements = @CompareToRoleRequirements
+                    WHERE CompetencyLearningResourceID = @CompetencyLearningResourceId",
+                    dbParameters
                 );
             }
 

--- a/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
@@ -67,6 +67,30 @@
 
         private readonly ILogger<LearningLogItemsDataService> logger;
 
+        private readonly object activityTypeIdLock = new();
+        private int? learningHubResourceActivityTypeId;
+
+        private int LearningHubResourceActivityTypeId
+        {
+            get
+            {
+                if (learningHubResourceActivityTypeId == null)
+                {
+                    lock (activityTypeIdLock)
+                    {
+                        if (learningHubResourceActivityTypeId == null)
+                        {
+                            learningHubResourceActivityTypeId = connection.ExecuteScalar<int>(
+                                @"SELECT TOP 1 ID FROM ActivityTypes WHERE TypeLabel = @learningHubResourceActivityLabel",
+                                new { learningHubResourceActivityLabel = LearningHubResourceActivityLabel });
+                        }
+                    }
+                }
+
+                return learningHubResourceActivityTypeId.Value;
+            }
+        }
+
         public LearningLogItemsDataService(IDbConnection connection, ILogger<LearningLogItemsDataService> logger)
         {
             this.connection = connection;
@@ -79,11 +103,10 @@
                 $@"SELECT
                         {LearningLogItemColumns}
                     FROM LearningLogItems l
-                    INNER JOIN ActivityTypes a ON a.ID = l.ActivityTypeID
                     INNER JOIN LearningResourceReferences AS lrr ON lrr.ID = l.LearningResourceReferenceID
                     WHERE LoggedById = @delegateUserId
-                    AND a.TypeLabel = '{LearningHubResourceActivityLabel}'",
-                new { delegateUserId }
+                      AND l.ActivityTypeID = @learningHubResourceActivityTypeId",
+                new { delegateUserId, learningHubResourceActivityTypeId = LearningHubResourceActivityTypeId }
             );
         }
 
@@ -93,11 +116,10 @@
                 $@"SELECT
                         {LearningLogItemColumns}
                     FROM LearningLogItems l
-                    INNER JOIN ActivityTypes a ON a.ID = l.ActivityTypeID
                     INNER JOIN LearningResourceReferences AS lrr ON lrr.ID = l.LearningResourceReferenceID
-                    WHERE a.TypeLabel = '{LearningHubResourceActivityLabel}'
-                    AND LearningLogItemID = @learningLogItemId",
-                new { learningLogItemId }
+                    WHERE l.ActivityTypeID = @learningHubResourceActivityTypeId
+                      AND LearningLogItemID = @learningLogItemId",
+                new { learningLogItemId, learningHubResourceActivityTypeId = LearningHubResourceActivityTypeId }
             );
         }
 
@@ -137,7 +159,7 @@
                         @activityName,
                         @resourceLink,
                         @learningResourceReferenceId,
-                        (SELECT TOP 1 ID FROM ActivityTypes WHERE TypeLabel = 'Learning Hub Resource'),
+                        @learningHubResourceActivityTypeId,
                         NULL,
                         NULL,
                         0,
@@ -150,7 +172,15 @@
                         NULL,
                         NULL,
                         NULL)",
-                new { addedDate, delegateUserId, activityName, resourceLink, learningResourceReferenceId }
+                new
+                {
+                    addedDate,
+                    delegateUserId,
+                    activityName,
+                    resourceLink,
+                    learningResourceReferenceId,
+                    learningHubResourceActivityTypeId = LearningHubResourceActivityTypeId
+                }
             );
 
             return learningLogItemId;

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDataService.cs
@@ -161,7 +161,7 @@
                          ON cas.SupervisorDelegateId = sd.ID
                     WHERE cas.Removed IS NULL
                       AND ca.RemovedDate IS NULL
-	                  AND sd.SupervisorAdminID = 10857
+	                  AND sd.SupervisorAdminID = @adminId
                 ),
                 ProfileCounts AS (
                     SELECT COUNT(DISTINCT sa.ID) AS ProfileCount
@@ -326,73 +326,66 @@
             if (delegateUserId == null)
             {
                 delegateUserId = (int?)connection.ExecuteScalar(
-                    @"SELECT da.UserID AS DelegateUserID 
-                            FROM Users u
-                            INNER JOIN DelegateAccounts da
-                            ON da.UserID = u.ID
-	                        LEFT JOIN UserCentreDetails ucd
-	                        ON ucd.UserID = u.ID
-                            AND ucd.CentreID = da.CentreID
-                            WHERE (ucd.Email = @delegateEmail OR u.PrimaryEmail = @delegateEmail)
-                            AND da.CentreID = @centreId", new { delegateEmail, centreId });
+                    @"SELECT da.UserID AS DelegateUserID
+                      FROM Users u
+                      INNER JOIN DelegateAccounts da ON da.UserID = u.ID
+                      LEFT JOIN UserCentreDetails ucd ON ucd.UserID = u.ID AND ucd.CentreID = da.CentreID
+                      WHERE (ucd.Email = @delegateEmail OR u.PrimaryEmail = @delegateEmail)
+                        AND da.CentreID = @centreId",
+                    new { delegateEmail, centreId });
             }
 
             int existingId = Convert.ToInt32(connection.ExecuteScalar(
-                @"
-                    SELECT COALESCE
-                    ((SELECT Top 1 ID
-                        FROM  SupervisorDelegates sd
-                        WHERE ((sd.SupervisorAdminID = @supervisorAdminID) OR (sd.SupervisorAdminID > 0 AND SupervisorEmail = @supervisorEmail AND @supervisorAdminID = NULL))
-		                      AND((sd.DelegateUserID = @delegateUserId) OR (sd.DelegateUserID > 0 AND DelegateEmail = @delegateEmail AND @delegateUserId = NULL)) ORDER BY sd.DelegateUserID 
-                        ), 0) AS ID",
+                @"SELECT COALESCE(
+                        (SELECT TOP 1 ID
+                         FROM SupervisorDelegates sd
+                         WHERE ((sd.SupervisorAdminID = @supervisorAdminID) OR (sd.SupervisorAdminID > 0 AND SupervisorEmail = @supervisorEmail AND @supervisorAdminID IS NULL))
+                           AND ((sd.DelegateUserID = @delegateUserId) OR (sd.DelegateUserID > 0 AND DelegateEmail = @delegateEmail AND @delegateUserId IS NULL))
+                         ORDER BY sd.DelegateUserID), 0)",
+                new { supervisorEmail, delegateEmail, supervisorAdminId, delegateUserId }));
+
+            if (existingId > 0)
+            {
+                connection.Execute(
+                    @"UPDATE SupervisorDelegates
+                      SET Removed = NULL,
+                          DelegateUserId = @delegateUserId,
+                          DelegateEmail = @delegateEmail
+                      WHERE ID = @existingId",
+                    new { delegateUserId, delegateEmail, existingId });
+                return existingId;
+            }
+
+            var numberOfAffectedRows = connection.Execute(
+                @"INSERT INTO SupervisorDelegates (SupervisorAdminID, DelegateEmail, DelegateUserID, SupervisorEmail, AddedByDelegate)
+                  VALUES (@supervisorAdminId, @delegateEmail, @delegateUserId, @supervisorEmail, @addedByDelegate)",
+                new { supervisorAdminId, delegateEmail, delegateUserId, supervisorEmail, addedByDelegate });
+            if (numberOfAffectedRows < 1)
+            {
+                logger.LogWarning(
+                    $"Not inserting SupervisorDelegate as db insert failed. supervisorAdminId: {supervisorAdminId}, delegateEmail: {delegateEmail}, delegateUserId: {delegateUserId}"
+                );
+                return -1;
+            }
+
+            existingId = Convert.ToInt32(connection.ExecuteScalar(
+                @"SELECT COALESCE(
+                        (SELECT ID
+                         FROM SupervisorDelegates sd
+                         WHERE SupervisorEmail = @supervisorEmail
+                           AND DelegateEmail = @delegateEmail
+                           AND ((@supervisorAdminID = 0) OR sd.SupervisorAdminID = @supervisorAdminID)
+                           AND ((@delegateUserID = 0) OR sd.DelegateUserID = @delegateUserID)
+                           AND sd.Removed IS NULL), 0)",
                 new
                 {
                     supervisorEmail,
                     delegateEmail,
                     supervisorAdminId = supervisorAdminId ?? 0,
                     delegateUserId = delegateUserId ?? 0
-                }
-            ));
+                }));
 
-            if (existingId > 0)
-            {
-                var numberOfAffectedRows = connection.Execute(@"UPDATE SupervisorDelegates SET Removed = NULL, DelegateUserId = @delegateUserId, 
-                                                                DelegateEmail = @delegateEmail WHERE ID = @existingId", new { delegateUserId, delegateEmail, existingId });
-                return existingId;
-            }
-            else
-            {
-                var numberOfAffectedRows = connection.Execute(
-                    @"INSERT INTO SupervisorDelegates (SupervisorAdminID, DelegateEmail, DelegateUserID, SupervisorEmail, AddedByDelegate)
-                    VALUES (@supervisorAdminId, @delegateEmail, @delegateUserId, @supervisorEmail, @addedByDelegate)",
-                    new { supervisorAdminId, delegateEmail, delegateUserId, supervisorEmail, addedByDelegate });
-                if (numberOfAffectedRows < 1)
-                {
-                    logger.LogWarning(
-                        $"Not inserting SupervisorDelegate as db insert failed. supervisorAdminId: {supervisorAdminId}, delegateEmail: {delegateEmail}, delegateUserId: {delegateUserId}"
-                    );
-                    return -1;
-                }
-
-                existingId = Convert.ToInt32(connection.ExecuteScalar(
-                    @"
-                    SELECT COALESCE
-                    ((SELECT ID
-                        FROM    SupervisorDelegates sd
-                        WHERE(SupervisorEmail = @supervisorEmail) AND(DelegateEmail = @delegateEmail)
-                            AND(sd.SupervisorAdminID = @supervisorAdminID OR @supervisorAdminID = 0)
-                            AND(sd.DelegateUserID = @delegateUserId OR @delegateUserID = 0)
-                            AND (sd.Removed IS NULL)
-                        ), 0) AS ID",
-                    new
-                    {
-                        supervisorEmail,
-                        delegateEmail,
-                        supervisorAdminId = supervisorAdminId ?? 0,
-                        delegateUserId = delegateUserId ?? 0
-                    }
-                )); return existingId;
-            }
+            return existingId;
         }
 
         public SupervisorDelegateDetail GetSupervisorDelegateDetailsById(int supervisorDelegateId, int adminId, int delegateUserId)
@@ -802,52 +795,48 @@
         {
             return connection.Query<CompetencyAssessment>(
                 $@"SELECT rp.ID, rp.Name AS CompetencyAssessmentName, rp.Description, rp.BrandID, rp.ParentSelfAssessmentID, rp.[National], rp.[Public], rp.CreatedByAdminID AS OwnerAdminID, rp.NRPProfessionalGroupID, rp.NRPSubGroupID, rp.NRPRoleID, rp.PublishStatusID, 0 AS UserRole, rp.CreatedDate,
-                            (SELECT BrandName
-                             FROM    Brands
-                             WHERE (BrandID = rp.BrandID)) AS Brand, '' AS ParentSelfAssessment, '' AS Owner, rp.Archived, rp.LastEdit,
-                             (SELECT ProfessionalGroup
-                             FROM    NRPProfessionalGroups
-                             WHERE (ID = rp.NRPProfessionalGroupID)) AS NRPProfessionalGroup,
-                            (SELECT SubGroup
-                             FROM    NRPSubGroups
-                             WHERE (ID = rp.NRPSubGroupID)) AS NRPSubGroup,
-                             (SELECT RoleProfile
-                             FROM    NRPRoles
-                             WHERE (ID = rp.NRPRoleID)) AS NRPRole, 0 AS SelfAssessmentReviewID
-                FROM   SelfAssessments AS rp INNER JOIN
-                         CentreSelfAssessments AS csa ON rp.ID = csa.SelfAssessmentID AND csa.CentreID = @centreId
-                WHERE (rp.ArchivedDate IS NULL) AND (rp.ID NOT IN
-                             (SELECT SelfAssessmentID
-                             FROM    CandidateAssessments AS CA
-                             WHERE (DelegateUserID = @delegateUserId) AND (RemovedDate IS NULL)
-                                AND (CompletedDate IS NULL)))
-                        AND ((rp.SupervisorSelfAssessmentReview = 1) OR (rp.SupervisorResultsReview = 1))
-                        AND (ISNULL(@categoryId, 0) = 0 OR rp.CategoryID = @categoryId) AND 
-						((CAST(rp.RetirementDate AS DATE) >= CAST(GETUTCDATE() AS DATE)) OR rp.RetirementDate IS NULL)", new { delegateUserId, centreId, categoryId }
+                             b.BrandName AS Brand, '' AS ParentSelfAssessment, '' AS Owner, rp.Archived, rp.LastEdit,
+                             pg.ProfessionalGroup AS NRPProfessionalGroup,
+                             sg.SubGroup AS NRPSubGroup,
+                             nr.RoleProfile AS NRPRole, 0 AS SelfAssessmentReviewID
+                FROM   SelfAssessments AS rp
+                INNER JOIN CentreSelfAssessments AS csa ON rp.ID = csa.SelfAssessmentID AND csa.CentreID = @centreId
+                LEFT JOIN Brands AS b ON b.BrandID = rp.BrandID
+                LEFT JOIN NRPProfessionalGroups AS pg ON pg.ID = rp.NRPProfessionalGroupID
+                LEFT JOIN NRPSubGroups AS sg ON sg.ID = rp.NRPSubGroupID
+                LEFT JOIN NRPRoles AS nr ON nr.ID = rp.NRPRoleID
+                WHERE rp.ArchivedDate IS NULL
+                  AND NOT EXISTS (
+                        SELECT 1
+                        FROM CandidateAssessments AS ca
+                        WHERE ca.DelegateUserID = @delegateUserId
+                          AND ca.RemovedDate IS NULL
+                          AND ca.CompletedDate IS NULL
+                          AND ca.SelfAssessmentID = rp.ID
+                    )
+                  AND ((rp.SupervisorSelfAssessmentReview = 1) OR (rp.SupervisorResultsReview = 1))
+                  AND (ISNULL(@categoryId, 0) = 0 OR rp.CategoryID = @categoryId)
+                  AND (rp.RetirementDate IS NULL OR CAST(rp.RetirementDate AS DATE) >= CAST(GETUTCDATE() AS DATE))", new { delegateUserId, centreId, categoryId }
                 );
         }
 
         public CompetencyAssessment? GetCompetencyAssessmentById(int selfAssessmentId)
         {
             return connection.Query<CompetencyAssessment>(
-                $@"SELECT ID, Name AS CompetencyAssessmentName, Description, BrandID, ParentSelfAssessmentID, [National], [Public], CreatedByAdminID AS OwnerAdminID, NRPProfessionalGroupID, NRPSubGroupID, NRPRoleID, PublishStatusID, 0 AS UserRole, CreatedDate,
-                 (SELECT BrandName
-                 FROM    Brands
-                 WHERE (BrandID = rp.BrandID)) AS Brand,
+                $@"SELECT rp.ID, rp.Name AS CompetencyAssessmentName, rp.Description, rp.BrandID, rp.ParentSelfAssessmentID, rp.[National], rp.[Public], rp.CreatedByAdminID AS OwnerAdminID, rp.NRPProfessionalGroupID, rp.NRPSubGroupID, rp.NRPRoleID, rp.PublishStatusID, 0 AS UserRole, rp.CreatedDate,
+                 b.BrandName AS Brand,
                  '' AS ParentSelfAssessment,
-                 '' AS Owner, Archived, LastEdit,
-                 (SELECT ProfessionalGroup
-                 FROM    NRPProfessionalGroups
-                 WHERE (ID = rp.NRPProfessionalGroupID)) AS NRPProfessionalGroup,
-                 (SELECT SubGroup
-                 FROM    NRPSubGroups
-                 WHERE (ID = rp.NRPSubGroupID)) AS NRPSubGroup,
-                 (SELECT RoleProfile
-                 FROM    NRPRoles
-                 WHERE (ID = rp.NRPRoleID)) AS NRPRole, 0 AS SelfAssessmentReviewID
-                 FROM   SelfAssessments AS rp 
-                 WHERE (ID = @selfAssessmentId)", new { selfAssessmentId }
-                ).FirstOrDefault();
+                 '' AS Owner, rp.Archived, rp.LastEdit,
+                 pg.ProfessionalGroup AS NRPProfessionalGroup,
+                 sg.SubGroup AS NRPSubGroup,
+                 nr.RoleProfile AS NRPRole, 0 AS SelfAssessmentReviewID
+                 FROM   SelfAssessments AS rp
+                 LEFT JOIN Brands AS b ON b.BrandID = rp.BrandID
+                 LEFT JOIN NRPProfessionalGroups AS pg ON pg.ID = rp.NRPProfessionalGroupID
+                 LEFT JOIN NRPSubGroups AS sg ON sg.ID = rp.NRPSubGroupID
+                 LEFT JOIN NRPRoles AS nr ON nr.ID = rp.NRPRoleID
+                 WHERE rp.ID = @selfAssessmentId", new { selfAssessmentId })
+                .FirstOrDefault();
         }
 
         public int EnrolDelegateOnAssessment(int delegateUserId, int supervisorDelegateId, int selfAssessmentId, DateTime? completeByDate, int adminId, int centreId, bool isLoggedInUser)
@@ -904,8 +893,8 @@
             else
             {
                 var numberOfAffectedRows = connection.Execute(
-                    @"INSERT INTO CandidateAssessments (DelegateUserID, SelfAssessmentID, CompleteByDate, EnrolmentMethodId, EnrolledByAdminId, CentreID,NonReportable)
-                    VALUES (@delegateUserId, @selfAssessmentId, @completeByDate, 2, @adminId, @centreId,@isLoggedInUser)",
+                    @"INSERT INTO CandidateAssessments (DelegateUserID, SelfAssessmentID, CompleteByDate, EnrolmentMethodId, EnrolledByAdminId, CentreID, NonReportable)
+                    VALUES (@delegateUserId, @selfAssessmentId, @completeByDate, 2, @adminId, @centreId, @isLoggedInUser)",
                     new { delegateUserId, selfAssessmentId, completeByDate, adminId, centreId, isLoggedInUser });
                 if (numberOfAffectedRows < 1)
                 {
@@ -918,6 +907,7 @@
                 return existingId;
             }
         }
+
         public int InsertCandidateAssessmentSupervisor(int delegateUserId, int supervisorDelegateId, int selfAssessmentId)
         {
             int candidateAssessmentId = Convert.ToInt32(connection.ExecuteScalar(

--- a/DigitalLearningSolutions.Data/DataServices/SupervisorDelegateDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/SupervisorDelegateDataService.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using Dapper;
     using DigitalLearningSolutions.Data.Models.Supervisor;
     using Microsoft.Extensions.Logging;
@@ -64,6 +65,13 @@
             IEnumerable<string> emails
         )
         {
+            var emailList = emails as IReadOnlyCollection<string> ?? emails.ToList();
+
+            if (!emailList.Any())
+            {
+                return Array.Empty<SupervisorDelegate>();
+            }
+
             return connection.Query<SupervisorDelegate>(
                 @"SELECT
                         sd.ID,
@@ -82,18 +90,25 @@
                       AND sd.DelegateEmail IN @emails
                       AND sd.DelegateUserID IS NULL
                       AND sd.Removed IS NULL",
-                new { centreId, emails }
+                new { centreId, emails = emailList }
             );
         }
 
         // TODO: HEEDLS-1014 - Change CandidateID to UserID
         public void UpdateSupervisorDelegateRecordsCandidateId(IEnumerable<int> supervisorDelegateIds, int delegateUserId)
         {
+            var supervisorDelegateIdList = supervisorDelegateIds as IReadOnlyCollection<int> ?? supervisorDelegateIds.ToList();
+
+            if (!supervisorDelegateIdList.Any())
+            {
+                return;
+            }
+
             connection.Execute(
                 @"UPDATE SupervisorDelegates
                     SET DelegateUserID = @delegateUserId
                     WHERE ID IN @supervisorDelegateIds",
-                new { supervisorDelegateIds, delegateUserId }
+                new { supervisorDelegateIds = supervisorDelegateIdList, delegateUserId }
             );
         }
     }


### PR DESCRIPTION
### JIRA link
[TD-7613](https://hee-tis.atlassian.net/browse/TD-7613)

### Description
In-place optimisations for queries across the data services relating to the competency framework service. These largely involve:
- replacing scalar subqueries with appropriate joins
- use of CTEs to avoid repeated table scans

No functional changes have been made; method signatures and return objects all remain the same (although a few have been made nullable deliberately). Developer testing has confirmed continued, like-for-like function and, in most cases, observable performance improvements.

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7613]: https://hee-tis.atlassian.net/browse/TD-7613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ