### PR TITLE
TD-7613 Fixes problem introduced during refactoring with missing table join

### DIFF
--- a/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/LearningLogItemsDataService.cs
@@ -104,6 +104,7 @@
                         {LearningLogItemColumns}
                     FROM LearningLogItems l
                     INNER JOIN LearningResourceReferences AS lrr ON lrr.ID = l.LearningResourceReferenceID
+                    INNER JOIN ActivityTypes AS a ON a.ID = l.ActivityTypeID
                     WHERE LoggedById = @delegateUserId
                       AND l.ActivityTypeID = @learningHubResourceActivityTypeId",
                 new { delegateUserId, learningHubResourceActivityTypeId = LearningHubResourceActivityTypeId }
@@ -117,6 +118,7 @@
                         {LearningLogItemColumns}
                     FROM LearningLogItems l
                     INNER JOIN LearningResourceReferences AS lrr ON lrr.ID = l.LearningResourceReferenceID
+                    INNER JOIN ActivityTypes AS a ON a.ID = l.ActivityTypeID
                     WHERE l.ActivityTypeID = @learningHubResourceActivityTypeId
                       AND LearningLogItemID = @learningLogItemId",
                 new { learningLogItemId, learningHubResourceActivityTypeId = LearningHubResourceActivityTypeId }

--- a/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
+++ b/DigitalLearningSolutions.Data/DataServices/UserDataService/DelegateUserCardDataService.cs
@@ -166,17 +166,17 @@
 			INNER JOIN Users AS u WITH (NOLOCK) ON u.ID = da.UserID
 			LEFT JOIN UserCentreDetails AS ucd WITH (NOLOCK) ON ucd.UserID = da.UserID AND ucd.CentreID = da.CentreID
 			INNER JOIN JobGroups AS jg WITH (NOLOCK) ON jg.JobGroupID = u.JobGroupID ";
-        private string DelegatewhereConditon = $@" Where ((CentreID = @centreId) OR (@centreId= 0))
+        private const string DelegateWhereConditionTemplate = @" WHERE ((CentreID = @centreId) OR (@centreId= 0))
                             AND ( FirstName + ' ' + LastName + ' ' + PrimaryEmail + ' ' + COALESCE(Email, '') + ' ' + COALESCE(CandidateNumber, '') LIKE N'%' + @searchString + N'%')
-					        AND ((@isActive = 'Any') OR (@isActive = 'true' AND DelegateActive = 1) OR (@isActive = 'false' AND DelegateActive = 0))
-					        AND ((@isPasswordSet = 'Any') OR (@isPasswordSet = 'true' AND (Password <>'')) OR (@isPasswordSet = 'false' AND (Password ='')))
-					        AND ((@isAdmin = 'Any') OR (@isAdmin = 'true' AND (AdminID is not null)) OR (@isAdmin = 'false' AND (AdminID is null)))
-					        AND ((@isUnclaimed = 'Any') OR (@isUnclaimed = 'true' AND (RegistrationConfirmationHash is not null)) OR (@isUnclaimed = 'false' AND (RegistrationConfirmationHash is null)))
-					        AND ((@isEmailVerified = 'Any') OR (@isEmailVerified = 'true' AND EmailVerified IS NOT NULL) OR (@isEmailVerified = 'false' AND EmailVerified IS NULL))
+						AND ((@isActive = 'Any') OR (@isActive = 'true' AND DelegateActive = 1) OR (@isActive = 'false' AND DelegateActive = 0))
+						AND ((@isPasswordSet = 'Any') OR (@isPasswordSet = 'true' AND (Password <>'')) OR (@isPasswordSet = 'false' AND (Password ='')))
+						AND ((@isAdmin = 'Any') OR (@isAdmin = 'true' AND (AdminID is not null)) OR (@isAdmin = 'false' AND (AdminID is null)))
+						AND ((@isUnclaimed = 'Any') OR (@isUnclaimed = 'true' AND (RegistrationConfirmationHash is not null)) OR (@isUnclaimed = 'false' AND (RegistrationConfirmationHash is null)))
+						AND ((@isEmailVerified = 'Any') OR (@isEmailVerified = 'true' AND EmailVerified IS NOT NULL) OR (@isEmailVerified = 'false' AND EmailVerified IS NULL))
 
-					        AND ((@registrationType = 'Any') OR (@registrationType = 'SelfRegistered' AND SelfReg = 1 AND ExternalReg = 0) OR 
-					        (@registrationType = 'SelfRegisteredExternal' AND SelfReg = 1 AND ExternalReg = 1) OR 
-					        (@registrationType = 'RegisteredByCentre' AND SelfReg = 0 AND (ExternalReg = 0 OR ExternalReg = 1)))
+						AND ((@registrationType = 'Any') OR (@registrationType = 'SelfRegistered' AND SelfReg = 1 AND ExternalReg = 0) OR 
+						(@registrationType = 'SelfRegisteredExternal' AND SelfReg = 1 AND ExternalReg = 1) OR 
+						(@registrationType = 'RegisteredByCentre' AND SelfReg = 0 AND (ExternalReg = 0 OR ExternalReg = 1)))
 
                             AND ((@jobGroupId = 0) OR (JobGroupID = @jobGroupId ))
 
@@ -218,6 +218,7 @@
                             ).ToList();
             }
         }
+
         public int GetCountDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
                                      string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
                                      int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
@@ -227,18 +228,19 @@
                 searchString = searchString.Trim();
             }
 
+            var delegateWhereCondition = DelegateWhereConditionTemplate;
+
             if (groupId.HasValue)
             {
-                var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
-											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
-											)";
-                DelegatewhereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+                var groupDelegatesForCentre = @"SELECT DelegateID FROM GroupDelegates WHERE GroupID IN (
+								SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
+							)";
+                delegateWhereCondition += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
             }
 
+            var delegateCountQuery = @$"SELECT COUNT(*) AS Matches FROM ( " + DelegateUserExportSelectQuery + " ) D " + delegateWhereCondition;
 
-            var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches FROM ( " + DelegateUserExportSelectQuery + " ) D " + DelegatewhereConditon;
-
-            int ResultCount = connection.ExecuteScalar<int>(
+            var resultCount = connection.ExecuteScalar<int>(
                 delegateCountQuery,
                 new
                 {
@@ -263,7 +265,8 @@
                 },
                 commandTimeout: 3000
             );
-            return ResultCount;
+
+            return resultCount;
         }
 
         public List<DelegateUserCard> GetDelegateUserCardsForExportByCentreId(String searchString, string sortBy, string sortDirection, int centreId,
@@ -274,12 +277,14 @@
             {
                 searchString = searchString.Trim();
             }
+
+            var delegateWhereCondition = DelegateWhereConditionTemplate;
             if (groupId.HasValue)
             {
-                var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
-											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
-											)";
-                DelegatewhereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+                var groupDelegatesForCentre = @"SELECT DelegateID FROM GroupDelegates WHERE GroupID IN (
+								SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
+							)";
+                delegateWhereCondition += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
             }
 
             string orderBy;
@@ -295,7 +300,7 @@
                 orderBy = " ORDER BY DateRegistered " + sortOrder;
 
             orderBy += " OFFSET @exportQueryRowLimit * (@currentRun - 1) ROWS  FETCH NEXT @exportQueryRowLimit ROWS ONLY";
-            var mainSql = "SELECT * FROM ( " + DelegateUserExportSelectQuery + " ) D " + DelegatewhereConditon + orderBy;
+            var mainSql = "SELECT * FROM ( " + DelegateUserExportSelectQuery + " ) D " + delegateWhereCondition + orderBy;
 
             IEnumerable<DelegateUserCard> delegateUserCard = connection.Query<DelegateUserCard>(
                 mainSql,
@@ -324,8 +329,9 @@
                 },
                 commandTimeout: 3000
             );
-            return (delegateUserCard).ToList();
+            return delegateUserCard.ToList();
         }
+
         public (IEnumerable<DelegateUserCard>, int) GetDelegateUserCards(string searchString, int offSet, int itemsPerPage, string sortBy, string sortDirection, int centreId,
                                     string isActive, string isPasswordSet, string isAdmin, string isUnclaimed, string isEmailVerified, string registrationType, int jobGroupId,
                                     int? groupId, string answer1, string answer2, string answer3, string answer4, string answer5, string answer6)
@@ -335,31 +341,39 @@
                 searchString = searchString.Trim();
             }
 
-
-            var groupDelegatesForCentre = $@"SELECT DelegateID FROM GroupDelegates WHERE GroupID in (
-											SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
-											)";
+            var delegateWhereCondition = DelegateWhereConditionTemplate;
             if (groupId.HasValue)
-                DelegatewhereConditon += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+            {
+                var groupDelegatesForCentre = @"SELECT DelegateID FROM GroupDelegates WHERE GroupID IN (
+								SELECT GroupID FROM Groups WHERE CentreID = @centreId AND RemovedDate IS NULL
+							)";
+                delegateWhereCondition += "AND D.ID IN ( " + groupDelegatesForCentre + " AND GroupID = @groupId )";
+            }
 
+            // Normalise sort direction to avoid SQL syntax errors
+            var normalisedSortDirection = "ASC";
+            if (!string.IsNullOrEmpty(sortDirection) && sortDirection.Equals("Descending", StringComparison.OrdinalIgnoreCase))
+            {
+                normalisedSortDirection = "DESC";
+            }
+            else if (!string.IsNullOrEmpty(sortDirection) &&
+                     (sortDirection.Equals("ASC", StringComparison.OrdinalIgnoreCase) || sortDirection.Equals("DESC", StringComparison.OrdinalIgnoreCase)))
+            {
+                normalisedSortDirection = sortDirection.ToUpperInvariant();
+            }
 
             string orderBy;
-
-            if (sortDirection == "Ascending")
-                sortDirection = " ASC ";
-            else
-                sortDirection = " DESC ";
-
             if (sortBy == "SearchableName")
-                orderBy = " ORDER BY LTRIM(LastName) " + sortDirection + ", LTRIM(FirstName) ";
-            else if(sortBy == "LastAccessed")
-                orderBy = " ORDER BY LastAccessed " + sortDirection;
+                orderBy = " ORDER BY LTRIM(LastName) " + normalisedSortDirection + ", LTRIM(FirstName) ";
+            else if (sortBy == "LastAccessed")
+                orderBy = " ORDER BY LastAccessed " + normalisedSortDirection;
             else
-                orderBy = " ORDER BY DateRegistered " + sortDirection;
+                orderBy = " ORDER BY DateRegistered " + normalisedSortDirection;
 
-            orderBy += " OFFSET " + offSet + " ROWS FETCH NEXT " + itemsPerPage + " ROWS ONLY ";
+            // Use parameter placeholders for OFFSET/FETCH to avoid concatenating numeric values into SQL
+            orderBy += " OFFSET @offSet ROWS FETCH NEXT @itemsPerPage ROWS ONLY ";
 
-            var mainSql = "SELECT * FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + DelegatewhereConditon + orderBy;
+            var mainSql = "SELECT * FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + delegateWhereCondition + orderBy;
 
             IEnumerable<DelegateUserCard> delegateUserCard = connection.Query<DelegateUserCard>(
                 mainSql,
@@ -389,9 +403,9 @@
                 commandTimeout: 3000
             );
 
-            var delegateCountQuery = @$"SELECT  COUNT(*) AS Matches FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + DelegatewhereConditon;
+            var delegateCountQuery = @$"SELECT COUNT(*) AS Matches FROM ( " + DelegateUserSelectQuery + DelegateUserFromTable + " ) D " + delegateWhereCondition;
 
-            int ResultCount = connection.ExecuteScalar<int>(
+            int resultCount = connection.ExecuteScalar<int>(
                 delegateCountQuery,
                 new
                 {
@@ -418,7 +432,7 @@
                 },
                 commandTimeout: 3000
             );
-            return (delegateUserCard, ResultCount);
+            return (delegateUserCard, resultCount);
         }
 
         public List<DelegateUserCard> GetDelegatesNotRegisteredForGroupByGroupId(int groupId, int centreId)


### PR DESCRIPTION
### JIRA link
[TD-7613](https://hee-tis.atlassian.net/browse/TD-7613)

### Description
Reinstates join to activity type that is still required for the select statement, which includes TypeLabel.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation


[TD-7613]: https://hee-tis.atlassian.net/browse/TD-7613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ