### PR TITLE
TD-7569 Issue showing Centre name already exists error on Edit centre details

### DIFF
--- a/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
+++ b/DigitalLearningSolutions.Web/Controllers/SuperAdmin/Centres/CentresController.cs
@@ -263,13 +263,12 @@ namespace DigitalLearningSolutions.Web.Controllers.SuperAdmin.Centres
             if (!string.IsNullOrEmpty(model.CentreName))
             {
                 var centres = centresService.GetAllCentres().ToList();
-                bool isExistingCentreName = centres.Where(center => center.Item1 == model.CentreId)
-                    .Select(center => center.Item2)
-                    .FirstOrDefault()
-                    .Equals(model.CentreName.Trim());
-                bool isCentreNamePresent = centres.Any(center => string.Equals(center.Item2.Trim(), model.CentreName?.Trim(), StringComparison.OrdinalIgnoreCase));
-
-                if (isCentreNamePresent && !isExistingCentreName)
+                string trimmedName = model.CentreName.Trim();
+                bool isDuplicateName = centres.Any(center =>
+                    center.Item1 != model.CentreId &&
+                    string.Equals(center.Item2?.Trim(), trimmedName, StringComparison.OrdinalIgnoreCase)
+                );
+                if (isDuplicateName)
                 {
                     ModelState.AddModelError("CentreName", CommonValidationErrorMessages.CentreNameAlreadyExist);
                 }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7569

### Description
Single query validation: Rather than retrieving all centres and performing two separate checks, validate whether any other centre (excluding the current CentreId) already has the proposed CentreName.
Excludes the current centre: The condition center.Item1 != model.CentreId ensures the current centre is ignored during the duplicate name check, preventing false validation errors when the name has not changed.
Consistent comparison: Both the existing and proposed centre names are trimmed and compared using StringComparison.OrdinalIgnoreCase to ensure consistent, case-insensitive validation.
Null-safe implementation: Using the null-conditional operator (center.Item2?.Trim()) prevents potential NullReferenceExceptions if a centre name is unexpectedly null.

### Screenshots

<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/7c1dc61d-6574-4944-a09c-a87bea8c2432" />

If the centre already exist
<img width="2496" height="1664" alt="image" src="https://github.com/user-attachments/assets/a08e1f79-f15b-40fe-a815-7b1c5ca21353" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
